### PR TITLE
feat: add first-class Books category

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ A short, hand-picked list of trusted sources:
 | Movies | YTS, The Pirate Bay, 1337x, Torrents.csv |
 | TV | EZTV, The Pirate Bay, 1337x |
 | Anime | Nyaa, SubsPlease |
+| Books | The Pirate Bay, Nyaa |
 
-**RuTracker** is available across Games, Movies, TV, and Anime and requires a free account. Sign in from the **Accounts** tab in the sidebar; credentials go only to rutracker.org and only the session cookie is stored locally. If asked for a captcha, follow the link and copy the code back.
+**RuTracker** is available across Games, Movies, TV, Anime, and Books and requires a free account. Sign in from the **Accounts** tab in the sidebar; credentials go only to rutracker.org and only the session cookie is stored locally. If asked for a captcha, follow the link and copy the code back.
 
-Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline. A source that keeps failing is set aside automatically for a while so it stops slowing searches down; you can also switch sources on and off yourself with `Shift+S`.
+Games are the only category that intentionally distributes executable software, so they come from FitGirl alone, a repacker with a long, trusted track record; the other categories are media or document files. If a source is down, the search carries on without it, and torlink tells you which one is offline. A source that keeps failing is set aside automatically for a while so it stops slowing searches down; you can also switch sources on and off yourself with `Shift+S`.
 
 ### Blocked by your network?
 

--- a/src/sources/books.test.ts
+++ b/src/sources/books.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { NYAA_LITERATURE_CATEGORY, nyaaLiterature } from "./nyaa";
+import { TPB_BOOK_CATEGORIES, tpbBooks } from "./piratebay";
+
+describe("Books sources", () => {
+  it("uses TPB's audiobook, ebook, and comics categories", () => {
+    expect([...TPB_BOOK_CATEGORIES]).toEqual([102, 601, 602]);
+    expect(tpbBooks).toMatchObject({ id: "tpb-books", group: "Books" });
+  });
+
+  it("uses Nyaa's Literature category", () => {
+    expect(NYAA_LITERATURE_CATEGORY).toBe("3_0");
+    expect(nyaaLiterature).toMatchObject({ id: "nyaa-literature", group: "Books" });
+  });
+});

--- a/src/sources/nyaa.ts
+++ b/src/sources/nyaa.ts
@@ -2,16 +2,22 @@ import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
 import { buildMagnet } from "./magnet";
 import { unescapeEntities } from "./rss";
 import { parseSize } from "../util/format";
-import type { SearchOptions, Source, TorrentResult } from "./types";
+import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 const BASE = "https://nyaa.si/";
+export const NYAA_LITERATURE_CATEGORY = "3_0";
 
 function tag(item: string, name: string): string {
   return item.match(new RegExp(`<${name}>(?:<!\\[CDATA\\[)?(.*?)(?:\\]\\]>)?</${name}>`, "s"))?.[1]?.trim() ?? "";
 }
 
