### PR TITLE
feat: add transfer limits and seeding targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Downloads run in the background while you keep searching, so you can queue up as
 
 When a torrent contains several files, torlink pauses before transferring payload data and lets you choose exactly which files to download. Use `Space` to toggle files, `a` to select all, and `Enter` to begin.
 
+Press `Shift+L` to set download/upload limits and automatic seeding targets. Values are entered as `download KB/s, upload KB/s, ratio, minutes`; zero or empty means unlimited. Seeding pauses when either configured target is reached.
+
 <p align="center">
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">
 </p>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -35,6 +35,10 @@ export interface Config {
   // Extra announce URLs (trackers) the user has added; appended to every
   // torrent added from now on.
   trackers: string[];
+  downloadLimitKbps?: number;
+  uploadLimitKbps?: number;
+  seedRatio?: number;
+  seedMinutes?: number;
 }
 
 export const defaultConfig: Config = {

--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -14,6 +14,8 @@ vi.mock("webtorrent", () => {
       add(): EventEmitter {
         return new EventEmitter();
       }
+      throttleDownload(): void {}
+      throttleUpload(): void {}
       destroy(): void {}
     },
   };

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -36,6 +36,8 @@ function message(e: unknown): string {
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+  private downloadLimit = -1;
+  private uploadLimit = -1;
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -49,8 +51,17 @@ export class TorrentEngine {
       const opts = process.platform === "darwin" ? { natPmp: false } : {};
       this.client = new WebTorrent(opts);
       this.client.on("error", () => {});
+      this.client.throttleDownload(this.downloadLimit);
+      this.client.throttleUpload(this.uploadLimit);
     }
     return this.client;
+  }
+
+  setLimits(downloadKbps?: number, uploadKbps?: number): void {
+    this.downloadLimit = downloadKbps && downloadKbps > 0 ? downloadKbps * 1024 : -1;
+    this.uploadLimit = uploadKbps && uploadKbps > 0 ? uploadKbps * 1024 : -1;
+    this.client?.throttleDownload(this.downloadLimit);
+    this.client?.throttleUpload(this.uploadLimit);
   }
 
   // `source` is a magnet URI, an infoHash, or a path to a .torrent file. Seeding

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -2,11 +2,22 @@ import path from "node:path";
 import os from "node:os";
 import { promises as fs } from "node:fs";
 import { describe, it, expect, afterEach } from "vitest";
-import { DownloadQueue, strayDownload, type DebridDeps } from "./queue";
+import { DownloadQueue, seedPolicyReached, strayDownload, type DebridDeps } from "./queue";
 import type { HistoryItem } from "./history";
 import { RealDebridError } from "../integrations/realdebrid";
 
 const tmpDirs: string[] = [];
+
+describe("seedPolicyReached", () => {
+  it("stops at either the configured ratio or duration", () => {
+    expect(seedPolicyReached(200, 100, 1_000, 2, 0)).toBe(true);
+    expect(seedPolicyReached(0, 100, 60_000, 0, 1)).toBe(true);
+    expect(seedPolicyReached(50, 100, 30_000, 2, 1)).toBe(false);
+  });
+  it("treats zero values as unlimited", () => {
+    expect(seedPolicyReached(10_000, 100, 10_000_000, 0, 0)).toBe(false);
+  });
+});
 async function tmpDir(): Promise<string> {
   const d = path.join(os.tmpdir(), `torlink-queue-${process.pid}-${tmpDirs.length}`);
   await fs.rm(d, { recursive: true, force: true });

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -75,6 +75,17 @@ export interface AddInput {
   sizeBytes?: number;
 }
 
+export function seedPolicyReached(
+  uploaded: number,
+  sizeBytes: number,
+  ageMs: number,
+  ratio: number,
+  minutes: number,
+): boolean {
+  return (ratio > 0 && sizeBytes > 0 && uploaded / sizeBytes >= ratio) ||
+    (minutes > 0 && ageMs >= minutes * 60_000);
+}
+
 export class DownloadQueue extends EventEmitter {
   private items = new Map<string, QueueItem>();
   private engine = new TorrentEngine();
@@ -92,12 +103,25 @@ export class DownloadQueue extends EventEmitter {
   private debridSem = new Semaphore(MAX_ACTIVE_DEBRID);
   private debridAttempts = new Map<string, number>();
   private trackers: string[] = [];
+  private seedRatio = 0;
+  private seedMinutes = 0;
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
   // for the next add / resume / re-seed.
   setTrackers(trackers: string[]): void {
     this.trackers = trackers;
+  }
+
+  setTransferPolicy(policy: {
+    downloadLimitKbps?: number;
+    uploadLimitKbps?: number;
+    seedRatio?: number;
+    seedMinutes?: number;
+  }): void {
+    this.engine.setLimits(policy.downloadLimitKbps, policy.uploadLimitKbps);
+    this.seedRatio = Math.max(0, policy.seedRatio ?? 0);
+    this.seedMinutes = Math.max(0, policy.seedMinutes ?? 0);
   }
 
   getItems(): QueueItem[] {
@@ -515,6 +539,17 @@ export class DownloadQueue extends EventEmitter {
       // hash-verify on-disk pieces, and during that window progress < 1 with
       // downloadSpeed > 0 is perfectly normal.
       const age = now - (this.seedStartedAt.get(sd.id) ?? 0);
+      if (seedPolicyReached(s.uploaded, sd.sizeBytes, age, this.seedRatio, this.seedMinutes)) {
+        this.engine.remove(sd.id);
+        this.seedStartedAt.delete(sd.id);
+        sd.status = "paused";
+        sd.uploadSpeed = 0;
+        sd.uploaded = s.uploaded;
+        sd.peers = 0;
+        void this.persistSeeds();
+        any = true;
+        continue;
+      }
       if (age > SEED_GRACE_MS && strayDownload(s)) {
         const hits = (this.strayHits.get(sd.id) ?? 0) + 1;
         this.strayHits.set(sd.id, hits);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -64,6 +64,7 @@ import { RutrackerPrompt, type LoginStatus } from "./components/RutrackerPrompt"
 import { Accounts } from "./components/Accounts";
 import { TrackersPrompt } from "./components/TrackersPrompt";
 import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
+import { LimitsPrompt, type TransferLimits } from "./components/LimitsPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -142,6 +143,7 @@ export function App({
   const [rutrackerCaptcha, setRutrackerCaptcha] = useState<Captcha | undefined>(undefined);
   const [rutrackerUser, setRutrackerUser] = useState<string | undefined>(undefined);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [editingLimits, setEditingLimits] = useState(false);
   const [pendingP2P, setPendingP2P] = useState<DownloadInput | null>(null);
   const [fileSelection, setFileSelection] = useState<QueueItem | null>(null);
   const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
@@ -176,6 +178,7 @@ export function App({
       const cfg = await loadConfig();
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
+      q.setTransferPolicy(cfg);
       q.restore(reconcileQueue(await loadQueue()));
       q.restoreHistory(await loadHistory());
       q.restoreSeeds(await loadSeeds());
@@ -299,6 +302,7 @@ export function App({
     (c: Config) => {
       setConfigState(c);
       queue?.setTrackers(c.trackers);
+      queue?.setTransferPolicy(c);
       void saveConfig(c);
     },
     [queue],
@@ -376,6 +380,13 @@ export function App({
     },
     [config, setConfig, closeTrackersPrompt],
   );
+
+  const setLimits = useCallback((limits: TransferLimits) => {
+    setEditingLimits(false);
+    if (!config) return;
+    setConfig({ ...config, ...limits });
+    setNotice("Transfer and seeding limits saved.");
+  }, [config, setConfig]);
 
   const setDownloadDir = useCallback(
     (raw: string) => {
@@ -958,7 +969,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
           ? "help"
           : region,
       setRegion,
@@ -1007,6 +1018,7 @@ export function App({
     editingDns,
     editingRutracker,
     editingTrackers,
+    editingLimits,
     toggleSource,
     pendingP2P,
     fileSelection,
@@ -1049,6 +1061,7 @@ export function App({
       if (editingDns) return; // the DNS prompt owns input
       if (editingRutracker) return; // the RuTracker prompt owns input
       if (editingTrackers) return; // the trackers prompt owns input
+      if (editingLimits) return; // the limits prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
       if (fileSelection) return; // the download file picker owns input
       if (torrentPrompt) return; // the torrent privacy warning owns input
@@ -1088,6 +1101,11 @@ export function App({
       if (input === "t") {
         setShowHelp(false);
         setEditingTrackers(true);
+        return;
+      }
+      if (input === "L") {
+        setShowHelp(false);
+        setEditingLimits(true);
         return;
       }
       if (input === "m") {
@@ -1398,11 +1416,22 @@ export function App({
           </Box>
         ) : null}
 
+        {editingLimits ? (
+          <Box marginTop={1}>
+            <LimitsPrompt
+              width={Math.max(30, Math.min(cols - 4, 72))}
+              value={store.config}
+              onSubmit={setLimits}
+              onCancel={() => setEditingLimits(false)}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
               ? "none"
               : "flex"
           }
@@ -1449,7 +1478,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
+              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
                 ? "none"
                 : "flex"
             }

--- a/src/ui/components/LimitsPrompt.test.ts
+++ b/src/ui/components/LimitsPrompt.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseLimits } from "./LimitsPrompt";
+
+describe("parseLimits", () => {
+  it("parses bandwidth and seed policy values", () => {
+    expect(parseLimits("5000,1000,2,60")).toEqual({
+      downloadLimitKbps: 5000, uploadLimitKbps: 1000, seedRatio: 2, seedMinutes: 60,
+    });
+  });
+  it("allows empty unlimited values and rejects invalid input", () => {
+    expect(parseLimits(",,1.5,")?.seedRatio).toBe(1.5);
+    expect(parseLimits("fast,1,2,3")).toBeNull();
+    expect(parseLimits("1,2,-1,3")).toBeNull();
+  });
+});

--- a/src/ui/components/LimitsPrompt.tsx
+++ b/src/ui/components/LimitsPrompt.tsx
@@ -1,0 +1,39 @@
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+
+export interface TransferLimits {
+  downloadLimitKbps?: number;
+  uploadLimitKbps?: number;
+  seedRatio?: number;
+  seedMinutes?: number;
+}
+
+export function parseLimits(raw: string): TransferLimits | null {
+  const values = raw.split(",").map((part) => part.trim());
+  if (values.length > 4) return null;
+  const parsed = values.map((value) => value === "" ? undefined : Number(value));
+  if (parsed.some((value) => value !== undefined && (!Number.isFinite(value) || value < 0))) return null;
+  return {
+    downloadLimitKbps: parsed[0], uploadLimitKbps: parsed[1],
+    seedRatio: parsed[2], seedMinutes: parsed[3],
+  };
+}
+
+export function LimitsPrompt({ width, value, onSubmit, onCancel }: {
+  width: number; value: TransferLimits; onSubmit: (limits: TransferLimits) => void; onCancel: () => void;
+}) {
+  useInput((_input, key) => { if (key.escape) onCancel(); });
+  const initial = [value.downloadLimitKbps, value.uploadLimitKbps, value.seedRatio, value.seedMinutes]
+    .map((v) => v ?? "").join(",");
+  return <Box flexDirection="column" width={width}>
+    <Panel title="transfer limits" width={width} focused height={2}>
+      <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+      <TextField defaultValue={initial} placeholder="download KB/s, upload KB/s, ratio, minutes" onSubmit={(raw) => {
+        const limits = parseLimits(raw); if (limits) onSubmit(limits);
+      }} />
+    </Panel>
+    <Text dimColor>0 or empty = unlimited. Example: 5000,1000,2,60</Text>
+  </Box>;
+}

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -22,6 +22,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "S", label: "Choose sources" },
       { keys: "D", label: "Custom DNS (bypass blocked networks)" },
       { keys: "t", label: "Extra trackers" },
+      { keys: "L", label: "Transfer and seeding limits" },
       { keys: "q", label: "Quit" },
     ],
   },

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -74,6 +74,8 @@ declare module "webtorrent" {
     get(torrentId: string): Torrent | null;
     remove(torrentId: string, cb?: (err?: Error) => void): void;
     destroy(cb?: (err?: Error) => void): void;
+    throttleDownload(rate: number): void;
+    throttleUpload(rate: number): void;
     createServer(opts?: { hostname?: string; pathname?: string }): TorrentServer;
   }
 


### PR DESCRIPTION
## Summary
Adds bandwidth (upload/download) limits and seeding targets so users can cap transfer rates and control how long/how much torrents seed after completing.

## Changes
- `src/config/config.ts` — persist limit/seeding settings
- `src/download/queue.ts`, `src/download/engine.ts` — apply rate limits and seeding targets
- `src/ui/components/LimitsPrompt.tsx`, `src/ui/App.tsx`, `src/ui/keymap.ts` — UI + keybinding to set limits
- Tests added in `engine.test.ts`, `queue.test.ts`, `LimitsPrompt.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)