### PR TITLE
docs: README updates for new features + fork's Star History

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ That's the only thing you'll type. torlink opens straight to a search bar: searc
 
 Type what you're looking for and press Enter. Results stream in from every source as they answer, tagged with size and how many people are sharing each one, so you can see what'll come down fast. Arrow to what you want and press `d` to save it.
 
+Press `s` to re-sort by seeders, size, or source, and `↑` in the search box to bring back a recent search. torlink remembers your sort and last category between runs, so it opens right where you left off.
+
 <p align="center">
   <img src="preview/browse.svg" alt="torlink's browse view: the sidebar, the search bar, and merged results from every source" style="max-width: 832px; width: 100%; height: auto;">
 </p>
@@ -56,7 +58,7 @@ A short, hand-picked list of trusted sources:
 | Category | Sources |
 | --- | --- |
 | Games | FitGirl |
-| Movies | YTS, The Pirate Bay, 1337x |
+| Movies | YTS, The Pirate Bay, 1337x, Torrents.csv |
 | TV | EZTV, SolidTorrents, The Pirate Bay, 1337x |
 | Anime | Nyaa, SubsPlease |
 
@@ -99,10 +101,10 @@ Your files stay on your disk, and nothing routes through a central server; torli
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=baairon%2Ftorlink&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=WarlaxZ%2Ftorlink&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=baairon/torlink&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=baairon/torlink&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=baairon/torlink&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=WarlaxZ/torlink&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=WarlaxZ/torlink&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=WarlaxZ/torlink&type=date&legend=top-left" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="preview/splash.svg" alt="torlink, curated torrents straight from your terminal" style="max-width: 832px; width: 100%; height: auto;">
 </p>
 
+> A fork of [baairon/torlink](https://github.com/baairon/torlink) with some extra quality-of-life touches — remembered preferences, search history, a source picker with an auto health-check, and an optional DNS-over-HTTPS escape hatch for blocked networks.
+
 Finding a torrent these days sucks. One site is a minefield of fake download buttons. Another hides the real link under a popup that spawns two more tabs. And after all that, half the results are dead, zero seeders.
 
 torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure. One search checks a short, curated list of reputable sources at once, and whatever you pick downloads straight to your computer. The files are yours, saved to your downloads folder.


### PR DESCRIPTION
Follow-up to #1 (now merged).

- Star History chart + link now track `WarlaxZ/torlink` (were pointing at the upstream `baairon/torlink`).
- Add **Torrents.csv** to the Movies sources row (new source from #1).
- Document search-history recall (`↑` in the search box) and that torlink remembers your sort + last category between runs.

(The Sources panel `Shift+S`, auto health-check, and custom-DNS section were already documented in #1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)