-async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
-  const params = new URLSearchParams({ page: "rss", q: query.trim(), c: "0_0", f: "0" });
+async function search(
+  query: string,
+  category: string,
+  source: SourceId,
+  opts: SearchOptions = {},
+): Promise<TorrentResult[]> {
+  const params = new URLSearchParams({ page: "rss", q: query.trim(), c: category, f: "0" });
   const res = await fetchResilient(`${BASE}?${params.toString()}`, {
     headers: { "User-Agent": USER_AGENT },
     signal: opts.signal,
@@ -33,7 +39,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
       sizeBytes: parseSize(tag(item, "nyaa:size")),
       seeders: Number.isFinite(seeders) ? seeders : 0,
       leechers: Number.isFinite(leechers) ? leechers : 0,
-      source: "nyaa",
+      source,
       magnet: buildMagnet(infoHash, name),
       added: dateStr ? new Date(dateStr).getTime() / 1000 : undefined,
     });
@@ -46,5 +52,14 @@ export const nyaa: Source = {
   label: "Nyaa",
   group: "Anime",
   homepage: "https://nyaa.si",
-  search,
+  search: (query, opts = {}) => search(query, "0_0", "nyaa", opts),
+};
+
+export const nyaaLiterature: Source = {
+  id: "nyaa-literature",
+  label: "Nyaa",
+  group: "Books",
+  homepage: "https://nyaa.si/?c=3_0",
+  search: (query, opts = {}) =>
+    search(query, NYAA_LITERATURE_CATEGORY, "nyaa-literature", opts),
 };

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -6,9 +6,12 @@ const API = "https://apibay.org";
 
 const MOVIE_CATS = new Set([201, 202, 207, 209]);
 const TV_CATS = new Set([205, 208]);
+// Audio Books, E-books, and Comics.
+export const TPB_BOOK_CATEGORIES: ReadonlySet<number> = new Set([102, 601, 602]);
 
 const TOP_MOVIES = `${API}/precompiled/data_top100_207.json`;
 const TOP_TV = `${API}/precompiled/data_top100_208.json`;
+const TOP_BOOKS = `${API}/precompiled/data_top100_601.json`;
 
 interface ApibayItem {
   id?: string;
@@ -55,7 +58,7 @@ async function fetchItems(url: string, opts: SearchOptions): Promise<ApibayItem[
 
 async function search(
   query: string,
-  cats: Set<number>,
+  cats: ReadonlySet<number>,
   browseUrl: string,
   source: SourceId,
   opts: SearchOptions,
@@ -88,4 +91,13 @@ export const tpbTv: Source = {
   group: "TV",
   homepage: "https://thepiratebay.org",
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),
+};
+
+export const tpbBooks: Source = {
+  id: "tpb-books",
+  label: "TPB",
+  group: "Books",
+  homepage: "https://thepiratebay.org",
+  search: (query, opts = {}) =>
+    search(query, TPB_BOOK_CATEGORIES, TOP_BOOKS, "tpb-books", opts),
 };

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -39,13 +39,24 @@ describe("toggleDisabledSource", () => {
 });
 
 describe("RuTracker sources", () => {
-  it("includes the four RuTracker sources", () => {
+  it("includes the five RuTracker sources", () => {
     const ids = SOURCES.map((s) => s.id);
     expect(ids).toEqual(
-      expect.arrayContaining(["rt-games", "rt-movies", "rt-tv", "rt-anime"]),
+      expect.arrayContaining(["rt-games", "rt-movies", "rt-tv", "rt-anime", "rt-books"]),
     );
     for (const s of SOURCES.filter((x) => x.id.startsWith("rt-"))) {
       expect(s.label).toBe("RuTracker");
     }
+  });
+});
+
+describe("Books sources", () => {
+  it("registers dedicated TPB, Nyaa, and RuTracker sources", () => {
+    const books = SOURCES.filter((source) => source.group === "Books");
+    expect(books.map((source) => source.id)).toEqual([
+      "tpb-books",
+      "nyaa-literature",
+      "rt-books",
+    ]);
   });
 });

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,9 +1,9 @@
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
-import { nyaa } from "./nyaa";
+import { nyaa, nyaaLiterature } from "./nyaa";
 import { subsplease } from "./subsplease";
 import { torrentsCsv } from "./torrentscsv";
-import { tpbMovies, tpbTv } from "./piratebay";
+import { tpbBooks, tpbMovies, tpbTv } from "./piratebay";
 import { x1337Movies, x1337Tv } from "./x1337";
 import { yts } from "./yts";
 import {
@@ -11,6 +11,7 @@ import {
   rutrackerMovies,
   rutrackerTv,
   rutrackerAnime,
+  rutrackerBooks,
 } from "./rutracker";
 import type { Source, SourceGroup, SourceId } from "./types";
 
@@ -25,10 +26,13 @@ export const SOURCES: readonly Source[] = [
   x1337Tv,
   nyaa,
   subsplease,
+  tpbBooks,
+  nyaaLiterature,
   rutrackerGames,
   rutrackerMovies,
   rutrackerTv,
   rutrackerAnime,
+  rutrackerBooks,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -52,7 +56,7 @@ export function toggleDisabledSource(
   return disabled.includes(id) ? disabled.filter((d) => d !== id) : [...disabled, id];
 }
 
-const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime"];
+const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime", "Books"];
 
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({

--- a/src/sources/rutracker/index.ts
+++ b/src/sources/rutracker/index.ts
@@ -35,6 +35,9 @@ const SECTION_GROUP: Record<string, SourceGroup> = {
   "Игры": "Games",
   "Кино, Видео и ТВ": "Movies",
   "Документалистика и юмор": "Movies",
+  "Книги и журналы": "Books",
+  "Обучение иностранным языкам": "Books",
+  "Аудиокниги": "Books",
 };
 
 const ANIME_RE = /аниме|anime|манга|manga|ранобэ/i;
@@ -44,6 +47,7 @@ const KEYWORD_RULES: { group: SourceGroup; re: RegExp }[] = [
   { group: "TV", re: /сериал|телесериал/i },
   { group: "Games", re: /игр|game|консол|playstation|xbox|nintendo|ps[2345]|repack/i },
   { group: "Movies", re: /кино|фильм|видео|мультфильм|movie/i },
+  { group: "Books", re: /книг|журнал|литератур|аудиокниг|учебник/i },
 ];
 
 const GROUP_SOURCE: Record<SourceGroup, SourceId> = {
@@ -51,6 +55,7 @@ const GROUP_SOURCE: Record<SourceGroup, SourceId> = {
   Movies: "rt-movies",
   TV: "rt-tv",
   Anime: "rt-anime",
+  Books: "rt-books",
 };
 
 interface ForumNode {
@@ -319,3 +324,4 @@ export const rutrackerGames = makeSource("rt-games", "Games");
 export const rutrackerMovies = makeSource("rt-movies", "Movies");
 export const rutrackerTv = makeSource("rt-tv", "TV");
 export const rutrackerAnime = makeSource("rt-anime", "Anime");
+export const rutrackerBooks = makeSource("rt-books", "Books");

--- a/src/sources/rutracker/parse.test.ts
+++ b/src/sources/rutracker/parse.test.ts
@@ -33,6 +33,8 @@ describe("parseRows", () => {
     expect(groupFor("PC игры")).toBe("Games");
     expect(groupFor("Зарубережные сериалы")).toBe("TV");
     expect(groupFor("Зарубережное кино")).toBe("Movies");
+    expect(groupFor("Электронные книги")).toBe("Books");
+    expect(groupFor("Аудиокниги (AAC)")).toBe("Books");
   });
 
   it("drops results that aren't one of the four tabs", () => {
@@ -58,6 +60,12 @@ const SELECT = `
   <optgroup label="&nbsp;Музыка">
     <option id="fs-408" value="408" class='fp-409' > |- Поп-музыка (lossless)&nbsp;</option>
   </optgroup>
+  <optgroup label="&nbsp;Книги и журналы">
+    <option id="fs-21" value="21" class='root_forum' >Книги и журналы (общий раздел)&nbsp;</option>
+  </optgroup>
+  <optgroup label="&nbsp;Аудиокниги">
+    <option id="fs-1909" value="1909" class='root_forum' >Аудиокниги (AAC, ALAC)&nbsp;</option>
+  </optgroup>
 </select>`;
 
 describe("buildGroupMap", () => {
@@ -66,6 +74,8 @@ describe("buildGroupMap", () => {
     expect(map.get(313)).toBe("Movies");
     expect(map.get(266)).toBe("TV");
     expect(map.get(973)).toBe("Games");
+    expect(map.get(21)).toBe("Books");
+    expect(map.get(1909)).toBe("Books");
   });
   it("overrides the section for anime nested under films", () => {
     expect(map.get(33)).toBe("Anime");

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -7,14 +7,17 @@ export type SourceId =
   | "torrents-csv"
   | "tpb-movies"
   | "tpb-tv"
+  | "tpb-books"
+  | "nyaa-literature"
   | "x1337-movies"
   | "x1337-tv"
   | "rt-games"
   | "rt-movies"
   | "rt-tv"
-  | "rt-anime";
+  | "rt-anime"
+  | "rt-books";
 
-export type SourceGroup = "Games" | "Movies" | "TV" | "Anime";
+export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Books";
 
 export interface TorrentResult {
   infoHash: string;

--- a/src/ui/store.test.ts
+++ b/src/ui/store.test.ts
@@ -8,6 +8,7 @@ describe("parseCategory", () => {
     expect(parseCategory("movies")).toBe("movies");
     expect(parseCategory("tv")).toBe("tv");
     expect(parseCategory("anime")).toBe("anime");
+    expect(parseCategory("books")).toBe("books");
   });
 
   it("falls back to 'all' for missing, unknown, or non-category values", () => {
@@ -33,5 +34,6 @@ describe("isCategory", () => {
     expect(isCategory("movies")).toBe(true);
     expect(isCategory("tv")).toBe(true);
     expect(isCategory("anime")).toBe(true);
+    expect(isCategory("books")).toBe(true);
   });
 });

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -9,7 +9,7 @@ import type { Sort } from "./sort";
 
 export type View = "splash" | "browser";
 
-export type Category = "all" | "games" | "movies" | "tv" | "anime";
+export type Category = "all" | "games" | "movies" | "tv" | "anime" | "books";
 
 export type Section = Category | "downloads" | "seeding" | "accounts";
 
@@ -25,6 +25,7 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
   { key: "movies", label: "Movies", group: "Movies" },
   { key: "tv", label: "TV", group: "TV" },
   { key: "anime", label: "Anime", group: "Anime" },
+  { key: "books", label: "Books", group: "Books" },
 ];
 
 // Parse a persisted category preference, falling back to "all" for anything

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -40,12 +40,15 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   subsplease: { tag: "SUB", color: "#b9a7e6" },
   "tpb-movies": { tag: "TPB", color: "#5fd0c5" },
   "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
+  "tpb-books": { tag: "TPB", color: "#5fd0c5" },
+  "nyaa-literature": { tag: "NYAA", color: COLOR.bright },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
   "rt-games": { tag: "RUT", color: "#8fce5a" },
   "rt-movies": { tag: "RUT", color: "#8fce5a" },
   "rt-tv": { tag: "RUT", color: "#8fce5a" },
   "rt-anime": { tag: "RUT", color: "#8fce5a" },
+  "rt-books": { tag: "RUT", color: "#8fce5a" },
 };
 
 // Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or


### PR DESCRIPTION
## What and why

<!-- What does this change do, and why? The diff shows the what; tell us the why. -->

## Checklist

- [ ] `npm run typecheck` is clean
- [ ] `npm test` passes
- [ ] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [ ] OS-touching code works on Windows, macOS, and Linux
- [ ] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)

New here? [CONTRIBUTING.md](../CONTRIBUTING.md) explains each of these with examples from real merged PRs.
