### PR TITLE
feat: add saved-search Watchlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Type what you're looking for and press Enter. Results stream in from every sourc
 
 Press `s` to re-sort by seeders, size, or source, and `↑` in the search box to bring back a recent search. torlink remembers your sort and last category between runs, so it opens right where you left off.
 
+Press `w` on any named search to add or remove it from your Watchlist. The Watchlist pane keeps up to 50 saved searches; press `Enter` to run one again or `x` to remove it.
+
 <p align="center">
   <img src="preview/browse.svg" alt="torlink's browse view: the sidebar, the search bar, and merged results from every source" style="max-width: 832px; width: 100%; height: auto;">
 </p>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -87,6 +87,8 @@ function makeStore(
     query: "",
     submitQuery: noop,
     searchHistory: [],
+    savedSearches: [],
+    toggleSavedSearch: noop,
     openAccounts: noop,
     section: "all",
     setSection: noop,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,6 +24,7 @@ export interface Config {
   // Recently-run searches (most-recent first) for up-arrow recall in the
   // search bar.
   searchHistory?: string[];
+  savedSearches?: string[];
   // Sources the user has switched off; they're skipped during search. Stored as
   // opaque strings — unknown ids are simply ignored by the registry.
   disabledSources?: string[];
@@ -92,6 +93,9 @@ export async function loadConfig(): Promise<Config> {
     // can't feed junk into the download engine.
     cfg.trackers = Array.isArray(parsed.trackers)
       ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
+      : [];
+    cfg.savedSearches = Array.isArray(parsed.savedSearches)
+      ? parsed.savedSearches.filter((query): query is string => typeof query === "string" && query.trim().length > 0).slice(0, 50)
       : [];
     return cfg;
   } catch {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -40,6 +40,7 @@ import {
 } from "./store";
 import { formatSort, parseSort, type Sort } from "./sort";
 import { addToHistory } from "./searchHistory";
+import { toggleSavedSearches } from "./savedSearches";
 import { toggleDisabledSource } from "../sources/registry";
 import { Logo } from "./components/Logo";
 import { RdBadge } from "./components/RdBadge";
@@ -62,6 +63,7 @@ import { SourcesPrompt } from "./components/SourcesPrompt";
 import { DnsPrompt } from "./components/DnsPrompt";
 import { RutrackerPrompt, type LoginStatus } from "./components/RutrackerPrompt";
 import { Accounts } from "./components/Accounts";
+import { Watchlist } from "./components/Watchlist";
 import { TrackersPrompt } from "./components/TrackersPrompt";
 import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
 import { LimitsPrompt, type TransferLimits } from "./components/LimitsPrompt";
@@ -354,6 +356,20 @@ export function App({
       void saveConfig(next);
       return next;
     });
+  }, []);
+
+  const toggleSavedSearch = useCallback((raw: string) => {
+    const query = raw.trim();
+    if (!query) return;
+    setConfigState((prev) => {
+      if (!prev) return prev;
+      const current = prev.savedSearches ?? [];
+      const savedSearches = toggleSavedSearches(current, query);
+      const next = { ...prev, savedSearches };
+      void saveConfig(next);
+      return next;
+    });
+    setNotice("Watchlist updated.");
   }, []);
 
   const closeFolderPrompt = useCallback(() => {
@@ -961,6 +977,8 @@ export function App({
       query,
       submitQuery,
       searchHistory: config.searchHistory ?? [],
+      savedSearches: config.savedSearches ?? [],
+      toggleSavedSearch,
       openAccounts,
       section,
       setSection: changeSection,
@@ -1005,6 +1023,7 @@ export function App({
     query,
     submitQuery,
     openAccounts,
+    toggleSavedSearch,
     section,
     changeSection,
     sort,
@@ -1471,6 +1490,9 @@ export function App({
                 onManageRutracker={openRutrackerPrompt}
                 onSignOutRutracker={signOutRutracker}
               />
+            </Box>
+            <Box display={section === "watchlist" ? "flex" : "none"} flexDirection="column">
+              <Watchlist />
             </Box>
           </Box>
         </Box>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -184,6 +184,7 @@ export function Results() {
     queue,
     sort,
     setSort,
+    toggleSavedSearch,
   } = useStore();
 
   const search = useConcurrentSearch(query, disabledSources);
@@ -299,6 +300,8 @@ export function Results() {
       } else if (input === "z") {
         setAliveOnly((current) => !current);
         setCursor(0);
+      } else if (input === "w" && query.trim()) {
+        toggleSavedSearch(query.trim());
       }
     },
     { isActive: focused && mode === "list" },

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -13,6 +13,7 @@ const FILTERS: NavItem[] = CATEGORIES.map((c) => ({
   label: c.label,
 }));
 const LIBRARY: NavItem[] = [
+  { key: "watchlist", label: "Watchlist" },
   { key: "downloads", label: "Downloads" },
   { key: "seeding", label: "Seeding" },
   { key: "accounts", label: "Accounts" },

--- a/src/ui/components/Watchlist.tsx
+++ b/src/ui/components/Watchlist.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { useStore } from "../store";
+import { Panel } from "./Panel";
+import { wrapStep } from "../move";
+import { COLOR, GUTTER, ICON } from "../theme";
+
+export function Watchlist() {
+  const { savedSearches, toggleSavedSearch, submitQuery, setSection, region, section, contentWidth, listRows } = useStore();
+  const focused = region === "content" && section === "watchlist";
+  const [cursor, setCursor] = useState(0);
+  const clamped = Math.min(cursor, Math.max(0, savedSearches.length - 1));
+  useInput((input, key) => {
+    if (key.upArrow || input === "k") setCursor(wrapStep(clamped, -1, savedSearches.length));
+    else if (key.downArrow || input === "j") setCursor(wrapStep(clamped, 1, savedSearches.length));
+    else if (key.return) {
+      const query = savedSearches[clamped];
+      if (query) { submitQuery(query); setSection("all"); }
+    } else if (input === "x") {
+      const query = savedSearches[clamped]; if (query) toggleSavedSearch(query);
+    }
+  }, { isActive: focused && savedSearches.length > 0 });
+  return <Panel title="watchlist" width={contentWidth} focused={focused} height={Math.max(5, listRows - 1)}>
+    {savedSearches.length === 0 ? <Text dimColor>Save a search with w from the results view.</Text> :
+      <Box flexDirection="column">{savedSearches.map((query, index) => <Box key={query}>
+        <Box width={GUTTER}><Text color={COLOR.accent}>{focused && index === clamped ? ICON.pointer : ""}</Text></Box>
+        <Text color={index === clamped ? COLOR.accent : undefined}>{query}</Text>
+      </Box>)}</Box>}
+  </Panel>;
+}

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -42,6 +42,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "↑", label: "Recall recent searches (while editing)" },
       { keys: "s", label: "Sort results" },
       { keys: "z", label: "Hide results with no seeders" },
+      { keys: "w", label: "Save or remove current search" },
       { keys: "d", label: "Download (P2P)" },
       { keys: "r", label: "Download via Real-Debrid" },
       { keys: "v", label: "Stream" },
@@ -111,6 +112,9 @@ export function footerHints(
       ALWAYS,
     ];
   }
+  if (section === "watchlist") {
+    return [NAVIGATE, { keys: "↵", label: "Run" }, { keys: "x", label: "Remove" }, SWITCH, ALWAYS];
+  }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
       return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, FOLDER, SWITCH, ALWAYS];
@@ -146,6 +150,7 @@ export function footerHints(
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "z", label: "Alive" },
+    { keys: "w", label: "Watch" },
     { keys: "/", label: "Search" },
     SWITCH,
     ALWAYS,

--- a/src/ui/savedSearches.test.ts
+++ b/src/ui/savedSearches.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { toggleSavedSearches } from "./savedSearches";
+
+describe("toggleSavedSearches", () => {
+  it("adds, removes, trims, and caps saved searches", () => {
+    expect(toggleSavedSearches(["old"], " new ")).toEqual(["new", "old"]);
+    expect(toggleSavedSearches(["new", "old"], "new")).toEqual(["old"]);
+    expect(toggleSavedSearches(["a", "b"], "c", 2)).toEqual(["c", "a"]);
+  });
+});

--- a/src/ui/savedSearches.ts
+++ b/src/ui/savedSearches.ts
@@ -1,0 +1,7 @@
+export function toggleSavedSearches(current: readonly string[], raw: string, limit = 50): string[] {
+  const query = raw.trim();
+  if (!query) return [...current];
+  return current.includes(query)
+    ? current.filter((item) => item !== query)
+    : [query, ...current].slice(0, limit);
+}

--- a/src/ui/store.test.ts
+++ b/src/ui/store.test.ts
@@ -25,6 +25,7 @@ describe("parseCategory", () => {
 describe("isCategory", () => {
   it("excludes the downloads/seeding/accounts sections", () => {
     expect(isCategory("accounts")).toBe(false);
+    expect(isCategory("watchlist")).toBe(false);
     expect(isCategory("downloads")).toBe(false);
     expect(isCategory("seeding")).toBe(false);
   });

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -11,12 +11,12 @@ export type View = "splash" | "browser";
 
 export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music" | "books";
 
-export type Section = Category | "downloads" | "seeding" | "accounts";
+export type Section = Category | "watchlist" | "downloads" | "seeding" | "accounts";
 
 // The "category" sections (all/games/movies/tv/anime) — i.e. the results view,
 // as opposed to the downloads/seeding/accounts views.
 export function isCategory(section: Section): boolean {
-  return section !== "downloads" && section !== "seeding" && section !== "accounts";
+  return section !== "watchlist" && section !== "downloads" && section !== "seeding" && section !== "accounts";
 }
 
 export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[] = [
@@ -54,6 +54,8 @@ export interface Store {
   submitQuery: (q: string) => void;
   // Recently-run searches (most-recent first) for up-arrow recall.
   searchHistory: string[];
+  savedSearches: string[];
+  toggleSavedSearch: (query: string) => void;
   // Jump to the browser view, select the Accounts pane, and focus it.
   openAccounts: () => void;
 


### PR DESCRIPTION
## Summary
Lets users save searches to a Watchlist and revisit them later from a dedicated sidebar view — the foundation for saved searches / subscriptions.

## Changes
- `src/ui/components/Watchlist.tsx` — new Watchlist view
- `src/ui/savedSearches.ts`, `src/ui/store.ts`, `src/config/config.ts` — persist and manage saved searches
- `src/ui/components/Sidebar.tsx`, `src/ui/components/Results.tsx`, `src/ui/App.tsx`, `src/ui/keymap.ts` — wire into UI + keybindings
- Tests added in `savedSearches.test.ts`, `store.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)