### PR TITLE
feat: add fail-closed VPN route guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Before opening a PR, skim [CONTRIBUTING.md](CONTRIBUTING.md); it lays out the ba
 
 Your files stay on your disk, and nothing routes through a central server; torlink only talks to the torrent network directly. Once a download finishes it keeps seeding by default, sharing it back so the next person can find it just as easily. The network only works because people pass things along, and even a few minutes makes a real difference. If you'd rather not, opt out anytime: open the Seeding tab, press `p` to pause or stop any item, and press it again to pick it back up. Always your call.
 
+For a fail-closed VPN setup, press `Shift+V` and enter the VPN interface name (`tun0`, `utun4`, or the Windows interface alias). Before any P2P download or stream starts, torlink verifies that the interface exists and owns the default route. It continues monitoring once per second and tears down active P2P sessions if that route changes. Real-Debrid transfers are unaffected. This is a route kill switch, not a replacement for firewall-level VPN rules.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=WarlaxZ%2Ftorlink&type=date&legend=top-left">

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -112,3 +112,10 @@ describe("config torrentStreamAck", () => {
     expect(cfg.torrentStreamAck).toBe(true);
   });
 });
+
+describe("config vpnInterface", () => {
+  it("round-trips the VPN kill-switch interface", async () => {
+    await saveConfig({ downloadDir: "/tmp/dl", trackers: [], vpnInterface: "tun0" });
+    expect((await loadConfig()).vpnInterface).toBe("tun0");
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,6 +40,8 @@ export interface Config {
   uploadLimitKbps?: number;
   seedRatio?: number;
   seedMinutes?: number;
+  // Fail-closed P2P guard: this interface must exist and own the default route.
+  vpnInterface?: string;
 }
 
 export const defaultConfig: Config = {

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -105,6 +105,12 @@ export class DownloadQueue extends EventEmitter {
   private trackers: string[] = [];
   private seedRatio = 0;
   private seedMinutes = 0;
+  private p2pAllowed = true;
+
+  setP2PAllowed(allowed: boolean): void {
+    this.p2pAllowed = allowed;
+    if (!allowed) this.killP2P();
+  }
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
@@ -172,6 +178,11 @@ export class DownloadQueue extends EventEmitter {
   }
 
   private startEngine(item: QueueItem): void {
+    if (!this.p2pAllowed) {
+      item.status = "paused";
+      item.error = "VPN kill switch blocked peer-to-peer traffic.";
+      return;
+    }
     this.engine.add(
       item.id,
       item.magnet,
@@ -647,6 +658,27 @@ export class DownloadQueue extends EventEmitter {
     if (!it) return;
     if (it.status === "downloading") this.pause(id);
     else if (it.status === "paused") this.resume(id);
+  }
+
+  killP2P(): void {
+    for (const item of this.items.values()) {
+      if (item.via === "realdebrid" || item.status !== "downloading") continue;
+      item.status = "paused";
+      item.speed = 0;
+      item.peers = 0;
+      this.engine.remove(item.id);
+    }
+    for (const seed of this.seeds.values()) {
+      if (seed.status !== "seeding") continue;
+      seed.status = "paused";
+      seed.uploadSpeed = 0;
+      seed.peers = 0;
+      this.engine.remove(seed.id);
+    }
+    this.changed();
+    void this.persist();
+    void this.persistSeeds();
+    this.maybeStopPoll();
   }
 
   // Delete a Real-Debrid item's partial files on disk (used when cancelling a

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -67,6 +67,7 @@ import { Watchlist } from "./components/Watchlist";
 import { TrackersPrompt } from "./components/TrackersPrompt";
 import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
 import { LimitsPrompt, type TransferLimits } from "./components/LimitsPrompt";
+import { VpnPrompt } from "./components/VpnPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -81,6 +82,7 @@ import {
 } from "../sources/rutracker/session";
 import { clearRutrackerCache } from "../sources/rutracker";
 import { clearCacheByPrefix } from "../sources/cache";
+import { vpnRouteIsSafe } from "../util/vpn";
 
 export interface DownloadInput {
   id: string;
@@ -146,6 +148,7 @@ export function App({
   const [rutrackerUser, setRutrackerUser] = useState<string | undefined>(undefined);
   const [editingTrackers, setEditingTrackers] = useState(false);
   const [editingLimits, setEditingLimits] = useState(false);
+  const [editingVpn, setEditingVpn] = useState(false);
   const [pendingP2P, setPendingP2P] = useState<DownloadInput | null>(null);
   const [fileSelection, setFileSelection] = useState<QueueItem | null>(null);
   const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
@@ -169,6 +172,7 @@ export function App({
   const [keepPrompt, setKeepPrompt] = useState<
     { session: TorrentStreamSession; input: DownloadInput } | null
   >(null);
+  const vpnUnsafe = useRef(false);
   const prepareAbort = useRef<AbortController | null>(null);
   const booting = useRef(false);
 
@@ -404,6 +408,24 @@ export function App({
     setNotice("Transfer and seeding limits saved.");
   }, [config, setConfig]);
 
+  const setVpnInterface = useCallback((raw: string) => {
+    setEditingVpn(false);
+    if (!config) return;
+    const vpnInterface = raw.trim() || undefined;
+    setConfig({ ...config, vpnInterface });
+    setNotice(vpnInterface ? `VPN guard set to ${vpnInterface}.` : "VPN guard disabled.");
+  }, [config, setConfig]);
+
+  const ensureVpnSafe = useCallback(async (): Promise<boolean> => {
+    const name = config?.vpnInterface?.trim();
+    if (!name) return true;
+    const safe = await vpnRouteIsSafe(name);
+    queue?.setP2PAllowed(safe);
+    if (!safe) setNotice(`P2P blocked: ${name} is not the active default route.`);
+    return safe;
+  }, [config, queue]);
+
+
   const setDownloadDir = useCallback(
     (raw: string) => {
       closeFolderPrompt();
@@ -486,11 +508,14 @@ export function App({
   const startDownload = useCallback(
     (input: DownloadInput) => {
       if (!config || !queue) return;
-      void fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});
-      queue.add(input, config.downloadDir);
-      setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
+      void (async () => {
+        if (!(await ensureVpnSafe())) return;
+        await fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});
+        queue.add(input, config.downloadDir);
+        setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
+      })();
     },
-    [config, queue],
+    [config, queue, ensureVpnSafe],
   );
 
   const startDebridDownload = useCallback(
@@ -565,6 +590,10 @@ export function App({
       });
       void (async () => {
         try {
+          if (!(await ensureVpnSafe())) {
+            setPreparing(null);
+            return;
+          }
           const session = await streamTorrent(input.magnet, { signal: controller.signal });
           if (controller.signal.aborted) {
             void session.stop();
@@ -592,8 +621,34 @@ export function App({
         }
       })();
     },
-    [config, preparing, streamFiles, activeStream, playStream],
+    [config, preparing, streamFiles, activeStream, playStream, ensureVpnSafe],
   );
+
+  useEffect(() => {
+    const name = config?.vpnInterface?.trim();
+    if (!queue) return;
+    if (!name) { vpnUnsafe.current = false; queue.setP2PAllowed(true); return; }
+    let alive = true;
+    const check = async (): Promise<void> => {
+      const safe = await vpnRouteIsSafe(name);
+      if (!alive) return;
+      queue.setP2PAllowed(safe);
+      if (!safe && !vpnUnsafe.current) {
+        vpnUnsafe.current = true;
+        const active = activeStreamRef.current;
+        if (active) {
+          activeStreamRef.current = null;
+          setActiveStream(null);
+          void active.session.stop();
+        }
+        setNotice(`VPN kill switch: ${name} lost the default route; P2P stopped.`);
+      } else if (safe) vpnUnsafe.current = false;
+    };
+    void check();
+    const timer = setInterval(() => void check(), 1000);
+    timer.unref();
+    return () => { alive = false; clearInterval(timer); };
+  }, [config?.vpnInterface, queue]);
 
   const stopStream = useCallback(() => {
     const active = activeStream;
@@ -987,7 +1042,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
           ? "help"
           : region,
       setRegion,
@@ -1038,6 +1093,7 @@ export function App({
     editingRutracker,
     editingTrackers,
     editingLimits,
+    editingVpn,
     toggleSource,
     pendingP2P,
     fileSelection,
@@ -1081,6 +1137,7 @@ export function App({
       if (editingRutracker) return; // the RuTracker prompt owns input
       if (editingTrackers) return; // the trackers prompt owns input
       if (editingLimits) return; // the limits prompt owns input
+      if (editingVpn) return; // the VPN prompt owns input
       if (pendingP2P) return; // the P2P warning owns input
       if (fileSelection) return; // the download file picker owns input
       if (torrentPrompt) return; // the torrent privacy warning owns input
@@ -1125,6 +1182,11 @@ export function App({
       if (input === "L") {
         setShowHelp(false);
         setEditingLimits(true);
+        return;
+      }
+      if (input === "V") {
+        setShowHelp(false);
+        setEditingVpn(true);
         return;
       }
       if (input === "m") {
@@ -1446,11 +1508,22 @@ export function App({
           </Box>
         ) : null}
 
+        {editingVpn ? (
+          <Box marginTop={1}>
+            <VpnPrompt
+              width={Math.max(30, Math.min(cols - 4, 72))}
+              value={store.config.vpnInterface ?? ""}
+              onSubmit={setVpnInterface}
+              onCancel={() => setEditingVpn(false)}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
               ? "none"
               : "flex"
           }
@@ -1500,7 +1573,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
+              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || streamFiles || preparing || torrentPrompt || keepPrompt
                 ? "none"
                 : "flex"
             }

--- a/src/ui/components/VpnPrompt.tsx
+++ b/src/ui/components/VpnPrompt.tsx
@@ -1,0 +1,17 @@
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { TextField } from "./TextField";
+import { COLOR, ICON } from "../theme";
+
+export function VpnPrompt({ width, value, onSubmit, onCancel }: {
+  width: number; value: string; onSubmit: (value: string) => void; onCancel: () => void;
+}) {
+  useInput((_input, key) => { if (key.escape) onCancel(); });
+  return <Box flexDirection="column" width={width}>
+    <Panel title="VPN kill switch" width={width} focused height={2}>
+      <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+      <TextField defaultValue={value} placeholder="interface name (tun0, utun4, My VPN)" onSubmit={onSubmit} />
+    </Panel>
+    <Text dimColor>Empty disables. P2P is blocked unless this interface owns the default route.</Text>
+  </Box>;
+}

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -23,6 +23,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "D", label: "Custom DNS (bypass blocked networks)" },
       { keys: "t", label: "Extra trackers" },
       { keys: "L", label: "Transfer and seeding limits" },
+      { keys: "V", label: "VPN kill switch" },
       { keys: "q", label: "Quit" },
     ],
   },

--- a/src/util/vpn.test.ts
+++ b/src/util/vpn.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { parseDefaultInterface } from "./vpn";
+
+describe("parseDefaultInterface", () => {
+  it("parses Linux, macOS, and Windows default routes", () => {
+    expect(parseDefaultInterface("linux", "default via 10.0.0.1 dev tun0 proto static")).toBe("tun0");
+    expect(parseDefaultInterface("darwin", "   route to: default\ninterface: utun4\n")).toBe("utun4");
+    expect(parseDefaultInterface("win32", "My VPN\r\n")).toBe("My VPN");
+  });
+});

--- a/src/util/vpn.ts
+++ b/src/util/vpn.ts
@@ -1,0 +1,31 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { networkInterfaces } from "node:os";
+
+const run = promisify(execFile);
+
+export function parseDefaultInterface(platform: NodeJS.Platform, output: string): string | null {
+  if (platform === "linux") return output.match(/\bdev\s+(\S+)/)?.[1] ?? null;
+  if (platform === "darwin") return output.match(/^\s*interface:\s*(\S+)/m)?.[1] ?? null;
+  if (platform === "win32") return output.trim().split(/\r?\n/).find(Boolean)?.trim() ?? null;
+  return null;
+}
+
+export async function defaultRouteInterface(platform: NodeJS.Platform = process.platform): Promise<string | null> {
+  try {
+    if (platform === "linux") return parseDefaultInterface(platform, (await run("ip", ["route", "show", "default"])).stdout);
+    if (platform === "darwin") return parseDefaultInterface(platform, (await run("route", ["-n", "get", "default"])).stdout);
+    if (platform === "win32") return parseDefaultInterface(platform, (await run("powershell.exe", [
+      "-NoProfile", "-Command", "(Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object RouteMetric | Select-Object -First 1).InterfaceAlias",
+    ])).stdout);
+  } catch {}
+  return null;
+}
+
+export async function vpnRouteIsSafe(name: string): Promise<boolean> {
+  const wanted = name.trim();
+  if (!wanted) return true;
+  const addresses = networkInterfaces()[wanted];
+  if (!addresses?.some((address) => !address.internal)) return false;
+  return (await defaultRouteInterface()) === wanted;
+}


### PR DESCRIPTION
## Summary
Adds fail-closed VPN binding / leak protection: downloads are blocked when the VPN interface is down or unbound, preventing traffic from leaking over the default route.

## Changes
- `src/util/vpn.ts` — detect VPN interface / route state
- `src/download/queue.ts`, `src/ui/App.tsx` — gate downloads on VPN state (fail-closed)
- `src/ui/components/VpnPrompt.tsx`, `src/ui/keymap.ts` — UI + keybinding
- `src/config/config.ts` — persist VPN guard settings
- Tests added in `vpn.test.ts`, `config.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)