### PR TITLE
feat: preserve source provenance for duplicate results

### DIFF
--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -29,6 +29,8 @@ export interface TorrentResult {
   leechers: number;
   numFiles?: number;
   source: SourceId;
+  /** Every source that returned this infohash; `source` is the healthiest copy. */
+  sources?: SourceId[];
   magnet: string;
   added?: number;
 }

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -105,6 +105,16 @@ function Detail({
           <DetailRow label="Files" value={<Text dimColor>{String(r.numFiles)}</Text>} />
         ) : null}
         {date ? <DetailRow label="Added" value={<Text dimColor>{date}</Text>} /> : null}
+        {(r.sources?.length ?? 0) > 1 ? (
+          <DetailRow
+            label="Sources"
+            value={
+              <Text dimColor>
+                {r.sources!.map((source) => sourceStyle(source).tag).join(", ")}
+              </Text>
+            }
+          />
+        ) : null}
         <DetailRow
           label="Hash"
           value={

--- a/src/ui/hooks/useConcurrentSearch.test.ts
+++ b/src/ui/hooks/useConcurrentSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldBench } from "./useConcurrentSearch";
+import { mergeDuplicateResults, shouldBench } from "./useConcurrentSearch";
 import { AuthRequiredError } from "../../sources/rutracker/session";
 import { HttpError } from "../../util/net";
 
@@ -18,5 +18,24 @@ describe("shouldBench", () => {
 
   it("benches on a non-Error thrown value", () => {
     expect(shouldBench("timed out")).toBe(true);
+  });
+});
+
+describe("mergeDuplicateResults", () => {
+  it("keeps the healthiest copy and records every source", () => {
+    const base = {
+      infoHash: "abc",
+      name: "Release",
+      sizeBytes: 10,
+      leechers: 0,
+      magnet: "magnet:?xt=urn:btih:abc",
+    } as const;
+    const merged = mergeDuplicateResults([
+      { ...base, source: "tpb-movies", seeders: 3 },
+      { ...base, source: "x1337-movies", seeders: 8 },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ source: "x1337-movies", seeders: 8 });
+    expect(merged[0]!.sources).toEqual(["tpb-movies", "x1337-movies"]);
   });
 });

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -42,11 +42,17 @@ function blankPerSource(sources: readonly Source[], loading: boolean): Record<So
   return out;
 }
 
-function dedupe(list: TorrentResult[]): TorrentResult[] {
+export function mergeDuplicateResults(list: TorrentResult[]): TorrentResult[] {
   const byHash = new Map<string, TorrentResult>();
   for (const r of list) {
     const existing = byHash.get(r.infoHash);
-    if (!existing || r.seeders > existing.seeders) byHash.set(r.infoHash, r);
+    if (!existing) {
+      byHash.set(r.infoHash, { ...r, sources: [r.source] });
+      continue;
+    }
+    const sources = [...new Set([...(existing.sources ?? [existing.source]), r.source])];
+    if (r.seeders > existing.seeders) byHash.set(r.infoHash, { ...r, sources });
+    else existing.sources = sources;
   }
   return [...byHash.values()];
 }
@@ -132,7 +138,7 @@ export function useConcurrentSearch(
           if (!alive) return;
           done += 1;
           setState({
-            results: defaultOrder(dedupe(collected.slice())),
+            results: defaultOrder(mergeDuplicateResults(collected.slice())),
             perSource: { ...per },
             loading: done < active.length,
             done,


### PR DESCRIPTION
## Summary
When the same torrent is returned by multiple sources, group the duplicates and preserve the list of sources it came from instead of silently dropping duplicates. The results view surfaces which sources provided each result.

## Changes
- `src/ui/hooks/useConcurrentSearch.ts` — merge duplicate results, retaining all source provenance
- `src/ui/components/Results.tsx` — display source provenance
- `src/sources/types.ts` — carry provenance on the result type
- Tests added in `useConcurrentSearch.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)