### PR TITLE
feat: add RuTracker Music source

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A short, hand-picked list of trusted sources:
 | Books | The Pirate Bay, Nyaa |
 | Music | The Pirate Bay, 1337x |
 
-**RuTracker** is available across Games, Movies, TV, Anime, and Books and requires a free account. Sign in from the **Accounts** tab in the sidebar; credentials go only to rutracker.org and only the session cookie is stored locally. If asked for a captcha, follow the link and copy the code back.
+**RuTracker** is available across Games, Movies, TV, Anime, Music, and Books and requires a free account. Sign in from the **Accounts** tab in the sidebar; credentials go only to rutracker.org and only the session cookie is stored locally. If asked for a captcha, follow the link and copy the code back.
 
 Games are the only category that intentionally distributes executable software, so they come from FitGirl alone, a repacker with a long, trusted track record; the other categories are media or document files. If a source is down, the search carries on without it, and torlink tells you which one is offline. A source that keeps failing is set aside automatically for a while so it stops slowing searches down; you can also switch sources on and off yourself with `Shift+S`.
 

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -39,10 +39,10 @@ describe("toggleDisabledSource", () => {
 });
 
 describe("RuTracker sources", () => {
-  it("includes the five RuTracker sources", () => {
+  it("includes the six RuTracker sources", () => {
     const ids = SOURCES.map((s) => s.id);
     expect(ids).toEqual(
-      expect.arrayContaining(["rt-games", "rt-movies", "rt-tv", "rt-anime", "rt-books"]),
+      expect.arrayContaining(["rt-games", "rt-movies", "rt-tv", "rt-anime", "rt-music", "rt-books"]),
     );
     for (const s of SOURCES.filter((x) => x.id.startsWith("rt-"))) {
       expect(s.label).toBe("RuTracker");
@@ -64,6 +64,10 @@ describe("Books sources", () => {
 describe("Music sources", () => {
   it("registers dedicated TPB and 1337x sources", () => {
     const music = SOURCES.filter((source) => source.group === "Music");
-    expect(music.map((source) => source.id)).toEqual(["tpb-music", "x1337-music"]);
+    expect(music.map((source) => source.id)).toEqual([
+      "tpb-music",
+      "x1337-music",
+      "rt-music",
+    ]);
   });
 });

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -11,6 +11,7 @@ import {
   rutrackerMovies,
   rutrackerTv,
   rutrackerAnime,
+  rutrackerMusic,
   rutrackerBooks,
 } from "./rutracker";
 import type { Source, SourceGroup, SourceId } from "./types";
@@ -34,6 +35,7 @@ export const SOURCES: readonly Source[] = [
   rutrackerMovies,
   rutrackerTv,
   rutrackerAnime,
+  rutrackerMusic,
   rutrackerBooks,
 ];
 

--- a/src/sources/rutracker/index.ts
+++ b/src/sources/rutracker/index.ts
@@ -30,7 +30,7 @@ interface Row {
   added?: number;
 }
 
-type RutrackerGroup = Exclude<SourceGroup, "Music">;
+type RutrackerGroup = SourceGroup;
 
 const SECTION_GROUP: Record<string, RutrackerGroup> = {
   "Сериалы": "TV",
@@ -40,6 +40,7 @@ const SECTION_GROUP: Record<string, RutrackerGroup> = {
   "Книги и журналы": "Books",
   "Обучение иностранным языкам": "Books",
   "Аудиокниги": "Books",
+  "Музыка": "Music",
 };
 
 const ANIME_RE = /аниме|anime|манга|manga|ранобэ/i;
@@ -50,6 +51,7 @@ const KEYWORD_RULES: { group: RutrackerGroup; re: RegExp }[] = [
   { group: "Games", re: /игр|game|консол|playstation|xbox|nintendo|ps[2345]|repack/i },
   { group: "Movies", re: /кино|фильм|видео|мультфильм|movie/i },
   { group: "Books", re: /книг|журнал|литератур|аудиокниг|учебник/i },
+  { group: "Music", re: /музык|рок|джаз|классик|саундтрек|lossless|flac/i },
 ];
 
 const GROUP_SOURCE: Record<RutrackerGroup, SourceId> = {
@@ -57,6 +59,7 @@ const GROUP_SOURCE: Record<RutrackerGroup, SourceId> = {
   Movies: "rt-movies",
   TV: "rt-tv",
   Anime: "rt-anime",
+  Music: "rt-music",
   Books: "rt-books",
 };
 
@@ -326,4 +329,5 @@ export const rutrackerGames = makeSource("rt-games", "Games");
 export const rutrackerMovies = makeSource("rt-movies", "Movies");
 export const rutrackerTv = makeSource("rt-tv", "TV");
 export const rutrackerAnime = makeSource("rt-anime", "Anime");
+export const rutrackerMusic = makeSource("rt-music", "Music");
 export const rutrackerBooks = makeSource("rt-books", "Books");

--- a/src/sources/rutracker/parse.test.ts
+++ b/src/sources/rutracker/parse.test.ts
@@ -35,10 +35,10 @@ describe("parseRows", () => {
     expect(groupFor("Зарубережное кино")).toBe("Movies");
     expect(groupFor("Электронные книги")).toBe("Books");
     expect(groupFor("Аудиокниги (AAC)")).toBe("Books");
+    expect(groupFor("Рок-музыка (lossless)")).toBe("Music");
   });
 
-  it("drops results that aren't one of the four tabs", () => {
-    expect(parseRows(TABLE(ROW("Рок-музыка (lossless)", "Some Album")))).toHaveLength(0);
+  it("drops results that aren't in a supported tab", () => {
     expect(parseRows(TABLE("<tr><td>nothing</td></tr>"))).toHaveLength(0);
   });
 });
@@ -81,8 +81,8 @@ describe("buildGroupMap", () => {
     expect(map.get(33)).toBe("Anime");
     expect(map.get(1390)).toBe("Anime");
   });
-  it("omits sections with no tab", () => {
-    expect(map.has(408)).toBe(false);
+  it("maps the music section", () => {
+    expect(map.get(408)).toBe("Music");
   });
 });
 

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -17,6 +17,7 @@ export type SourceId =
   | "rt-movies"
   | "rt-tv"
   | "rt-anime"
+  | "rt-music"
   | "rt-books";
 
 export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music" | "Books";

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -50,6 +50,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "rt-movies": { tag: "RUT", color: "#8fce5a" },
   "rt-tv": { tag: "RUT", color: "#8fce5a" },
   "rt-anime": { tag: "RUT", color: "#8fce5a" },
+  "rt-music": { tag: "RUT", color: "#8fce5a" },
   "rt-books": { tag: "RUT", color: "#8fce5a" },
 };
 


### PR DESCRIPTION
## Summary
Adds RuTracker as a first-class source for the Music category, extending music search coverage alongside the existing TPB/1337x sources.

## Changes
- `src/sources/registry.ts` — register RuTracker under the Music category
- `src/sources/rutracker/index.ts` — support the music category in the RuTracker source
- `src/sources/types.ts`, `src/ui/theme.ts` — supporting type/theme wiring
- Tests updated in `registry.test.ts` / `parse.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)