### PR TITLE
feat: publish self-contained release bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release binaries
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: torlnk-linux-x64.tar.gz
+            archive: tar
+          - os: macos-15-intel
+            asset: torlnk-macos-x64.tar.gz
+            archive: tar
+          - os: macos-15
+            asset: torlnk-macos-arm64.tar.gz
+            archive: tar
+          - os: windows-latest
+            asset: torlnk-windows-x64.zip
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm prune --omit=dev
+      - name: Package self-contained runtime (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir torlnk-runtime
+          cp "$(command -v node)" torlnk-runtime/node
+          cp -R dist node_modules package.json LICENSE README.md torlnk-runtime/
+          printf '%s\n' '#!/bin/sh' 'DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)' 'exec "$DIR/node" "$DIR/dist/cli.cjs" "$@"' > torlnk-runtime/torlnk
+          chmod +x torlnk-runtime/node torlnk-runtime/torlnk
+          tar -czf "${{ matrix.asset }}" torlnk-runtime
+      - name: Package self-contained runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory torlnk-runtime
+          Copy-Item (Get-Command node).Source torlnk-runtime/node.exe
+          Copy-Item -Recurse dist,node_modules torlnk-runtime/
+          Copy-Item package.json,LICENSE,README.md torlnk-runtime/
+          Set-Content torlnk-runtime/torlnk.cmd '@echo off`r`n"%~dp0node.exe" "%~dp0dist\cli.cjs" %*'
+          Compress-Archive -Path torlnk-runtime -DestinationPath "${{ matrix.asset }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - run: cd artifacts && sha256sum torlnk-* > SHA256SUMS
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/torlnk-*
+            artifacts/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+sea-prep.blob
 .DS_Store
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ torlink is a torrent finder that lives in your terminal, with zero setup and not
 
 ## Get started
 
-This is a fork, so it isn't published to npm — you build it from source once, then run it. All you need is [Node 22+](https://nodejs.org).
+Download a standalone executable from [Releases](https://github.com/WarlaxZ/torlink/releases), or install the latest macOS/Linux build without Node:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/WarlaxZ/torlink/main/scripts/install.sh | sh
+```
+
+You can still build from source with [Node 22+](https://nodejs.org):
 
 1. **Clone this repo** and open the folder.
 2. **Install and build:**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+repo="${TORLINK_REPO:-WarlaxZ/torlink}"
+install_dir="${TORLINK_INSTALL_DIR:-$HOME/.local/bin}"
+runtime_dir="${TORLINK_RUNTIME_DIR:-$HOME/.local/share/torlnk}"
+os=$(uname -s)
+arch=$(uname -m)
+
+case "$os:$arch" in
+  Linux:x86_64|Linux:amd64) asset=torlnk-linux-x64.tar.gz ;;
+  Darwin:x86_64) asset=torlnk-macos-x64.tar.gz ;;
+  Darwin:arm64) asset=torlnk-macos-arm64.tar.gz ;;
+  *) echo "No prebuilt torlnk binary for $os/$arch" >&2; exit 1 ;;
+esac
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+base="https://github.com/$repo/releases/latest/download"
+curl -fL "$base/$asset" -o "$tmp/$asset"
+curl -fL "$base/SHA256SUMS" -o "$tmp/SHA256SUMS"
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$tmp" && grep "  $asset\$" SHA256SUMS | sha256sum -c -)
+else
+  (cd "$tmp" && grep "  $asset\$" SHA256SUMS | shasum -a 256 -c -)
+fi
+tar -xzf "$tmp/$asset" -C "$tmp"
+mkdir -p "$install_dir"
+rm -rf "$runtime_dir"
+mkdir -p "$(dirname "$runtime_dir")"
+mv "$tmp/torlnk-runtime" "$runtime_dir"
+printf '%s\n' '#!/bin/sh' "exec \"$runtime_dir/node\" \"$runtime_dir/dist/cli.cjs\" \"\$@\"" > "$install_dir/torlnk"
+chmod 755 "$install_dir/torlnk"
+echo "Installed torlnk to $install_dir/torlnk"


### PR DESCRIPTION
## Summary
Adds distribution/packaging improvements so users can install torlink without a dev toolchain: a GitHub Actions release workflow that builds and publishes self-contained release bundles, plus a one-line install script.

## Changes
- `.github/workflows/release.yml` — CI workflow to build and publish self-contained release bundles on tag
- `scripts/install.sh` — one-line installer that fetches and installs a release bundle
- `README.md` — document the install flow
- `.gitignore` — ignore build/release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)