### PR TITLE
feat: stream via torrent when Real-Debrid is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,24 @@ Downloads run in the background while you keep searching, so you can queue up as
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">
 </p>
 
+## Streaming
+
+Don't want to wait for a download? Press **`v`** on a movie or an episode and torlink opens the largest video file straight in your media player while it downloads. The first time it'll ask which player to use (`mpv`, `iina`, `vlc`, or a path); after that it just plays. You can set one ahead of time with `TORLINK_PLAYER`.
+
+Without Real-Debrid, streaming runs **peer-to-peer** through a local server — the pieces you're watching download to a temporary folder as they play. Because that connects you straight to the swarm, torlink warns you once that your IP is visible to peers before the first torrent stream. While it plays, a banner shows the active stream; press **`x`** to stop. If the file finished downloading by the time you stop, torlink offers to **keep** it — moving it into your downloads folder to seed — otherwise the temporary copy is cleaned up.
+
+With a Real-Debrid account connected (below), `v` streams from Real-Debrid's servers instead: faster, no waiting on seeders, and your IP never touches the swarm. torlink takes that route automatically whenever your account is active, and only falls back to a torrent stream if you confirm it — so setting up Real-Debrid never quietly drops you onto peer-to-peer.
+
 ## Real-Debrid (optional)
 
 torlink works great on its own, but if you have a [Real-Debrid](https://real-debrid.com) account you can plug it in for a noticeably better ride. Real-Debrid pulls the torrent onto its own servers and hands you back a plain, direct download. That means full speed even on a torrent with no seeders, nothing waiting on a swarm to wake up, and — because Real-Debrid does the torrenting, not you — your IP never touches the network.
 
 To connect it, open the **Accounts** tab in the sidebar (alongside Downloads and Seeding), select Real-Debrid, paste your API token from [real-debrid.com/apitoken](https://real-debrid.com/apitoken), and torlink checks it and remembers it. (Prefer to keep the token off disk? Set `REALDEBRID_API_TOKEN` in your environment instead and torlink picks it up.)
 
-Once it's connected, every result gains two new moves:
+Once it's connected, downloading and streaming get an upgrade:
 
 - **`r` — download via Real-Debrid.** torlink hands the magnet to Real-Debrid, waits for it to be ready, and downloads the direct link straight to your folder. If it's already in Real-Debrid's cache it's basically instant. The plain `d` download still works exactly as before, but now it warns you first, since that route is peer-to-peer and exposes your IP.
-- **`v` — stream it.** For a movie or an episode, skip the download entirely: torlink resolves the largest video file and opens it in your media player. The first time, it'll ask which player to use (`mpv`, `iina`, `vlc`, or a path); after that it just plays. You can also set one ahead of time with `TORLINK_PLAYER`.
+- **`v` — stream via Real-Debrid.** [Streaming](#streaming) now routes through Real-Debrid's servers instead of the swarm — full-speed even with no seeders, and your IP stays private. If Real-Debrid can't prepare it (or your premium's lapsed), torlink tells you and offers a torrent stream instead rather than switching to peer-to-peer on its own.
 
 Real-Debrid torrents are fetched, not seeded, so they land in Recently downloaded and never join the Seeding tab. Heads up: Real-Debrid's torrent features need an active **premium** account — torlink will tell you if yours isn't.
 

--- a/docs/superpowers/plans/2026-07-03-torrent-streaming.md
+++ b/docs/superpowers/plans/2026-07-03-torrent-streaming.md
@@ -1,0 +1,922 @@
+# Torrent Streaming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Stream action (`v`) work peer-to-peer via WebTorrent when Real-Debrid isn't configured, streaming a torrent's largest video into the user's media player while it downloads to a temp dir.
+
+**Architecture:** A new self-contained `torrentStream` engine turns a magnet into a locally-served HTTP URL (WebTorrent's built-in Node server) and returns files in the same `{ url, filename, bytes }` shape Real-Debrid produces, so the existing stream picker and player-launch code are reused unchanged. `streamResult` in `App.tsx` gains a pure decision branch: no RD token → torrent (warn once, remembered); RD configured but not working → always-warn confirm; RD working → unchanged. Streaming is ephemeral (temp dir, auto-cleaned) with an offer-to-keep prompt when the file finished.
+
+**Tech Stack:** TypeScript, React + Ink (terminal UI), WebTorrent 2.x, Vitest.
+
+## Global Constraints
+
+- Node 22+ (project floor). Do not touch `.venv` or `node_modules`.
+- Run `npm run lint`* and `npm test` before considering any task done. (*If no `lint` script exists, run `npm run typecheck`; the repo uses `tsc --noEmit`.)
+- TDD: write the failing test first, prove it fails, then implement.
+- WebTorrent is already a dependency (`webtorrent@^2.4.1`, installed 2.8.5). Do not add new runtime dependencies.
+- Never *silently* fall back to peer-to-peer when Real-Debrid is configured — P2P exposes the user's real IP; a configured user expects RD's proxy. "Not configured" (no token) and "configured but not working" (present token that is non-premium or errors) are distinct states with distinct behaviour.
+- Mock WebTorrent's network layer in tests (no real swarm), mirroring `src/download/queue.test.ts`.
+
+---
+
+## File Structure
+
+- `src/util/player.ts` — **modify.** Becomes the home of the shared `StreamFile` shape (currently `ResolvedFile` lives in `realdebrid.ts`).
+- `src/integrations/realdebrid.ts` — **modify.** Re-export `ResolvedFile` as an alias of `StreamFile` (keeps every existing import working).
+- `src/webtorrent.d.ts` — **modify.** Add the client `createServer()` + Node server types.
+- `src/integrations/torrentStream.ts` — **create.** The magnet → playable-URL engine.
+- `src/integrations/torrentStream.test.ts` — **create.**
+- `src/ui/streamRoute.ts` — **create.** Pure RD-state → route decision.
+- `src/ui/streamRoute.test.ts` — **create.**
+- `src/config/config.ts` — **modify.** Add `torrentStreamAck?: boolean`.
+- `src/config/config.test.ts` — **modify.** Round-trip test for the new field.
+- `src/ui/App.tsx` — **modify.** Route branch, active-stream state, stop key, prompts, keep flow.
+- `src/ui/keymap.ts` — **modify.** Update the `v` label and add the stop hint.
+- `src/ui/streamKeep.ts` — **create.** Pure helper for the keep move-path decision.
+- `src/ui/streamKeep.test.ts` — **create.**
+
+---
+
+## Task 1: Shared `StreamFile` type
+
+**Files:**
+- Modify: `src/util/player.ts` (top of file + `pickStreamFile`/`streamCandidates` signatures)
+- Modify: `src/integrations/realdebrid.ts:20-24`
+
+**Interfaces:**
+- Produces: `export interface StreamFile { url: string; filename: string; bytes: number }` in `src/util/player.ts`. `ResolvedFile` becomes `export type ResolvedFile = StreamFile` in `realdebrid.ts`. Because the shapes are structurally identical, all existing consumers keep compiling.
+
+- [ ] **Step 1: Define `StreamFile` in `player.ts`**
+
+`src/util/player.ts` currently begins by importing `ResolvedFile` from `realdebrid`. Replace that import with a local definition and use it throughout the file:
+
+```ts
+// at top of src/util/player.ts — remove:  import type { ResolvedFile } from "../integrations/realdebrid";
+// add:
+export interface StreamFile {
+  url: string;
+  filename: string;
+  bytes: number;
+}
+```
+
+Then replace the two `ResolvedFile` usages in this file (`pickStreamFile(files: ResolvedFile[])`, `streamCandidates(files: ResolvedFile[])`) with `StreamFile`.
+
+- [ ] **Step 2: Re-point `ResolvedFile` in `realdebrid.ts`**
+
+In `src/integrations/realdebrid.ts`, replace the interface (lines 20-24):
+
+```ts
+import type { StreamFile } from "../util/player";
+
+// A resolved, directly-fetchable file (Real-Debrid direct link, or a
+// local torrent-stream URL). Structurally identical to StreamFile.
+export type ResolvedFile = StreamFile;
+```
+
+- [ ] **Step 3: Run typecheck to verify no breakage**
+
+Run: `npm run typecheck`
+Expected: PASS (all existing `ResolvedFile` imports in `App.tsx`, `StreamFilePrompt.tsx` still resolve via the alias).
+
+- [ ] **Step 4: Run the suite**
+
+Run: `npm test`
+Expected: PASS (no behavioural change; `player.test.ts` still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/player.ts src/integrations/realdebrid.ts
+git commit -m "refactor: extract shared StreamFile shape for streaming sources"
+```
+
+---
+
+## Task 2: Stream-route decision (pure function)
+
+**Files:**
+- Create: `src/ui/streamRoute.ts`
+- Test: `src/ui/streamRoute.test.ts`
+
+**Interfaces:**
+- Consumes: `Config` (`src/config/config.ts`), `RdStatus` (`src/integrations/rdStatus.ts`), and `resolveRealDebridToken` (`src/config/config.ts`).
+- Produces:
+```ts
+export type StreamRoute =
+  | { kind: "realdebrid" }                    // attempt RD (working, or premium-unknown)
+  | { kind: "torrent-auto" }                  // no RD token → torrent (one-time warn)
+  | { kind: "torrent-confirm"; reason: string }; // RD configured but not working → always warn
+
+export function classifyStreamRoute(config: Config, rdStatus: RdStatus | null): StreamRoute;
+```
+
+- [ ] **Step 1: Write the failing test**
+
+`src/ui/streamRoute.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { classifyStreamRoute } from "./streamRoute";
+import type { Config } from "../config/config";
+import type { RdStatus } from "../integrations/rdStatus";
+
+const base: Config = { downloadDir: "/tmp/dl", trackers: [] };
+const withToken: Config = { ...base, realDebridToken: "tok" };
+
+describe("classifyStreamRoute", () => {
+  it("no token -> torrent-auto", () => {
+    expect(classifyStreamRoute(base, null)).toEqual({ kind: "torrent-auto" });
+  });
+
+  it("token + premium -> realdebrid", () => {
+    const rd: RdStatus = { username: "u", premium: true, premiumUntil: null };
+    expect(classifyStreamRoute(withToken, rd)).toEqual({ kind: "realdebrid" });
+  });
+
+  it("token + status unknown -> realdebrid (let the attempt decide)", () => {
+    expect(classifyStreamRoute(withToken, null)).toEqual({ kind: "realdebrid" });
+  });
+
+  it("token + non-premium -> torrent-confirm with a reason", () => {
+    const rd: RdStatus = { username: "u", premium: false, premiumUntil: null };
+    const r = classifyStreamRoute(withToken, rd);
+    expect(r.kind).toBe("torrent-confirm");
+    expect((r as { reason: string }).reason).toMatch(/premium/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- streamRoute`
+Expected: FAIL (`classifyStreamRoute` not defined).
+
+- [ ] **Step 3: Implement**
+
+`src/ui/streamRoute.ts`:
+
+```ts
+import { type Config, resolveRealDebridToken } from "../config/config";
+import type { RdStatus } from "../integrations/rdStatus";
+
+export type StreamRoute =
+  | { kind: "realdebrid" }
+  | { kind: "torrent-auto" }
+  | { kind: "torrent-confirm"; reason: string };
+
+// Decide how `v` should stream, given RD config + last-known account status.
+// "Not configured" (no token) auto-routes to torrent; a present-but-non-premium
+// token is "configured but not working" and requires an explicit confirm so we
+// never silently expose the user's IP after they set RD up.
+export function classifyStreamRoute(config: Config, rdStatus: RdStatus | null): StreamRoute {
+  if (!resolveRealDebridToken(config)) return { kind: "torrent-auto" };
+  if (rdStatus && !rdStatus.premium) {
+    return { kind: "torrent-confirm", reason: "your Real-Debrid premium isn't active" };
+  }
+  return { kind: "realdebrid" };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- streamRoute`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/streamRoute.ts src/ui/streamRoute.test.ts
+git commit -m "feat: add stream-route decision (RD vs torrent)"
+```
+
+---
+
+## Task 3: Config field for the one-time privacy acknowledgement
+
+**Files:**
+- Modify: `src/config/config.ts` (`Config` interface, near `mediaPlayer?`)
+- Test: `src/config/config.test.ts`
+
+**Interfaces:**
+- Produces: `Config.torrentStreamAck?: boolean` — set true once the user has acknowledged that torrent streaming exposes their IP (the not-configured path only). Absent/false = not acknowledged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/config/config.test.ts` (match the file's existing import/style; adapt the loader call to whatever helper the file already uses to read/write config):
+
+```ts
+it("persists torrentStreamAck across a write/read round-trip", async () => {
+  const cfg = { ...defaultConfig, torrentStreamAck: true };
+  await writeConfig(cfg);            // use the same write helper other tests use
+  const read = await loadConfig();   // use the same load helper other tests use
+  expect(read.torrentStreamAck).toBe(true);
+});
+```
+
+If the config test file has no such round-trip helper, instead assert the field is accepted by the type and defaults to `undefined`:
+
+```ts
+it("defaults torrentStreamAck to undefined", () => {
+  expect(defaultConfig.torrentStreamAck).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- config`
+Expected: FAIL (property `torrentStreamAck` does not exist on type `Config`).
+
+- [ ] **Step 3: Implement**
+
+In `src/config/config.ts`, add to the `Config` interface just after `mediaPlayer?`:
+
+```ts
+  // Set once the user has acknowledged that streaming via torrent exposes their
+  // IP to the swarm (the no-Real-Debrid path). Absent/false = not yet warned.
+  torrentStreamAck?: boolean;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- config`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/config.ts src/config/config.test.ts
+git commit -m "feat: add torrentStreamAck config field"
+```
+
+---
+
+## Task 4: Torrent stream engine
+
+**Files:**
+- Modify: `src/webtorrent.d.ts`
+- Create: `src/integrations/torrentStream.ts`
+- Test: `src/integrations/torrentStream.test.ts`
+
+**Interfaces:**
+- Consumes: `StreamFile` (`src/util/player.ts`), `WebTorrent` (`webtorrent`).
+- Produces:
+```ts
+export interface TorrentStreamSession {
+  name: string;
+  files: StreamFile[];        // all files, mapped to local server URLs
+  dir: string;                // temp download dir (root)
+  isComplete(): boolean;      // torrent fully downloaded (safe to keep)
+  stop(opts?: { keep?: boolean }): Promise<void>; // close server + client; rm dir unless keep
+}
+
+export interface StreamTorrentOptions {
+  signal?: AbortSignal;
+  metadataTimeoutMs?: number;                       // default 60_000
+  // Injection seams for tests:
+  createClient?: () => WebTorrentLike;
+  tmpBase?: string;                                 // default os.tmpdir()
+  mkdtemp?: (prefix: string) => Promise<string>;
+  rm?: (dir: string) => Promise<void>;
+}
+
+export function streamTorrent(magnet: string, opts?: StreamTorrentOptions): Promise<TorrentStreamSession>;
+```
+`WebTorrentLike` is the minimal structural subset the engine touches (see Step 3), so tests can pass a fake without a real swarm.
+
+- [ ] **Step 1: Extend the WebTorrent type shim**
+
+WebTorrent's server lives on the **client** (`client.createServer(opts?)`) and serves each file at `http://<host>:<port>/webtorrent/<infoHash>/<encodeURI(file.path)>` (verified in `node_modules/webtorrent/lib/server.js`: `serveTorrentPage` builds `${pathname}/${torrent.infoHash}/${file.path}` and the request handler does `decodeURI` then matches `file.path.replace(/\\/g,'/')`).
+
+Add to `src/webtorrent.d.ts` inside the `WebTorrent` class and module:
+
+```ts
+  interface TorrentServer {
+    listen(port?: number, hostname?: string, cb?: () => void): void;
+    address(): { port: number } | null;
+    close(cb?: () => void): void;
+    destroy(cb?: () => void): void;
+  }
+```
+and add to the `WebTorrent` class body:
+```ts
+    createServer(opts?: { hostname?: string; pathname?: string }): TorrentServer;
+```
+Export `TorrentServer` from the module alongside `Torrent`/`TorrentFile`.
+
+- [ ] **Step 2: Write the failing test**
+
+`src/integrations/torrentStream.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { streamTorrent } from "./torrentStream";
+
+// Minimal fakes ---------------------------------------------------------------
+function fakeServer() {
+  return {
+    listen: (_p: number, _h: string | (() => void), cb?: () => void) => {
+      const done = typeof _h === "function" ? _h : cb;
+      done?.();
+    },
+    address: () => ({ port: 54321 }),
+    close: (cb?: () => void) => cb?.(),
+    destroy: (cb?: () => void) => cb?.(),
+  };
+}
+
+function fakeTorrent() {
+  const t = new EventEmitter() as any;
+  t.infoHash = "abc123";
+  t.name = "Big Buck Bunny";
+  t.done = false;
+  t.files = [
+    { name: "readme.txt", path: "Big Buck Bunny/readme.txt", length: 100 },
+    { name: "bbb.mp4", path: "Big Buck Bunny/bbb.mp4", length: 5000 },
+  ];
+  return t;
+}
+
+function fakeClient(torrent: any) {
+  return {
+    add: (_magnet: string, _opts: unknown) => {
+      queueMicrotask(() => torrent.emit("metadata"));
+      return torrent;
+    },
+    createServer: () => fakeServer(),
+    get: () => torrent,
+    remove: (_id: string, cb?: () => void) => cb?.(),
+    destroy: (cb?: () => void) => cb?.(),
+  };
+}
+
+describe("streamTorrent", () => {
+  it("maps files to local server URLs after metadata", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?xt=urn:btih:abc123", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-x",
+      rm,
+    });
+    expect(session.name).toBe("Big Buck Bunny");
+    const mp4 = session.files.find((f) => f.filename === "bbb.mp4")!;
+    expect(mp4.bytes).toBe(5000);
+    expect(mp4.url).toBe(
+      "http://localhost:54321/webtorrent/abc123/Big%20Buck%20Bunny/bbb.mp4",
+    );
+  });
+
+  it("stop() without keep removes the temp dir", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?x", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-y",
+      rm,
+    });
+    await session.stop();
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-y");
+  });
+
+  it("stop({keep:true}) leaves the temp dir in place", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?x", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-z",
+      rm,
+    });
+    await session.stop({ keep: true });
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it("rejects when metadata never arrives before the timeout", async () => {
+    const torrent = new EventEmitter() as any; // never emits metadata
+    const client = {
+      add: () => torrent,
+      createServer: () => fakeServer(),
+      get: () => torrent,
+      remove: (_i: string, cb?: () => void) => cb?.(),
+      destroy: (cb?: () => void) => cb?.(),
+    };
+    const rm = vi.fn(async () => {});
+    await expect(
+      streamTorrent("magnet:?x", {
+        createClient: () => client as any,
+        mkdtemp: async () => "/tmp/torlink-stream-timeout",
+        rm,
+        metadataTimeoutMs: 5,
+      }),
+    ).rejects.toThrow(/no peers|metadata|timed out/i);
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-timeout");
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm test -- torrentStream`
+Expected: FAIL (`streamTorrent` not defined).
+
+- [ ] **Step 4: Implement the engine**
+
+`src/integrations/torrentStream.ts`:
+
+```ts
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import WebTorrent from "webtorrent";
+import type { StreamFile } from "../util/player";
+
+export interface TorrentStreamSession {
+  name: string;
+  files: StreamFile[];
+  dir: string;
+  isComplete(): boolean;
+  stop(opts?: { keep?: boolean }): Promise<void>;
+}
+
+// The minimal structural subset of the WebTorrent client the engine touches,
+// so tests can inject a fake without a real swarm.
+export interface WebTorrentLike {
+  add(magnet: string, opts: { path: string }): TorrentLike;
+  createServer(opts?: { hostname?: string; pathname?: string }): ServerLike;
+  get(id: string): TorrentLike | null;
+  remove(id: string, cb?: (err?: Error) => void): void;
+  destroy(cb?: (err?: Error) => void): void;
+}
+interface TorrentLike {
+  infoHash: string;
+  name: string;
+  done: boolean;
+  files: { name: string; path: string; length: number }[];
+  on(event: "metadata" | "error", cb: (arg?: unknown) => void): void;
+  destroy(cb?: (err?: Error) => void): void;
+}
+interface ServerLike {
+  listen(port?: number, hostname?: string, cb?: () => void): void;
+  address(): { port: number } | null;
+  close(cb?: () => void): void;
+}
+
+export interface StreamTorrentOptions {
+  signal?: AbortSignal;
+  metadataTimeoutMs?: number;
+  createClient?: () => WebTorrentLike;
+  tmpBase?: string;
+  mkdtemp?: (prefix: string) => Promise<string>;
+  rm?: (dir: string) => Promise<void>;
+}
+
+const DEFAULT_METADATA_TIMEOUT_MS = 60_000;
+
+function toStreamFiles(
+  torrent: TorrentLike,
+  host: string,
+  port: number,
+): StreamFile[] {
+  return torrent.files.map((f) => {
+    const rel = f.path.replace(/\\/g, "/");
+    return {
+      url: `http://${host}:${port}/webtorrent/${torrent.infoHash}/${encodeURI(rel)}`,
+      filename: f.name,
+      bytes: f.length,
+    };
+  });
+}
+
+export async function streamTorrent(
+  magnet: string,
+  opts: StreamTorrentOptions = {},
+): Promise<TorrentStreamSession> {
+  const createClient = opts.createClient ?? (() => new WebTorrent() as unknown as WebTorrentLike);
+  const mkdtemp = opts.mkdtemp ?? ((prefix) => fs.mkdtemp(prefix));
+  const rm = opts.rm ?? ((dir) => fs.rm(dir, { recursive: true, force: true }));
+  const timeoutMs = opts.metadataTimeoutMs ?? DEFAULT_METADATA_TIMEOUT_MS;
+  const host = "localhost";
+
+  const dir = await mkdtemp(path.join(opts.tmpBase ?? os.tmpdir(), "torlink-stream-"));
+  const client = createClient();
+  client.destroy && ((client as { on?: (e: string, cb: () => void) => void }).on?.("error", () => {}));
+
+  const cleanup = async () => {
+    try {
+      await new Promise<void>((res) => client.destroy(() => res()));
+    } catch {}
+    await rm(dir).catch(() => {});
+  };
+
+  return new Promise<TorrentStreamSession>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      void cleanup().finally(() =>
+        reject(new Error("No peers found — couldn't start the stream (metadata timed out).")),
+      );
+    }, timeoutMs);
+
+    if (opts.signal) {
+      opts.signal.addEventListener("abort", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        void cleanup().finally(() => reject(new Error("Stream cancelled.")));
+      });
+    }
+
+    let torrent: TorrentLike;
+    try {
+      torrent = client.add(magnet, { path: dir });
+    } catch (e) {
+      settled = true;
+      clearTimeout(timer);
+      void cleanup().finally(() => reject(e instanceof Error ? e : new Error(String(e))));
+      return;
+    }
+
+    torrent.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      void cleanup().finally(() =>
+        reject(err instanceof Error ? err : new Error(String(err))),
+      );
+    });
+
+    torrent.on("metadata", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const server = client.createServer();
+      server.listen(0, host, () => {
+        const port = server.address()?.port ?? 0;
+        resolve({
+          name: torrent.name,
+          files: toStreamFiles(torrent, host, port),
+          dir,
+          isComplete: () => torrent.done === true,
+          stop: async ({ keep = false }: { keep?: boolean } = {}) => {
+            await new Promise<void>((res) => server.close(() => res()));
+            await new Promise<void>((res) => client.destroy(() => res()));
+            if (!keep) await rm(dir).catch(() => {});
+          },
+        });
+      });
+    });
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- torrentStream`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/webtorrent.d.ts src/integrations/torrentStream.ts src/integrations/torrentStream.test.ts
+git commit -m "feat: add ephemeral torrent stream engine"
+```
+
+---
+
+## Task 5: Wire torrent streaming into the app (ephemeral, auto-clean)
+
+This task makes `v` stream via torrent end-to-end with the privacy prompts and an active-stream indicator, cleaning up on stop or quit. The "offer to keep" flow is added in Task 6 (until then, stop always cleans up).
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+- Modify: `src/ui/keymap.ts`
+
+**Interfaces:**
+- Consumes: `classifyStreamRoute` (Task 2), `streamTorrent`/`TorrentStreamSession` (Task 4), `streamCandidates`/`playStream` (existing), `ConfirmPrompt` (existing), `Config.torrentStreamAck` (Task 3), `rdStatus` state (already in `App.tsx`).
+- Produces: torrent streaming behaviour on the existing `v` action; no new store method (reuses `streamResult`).
+
+- [ ] **Step 1: Update the keymap labels/hints**
+
+In `src/ui/keymap.ts`: change line 45 `{ keys: "v", label: "Stream via Real-Debrid" }` to `{ keys: "v", label: "Stream" }` (it now covers both paths), and add a hint in the Search group for stopping an active stream: `{ keys: "x", label: "Stop active stream" }`. Update the second `v` label (`:138`) similarly if it still says anything RD-specific.
+
+- [ ] **Step 2: Add imports and active-stream state in `App.tsx`**
+
+Add imports near the existing stream imports (line 16 / 54-56):
+
+```ts
+import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
+import { classifyStreamRoute } from "./streamRoute";
+```
+
+Add state near `pendingStreamUrl`/`streamFiles` (lines 140-143):
+
+```ts
+const [activeStream, setActiveStream] = useState<{ session: TorrentStreamSession; name: string } | null>(null);
+// Confirm state for the two torrent privacy prompts.
+const [torrentPrompt, setTorrentPrompt] = useState<
+  { input: DownloadInput; reason?: string } | null
+>(null);
+```
+
+- [ ] **Step 3: Add the torrent-stream starter**
+
+Add a `useCallback` alongside `streamResult` (before it, so `streamResult` can call it). It reuses `streamCandidates` + `playStream` exactly like the RD path:
+
+```ts
+const startTorrentStream = useCallback(
+  (input: DownloadInput) => {
+    if (!config) return;
+    if (preparing || streamFiles || activeStream) return;
+    const controller = new AbortController();
+    prepareAbort.current = controller;
+    setPreparing({ label: truncate(cleanText(input.name), 32), phase: "caching", pct: 0 });
+    void (async () => {
+      try {
+        const session = await streamTorrent(input.magnet, { signal: controller.signal });
+        if (controller.signal.aborted) { void session.stop(); return; }
+        prepareAbort.current = null;
+        setPreparing(null);
+        const candidates = streamCandidates(session.files).sort((a, b) => b.bytes - a.bytes);
+        if (candidates.length === 0) {
+          setNotice("This torrent has nothing to stream.");
+          void session.stop();
+          return;
+        }
+        setActiveStream({ session, name: input.name });
+        const file = candidates[0]!; // TODO multi-file picker reuse — see note
+        void playStream(file.url, input.name);
+      } catch (e) {
+        prepareAbort.current = null;
+        setPreparing(null);
+        if (controller.signal.aborted) return;
+        setNotice(e instanceof Error ? e.message : "Couldn't start torrent stream.");
+      }
+    })();
+  },
+  [config, preparing, streamFiles, activeStream, playStream],
+);
+```
+
+Note on the multi-file picker: to reuse `StreamFilePrompt` for torrent (as with RD), have `startTorrentStream` set `streamFiles` when `candidates.length > 1` and, when the existing `finishStream` picks a file, ensure `activeStream` is already set so cleanup can find the session. The simplest correct wiring: set `setActiveStream({ session, name })` first, then `if (candidates.length > 1) setStreamFiles(candidates); else playStream(candidates[0].url, name)`. `finishStream` already calls `playStream`; no change needed there. Implement it this way and delete the `// TODO` line.
+
+- [ ] **Step 4: Branch `streamResult` on the route**
+
+Replace the early `if (!token) { setNotice(...); return; }` block (lines 493-497) with the route decision. Keep the rest of the RD path unchanged:
+
+```ts
+const route = classifyStreamRoute(config, rdStatus);
+if (route.kind === "torrent-auto") {
+  if (config.torrentStreamAck) { startTorrentStream(input); return; }
+  setTorrentPrompt({ input }); // one-time warning, remembered on confirm
+  return;
+}
+if (route.kind === "torrent-confirm") {
+  setTorrentPrompt({ input, reason: route.reason }); // always warn
+  return;
+}
+// route.kind === "realdebrid": fall through to the existing RD flow below.
+const token = resolveRealDebridToken(config);
+```
+
+Add `rdStatus`, `startTorrentStream` to the `streamResult` dependency array.
+
+- [ ] **Step 5: Render the privacy confirm prompt**
+
+In the prompt-rendering region (near the `pendingP2P` block, ~line 1094), add a branch. The message differs by whether a `reason` is present (configured-but-not-working = always warn; no reason = one-time warn):
+
+```tsx
+{torrentPrompt ? (
+  <ConfirmPrompt
+    width={contentWidth}
+    title={torrentPrompt.reason ? "Real-Debrid unavailable" : "Stream via torrent?"}
+    message={
+      torrentPrompt.reason
+        ? `${torrentPrompt.reason}. Streaming via torrent connects you directly to peers, so your IP is visible to the swarm. Continue via torrent?`
+        : "Streaming via torrent connects you directly to peers, so your IP is visible to the swarm (Real-Debrid keeps it private). Continue?"
+    }
+    onConfirm={() => {
+      const { input, reason } = torrentPrompt;
+      setTorrentPrompt(null);
+      // Remember the acknowledgement only for the no-RD one-time warning.
+      if (!reason && config) setConfig({ ...config, torrentStreamAck: true });
+      startTorrentStream(input);
+    }}
+    onCancel={() => { setTorrentPrompt(null); setNotice("Stream cancelled."); }}
+  />
+) : null}
+```
+
+Guard input while it's open: add `if (torrentPrompt) return;` next to the existing `if (pendingP2P) return;` guard (~line 893), and include `torrentPrompt` in the big overlay-open boolean expressions (lines 809/1132/1178 etc., wherever `pendingP2P` appears) so global keys don't fire behind it.
+
+- [ ] **Step 6: Active-stream indicator + stop key + quit cleanup**
+
+Add a stop handler and wire the stop key. Because `x` is bound in the Downloads/Accounts sections, intercept it at the top of the main `useInput` (before section handlers) **only when a stream is active**:
+
+```ts
+const stopStream = useCallback(() => {
+  const active = activeStream;
+  if (!active) return;
+  setActiveStream(null);
+  void active.session.stop(); // Task 6 replaces this with the keep prompt
+  setNotice("Stream stopped.");
+}, [activeStream]);
+```
+
+In the main input handler, near the top (after the overlay guards), add:
+
+```ts
+if (activeStream && (input === "x" || input === "X")) { stopStream(); return; }
+```
+
+Show the indicator: in the footer/notice area, when `activeStream` is set, render a line such as `▶ Streaming <name> via torrent · your IP is visible to peers · x to stop` (reuse the existing notice/footer styling; keep it non-modal so the user can keep browsing).
+
+On quit: in the existing `quitAll`/unmount path (`src/index.tsx:49` teardown and `App`'s quit handler), call `activeStream?.session.stop()` so the temp dir is cleaned. Add it to the quit callback in `App.tsx` and, defensively, a `useEffect` cleanup that stops the session on unmount.
+
+- [ ] **Step 7: Typecheck + full suite**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS.
+
+- [ ] **Step 8: Manual verification (use the `verify` skill / `run` skill)**
+
+Build and run the app with **no** RD token configured; search, press `v` on a well-seeded result (e.g. a Linux ISO), confirm the one-time warning appears, accept it, and confirm the file opens in mpv/vlc and streams. Press `v` again on another item and confirm the warning does **not** reappear (remembered). Configure a non-premium/invalid RD token and confirm `v` shows the always-warn confirm instead of auto-streaming. Press `x` to stop and confirm the temp dir under the OS temp dir is deleted.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/App.tsx src/ui/keymap.ts
+git commit -m "feat: stream via torrent when Real-Debrid is unavailable"
+```
+
+---
+
+## Task 6: Offer-to-keep flow
+
+When the user stops a torrent stream (or quits) and the file fully downloaded, offer to keep it as a real download + seed, reusing the download queue. Partial downloads are cleaned up with no prompt.
+
+**Files:**
+- Create: `src/ui/streamKeep.ts`
+- Test: `src/ui/streamKeep.test.ts`
+- Modify: `src/ui/App.tsx`
+
+**Interfaces:**
+- Consumes: `TorrentStreamSession` (`dir`, `name`, `isComplete`), `DownloadInput`, `startDownload` (existing, `queue.add(input, dir)`), `Config.downloadDir`.
+- Produces:
+```ts
+// Pure: decide the move for a kept stream. Returns the source (temp) and
+// destination (downloads) paths for the torrent's top-level folder.
+export function keepMovePlan(args: {
+  streamDir: string;   // session.dir (temp root)
+  torrentName: string; // session.name (top-level folder inside streamDir)
+  downloadDir: string; // config.downloadDir
+}): { from: string; to: string };
+```
+
+- [ ] **Step 1: Write the failing test**
+
+`src/ui/streamKeep.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { keepMovePlan } from "./streamKeep";
+
+describe("keepMovePlan", () => {
+  it("moves the torrent's top-level folder from temp into downloads", () => {
+    const plan = keepMovePlan({
+      streamDir: "/tmp/torlink-stream-abc",
+      torrentName: "Big Buck Bunny",
+      downloadDir: "/home/u/Downloads",
+    });
+    expect(plan.from).toBe(path.join("/tmp/torlink-stream-abc", "Big Buck Bunny"));
+    expect(plan.to).toBe(path.join("/home/u/Downloads", "Big Buck Bunny"));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- streamKeep`
+Expected: FAIL (`keepMovePlan` not defined).
+
+- [ ] **Step 3: Implement**
+
+`src/ui/streamKeep.ts`:
+
+```ts
+import path from "node:path";
+
+// WebTorrent lays a multi-file torrent out under <dir>/<torrent.name>/… and a
+// single-file torrent directly at <dir>/<file>. We move the top-level entry
+// named after the torrent; a single-file torrent's name IS that file.
+export function keepMovePlan(args: {
+  streamDir: string;
+  torrentName: string;
+  downloadDir: string;
+}): { from: string; to: string } {
+  return {
+    from: path.join(args.streamDir, args.torrentName),
+    to: path.join(args.downloadDir, args.torrentName),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- streamKeep`
+Expected: PASS.
+
+- [ ] **Step 5: Add the keep prompt + move/reseed in `App.tsx`**
+
+Add state: `const [keepPrompt, setKeepPrompt] = useState<{ session: TorrentStreamSession; input: DownloadInput } | null>(null);`
+
+`stopStream` (Task 5) becomes: if the session is complete, open the keep prompt instead of cleaning up immediately. Thread the originating `DownloadInput` through `activeStream` (extend it to `{ session, name, input }`).
+
+```ts
+const stopStream = useCallback(() => {
+  const active = activeStream;
+  if (!active) return;
+  setActiveStream(null);
+  if (active.session.isComplete()) {
+    setKeepPrompt({ session: active.session, input: active.input });
+  } else {
+    void active.session.stop(); // partial: discard
+    setNotice("Stream stopped.");
+  }
+}, [activeStream]);
+```
+
+Render the keep prompt (reuse `ConfirmPrompt`):
+
+```tsx
+{keepPrompt ? (
+  <ConfirmPrompt
+    width={contentWidth}
+    title="Keep this download?"
+    message={`"${truncate(cleanText(keepPrompt.session.name), 40)}" finished downloading. Keep it in your downloads and seed it?`}
+    onConfirm={() => {
+      const { session, input } = keepPrompt;
+      setKeepPrompt(null);
+      void (async () => {
+        await session.stop({ keep: true }); // close server/client, leave files
+        if (!config) return;
+        const { keepMovePlan } = await import("./streamKeep");
+        const { from, to } = keepMovePlan({
+          streamDir: session.dir, torrentName: session.name, downloadDir: config.downloadDir,
+        });
+        try {
+          await fs.mkdir(config.downloadDir, { recursive: true });
+          await fs.rename(from, to);       // fast path (same volume)
+        } catch {
+          // cross-device: fall back to a recursive copy then remove
+          await fs.cp(from, to, { recursive: true }).catch(() => {});
+          await fs.rm(from, { recursive: true, force: true }).catch(() => {});
+        }
+        startDownload(input);              // queue.add verifies on-disk files + seeds
+        setNotice(`Kept & seeding: ${truncate(cleanText(session.name), 32)}`);
+      })();
+    }}
+    onCancel={() => {
+      const { session } = keepPrompt;
+      setKeepPrompt(null);
+      void session.stop(); // discard temp
+      setNotice("Stream stopped.");
+    }}
+  />
+) : null}
+```
+
+Add `keepPrompt` to the input guards and overlay-open expressions like the other prompts. Import `fs` (`import { promises as fs } from "node:fs"`) if not already imported at the top of `App.tsx`.
+
+- [ ] **Step 6: Typecheck + full suite**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Manual verification**
+
+With no RD token, stream a small well-seeded torrent to completion, press `x`, confirm the keep prompt appears, accept it, and confirm the file now lives in the downloads folder and appears in the Downloads/Seeding list (verify the temp dir is gone). Repeat but stop **before** completion and confirm no keep prompt and the temp dir is removed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/streamKeep.ts src/ui/streamKeep.test.ts src/ui/App.tsx
+git commit -m "feat: offer to keep a completed torrent stream as a download"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** trigger/decision (Task 2 + 5 Step 4), torrent engine + local server + shared shape (Tasks 1, 4), ephemeral temp + cleanup (Task 4, Task 5 Step 6), offer-to-keep (Task 6), privacy warnings one-time + always (Task 3 + Task 5 Step 5), active-stream indicator + stop (Task 5 Step 6), tests + TDD (every task). All spec sections map to a task.
+- **Open items resolved from the spec:** WebTorrent server API confirmed as `client.createServer()` with URL `…/webtorrent/<infoHash>/<encodeURI(path)>` (Task 4 Step 1); shared type resolved via `StreamFile` in `player.ts` + `ResolvedFile` alias (Task 1); config field named `torrentStreamAck` (Task 3); partial downloads get **no** keep prompt (Task 6 Step 5).
+- **Type consistency:** `StreamFile`/`ResolvedFile` structurally identical; `classifyStreamRoute` returns `StreamRoute` consumed in Task 5 Step 4; `TorrentStreamSession` shape consumed in Tasks 5-6.
+- **Risk to verify during Task 5:** the top-level `x`-while-streaming interception must not regress the Downloads/Accounts `x` bindings — verified in Task 5 Step 8.
+```

--- a/docs/superpowers/specs/2026-07-03-torrent-streaming-design.md
+++ b/docs/superpowers/specs/2026-07-03-torrent-streaming-design.md
@@ -1,0 +1,191 @@
+# Torrent streaming
+
+**Date:** 2026-07-03
+**Status:** Approved (design)
+**Builds on:** the existing Real-Debrid streaming feature (`v` = "Stream via Real-Debrid").
+
+## Motivation
+
+Today the **Stream** action (`v`) works **only via Real-Debrid**: it resolves the
+magnet through RD into a direct HTTPS URL and hands that to an external media
+player (mpv/iina/vlc). Users without a Real-Debrid account get nothing when they
+press `v`.
+
+WebTorrent is already a dependency (used to download-to-disk and seed in
+`src/download/engine.ts`) and can serve a torrent's files over a local HTTP
+server while downloading. This adds a **torrent streaming** path so that `v`
+works without Real-Debrid — the file streams peer-to-peer straight to the same
+media player.
+
+## Scope
+
+**In scope**
+
+- A new torrent-stream module that turns a magnet into a locally-served,
+  playable HTTP URL via WebTorrent, exposing files in the **same
+  `{ url, filename, bytes }` shape** Real-Debrid produces.
+- Decision logic on `v` that routes between Real-Debrid and torrent based on RD
+  state (see below).
+- Reuse of the existing stream picker (`streamCandidates` / `StreamFilePrompt`)
+  and player launch (`launchPlayer`) — unchanged.
+- Ephemeral temp storage for the stream, with an **offer-to-keep** prompt when
+  the stream ends and the file fully downloaded.
+- An active-stream indicator with a key to stop the stream.
+- Two privacy warnings (one-time-remembered and always-warn) — see below.
+- One new config field for the remembered privacy acknowledgement.
+- Unit tests (TDD) for the decision logic, the file-shape adapter, and cleanup.
+
+**Out of scope (YAGNI)**
+
+- Streaming *from* Real-Debrid changes — the RD path is untouched.
+- In-app playback / rendering — we keep handing a URL to an external player.
+- Sequential-download tuning, subtitle handling, transcoding.
+- Any new keybinding — the single `v` key is retained.
+- Streaming multiple torrents at once — one active stream at a time (mirrors the
+  existing one-prepare-at-a-time guard in `streamResult`).
+
+## Decision logic (single `v` key)
+
+`streamResult` (`src/ui/App.tsx`) branches on Real-Debrid state. **"Not
+configured" and "not working" are deliberately different states:**
+
+| RD state | Meaning | Behaviour |
+|---|---|---|
+| **Not configured** | No RD token (`resolveRealDebridToken` empty) | Stream via torrent. Show the **one-time** privacy warning (remembered); once acknowledged, go straight to torrent on future streams. |
+| **Configured but not working** | Token present but non-premium, RD API error, or stall | **Always** show a confirm combining the specific RD problem + the P2P privacy warning. Only proceed to torrent on explicit "yes". Never automatic. The remembered acknowledgement does **not** suppress this. |
+| **Working** | Token present, premium active, RD resolves | Real-Debrid stream, exactly as today. |
+
+Rationale: a user who configured RD expects its anonymity (RD proxies; torrent
+exposes the real IP to peers). So we never *silently* fall back to peer-to-peer
+when RD was set up — we surface the problem and require an explicit choice every
+time. Only a user with no RD at all gets the auto-torrent path (and even they
+are warned once).
+
+Note on "non-premium": a present-but-non-premium token counts as **configured
+but not working** → always-warn confirm, not auto.
+
+## Architecture
+
+### New: torrent stream engine
+
+A new module (proposed `src/integrations/torrentStream.ts`) responsible for the
+magnet → playable-URL lifecycle. It is kept **separate** from the download
+`TorrentEngine`/queue so streaming does not interfere with the download list or
+seeding, and so its lifecycle (temp dir, local server) is self-contained.
+
+Responsibilities:
+
+1. Create a WebTorrent client whose files download to an **ephemeral temp dir**
+   (e.g. under the OS temp dir).
+2. `add(magnet, { path: tmpDir })`, wait for the `metadata` event.
+3. Start WebTorrent's built-in local HTTP server bound to an ephemeral port.
+4. Enumerate `torrent.files` and adapt them to the existing stream file shape
+   `{ url, filename, bytes }`, where `url` is the local server URL for that file
+   (`http://localhost:<port>/…`) and `bytes` is `file.length`. This lets the
+   existing `streamCandidates` picker and `launchPlayer` consume torrent files
+   with **no changes**.
+5. Return a handle exposing: the file list, and `stop()` which closes the
+   server, destroys the client, and (unless the caller keeps it) deletes the
+   temp dir.
+
+The exact WebTorrent server/URL API (`torrent.createServer()` vs. per-file
+stream URL) is pinned down during implementation; the module boundary above is
+what matters.
+
+### File-shape adapter
+
+The current `ResolvedFile` type (`{ url, filename, bytes }`) lives in
+`src/integrations/realdebrid.ts`. To share it with torrent streaming without a
+circular dependency, the plan will either (a) move the type to a neutral
+location (e.g. `src/util/player.ts`, which already imports it) and have both RD
+and torrent-stream produce it, or (b) define a shared `StreamFile` alias. The
+plan step picks one; the intent is a single shape that `streamCandidates`,
+`StreamFilePrompt`, and `playStream` operate on regardless of source.
+
+### App/UI wiring (`src/ui/App.tsx`)
+
+- `streamResult` gains the decision branch above. The RD path is factored out
+  so the torrent path is a sibling, not a rewrite.
+- New state for an **active torrent stream** (the engine handle + display name),
+  plus notice/indicator rendering.
+- New prompt(s) for: the one-time privacy warning, the always-warn RD-failed
+  confirm, and the offer-to-keep prompt. These reuse the existing
+  `ConfirmPrompt` component where possible.
+
+### Lifecycle & storage
+
+External players (especially macOS `open -a`) detach, so we **cannot reliably
+detect player exit**. Therefore:
+
+- After launching the player, the app shows an **active-stream indicator**:
+  e.g. `Streaming <name> via torrent — press x to stop`.
+- The torrent keeps downloading/serving in the background while watched.
+- On **stop** (user presses the stop key) or **app quit**:
+  - If the file **fully downloaded**, prompt **"Keep this download?"**
+    - Yes → move/register the file into the downloads folder and seed it via the
+      existing download queue (reusing the queue's re-seed-from-existing path).
+    - No → tear down and delete the temp dir.
+  - If **partial**, tear down and delete the temp dir (no keep prompt, or a
+    keep prompt that is disabled — the plan picks the simpler of the two).
+- Only **one** active torrent stream at a time; starting a new one stops the
+  previous (with its cleanup/keep handling).
+
+### Privacy warnings
+
+- **One-time (not-configured path):** a new config field
+  `torrentStreamAck?: boolean` (name TBD in plan) records that the user has
+  acknowledged that torrent streaming exposes their IP. First torrent stream
+  shows the warning as a `ConfirmPrompt`; on confirm, set the flag and never ask
+  again for the not-configured path.
+- **Always (configured-but-not-working path):** a confirm that states the
+  specific RD problem *and* the P2P exposure, shown **every time**, independent
+  of `torrentStreamAck`.
+
+### Config
+
+- Add `torrentStreamAck?: boolean` to `Config` (`src/config/config.ts`), with a
+  helper if the pattern warrants it. Defaults to unset/false. Follows the
+  existing optional-field convention (unknown/absent degrades to "not
+  acknowledged").
+
+## Error handling
+
+- **Metadata timeout / no peers:** if WebTorrent gets no metadata within a
+  bounded window (mirroring RD's stall handling), stop, clean up, and show a
+  clear notice ("No peers found — couldn't start the stream.").
+- **No player found:** the existing `StreamPlayerPrompt` path still applies — but
+  note the local URL is only valid while the stream engine is alive, so the
+  keep-alive/indicator must remain until the user resolves the player prompt or
+  cancels.
+- **Cancellation** mid-prepare: reuse the existing `cancelPreparing` pattern;
+  ensure the engine is torn down and temp dir removed.
+- **Temp cleanup on crash/quit:** best-effort cleanup on stop and on app
+  unmount; a stale temp dir is not fatal (OS temp is reclaimable).
+
+## Testing (TDD)
+
+Write tests first, prove they fail, then implement:
+
+1. **Decision logic** — given RD state (not configured / non-premium / API error
+   / working), assert the chosen action (torrent-auto / always-warn confirm /
+   RD stream). Pure function extracted from `streamResult` so it's testable
+   without the UI.
+2. **File-shape adapter** — given a fake WebTorrent torrent (files with
+   `name`/`length`), assert it maps to `{ url, filename, bytes }` and that
+   `streamCandidates` picks the largest video, matching RD behaviour.
+3. **Privacy-warning gating** — one-time flag suppresses the not-configured
+   warning after acknowledgement, but the configured-but-not-working confirm
+   always fires.
+4. **Cleanup** — `stop()` without keep deletes the temp dir; with keep, it is
+   preserved/handed to the queue.
+
+WebTorrent's network layer is mocked (same approach as
+`src/download/queue.test.ts`, which avoids spinning up a real client). Run the
+linter and the full `vitest` suite before considering the work done.
+
+## Open items for the plan (not blocking design approval)
+
+- Exact WebTorrent server API and per-file URL format.
+- Whether to move `ResolvedFile` or introduce a `StreamFile` alias.
+- Final config field name and any accessor helper.
+- Whether partial-download offers a (disabled) keep prompt or none.

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -107,6 +107,7 @@ function makeStore(
     startDebridDownload: noop,
     streamResult: noop,
     debridConfigured: false,
+    streamActive: false,
     rdStatus: null,
     copyLink: noop,
     copyMagnet: noop,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -100,3 +100,15 @@ describe("resolveMediaPlayer", () => {
     expect(resolveMediaPlayer({ downloadDir: "/d", mediaPlayer: "mpv", trackers: [] })).toBe("iina");
   });
 });
+
+describe("config torrentStreamAck", () => {
+  it("round-trips torrentStreamAck across a save/load cycle", async () => {
+    await saveConfig({
+      downloadDir: "/tmp/dl",
+      torrentStreamAck: true,
+      trackers: [],
+    });
+    const cfg = await loadConfig();
+    expect(cfg.torrentStreamAck).toBe(true);
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,6 +13,9 @@ export interface Config {
   // or an absolute path). Empty/unset falls back to auto-detection. A
   // TORLINK_PLAYER env var overrides it.
   mediaPlayer?: string;
+  // Set once the user has acknowledged that streaming via torrent exposes their
+  // IP to the swarm (the no-Real-Debrid path). Absent/false = not yet warned.
+  torrentStreamAck?: boolean;
   // Remembered UI preferences, so torlink reopens the way you left it. Both are
   // stored as opaque strings validated by the UI layer (parseSort/parseCategory)
   // so a hand-edited or stale value degrades gracefully to the default.

--- a/src/integrations/realdebrid.ts
+++ b/src/integrations/realdebrid.ts
@@ -1,5 +1,6 @@
 import { fetchResilient, HttpError, USER_AGENT, type FetchImpl } from "../util/net";
 import { log } from "../util/logger";
+import type { StreamFile } from "../util/player";
 
 export type RealDebridFetch = FetchImpl;
 
@@ -17,11 +18,9 @@ const DEFAULT_POLL_MS = 2000;
 // counts — a torrent that keeps making progress is never timed out.
 const DEFAULT_STALL_MS = 180_000;
 
-export interface ResolvedFile {
-  url: string;
-  filename: string;
-  bytes: number;
-}
+// A resolved, directly-fetchable file (Real-Debrid direct link, or a
+// local torrent-stream URL). Structurally identical to StreamFile.
+export type ResolvedFile = StreamFile;
 
 export interface RealDebridUser {
   username: string;

--- a/src/integrations/torrentStream.test.ts
+++ b/src/integrations/torrentStream.test.ts
@@ -125,6 +125,19 @@ describe("streamTorrent", () => {
     expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-error");
   });
 
+  it("stop() is idempotent — calling it twice does not throw and only cleans up once", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?x", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-idempotent",
+      rm,
+    });
+    await expect(session.stop()).resolves.not.toThrow();
+    await expect(session.stop()).resolves.not.toThrow();
+    expect(rm).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects and removes the temp dir when the signal is aborted before metadata", async () => {
     const torrent = new EventEmitter() as any; // never emits metadata
     const client = {

--- a/src/integrations/torrentStream.test.ts
+++ b/src/integrations/torrentStream.test.ts
@@ -101,4 +101,49 @@ describe("streamTorrent", () => {
     ).rejects.toThrow(/no peers|metadata|timed out/i);
     expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-timeout");
   });
+
+  it("rejects and removes the temp dir when the torrent errors before metadata", async () => {
+    const torrent = new EventEmitter() as any;
+    const client = {
+      add: (_magnet: string, _opts: unknown) => {
+        queueMicrotask(() => torrent.emit("error", new Error("swarm boom")));
+        return torrent;
+      },
+      createServer: () => fakeServer(),
+      get: () => torrent,
+      remove: (_i: string, cb?: () => void) => cb?.(),
+      destroy: (cb?: () => void) => cb?.(),
+    };
+    const rm = vi.fn(async () => {});
+    await expect(
+      streamTorrent("magnet:?x", {
+        createClient: () => client as any,
+        mkdtemp: async () => "/tmp/torlink-stream-error",
+        rm,
+      }),
+    ).rejects.toThrow(/swarm boom/);
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-error");
+  });
+
+  it("rejects and removes the temp dir when the signal is aborted before metadata", async () => {
+    const torrent = new EventEmitter() as any; // never emits metadata
+    const client = {
+      add: () => torrent,
+      createServer: () => fakeServer(),
+      get: () => torrent,
+      remove: (_i: string, cb?: () => void) => cb?.(),
+      destroy: (cb?: () => void) => cb?.(),
+    };
+    const rm = vi.fn(async () => {});
+    const controller = new AbortController();
+    const promise = streamTorrent("magnet:?x", {
+      createClient: () => client as any,
+      mkdtemp: async () => "/tmp/torlink-stream-abort",
+      rm,
+      signal: controller.signal,
+    });
+    queueMicrotask(() => controller.abort());
+    await expect(promise).rejects.toThrow(/cancelled/i);
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-abort");
+  });
 });

--- a/src/integrations/torrentStream.test.ts
+++ b/src/integrations/torrentStream.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { streamTorrent } from "./torrentStream";
+
+// Minimal fakes ---------------------------------------------------------------
+function fakeServer() {
+  return {
+    listen: (_p: number, _h: string | (() => void), cb?: () => void) => {
+      const done = typeof _h === "function" ? _h : cb;
+      done?.();
+    },
+    address: () => ({ port: 54321 }),
+    close: (cb?: () => void) => cb?.(),
+    destroy: (cb?: () => void) => cb?.(),
+  };
+}
+
+function fakeTorrent() {
+  const t = new EventEmitter() as any;
+  t.infoHash = "abc123";
+  t.name = "Big Buck Bunny";
+  t.done = false;
+  t.files = [
+    { name: "readme.txt", path: "Big Buck Bunny/readme.txt", length: 100 },
+    { name: "bbb.mp4", path: "Big Buck Bunny/bbb.mp4", length: 5000 },
+  ];
+  return t;
+}
+
+function fakeClient(torrent: any) {
+  return {
+    add: (_magnet: string, _opts: unknown) => {
+      queueMicrotask(() => torrent.emit("metadata"));
+      return torrent;
+    },
+    createServer: () => fakeServer(),
+    get: () => torrent,
+    remove: (_id: string, cb?: () => void) => cb?.(),
+    destroy: (cb?: () => void) => cb?.(),
+  };
+}
+
+describe("streamTorrent", () => {
+  it("maps files to local server URLs after metadata", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?xt=urn:btih:abc123", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-x",
+      rm,
+    });
+    expect(session.name).toBe("Big Buck Bunny");
+    const mp4 = session.files.find((f) => f.filename === "bbb.mp4")!;
+    expect(mp4.bytes).toBe(5000);
+    expect(mp4.url).toBe(
+      "http://localhost:54321/webtorrent/abc123/Big%20Buck%20Bunny/bbb.mp4",
+    );
+  });
+
+  it("stop() without keep removes the temp dir", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?x", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-y",
+      rm,
+    });
+    await session.stop();
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-y");
+  });
+
+  it("stop({keep:true}) leaves the temp dir in place", async () => {
+    const torrent = fakeTorrent();
+    const rm = vi.fn(async () => {});
+    const session = await streamTorrent("magnet:?x", {
+      createClient: () => fakeClient(torrent) as any,
+      mkdtemp: async () => "/tmp/torlink-stream-z",
+      rm,
+    });
+    await session.stop({ keep: true });
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it("rejects when metadata never arrives before the timeout", async () => {
+    const torrent = new EventEmitter() as any; // never emits metadata
+    const client = {
+      add: () => torrent,
+      createServer: () => fakeServer(),
+      get: () => torrent,
+      remove: (_i: string, cb?: () => void) => cb?.(),
+      destroy: (cb?: () => void) => cb?.(),
+    };
+    const rm = vi.fn(async () => {});
+    await expect(
+      streamTorrent("magnet:?x", {
+        createClient: () => client as any,
+        mkdtemp: async () => "/tmp/torlink-stream-timeout",
+        rm,
+        metadataTimeoutMs: 5,
+      }),
+    ).rejects.toThrow(/no peers|metadata|timed out/i);
+    expect(rm).toHaveBeenCalledWith("/tmp/torlink-stream-timeout");
+  });
+});

--- a/src/integrations/torrentStream.ts
+++ b/src/integrations/torrentStream.ts
@@ -128,12 +128,15 @@ export async function streamTorrent(
       const server = client.createServer();
       server.listen(0, host, () => {
         const port = server.address()?.port ?? 0;
+        let stopped = false;
         resolve({
           name: torrent.name,
           files: toStreamFiles(torrent, host, port),
           dir,
           isComplete: () => torrent.done === true,
           stop: async ({ keep = false }: { keep?: boolean } = {}) => {
+            if (stopped) return;
+            stopped = true;
             await new Promise<void>((res) => server.close(() => res()));
             await new Promise<void>((res) => client.destroy(() => res()));
             if (!keep) await rm(dir).catch(() => {});

--- a/src/integrations/torrentStream.ts
+++ b/src/integrations/torrentStream.ts
@@ -1,0 +1,145 @@
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import WebTorrent from "webtorrent";
+import type { StreamFile } from "../util/player";
+
+export interface TorrentStreamSession {
+  name: string;
+  files: StreamFile[];
+  dir: string;
+  isComplete(): boolean;
+  stop(opts?: { keep?: boolean }): Promise<void>;
+}
+
+// The minimal structural subset of the WebTorrent client the engine touches,
+// so tests can inject a fake without a real swarm.
+export interface WebTorrentLike {
+  add(magnet: string, opts: { path: string }): TorrentLike;
+  createServer(opts?: { hostname?: string; pathname?: string }): ServerLike;
+  get(id: string): TorrentLike | null;
+  remove(id: string, cb?: (err?: Error) => void): void;
+  destroy(cb?: (err?: Error) => void): void;
+}
+interface TorrentLike {
+  infoHash: string;
+  name: string;
+  done: boolean;
+  files: { name: string; path: string; length: number }[];
+  on(event: "metadata" | "error", cb: (arg?: unknown) => void): void;
+  destroy(cb?: (err?: Error) => void): void;
+}
+interface ServerLike {
+  listen(port?: number, hostname?: string, cb?: () => void): void;
+  address(): { port: number } | null;
+  close(cb?: () => void): void;
+}
+
+export interface StreamTorrentOptions {
+  signal?: AbortSignal;
+  metadataTimeoutMs?: number;
+  createClient?: () => WebTorrentLike;
+  tmpBase?: string;
+  mkdtemp?: (prefix: string) => Promise<string>;
+  rm?: (dir: string) => Promise<void>;
+}
+
+const DEFAULT_METADATA_TIMEOUT_MS = 60_000;
+
+function toStreamFiles(
+  torrent: TorrentLike,
+  host: string,
+  port: number,
+): StreamFile[] {
+  return torrent.files.map((f) => {
+    const rel = f.path.replace(/\\/g, "/");
+    return {
+      url: `http://${host}:${port}/webtorrent/${torrent.infoHash}/${encodeURI(rel)}`,
+      filename: f.name,
+      bytes: f.length,
+    };
+  });
+}
+
+export async function streamTorrent(
+  magnet: string,
+  opts: StreamTorrentOptions = {},
+): Promise<TorrentStreamSession> {
+  const createClient = opts.createClient ?? (() => new WebTorrent() as unknown as WebTorrentLike);
+  const mkdtemp = opts.mkdtemp ?? ((prefix) => fs.mkdtemp(prefix));
+  const rm = opts.rm ?? ((dir) => fs.rm(dir, { recursive: true, force: true }));
+  const timeoutMs = opts.metadataTimeoutMs ?? DEFAULT_METADATA_TIMEOUT_MS;
+  const host = "localhost";
+
+  const dir = await mkdtemp(path.join(opts.tmpBase ?? os.tmpdir(), "torlink-stream-"));
+  const client = createClient();
+
+  const cleanup = async () => {
+    try {
+      await new Promise<void>((res) => client.destroy(() => res()));
+    } catch {
+      /* already destroyed, or destroy itself failed — nothing more we can do */
+    }
+    await rm(dir).catch(() => {});
+  };
+
+  return new Promise<TorrentStreamSession>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      void cleanup().finally(() =>
+        reject(new Error("No peers found — couldn't start the stream (metadata timed out).")),
+      );
+    }, timeoutMs);
+
+    if (opts.signal) {
+      opts.signal.addEventListener("abort", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        void cleanup().finally(() => reject(new Error("Stream cancelled.")));
+      });
+    }
+
+    let torrent: TorrentLike;
+    try {
+      torrent = client.add(magnet, { path: dir });
+    } catch (e) {
+      settled = true;
+      clearTimeout(timer);
+      void cleanup().finally(() => reject(e instanceof Error ? e : new Error(String(e))));
+      return;
+    }
+
+    torrent.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      void cleanup().finally(() =>
+        reject(err instanceof Error ? err : new Error(String(err))),
+      );
+    });
+
+    torrent.on("metadata", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const server = client.createServer();
+      server.listen(0, host, () => {
+        const port = server.address()?.port ?? 0;
+        resolve({
+          name: torrent.name,
+          files: toStreamFiles(torrent, host, port),
+          dir,
+          isComplete: () => torrent.done === true,
+          stop: async ({ keep = false }: { keep?: boolean } = {}) => {
+            await new Promise<void>((res) => server.close(() => res()));
+            await new Promise<void>((res) => client.destroy(() => res()));
+            if (!keep) await rm(dir).catch(() => {});
+          },
+        });
+      });
+    });
+  });
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,6 +17,7 @@ import { detectPlayer, launchPlayer, streamCandidates } from "../util/player";
 import type { ResolvedFile } from "../integrations/realdebrid";
 import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
 import { classifyStreamRoute } from "./streamRoute";
+import { keepMovePlan } from "./streamKeep";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
 import { loadHistory } from "../download/history";
@@ -144,10 +145,16 @@ export function App({
   const [rdStatus, setRdStatus] = useState<RdStatus | null>(null);
   const [streamFiles, setStreamFiles] = useState<ResolvedFile[] | null>(null);
   const [preparing, setPreparing] = useState<{ label: string; phase: "caching" | "fetching"; pct: number } | null>(null);
-  const [activeStream, setActiveStream] = useState<{ session: TorrentStreamSession; name: string } | null>(null);
+  const [activeStream, setActiveStream] = useState<
+    { session: TorrentStreamSession; name: string; input: DownloadInput } | null
+  >(null);
   // Confirm state for the two torrent privacy prompts.
   const [torrentPrompt, setTorrentPrompt] = useState<
     { input: DownloadInput; reason?: string } | null
+  >(null);
+  // Offer to keep a fully-downloaded torrent stream as a real download + seed.
+  const [keepPrompt, setKeepPrompt] = useState<
+    { session: TorrentStreamSession; input: DownloadInput } | null
   >(null);
   const prepareAbort = useRef<AbortController | null>(null);
   const booting = useRef(false);
@@ -264,13 +271,17 @@ export function App({
     // exit; the unmount effect still runs suspend() for the engine teardown.
     queue?.persistSync();
     void activeStream?.session.stop();
+    // A keep prompt awaiting a decision still holds a live (complete) stream
+    // session — discard it too rather than leaking its temp dir on quit.
+    void keepPrompt?.session.stop();
     // Clear so the unmount-only cleanup effect below has nothing left to
     // re-stop (stop() is also idempotent, but this avoids relying on that).
     activeStreamRef.current = null;
     setActiveStream(null);
+    setKeepPrompt(null);
     if (onQuit) onQuit();
     else exit();
-  }, [queue, onQuit, exit, activeStream]);
+  }, [queue, onQuit, exit, activeStream, keepPrompt]);
 
   const setConfig = useCallback(
     (c: Config) => {
@@ -523,7 +534,7 @@ export function App({
             void session.stop();
             return;
           }
-          setActiveStream({ session, name: input.name });
+          setActiveStream({ session, name: input.name, input });
           if (candidates.length > 1) {
             setStreamFiles(candidates);
           } else {
@@ -544,8 +555,14 @@ export function App({
     const active = activeStream;
     if (!active) return;
     setActiveStream(null);
-    void active.session.stop(); // Task 6 replaces this with an offer-to-keep prompt
-    setNotice("Stream stopped.");
+    if (active.session.isComplete()) {
+      // Fully downloaded: offer to keep it as a real download + seed instead
+      // of discarding the temp files.
+      setKeepPrompt({ session: active.session, input: active.input });
+    } else {
+      void active.session.stop(); // partial: discard
+      setNotice("Stream stopped.");
+    }
   }, [activeStream]);
 
   // Keep a ref to the latest active stream so the unmount-only cleanup effect
@@ -897,7 +914,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
           ? "help"
           : region,
       setRegion,
@@ -950,6 +967,7 @@ export function App({
     streamFiles,
     preparing,
     torrentPrompt,
+    keepPrompt,
     activeStream,
     captureMode,
     downloadFocus,
@@ -986,6 +1004,7 @@ export function App({
       if (editingTrackers) return; // the trackers prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
       if (torrentPrompt) return; // the torrent privacy warning owns input
+      if (keepPrompt) return; // the keep-download prompt owns input
       if (streamFiles) return; // the file picker owns input
       if (preparing) {
         if (key.escape) cancelPreparing();
@@ -1253,6 +1272,45 @@ export function App({
           </Box>
         ) : null}
 
+        {keepPrompt ? (
+          <Box marginTop={1}>
+            <ConfirmPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              title="Keep this download?"
+              message={`"${truncate(cleanText(keepPrompt.session.name), 40)}" finished downloading. Keep it in your downloads and seed it?`}
+              onConfirm={() => {
+                const { session, input } = keepPrompt;
+                setKeepPrompt(null);
+                void (async () => {
+                  await session.stop({ keep: true }); // close server/client, leave files
+                  if (!config) return;
+                  const { from, to } = keepMovePlan({
+                    streamDir: session.dir,
+                    torrentName: session.name,
+                    downloadDir: config.downloadDir,
+                  });
+                  try {
+                    await fs.mkdir(config.downloadDir, { recursive: true });
+                    await fs.rename(from, to); // fast path (same volume)
+                  } catch {
+                    // cross-device: fall back to a recursive copy then remove
+                    await fs.cp(from, to, { recursive: true }).catch(() => {});
+                    await fs.rm(from, { recursive: true, force: true }).catch(() => {});
+                  }
+                  startDownload(input); // queue.add verifies on-disk files + seeds
+                  setNotice(`Kept & seeding: ${truncate(cleanText(session.name), 32)}`);
+                })();
+              }}
+              onCancel={() => {
+                const { session } = keepPrompt;
+                setKeepPrompt(null);
+                void session.stop(); // discard temp
+                setNotice("Stream stopped.");
+              }}
+            />
+          </Box>
+        ) : null}
+
         {editingTrackers ? (
           <Box marginTop={1}>
             <TrackersPrompt
@@ -1268,7 +1326,7 @@ export function App({
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
               ? "none"
               : "flex"
           }
@@ -1315,7 +1373,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
+              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
                 ? "none"
                 : "flex"
             }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,7 +17,7 @@ import { detectPlayer, launchPlayer, streamCandidates } from "../util/player";
 import type { ResolvedFile } from "../integrations/realdebrid";
 import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
 import { classifyStreamRoute } from "./streamRoute";
-import { keepMovePlan } from "./streamKeep";
+import { keepMovePlan, moveKeptFiles } from "./streamKeep";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
 import { loadHistory } from "../download/history";
@@ -572,11 +572,20 @@ export function App({
     activeStreamRef.current = activeStream;
   }, [activeStream]);
 
+  // Same pattern for a pending keep prompt: it still holds a live (complete)
+  // stream session awaiting a keep/discard decision, so it needs the same
+  // unmount-time cleanup as activeStreamRef.
+  const keepPromptRef = useRef<typeof keepPrompt>(null);
+  useEffect(() => {
+    keepPromptRef.current = keepPrompt;
+  }, [keepPrompt]);
+
   // Defensively make sure a live torrent-stream session (and its temp dir)
   // don't leak past the process if the component unmounts unexpectedly.
   useEffect(() => {
     return () => {
       void activeStreamRef.current?.session.stop();
+      void keepPromptRef.current?.session.stop();
     };
   }, []);
 
@@ -1282,23 +1291,29 @@ export function App({
                 const { session, input } = keepPrompt;
                 setKeepPrompt(null);
                 void (async () => {
-                  await session.stop({ keep: true }); // close server/client, leave files
-                  if (!config) return;
-                  const { from, to } = keepMovePlan({
-                    streamDir: session.dir,
-                    torrentName: session.name,
-                    downloadDir: config.downloadDir,
-                  });
                   try {
-                    await fs.mkdir(config.downloadDir, { recursive: true });
-                    await fs.rename(from, to); // fast path (same volume)
+                    await session.stop({ keep: true }); // close server/client, leave files
+                    if (!config) return;
+                    const plan = keepMovePlan({
+                      streamDir: session.dir,
+                      torrentName: session.name,
+                      downloadDir: config.downloadDir,
+                    });
+                    const ok = await moveKeptFiles(plan, config.downloadDir, {
+                      mkdir: (dir, opts) => fs.mkdir(dir, opts),
+                      rename: (from, to) => fs.rename(from, to),
+                      cp: (from, to, opts) => fs.cp(from, to, opts),
+                      rm: (from, opts) => fs.rm(from, opts),
+                    });
+                    if (!ok) {
+                      setNotice("Couldn't keep the download — files left in a temp folder.");
+                      return;
+                    }
+                    startDownload(input); // queue.add verifies on-disk files + seeds
+                    setNotice(`Kept & seeding: ${truncate(cleanText(session.name), 32)}`);
                   } catch {
-                    // cross-device: fall back to a recursive copy then remove
-                    await fs.cp(from, to, { recursive: true }).catch(() => {});
-                    await fs.rm(from, { recursive: true, force: true }).catch(() => {});
+                    setNotice("Couldn't keep the download — files left in a temp folder.");
                   }
-                  startDownload(input); // queue.add verifies on-disk files + seeds
-                  setNotice(`Kept & seeding: ${truncate(cleanText(session.name), 32)}`);
                 })();
               }}
               onCancel={() => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,6 +15,8 @@ import { validateToken, isPremiumActive, resolveMagnet, isTokenRejection } from 
 import { rdStatusFromUser, type RdStatus } from "../integrations/rdStatus";
 import { detectPlayer, launchPlayer, streamCandidates } from "../util/player";
 import type { ResolvedFile } from "../integrations/realdebrid";
+import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
+import { classifyStreamRoute } from "./streamRoute";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
 import { loadHistory } from "../download/history";
@@ -142,6 +144,11 @@ export function App({
   const [rdStatus, setRdStatus] = useState<RdStatus | null>(null);
   const [streamFiles, setStreamFiles] = useState<ResolvedFile[] | null>(null);
   const [preparing, setPreparing] = useState<{ label: string; phase: "caching" | "fetching"; pct: number } | null>(null);
+  const [activeStream, setActiveStream] = useState<{ session: TorrentStreamSession; name: string } | null>(null);
+  // Confirm state for the two torrent privacy prompts.
+  const [torrentPrompt, setTorrentPrompt] = useState<
+    { input: DownloadInput; reason?: string } | null
+  >(null);
   const prepareAbort = useRef<AbortController | null>(null);
   const booting = useRef(false);
 
@@ -256,9 +263,10 @@ export function App({
     // Flush all state synchronously up front so nothing is lost to the hard
     // exit; the unmount effect still runs suspend() for the engine teardown.
     queue?.persistSync();
+    void activeStream?.session.stop();
     if (onQuit) onQuit();
     else exit();
-  }, [queue, onQuit, exit]);
+  }, [queue, onQuit, exit, activeStream]);
 
   const setConfig = useCallback(
     (c: Config) => {
@@ -486,10 +494,89 @@ export function App({
     setNotice("Stream cancelled.");
   }, []);
 
+  // Stream a torrent directly (no Real-Debrid): cache metadata, spin up a
+  // local HTTP server for the files, then hand off to the same player/picker
+  // path the Real-Debrid flow uses.
+  const startTorrentStream = useCallback(
+    (input: DownloadInput) => {
+      if (!config) return;
+      if (preparing || streamFiles || activeStream) return;
+      const controller = new AbortController();
+      prepareAbort.current = controller;
+      setPreparing({ label: truncate(cleanText(input.name), 32), phase: "caching", pct: 0 });
+      void (async () => {
+        try {
+          const session = await streamTorrent(input.magnet, { signal: controller.signal });
+          if (controller.signal.aborted) {
+            void session.stop();
+            return;
+          }
+          prepareAbort.current = null;
+          setPreparing(null);
+          const candidates = streamCandidates(session.files).sort((a, b) => b.bytes - a.bytes);
+          if (candidates.length === 0) {
+            setNotice("This torrent has nothing to stream.");
+            void session.stop();
+            return;
+          }
+          setActiveStream({ session, name: input.name });
+          if (candidates.length > 1) {
+            setStreamFiles(candidates);
+          } else {
+            void playStream(candidates[0]!.url, input.name);
+          }
+        } catch (e) {
+          prepareAbort.current = null;
+          setPreparing(null);
+          if (controller.signal.aborted) return;
+          setNotice(e instanceof Error ? e.message : "Couldn't start torrent stream.");
+        }
+      })();
+    },
+    [config, preparing, streamFiles, activeStream, playStream],
+  );
+
+  const stopStream = useCallback(() => {
+    const active = activeStream;
+    if (!active) return;
+    setActiveStream(null);
+    void active.session.stop(); // Task 6 replaces this with an offer-to-keep prompt
+    setNotice("Stream stopped.");
+  }, [activeStream]);
+
+  // Keep a ref to the latest active stream so the unmount-only cleanup effect
+  // below (and quitAll) can reach it without re-running on every change.
+  const activeStreamRef = useRef<typeof activeStream>(null);
+  useEffect(() => {
+    activeStreamRef.current = activeStream;
+  }, [activeStream]);
+
+  // Defensively make sure a live torrent-stream session (and its temp dir)
+  // don't leak past the process if the component unmounts unexpectedly.
+  useEffect(() => {
+    return () => {
+      void activeStreamRef.current?.session.stop();
+    };
+  }, []);
+
   const streamResult = useCallback(
     (input: DownloadInput) => {
       if (!config) return;
       if (preparing || streamFiles) return; // one prepare/pick at a time
+      const route = classifyStreamRoute(config, rdStatus);
+      if (route.kind === "torrent-auto") {
+        if (config.torrentStreamAck) {
+          startTorrentStream(input);
+          return;
+        }
+        setTorrentPrompt({ input }); // one-time warning, remembered on confirm
+        return;
+      }
+      if (route.kind === "torrent-confirm") {
+        setTorrentPrompt({ input, reason: route.reason }); // always warn
+        return;
+      }
+      // route.kind === "realdebrid": fall through to the existing RD flow.
       const token = resolveRealDebridToken(config);
       if (!token) {
         setNotice("Set a Real-Debrid token first — open the Accounts tab.");
@@ -542,7 +629,7 @@ export function App({
         }
       })();
     },
-    [config, finishStream, preparing, streamFiles],
+    [config, finishStream, preparing, streamFiles, rdStatus, startTorrentStream],
   );
 
   const closePlayerPrompt = useCallback(() => {
@@ -806,7 +893,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
           ? "help"
           : region,
       setRegion,
@@ -857,6 +944,7 @@ export function App({
     pendingP2P,
     streamFiles,
     preparing,
+    torrentPrompt,
     captureMode,
     downloadFocus,
     seedFocus,
@@ -891,10 +979,15 @@ export function App({
       if (editingRutracker) return; // the RuTracker prompt owns input
       if (editingTrackers) return; // the trackers prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
+      if (torrentPrompt) return; // the torrent privacy warning owns input
       if (streamFiles) return; // the file picker owns input
       if (preparing) {
         if (key.escape) cancelPreparing();
         return; // swallow other keys while preparing
+      }
+      if (activeStream && (input === "x" || input === "X")) {
+        stopStream();
+        return;
       }
       if (captureMode === "text") return;
       if (showHelp) {
@@ -994,6 +1087,13 @@ export function App({
                   : `Fetching link… ${prepElapsed}s  (esc cancels)`
               }
             />
+          </Box>
+        ) : null}
+        {activeStream ? (
+          <Box>
+            <Text color={COLOR.warn}>
+              {`▶ Streaming ${truncate(cleanText(activeStream.name), 40)} via torrent · your IP is visible to peers · x to stop`}
+            </Text>
           </Box>
         ) : null}
         {showTopRule ? <Rule width={ruleWidth} /> : null}
@@ -1114,6 +1214,31 @@ export function App({
           </Box>
         ) : null}
 
+        {torrentPrompt ? (
+          <Box marginTop={1}>
+            <ConfirmPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              title={torrentPrompt.reason ? "Real-Debrid unavailable" : "Stream via torrent?"}
+              message={
+                torrentPrompt.reason
+                  ? `${torrentPrompt.reason}. Streaming via torrent connects you directly to peers, so your IP is visible to the swarm. Continue via torrent?`
+                  : "Streaming via torrent connects you directly to peers, so your IP is visible to the swarm (Real-Debrid keeps it private). Continue?"
+              }
+              onConfirm={() => {
+                const { input, reason } = torrentPrompt;
+                setTorrentPrompt(null);
+                // Remember the acknowledgement only for the no-RD one-time warning.
+                if (!reason && config) setConfig({ ...config, torrentStreamAck: true });
+                startTorrentStream(input);
+              }}
+              onCancel={() => {
+                setTorrentPrompt(null);
+                setNotice("Stream cancelled.");
+              }}
+            />
+          </Box>
+        ) : null}
+
         {editingTrackers ? (
           <Box marginTop={1}>
             <TrackersPrompt
@@ -1129,7 +1254,7 @@ export function App({
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
               ? "none"
               : "flex"
           }
@@ -1175,7 +1300,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing
+              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt
                 ? "none"
                 : "flex"
             }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -264,6 +264,10 @@ export function App({
     // exit; the unmount effect still runs suspend() for the engine teardown.
     queue?.persistSync();
     void activeStream?.session.stop();
+    // Clear so the unmount-only cleanup effect below has nothing left to
+    // re-stop (stop() is also idempotent, but this avoids relying on that).
+    activeStreamRef.current = null;
+    setActiveStream(null);
     if (onQuit) onQuit();
     else exit();
   }, [queue, onQuit, exit, activeStream]);
@@ -908,6 +912,7 @@ export function App({
       startDebridDownload,
       streamResult,
       debridConfigured: resolveRealDebridToken(config) !== "",
+      streamActive: activeStream !== null,
       rdStatus,
       copyLink,
       copyMagnet,
@@ -945,6 +950,7 @@ export function App({
     streamFiles,
     preparing,
     torrentPrompt,
+    activeStream,
     captureMode,
     downloadFocus,
     seedFocus,
@@ -1185,6 +1191,14 @@ export function App({
               onSelect={(file) => finishStream(file)}
               onCancel={() => {
                 setStreamFiles(null);
+                // The Real-Debrid path has no activeStream (files are hosted
+                // by RD, not a local torrent session), so this only fires for
+                // the torrent-stream path — leave that path unaffected.
+                if (activeStream) {
+                  void activeStream.session.stop();
+                  activeStreamRef.current = null;
+                  setActiveStream(null);
+                }
                 setNotice("Stream cancelled.");
               }}
             />
@@ -1288,6 +1302,7 @@ export function App({
                 rdToken={resolveRealDebridToken(store.config)}
                 rdStatus={rdStatus}
                 rutrackerUser={rutrackerUser}
+                streamActive={store.streamActive}
                 onManageRd={openTokenPrompt}
                 onSignOutRd={clearRealDebridToken}
                 onManageRutracker={openRutrackerPrompt}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -144,7 +144,12 @@ export function App({
   const [notice, setNotice] = useState<string | null>(null);
   const [rdStatus, setRdStatus] = useState<RdStatus | null>(null);
   const [streamFiles, setStreamFiles] = useState<ResolvedFile[] | null>(null);
-  const [preparing, setPreparing] = useState<{ label: string; phase: "caching" | "fetching"; pct: number } | null>(null);
+  const [preparing, setPreparing] = useState<{
+    label: string;
+    phase: "caching" | "fetching";
+    pct: number;
+    source: "rd" | "torrent";
+  } | null>(null);
   const [activeStream, setActiveStream] = useState<
     { session: TorrentStreamSession; name: string; input: DownloadInput } | null
   >(null);
@@ -518,7 +523,12 @@ export function App({
       if (preparing || streamFiles || activeStream) return;
       const controller = new AbortController();
       prepareAbort.current = controller;
-      setPreparing({ label: truncate(cleanText(input.name), 32), phase: "caching", pct: 0 });
+      setPreparing({
+        label: truncate(cleanText(input.name), 32),
+        phase: "caching",
+        pct: 0,
+        source: "torrent",
+      });
       void (async () => {
         try {
           const session = await streamTorrent(input.magnet, { signal: controller.signal });
@@ -593,6 +603,10 @@ export function App({
     (input: DownloadInput) => {
       if (!config) return;
       if (preparing || streamFiles) return; // one prepare/pick at a time
+      if (activeStream) {
+        setNotice("Stop the current stream first (x).");
+        return;
+      }
       const route = classifyStreamRoute(config, rdStatus);
       if (route.kind === "torrent-auto") {
         if (config.torrentStreamAck) {
@@ -615,7 +629,7 @@ export function App({
       const label = truncate(cleanText(input.name), 32);
       const controller = new AbortController();
       prepareAbort.current = controller;
-      setPreparing({ label, phase: "caching", pct: 0 });
+      setPreparing({ label, phase: "caching", pct: 0, source: "rd" });
       void (async () => {
         try {
           const files = await resolveMagnet(token, input.magnet, {
@@ -655,11 +669,14 @@ export function App({
             setEditingToken(true);
             return;
           }
-          setNotice(`Real-Debrid: ${e instanceof Error ? e.message : "couldn't prepare stream"}`);
+          setTorrentPrompt({
+            input,
+            reason: `Real-Debrid couldn't prepare this stream (${e instanceof Error ? e.message : "unknown error"})`,
+          });
         }
       })();
     },
-    [config, finishStream, preparing, streamFiles, rdStatus, startTorrentStream],
+    [config, finishStream, preparing, streamFiles, activeStream, rdStatus, startTorrentStream],
   );
 
   const closePlayerPrompt = useCallback(() => {
@@ -1116,9 +1133,11 @@ export function App({
           <Box>
             <Spinner
               label={
-                preparing.phase === "caching"
-                  ? `Caching on Real-Debrid… ${preparing.pct}% · ${prepElapsed}s  (esc cancels)`
-                  : `Fetching link… ${prepElapsed}s  (esc cancels)`
+                preparing.source === "torrent"
+                  ? `Finding peers… ${preparing.label} · ${prepElapsed}s  (esc cancels)`
+                  : preparing.phase === "caching"
+                    ? `Caching on Real-Debrid… ${preparing.pct}% · ${prepElapsed}s  (esc cancels)`
+                    : `Fetching link… ${prepElapsed}s  (esc cancels)`
               }
             />
           </Box>

--- a/src/ui/components/Accounts.tsx
+++ b/src/ui/components/Accounts.tsx
@@ -11,6 +11,9 @@ interface AccountsProps {
   rdToken: string;
   rdStatus: RdStatus | null;
   rutrackerUser?: string;
+  // True while a torrent stream is active; "x" is reserved for stopping it
+  // globally, so sign-out must not also fire on the same keystroke.
+  streamActive?: boolean;
   onManageRd: () => void;
   onSignOutRd: () => void;
   onManageRutracker: () => void;
@@ -32,6 +35,7 @@ export function Accounts({
   rdToken,
   rdStatus,
   rutrackerUser,
+  streamActive = false,
   onManageRd,
   onSignOutRd,
   onManageRutracker,
@@ -71,7 +75,7 @@ export function Accounts({
       if (key.upArrow) setCursor(wrapStep(clamped, -1, rows.length));
       else if (key.downArrow) setCursor(wrapStep(clamped, 1, rows.length));
       else if (key.return) rows[clamped]!.onManage();
-      else if (input === "x" && rows[clamped]!.signedIn) rows[clamped]!.onSignOut();
+      else if (input === "x" && !streamActive && rows[clamped]!.signedIn) rows[clamped]!.onSignOut();
     },
     { isActive: focused },
   );

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -86,7 +86,7 @@ function SourceBadge({
 }
 
 export function Downloads() {
-  const { queue, region, section, contentWidth, listRows, startDownload, setDownloadFocus, copyLink, setNotice } = useStore();
+  const { queue, region, section, contentWidth, listRows, startDownload, setDownloadFocus, copyLink, setNotice, streamActive } = useStore();
   const active = useQueueItems(queue);
   const recent = useQueueHistory(queue);
   const focused = region === "content" && section === "downloads";
@@ -119,7 +119,7 @@ export function Downloads() {
       if (key.upArrow || input === "k") setCursor(wrapStep(clamped, -1, total));
       else if (key.downArrow || input === "j") setCursor(wrapStep(clamped, 1, total));
       else if (input === "f") queue.retryFailed();
-      else if (input === "x") queue.clearHistory();
+      else if (input === "x" && !streamActive) queue.clearHistory();
       else if (inActive) {
         const it = active[clamped];
         if (!it) return;

--- a/src/ui/keymap.test.ts
+++ b/src/ui/keymap.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import { footerHints, HELP_GROUPS } from "./keymap";
 
 describe("footerHints results view", () => {
-  it("offers the Real-Debrid shortcut only when a token is configured", () => {
+  it("offers the Real-Debrid shortcut only when a token is configured, but Stream always", () => {
     const without = footerHints("content", "all", null, null, false);
     expect(without.some((h) => h.keys === "r")).toBe(false);
-    expect(without.some((h) => h.keys === "v")).toBe(false);
+    // Torrent streaming needs no Real-Debrid token, so its hint must be
+    // visible for exactly the users who don't have one configured.
+    expect(without.some((h) => h.keys === "v")).toBe(true);
 
     const withToken = footerHints("content", "all", null, null, true);
     const labels = withToken.map((h) => h.label);

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -133,12 +133,8 @@ export function footerHints(
   return [
     NAVIGATE,
     { keys: "d", label: "Download" },
-    ...(debridConfigured
-      ? [
-          { keys: "r", label: "Real-Debrid" },
-          { keys: "v", label: "Stream" },
-        ]
-      : []),
+    ...(debridConfigured ? [{ keys: "r", label: "Real-Debrid" }] : []),
+    { keys: "v", label: "Stream" },
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "/", label: "Search" },

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -42,9 +42,10 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "s", label: "Sort results" },
       { keys: "d", label: "Download (P2P)" },
       { keys: "r", label: "Download via Real-Debrid" },
-      { keys: "v", label: "Stream via Real-Debrid" },
+      { keys: "v", label: "Stream" },
       { keys: "y", label: "Copy magnet" },
       { keys: "m", label: "Paste magnet" },
+      { keys: "x", label: "Stop active stream" },
     ],
   },
   {

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -107,6 +107,10 @@ export interface Store {
   }) => void;
   // True when an RD token is available (config or env var).
   debridConfigured: boolean;
+  // True while a torrent-stream session is live. While true, "x" is reserved
+  // globally for stopping the stream, so components with their own "x"
+  // handler (clear history, sign out) must ignore it.
+  streamActive: boolean;
   // The validated Real-Debrid account, or null when unknown/not connected.
   rdStatus: RdStatus | null;
   // Copy an arbitrary link (e.g. a resolved RD direct URL) to the clipboard.

--- a/src/ui/streamKeep.test.ts
+++ b/src/ui/streamKeep.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import path from "node:path";
-import { keepMovePlan } from "./streamKeep";
+import { keepMovePlan, moveKeptFiles, type KeepFsOps } from "./streamKeep";
 
 describe("keepMovePlan", () => {
   it("moves the torrent's top-level folder from temp into downloads", () => {
@@ -11,5 +11,49 @@ describe("keepMovePlan", () => {
     });
     expect(plan.from).toBe(path.join("/tmp/torlink-stream-abc", "Big Buck Bunny"));
     expect(plan.to).toBe(path.join("/home/u/Downloads", "Big Buck Bunny"));
+  });
+});
+
+describe("moveKeptFiles", () => {
+  const plan = { from: "/tmp/torlink-stream-abc/Movie", to: "/home/u/Downloads/Movie" };
+  const downloadDir = "/home/u/Downloads";
+
+  function makeFs(overrides: Partial<KeepFsOps> = {}): KeepFsOps {
+    return {
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      rename: vi.fn().mockResolvedValue(undefined),
+      cp: vi.fn().mockResolvedValue(undefined),
+      rm: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  it("returns true when rename succeeds, without touching cp/rm", async () => {
+    const fs = makeFs();
+    const ok = await moveKeptFiles(plan, downloadDir, fs);
+    expect(ok).toBe(true);
+    expect(fs.rename).toHaveBeenCalledWith(plan.from, plan.to);
+    expect(fs.cp).not.toHaveBeenCalled();
+    expect(fs.rm).not.toHaveBeenCalled();
+  });
+
+  it("falls back to copy+remove when rename fails across devices", async () => {
+    const fs = makeFs({
+      rename: vi.fn().mockRejectedValue(new Error("EXDEV")),
+    });
+    const ok = await moveKeptFiles(plan, downloadDir, fs);
+    expect(ok).toBe(true);
+    expect(fs.cp).toHaveBeenCalledWith(plan.from, plan.to, { recursive: true });
+    expect(fs.rm).toHaveBeenCalledWith(plan.from, { recursive: true, force: true });
+  });
+
+  it("preserves the source and returns false when both rename and copy fail", async () => {
+    const fs = makeFs({
+      rename: vi.fn().mockRejectedValue(new Error("EXDEV")),
+      cp: vi.fn().mockRejectedValue(new Error("ENOSPC")),
+    });
+    const ok = await moveKeptFiles(plan, downloadDir, fs);
+    expect(ok).toBe(false);
+    expect(fs.rm).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/streamKeep.test.ts
+++ b/src/ui/streamKeep.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { keepMovePlan } from "./streamKeep";
+
+describe("keepMovePlan", () => {
+  it("moves the torrent's top-level folder from temp into downloads", () => {
+    const plan = keepMovePlan({
+      streamDir: "/tmp/torlink-stream-abc",
+      torrentName: "Big Buck Bunny",
+      downloadDir: "/home/u/Downloads",
+    });
+    expect(plan.from).toBe(path.join("/tmp/torlink-stream-abc", "Big Buck Bunny"));
+    expect(plan.to).toBe(path.join("/home/u/Downloads", "Big Buck Bunny"));
+  });
+});

--- a/src/ui/streamKeep.ts
+++ b/src/ui/streamKeep.ts
@@ -13,3 +13,37 @@ export function keepMovePlan(args: {
     to: path.join(args.downloadDir, args.torrentName),
   };
 }
+
+// Injected fs seams so the move is unit-testable without touching disk.
+export interface KeepFsOps {
+  mkdir: (dir: string, opts: { recursive: true }) => Promise<unknown>;
+  rename: (from: string, to: string) => Promise<void>;
+  cp: (from: string, to: string, opts: { recursive: true }) => Promise<void>;
+  rm: (from: string, opts: { recursive: true; force: true }) => Promise<void>;
+}
+
+// Move a completed stream's files into the downloads folder. Tries a fast
+// rename, falling back to copy+remove across devices. Returns true only if the
+// files demonstrably landed at `to`; on failure it does NOT delete the source
+// (so a kept download is never lost) and returns false.
+export async function moveKeptFiles(
+  plan: { from: string; to: string },
+  downloadDir: string,
+  fs: KeepFsOps,
+): Promise<boolean> {
+  await fs.mkdir(downloadDir, { recursive: true });
+  try {
+    await fs.rename(plan.from, plan.to);
+    return true;
+  } catch {
+    // Cross-device or rename-not-permitted: copy then remove the source, but
+    // only remove once the copy has succeeded — otherwise leave the source.
+    try {
+      await fs.cp(plan.from, plan.to, { recursive: true });
+    } catch {
+      return false; // copy failed: source untouched, nothing kept
+    }
+    await fs.rm(plan.from, { recursive: true, force: true }).catch(() => {});
+    return true;
+  }
+}

--- a/src/ui/streamKeep.ts
+++ b/src/ui/streamKeep.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+// WebTorrent lays a multi-file torrent out under <dir>/<torrent.name>/… and a
+// single-file torrent directly at <dir>/<file>. We move the top-level entry
+// named after the torrent; a single-file torrent's name IS that file.
+export function keepMovePlan(args: {
+  streamDir: string;
+  torrentName: string;
+  downloadDir: string;
+}): { from: string; to: string } {
+  return {
+    from: path.join(args.streamDir, args.torrentName),
+    to: path.join(args.downloadDir, args.torrentName),
+  };
+}

--- a/src/ui/streamRoute.test.ts
+++ b/src/ui/streamRoute.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { classifyStreamRoute } from "./streamRoute";
+import type { Config } from "../config/config";
+import type { RdStatus } from "../integrations/rdStatus";
+
+const base: Config = { downloadDir: "/tmp/dl", trackers: [] };
+const withToken: Config = { ...base, realDebridToken: "tok" };
+
+describe("classifyStreamRoute", () => {
+  it("no token -> torrent-auto", () => {
+    expect(classifyStreamRoute(base, null)).toEqual({ kind: "torrent-auto" });
+  });
+
+  it("token + premium -> realdebrid", () => {
+    const rd: RdStatus = { username: "u", premium: true, premiumUntil: null };
+    expect(classifyStreamRoute(withToken, rd)).toEqual({ kind: "realdebrid" });
+  });
+
+  it("token + status unknown -> realdebrid (let the attempt decide)", () => {
+    expect(classifyStreamRoute(withToken, null)).toEqual({ kind: "realdebrid" });
+  });
+
+  it("token + non-premium -> torrent-confirm with a reason", () => {
+    const rd: RdStatus = { username: "u", premium: false, premiumUntil: null };
+    const r = classifyStreamRoute(withToken, rd);
+    expect(r.kind).toBe("torrent-confirm");
+    expect((r as { reason: string }).reason).toMatch(/premium/i);
+  });
+});

--- a/src/ui/streamRoute.ts
+++ b/src/ui/streamRoute.ts
@@ -1,0 +1,19 @@
+import { type Config, resolveRealDebridToken } from "../config/config";
+import type { RdStatus } from "../integrations/rdStatus";
+
+export type StreamRoute =
+  | { kind: "realdebrid" }
+  | { kind: "torrent-auto" }
+  | { kind: "torrent-confirm"; reason: string };
+
+// Decide how `v` should stream, given RD config + last-known account status.
+// "Not configured" (no token) auto-routes to torrent; a present-but-non-premium
+// token is "configured but not working" and requires an explicit confirm so we
+// never silently expose the user's IP after they set RD up.
+export function classifyStreamRoute(config: Config, rdStatus: RdStatus | null): StreamRoute {
+  if (!resolveRealDebridToken(config)) return { kind: "torrent-auto" };
+  if (rdStatus && !rdStatus.premium) {
+    return { kind: "torrent-confirm", reason: "your Real-Debrid premium isn't active" };
+  }
+  return { kind: "realdebrid" };
+}

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -2,7 +2,12 @@ import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { spawn } from "node:child_process";
-import type { ResolvedFile } from "../integrations/realdebrid";
+
+export interface StreamFile {
+  url: string;
+  filename: string;
+  bytes: number;
+}
 
 // Extensions we treat as playable video, most-common first.
 const VIDEO_EXTS = new Set([
@@ -43,7 +48,7 @@ function ext(name: string): string {
  * Pick the file most worth streaming: the largest video file, or — if nothing
  * looks like video — the largest file overall. Returns null for an empty list.
  */
-export function pickStreamFile(files: ResolvedFile[]): ResolvedFile | null {
+export function pickStreamFile(files: StreamFile[]): StreamFile | null {
   if (files.length === 0) return null;
   const videos = files.filter((f) => VIDEO_EXTS.has(ext(f.filename)));
   const pool = videos.length > 0 ? videos : files;
@@ -55,7 +60,7 @@ export function pickStreamFile(files: ResolvedFile[]): ResolvedFile | null {
  * otherwise every file. Used to decide whether to show a picker (2+ items) and
  * what to list. Mirrors pickStreamFile's video heuristic.
  */
-export function streamCandidates(files: ResolvedFile[]): ResolvedFile[] {
+export function streamCandidates(files: StreamFile[]): StreamFile[] {
   const videos = files.filter((f) => VIDEO_EXTS.has(ext(f.filename)));
   return videos.length > 0 ? videos : files;
 }

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -44,6 +44,13 @@ declare module "webtorrent" {
     lsd?: boolean;
   }
 
+  interface TorrentServer {
+    listen(port?: number, hostname?: string, cb?: () => void): void;
+    address(): { port: number } | null;
+    close(cb?: () => void): void;
+    destroy(cb?: () => void): void;
+  }
+
   class WebTorrent extends EventEmitter {
     constructor(opts?: WebTorrentOptions);
     readonly torrents: Torrent[];
@@ -63,8 +70,9 @@ declare module "webtorrent" {
     get(torrentId: string): Torrent | null;
     remove(torrentId: string, cb?: (err?: Error) => void): void;
     destroy(cb?: (err?: Error) => void): void;
+    createServer(opts?: { hostname?: string; pathname?: string }): TorrentServer;
   }
 
   export default WebTorrent;
-  export type { Torrent, TorrentFile };
+  export type { Torrent, TorrentFile, TorrentServer };
 }


### PR DESCRIPTION
## What

The **Stream** action (`v`) previously worked only via Real-Debrid. It now also streams **peer-to-peer via WebTorrent** when RD isn't set up — the file plays in your media player (mpv/iina/vlc) while it downloads.

## How `v` decides (the safety model)

"Not configured" and "not working" are deliberately distinct — a configured user is **never** silently sent peer-to-peer (P2P exposes your real IP; RD proxies it):

| Real-Debrid state | Behaviour |
|---|---|
| **Not configured** (no token) | Stream via torrent. One-time IP-exposure warning, remembered. |
| **Configured but not working** (non-premium, or an API error / stall) | **Always** shows a confirm ("RD had a problem … stream via torrent instead? Your IP will be visible"). Never automatic. The one-time ack never suppresses this. |
| **Working** | Real-Debrid stream, unchanged. |

## How it works

- New `streamTorrent` engine (`src/integrations/torrentStream.ts`) turns a magnet into a WebTorrent **local HTTP-server URL**, streaming to an **ephemeral temp dir**, and returns files in the same `{ url, filename, bytes }` shape RD uses — so the existing file picker and player-launch are reused unchanged.
- Active-stream indicator with `x` to stop. On stop, if the torrent **fully downloaded**, an **offer-to-keep** prompt moves it into your downloads folder and seeds it via the existing queue; otherwise the temp dir is discarded.
- New `torrentStreamAck` config field records the one-time warning acknowledgement.
- README updated with a Streaming section.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-03-torrent-streaming-design.md`
- Plan: `docs/superpowers/plans/2026-07-03-torrent-streaming.md`

## Testing

- 294 unit tests pass (engine URL-mapping + timeout/abort/error cleanup + idempotent stop; route decision; config round-trip; data-loss-safe keep-move), `tsc --noEmit` clean, `npm run build` succeeds.
- **Not yet exercised:** the interactive path (real magnet → peers → external player) — recommend a manual smoke test. Built and reviewed across the branch (final whole-branch review verified cross-task integration, the IP-privacy contract, and lifecycle/leak handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)