### PR TITLE
feat: select files before multi-file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Active downloads sit up top with their progress, speed, and time left; when one 
 
 Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder, and the Downloads pane keeps tabs on each one. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
 
+When a torrent contains several files, torlink pauses before transferring payload data and lets you choose exactly which files to download. Use `Space` to toggle files, `a` to select all, and `Enter` to begin.
+
 <p align="center">
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">
 </p>

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -16,6 +16,7 @@ export interface TorrentMeta {
   name: string;
   total: number;
   files: number;
+  fileList: { index: number; name: string; path: string; length: number }[];
   // The .torrent metadata (piece hashes), available once metadata arrives. We
   // persist it so a later re-seed can verify the on-disk file without having to
   // re-fetch metadata from the swarm (which a bare magnet would require).
@@ -63,6 +64,7 @@ export class TorrentEngine {
     dir: string,
     handlers: AddHandlers,
     announce?: string[],
+    selectedFileIndices?: number[],
   ): void {
     const client = this.ensureClient();
     const existing = this.torrents.get(id);
@@ -84,10 +86,25 @@ export class TorrentEngine {
     this.torrents.set(id, torrent);
 
     torrent.on("metadata", () => {
+      const fileList = (torrent.files ?? []).map((file, index) => ({
+        index,
+        name: file.name,
+        path: file.path,
+        length: file.length,
+      }));
+      if (fileList.length > 1) {
+        for (const file of torrent.files) file.deselect();
+        if (selectedFileIndices?.length) {
+          for (const index of selectedFileIndices) torrent.files[index]?.select();
+        } else {
+          torrent.pause();
+        }
+      }
       handlers.onMetadata?.({
         name: torrent.name,
         total: torrent.length,
         files: torrent.files?.length ?? 0,
+        fileList,
         torrentFile: torrent.torrentFile,
       });
     });
@@ -103,6 +120,14 @@ export class TorrentEngine {
         torrent.destroy();
       } catch {}
     });
+  }
+
+  selectFiles(id: string, indices: number[]): void {
+    const torrent = this.torrents.get(id);
+    if (!torrent || indices.length === 0) return;
+    for (const file of torrent.files ?? []) file.deselect();
+    for (const index of indices) torrent.files?.[index]?.select();
+    torrent.resume();
   }
 
   // The TCP port the client accepts incoming peers on (diagnostics / tests).

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -59,6 +59,29 @@ describe("DownloadQueue seeding", () => {
   });
 });
 
