### PR TITLE
feat: in-app custom DNS (DoH) picker + fix fork run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ torlink is a torrent finder that lives in your terminal, with zero setup and not
 
 ## Get started
 
-1. **Install Node** (from [nodejs.org](https://nodejs.org)), it's all torlink needs.
-2. **Open your terminal.**
+This is a fork, so it isn't published to npm — you build it from source once, then run it. All you need is [Node 22+](https://nodejs.org).
+
+1. **Clone this repo** and open the folder.
+2. **Install and build:**
+
+   ```sh
+   npm install
+   npm run build
+   ```
+
 3. **Start it:**
 
    ```sh
-   npx torlnk
+   npm start
    ```
 
-That's the only thing you'll type. torlink opens straight to a search bar: search for what you want, paste in a magnet link, or just press Enter on an empty box to browse the curated library. From there it's all keypresses, nothing to memorize, and `?` brings up the full list anytime.
+torlink opens straight to a search bar: search for what you want, paste in a magnet link, or just press Enter on an empty box to browse the curated library. From there it's all keypresses, nothing to memorize, and `?` brings up the full list anytime.
 
 ## Finding something
 
@@ -68,13 +76,15 @@ Games are the only category that can run code, so they come from FitGirl alone, 
 
 ### Blocked by your network?
 
-Some networks (ISPs, work Wi-Fi, some routers) quietly block torrent sites at the DNS level, so every source looks offline. If that's happening, point torlink's own lookups at a public resolver over DNS-over-HTTPS — it doesn't touch the rest of your system:
+Some networks (ISPs, work Wi-Fi, some routers) quietly block torrent sites at the DNS level, so every source looks offline. If that's happening, point torlink's own lookups at a public resolver over DNS-over-HTTPS — it doesn't touch the rest of your system.
+
+The easiest way is right in the app: press `Shift+D` and enter a resolver alias or IPs. It's saved and applied straight away, no restart. `cloudflare`, `google`, `quad9`, and `opendns` are recognised, or pass resolver IPs directly (e.g. `1.1.1.1,1.0.0.1`).
+
+Prefer an environment variable? Set `TORLINK_DNS` before launching (it takes precedence over the in-app setting):
 
 ```sh
-TORLINK_DNS=cloudflare npx torlnk
+TORLINK_DNS=cloudflare npm start
 ```
-
-`cloudflare`, `google`, and `quad9` are recognised, or pass resolver IPs directly (e.g. `TORLINK_DNS=1.1.1.1,1.0.0.1`). You can also set `"dnsServers"` in the config file to make it stick.
 
 ## Contributing
 
@@ -92,7 +102,7 @@ To run or work on torlink locally:
    Or build it and run the bundled version:
    ```sh
    npm run build
-   npx torlnk
+   npm start
    ```
 
 Before opening a PR, skim [CONTRIBUTING.md](CONTRIBUTING.md); it lays out the bar with examples from real merged PRs.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -55,6 +55,7 @@ import { ConfirmPrompt } from "./components/ConfirmPrompt";
 import { StreamPlayerPrompt } from "./components/StreamPlayerPrompt";
 import { StreamFilePrompt } from "./components/StreamFilePrompt";
 import { SourcesPrompt } from "./components/SourcesPrompt";
+import { DnsPrompt } from "./components/DnsPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -117,6 +118,7 @@ export function App({
   const [editingToken, setEditingToken] = useState(false);
   const [editingPlayer, setEditingPlayer] = useState(false);
   const [editingSources, setEditingSources] = useState(false);
+  const [editingDns, setEditingDns] = useState(false);
   const [pendingP2P, setPendingP2P] = useState<DownloadInput | null>(null);
   const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -519,6 +521,43 @@ export function App({
     [config, setConfig, pendingStreamUrl],
   );
 
+  const openDnsPrompt = useCallback(() => {
+    setShowHelp(false);
+    setEditingDns(true);
+  }, []);
+
+  // Persist a custom DNS spec and apply it immediately, so the next search uses
+  // it without a restart. An empty value falls back to the system resolver.
+  const setDns = useCallback(
+    (raw: string) => {
+      setEditingDns(false);
+      if (!config) return;
+      const spec = raw.trim();
+      const servers = spec ? spec.split(",").map((s) => s.trim()).filter(Boolean) : [];
+      const next: Config = { ...config, dnsServers: servers.length ? servers : undefined };
+      setConfig(next);
+      setDnsServers(resolveDnsServers(next));
+      if (process.env["TORLINK_DNS"]?.trim()) {
+        setNotice("DNS saved, but TORLINK_DNS is set — unset it for the change to apply.");
+      } else {
+        setNotice(servers.length ? `Custom DNS set: ${servers.join(", ")}` : "Using system DNS.");
+      }
+    },
+    [config, setConfig],
+  );
+
+  const clearDns = useCallback(() => {
+    setEditingDns(false);
+    if (!config) return;
+    setConfig({ ...config, dnsServers: undefined });
+    if (process.env["TORLINK_DNS"]?.trim()) {
+      setNotice("DNS is set via TORLINK_DNS — unset the env var to use system DNS.");
+      return;
+    }
+    setDnsServers([]);
+    setNotice("Using system DNS.");
+  }, [config, setConfig]);
+
   // The plain (P2P) download button: when Real-Debrid is configured, route
   // through a warning first since P2P exposes the user's IP to the swarm.
   const requestP2PDownload = useCallback(
@@ -652,7 +691,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || pendingP2P || streamFiles || preparing
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || pendingP2P || streamFiles || preparing
           ? "help"
           : region,
       setRegion,
@@ -696,6 +735,7 @@ export function App({
     editingToken,
     editingPlayer,
     editingSources,
+    editingDns,
     toggleSource,
     pendingP2P,
     streamFiles,
@@ -730,6 +770,7 @@ export function App({
       if (editingToken) return; // the token prompt owns input
       if (editingPlayer) return; // the media-player prompt owns input
       if (editingSources) return; // the sources panel owns input
+      if (editingDns) return; // the DNS prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
       if (streamFiles) return; // the file picker owns input
       if (preparing) {
@@ -758,6 +799,10 @@ export function App({
       if (input === "S") {
         setShowHelp(false);
         setEditingSources(true);
+        return;
+      }
+      if (input === "D") {
+        openDnsPrompt();
         return;
       }
       if (input === "m") {
@@ -886,6 +931,19 @@ export function App({
           </Box>
         ) : null}
 
+        {editingDns ? (
+          <Box marginTop={1}>
+            <DnsPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              value={(store.config.dnsServers ?? []).join(",")}
+              envOverride={!!process.env["TORLINK_DNS"]?.trim()}
+              onSubmit={setDns}
+              onClear={clearDns}
+              onCancel={() => setEditingDns(false)}
+            />
+          </Box>
+        ) : null}
+
         {streamFiles ? (
           <Box marginTop={1}>
             <StreamFilePrompt
@@ -927,7 +985,7 @@ export function App({
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || pendingP2P || streamFiles || preparing
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || pendingP2P || streamFiles || preparing
               ? "none"
               : "flex"
           }
@@ -962,7 +1020,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || pendingP2P || streamFiles || preparing
+              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || pendingP2P || streamFiles || preparing
                 ? "none"
                 : "flex"
             }

--- a/src/ui/components/DnsPrompt.test.tsx
+++ b/src/ui/components/DnsPrompt.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { DnsPrompt } from "./DnsPrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+const CTRL_X = String.fromCharCode(24);
+
+describe("DnsPrompt", () => {
+  it("renders the current resolver value", () => {
+    const { lastFrame } = render(
+      <DnsPrompt
+        width={60}
+        value="cloudflare"
+        envOverride={false}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("cloudflare");
+  });
+
+  it("submits the typed value on enter", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <DnsPrompt
+        width={60}
+        value=""
+        envOverride={false}
+        onSubmit={onSubmit}
+        onClear={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    await flush();
+    stdin.write("quad9");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("quad9");
+  });
+
+  it("clears on ctrl+x when a value is set", async () => {
+    const onClear = vi.fn();
+    const { stdin } = render(
+      <DnsPrompt
+        width={60}
+        value="cloudflare"
+        envOverride={false}
+        onSubmit={() => {}}
+        onClear={onClear}
+        onCancel={() => {}}
+      />,
+    );
+    await flush();
+    stdin.write(CTRL_X);
+    await flush();
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on escape", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <DnsPrompt
+        width={60}
+        value=""
+        envOverride={false}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("notes when the value is pinned by the TORLINK_DNS env var", () => {
+    const { lastFrame } = render(
+      <DnsPrompt
+        width={60}
+        value="1.1.1.1"
+        envOverride
+        onSubmit={() => {}}
+        onClear={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("TORLINK_DNS");
+  });
+});

--- a/src/ui/components/DnsPrompt.tsx
+++ b/src/ui/components/DnsPrompt.tsx
@@ -1,0 +1,65 @@
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+
+interface DnsPromptProps {
+  width: number;
+  // The current resolver spec, comma-joined (e.g. "cloudflare" or "1.1.1.1,1.0.0.1").
+  value: string;
+  // True when TORLINK_DNS is set, so an edit here won't take effect until it's unset.
+  envOverride: boolean;
+  onSubmit: (value: string) => void;
+  onClear: () => void;
+  onCancel: () => void;
+}
+
+export function DnsPrompt({ width, value, envOverride, onSubmit, onClear, onCancel }: DnsPromptProps) {
+  useInput((input, key) => {
+    if (key.escape) onCancel();
+    else if (key.ctrl && input === "x") onClear();
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="custom DNS (DNS-over-HTTPS)" width={width} focused height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField
+              defaultValue={value}
+              placeholder="e.g. cloudflare, or 1.1.1.1,1.0.0.1"
+              onSubmit={onSubmit}
+            />
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1} flexDirection="column">
+        <Box>
+          <Text color={COLOR.alt}>↵</Text>
+          <Text dimColor> save</Text>
+          {value ? (
+            <>
+              <Text dimColor>{`     ${ICON.dot}     `}</Text>
+              <Text color={COLOR.alt}>^x</Text>
+              <Text dimColor> use system DNS</Text>
+            </>
+          ) : null}
+          <Text dimColor>{`     ${ICON.dot}     `}</Text>
+          <Text color={COLOR.alt}>esc</Text>
+          <Text dimColor> cancel</Text>
+        </Box>
+        <Text dimColor>
+          Routes torlink&apos;s own lookups over HTTPS to get past networks that block torrent
+          sites. Aliases: cloudflare, google, quad9, opendns — or pass resolver IPs. Empty uses
+          your system DNS.
+        </Text>
+        {envOverride ? (
+          <Text color={COLOR.warn}>
+            {`${ICON.warn} Pinned by the TORLINK_DNS env var — unset it for this to take effect.`}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -21,6 +21,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "o", label: "Download folder" },
       { keys: "k", label: "Real-Debrid token" },
       { keys: "S", label: "Choose sources" },
+      { keys: "D", label: "Custom DNS (bypass blocked networks)" },
       { keys: "q", label: "Quit" },
     ],
   },


### PR DESCRIPTION
## Summary

Two changes:

**1. Expose the DNS-over-HTTPS setting in the UI.** The DoH backend already existed (`dnsServers` config + `TORLINK_DNS` env), but nothing in the TUI surfaced it — you could only set it via the env var or by hand-editing `config.json`. This adds a prompt bound to **`Shift+D`** (paralleling `Shift+S` for sources) that saves and applies a resolver alias or IPs immediately, no restart. It warns when `TORLINK_DNS` is set, since the env var takes precedence.

**2. Fix the README run instructions for the fork.** `npx torlnk` fetches the upstream package from npm, which this fork isn't published to. Replaced all three occurrences with the build-from-source path.

## Changes

- **`src/ui/components/DnsPrompt.tsx`** (new) — prompt for a resolver alias (`cloudflare`, `google`, `quad9`, `opendns`) or raw IPs. `↵` save · `^x` back to system DNS · `esc` cancel · env-override warning.
- **`src/ui/components/DnsPrompt.test.tsx`** (new) — render / submit / clear / cancel / env-note (written first, TDD).
- **`src/ui/App.tsx`** — `Shift+D` keybinding, `setDns`/`clearDns` handlers (persist + apply live), input-guard and modal-open wiring.
- **`src/ui/keymap.ts`** — `D — Custom DNS` entry in the `?` help overlay.
- **`README.md`** — Get started + Contributing now use `npm install && npm run build` / `npm start`; blocked-network section documents the in-app `Shift+D` option first, with `TORLINK_DNS` as the env alternative.

## Verification

- `tsc --noEmit` clean
- Full suite passes (29 files / 219 tests)
- `npm run build` succeeds — confirms the README's build/run path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)