+describe("DownloadQueue file selection", () => {
+  it("rejects an empty or unknown selection", () => {
+    const q = new DownloadQueue();
+    q.restore([{
+      id: "pick1",
+      name: "Collection",
+      magnet: "magnet:?xt=urn:btih:2222222222222222222222222222222222222222",
+      dir: "/downloads",
+      status: "selecting",
+      progress: 0,
+      totalBytes: 30,
+      downloadedBytes: 0,
+      speed: 0,
+      peers: 0,
+      addedAt: 1,
+      availableFiles: [{ index: 0, name: "a", path: "a.epub", length: 10 }],
+    }]);
+    expect(q.selectFiles("pick1", [])).toBe(false);
+    expect(q.selectFiles("pick1", [99])).toBe(false);
+    q.suspend();
+  });
+});
+
 describe("DownloadQueue Real-Debrid path", () => {
   const input = {
     id: "rd1",

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -148,7 +148,33 @@ export class DownloadQueue extends EventEmitter {
   }
 
   private startEngine(item: QueueItem): void {
-    this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    this.engine.add(
+      item.id,
+      item.magnet,
+      item.dir,
+      this.engineHandlers(item.id),
+      this.trackers,
+      item.selectedFileIndices,
+    );
+  }
+
+  selectFiles(id: string, indices: number[]): boolean {
+    const item = this.items.get(id);
+    if (!item || item.status !== "selecting" || indices.length === 0) return false;
+    const valid = [...new Set(indices)].filter((index) =>
+      item.availableFiles?.some((file) => file.index === index),
+    );
+    if (valid.length === 0) return false;
+    item.selectedFileIndices = valid;
+    item.status = "downloading";
+    item.totalBytes = (item.availableFiles ?? [])
+      .filter((file) => valid.includes(file.index))
+      .reduce((sum, file) => sum + file.length, 0);
+    this.engine.selectFiles(id, valid);
+    this.ensurePoll();
+    this.changed();
+    void this.persist();
+    return true;
   }
 
   // Keep the queue's notion of the current Real-Debrid token in sync with config
@@ -371,6 +397,11 @@ export class DownloadQueue extends EventEmitter {
         if (meta.name) it.name = meta.name;
         if (meta.total) it.totalBytes = meta.total;
         it.files = meta.files;
+        it.availableFiles = meta.fileList;
+        if (meta.fileList.length > 1 && !it.selectedFileIndices?.length) {
+          it.status = "selecting";
+          it.speed = 0;
+        }
         this.changed();
         void this.persist();
       },
@@ -780,7 +811,7 @@ export class DownloadQueue extends EventEmitter {
         raw.peers = 0;
       }
       this.items.set(raw.id, raw);
-      if (raw.status === "downloading") this.startEngine(raw);
+      if (raw.status === "downloading" || raw.status === "selecting") this.startEngine(raw);
     }
     if (this.activeCount > 0) this.ensurePoll();
     this.changed();

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -1,6 +1,13 @@
 import type { SourceId } from "../sources/types";
 
-export type DownloadStatus = "downloading" | "paused" | "completed" | "failed";
+export type DownloadStatus = "selecting" | "downloading" | "paused" | "completed" | "failed";
+
+export interface TorrentFileChoice {
+  index: number;
+  name: string;
+  path: string;
+  length: number;
+}
 
 // How an item is being fetched: classic peer-to-peer (webtorrent) or via
 // Real-Debrid (resolve the magnet to direct links, then download over HTTP).
@@ -40,6 +47,8 @@ export interface QueueItem {
   peers: number;
   eta?: number;
   files?: number;
+  availableFiles?: TorrentFileChoice[];
+  selectedFileIndices?: number[];
   error?: string;
   addedAt: number;
   // Absent means "p2p" for back-compatibility with items persisted before

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -63,10 +63,12 @@ import { DnsPrompt } from "./components/DnsPrompt";
 import { RutrackerPrompt, type LoginStatus } from "./components/RutrackerPrompt";
 import { Accounts } from "./components/Accounts";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
 import type { SourceId } from "../sources/types";
+import type { QueueItem } from "../download/types";
 import {
   login as rutrackerLogin,
   getSession as getRutrackerSession,
@@ -141,6 +143,7 @@ export function App({
   const [rutrackerUser, setRutrackerUser] = useState<string | undefined>(undefined);
   const [editingTrackers, setEditingTrackers] = useState(false);
   const [pendingP2P, setPendingP2P] = useState<DownloadInput | null>(null);
+  const [fileSelection, setFileSelection] = useState<QueueItem | null>(null);
   const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [rdStatus, setRdStatus] = useState<RdStatus | null>(null);
@@ -241,6 +244,8 @@ export function App({
   useEffect(() => {
     if (!queue) return;
     const onUpdate = (): void => {
+      const selecting = queue.getItems().find((it) => it.status === "selecting");
+      setFileSelection(selecting ? { ...selecting } : null);
       for (const it of queue.getItems()) {
         if (it.status !== "failed" || it.via !== "realdebrid" || !it.error) continue;
         if (reauthSeen.current.has(it.id)) continue;
@@ -254,6 +259,7 @@ export function App({
       }
     };
     queue.on("update", onUpdate);
+    onUpdate();
     return () => {
       queue.off("update", onUpdate);
     };
@@ -952,7 +958,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
           ? "help"
           : region,
       setRegion,
@@ -1003,6 +1009,7 @@ export function App({
     editingTrackers,
     toggleSource,
     pendingP2P,
+    fileSelection,
     streamFiles,
     preparing,
     torrentPrompt,
@@ -1043,6 +1050,7 @@ export function App({
       if (editingRutracker) return; // the RuTracker prompt owns input
       if (editingTrackers) return; // the trackers prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
+      if (fileSelection) return; // the download file picker owns input
       if (torrentPrompt) return; // the torrent privacy warning owns input
       if (keepPrompt) return; // the keep-download prompt owns input
       if (streamFiles) return; // the file picker owns input
@@ -1266,6 +1274,26 @@ export function App({
           </Box>
         ) : null}
 
+        {fileSelection?.availableFiles ? (
+          <Box marginTop={1}>
+            <DownloadFilePrompt
+              width={Math.max(30, Math.min(cols - 4, 78))}
+              files={fileSelection.availableFiles}
+              onSubmit={(indices) => {
+                if (queue?.selectFiles(fileSelection.id, indices)) {
+                  setFileSelection(null);
+                  setNotice(`Downloading ${indices.length} selected file${indices.length === 1 ? "" : "s"}.`);
+                }
+              }}
+              onCancel={() => {
+                queue?.cancel(fileSelection.id);
+                setFileSelection(null);
+                setNotice("Download cancelled.");
+              }}
+            />
+          </Box>
+        ) : null}
+
         {pendingP2P ? (
           <Box marginTop={1}>
             <ConfirmPrompt
@@ -1374,7 +1402,7 @@ export function App({
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
               ? "none"
               : "flex"
           }

--- a/src/ui/components/DownloadFilePrompt.tsx
+++ b/src/ui/components/DownloadFilePrompt.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { COLOR, GUTTER, ICON } from "../theme";
+import { cleanText, formatBytes, truncate } from "../../util/format";
+import type { TorrentFileChoice } from "../../download/types";
+
+export function DownloadFilePrompt({
+  width,
+  files,
+  onSubmit,
+  onCancel,
+}: {
+  width: number;
+  files: TorrentFileChoice[];
+  onSubmit: (indices: number[]) => void;
+  onCancel: () => void;
+}) {
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<Set<number>>(() => new Set(files.map((f) => f.index)));
+  const clamped = Math.min(cursor, Math.max(0, files.length - 1));
+  const chosen = useMemo(() => [...selected], [selected]);
+
+  useInput((input, key) => {
+    if (key.escape) return onCancel();
+    if (key.upArrow || input === "k") setCursor(Math.max(0, clamped - 1));
+    else if (key.downArrow || input === "j") setCursor(Math.min(files.length - 1, clamped + 1));
+    else if (input === " ") {
+      const index = files[clamped]?.index;
+      if (index === undefined) return;
+      setSelected((current) => {
+        const next = new Set(current);
+        if (next.has(index)) next.delete(index); else next.add(index);
+        return next;
+      });
+    } else if (input === "a") setSelected(new Set(files.map((f) => f.index)));
+    else if (key.return && chosen.length > 0) onSubmit(chosen);
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="choose files to download" width={width} focused height={Math.min(files.length + 1, 10)}>
+        {files.slice(0, 9).map((file, i) => {
+          const here = i === clamped;
+          return (
+            <Box key={file.index}>
+              <Box width={GUTTER}><Text color={COLOR.accent}>{here ? ICON.pointer : ""}</Text></Box>
+              <Text color={selected.has(file.index) ? COLOR.good : COLOR.alt}>
+                {selected.has(file.index) ? "[x]" : "[ ]"}
+              </Text>
+              <Box flexGrow={1} minWidth={0} marginLeft={1}>
+                <Text bold={here} wrap="truncate-end">{truncate(cleanText(file.path), Math.max(10, width - 22))}</Text>
+              </Box>
+              <Text dimColor>{formatBytes(file.length)}</Text>
+            </Box>
+          );
+        })}
+      </Panel>
+      <Text dimColor>↑↓ move  ·  space toggle  ·  a all  ·  ↵ download  ·  esc cancel</Text>
+    </Box>
+  );
+}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -24,16 +24,19 @@ const MARK = 2;
 function statusColor(status: QueueItem["status"]): string {
   if (status === "failed") return COLOR.bad;
   if (status === "paused") return PAUSED;
+  if (status === "selecting") return COLOR.warn;
   return COLOR.accent;
 }
 
 function statusIcon(status: QueueItem["status"]): string {
   if (status === "failed") return ICON.error;
   if (status === "paused") return ICON.pause;
+  if (status === "selecting") return ICON.pending;
   return ICON.down;
 }
 
 function rightStats(it: QueueItem): string {
+  if (it.status === "selecting") return `choose files  ${it.files ?? 0} available`;
   if (it.status === "downloading") {
     // Real-Debrid first caches the torrent on its cloud (resolving), then we
     // pull it over HTTP — no swarm, so no peer count.

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,8 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    select(priority?: number): void;
+    deselect(): void;
   }
 
   interface Torrent extends EventEmitter {


### PR DESCRIPTION
## Summary
For multi-file torrents, prompt the user to choose which files to download rather than fetching the entire torrent. Selected files flow through the download queue and engine.

## Changes
- `src/ui/components/DownloadFilePrompt.tsx` — new file-selection prompt
- `src/download/queue.ts`, `src/download/engine.ts`, `src/download/types.ts` — carry and honour the file selection
- `src/ui/App.tsx`, `src/ui/components/Downloads.tsx` — wire the prompt into the download flow
- Tests added in `queue.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)