### PR TITLE
fix(splash): stop single-key shortcuts firing while typing a search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.1.1",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -89,7 +89,6 @@ function makeStore(
     searchHistory: [],
     savedSearches: [],
     toggleSavedSearch: noop,
-    openAccounts: noop,
     section: "all",
     setSection: noop,
     sort: "none",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -458,13 +458,6 @@ export function App({
     setEditingToken(true);
   }, []);
 
-  const openAccounts = useCallback(() => {
-    setView("browser");
-    setShowHelp(false);
-    setSection("accounts");
-    setRegion("content");
-  }, []);
-
   const setRealDebridToken = useCallback(
     (raw: string) => {
       closeTokenPrompt();
@@ -1034,7 +1027,6 @@ export function App({
       searchHistory: config.searchHistory ?? [],
       savedSearches: config.savedSearches ?? [],
       toggleSavedSearch,
-      openAccounts,
       section,
       setSection: changeSection,
       sort,
@@ -1077,7 +1069,6 @@ export function App({
     view,
     query,
     submitQuery,
-    openAccounts,
     toggleSavedSearch,
     section,
     changeSection,

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -56,8 +56,6 @@ export interface Store {
   searchHistory: string[];
   savedSearches: string[];
   toggleSavedSearch: (query: string) => void;
-  // Jump to the browser view, select the Accounts pane, and focus it.
-  openAccounts: () => void;
 
   section: Section;
   setSection: (s: Section) => void;

--- a/src/ui/views/Splash.test.tsx
+++ b/src/ui/views/Splash.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { StoreContext, type Store } from "../store";
+import { Splash } from "./Splash";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const TAB = "\t";
+const ESC = String.fromCharCode(27);
+
+function storeStub(overrides: Partial<Store> = {}): Store {
+  return {
+    submitQuery: () => {},
+    searchHistory: [],
+    quitAll: () => {},
+    cols: 80,
+    rows: 24,
+    debridConfigured: false,
+    rdStatus: null,
+    setView: () => {},
+    setRegion: () => {},
+    ...overrides,
+  } as unknown as Store;
+}
+
+function renderSplash(overrides: Partial<Store> = {}) {
+  return render(
+    <StoreContext.Provider value={storeStub(overrides)}>
+      <Splash />
+    </StoreContext.Provider>,
+  );
+}
+
+describe("Splash", () => {
+  it("does not navigate away when the query starts with a shortcut letter", async () => {
+    // Regression: typing the first letter of a search (e.g. the "a" of "alex")
+    // must not fire a single-key shortcut, because the search field is always
+    // focused here and owns every printable keystroke.
+    const setView = vi.fn();
+    const setRegion = vi.fn();
+    const { stdin } = renderSplash({ setView, setRegion });
+    await flush();
+    stdin.write("a");
+    await flush();
+    expect(setView).not.toHaveBeenCalled();
+    expect(setRegion).not.toHaveBeenCalled();
+  });
+
+  it("drops into the sidebar menu on tab", async () => {
+    const setView = vi.fn();
+    const setRegion = vi.fn();
+    const { stdin } = renderSplash({ setView, setRegion });
+    await flush();
+    stdin.write(TAB);
+    await flush();
+    expect(setView).toHaveBeenCalledWith("browser");
+    expect(setRegion).toHaveBeenCalledWith("sidebar");
+  });
+
+  it("submits the typed query on enter", async () => {
+    const submitQuery = vi.fn();
+    const { stdin } = renderSplash({ submitQuery });
+    await flush();
+    stdin.write("alex");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(submitQuery).toHaveBeenCalledWith("alex");
+  });
+
+  it("quits on escape", async () => {
+    const quitAll = vi.fn();
+    const { stdin } = renderSplash({ quitAll });
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(quitAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -11,13 +11,18 @@ const CATEGORIES = sourcesByGroup()
   .join(`  ${ICON.dot}  `);
 
 export function Splash() {
-  const { submitQuery, searchHistory, quitAll, cols, rows, debridConfigured, rdStatus, openAccounts } = useStore();
+  const { submitQuery, searchHistory, quitAll, cols, rows, debridConfigured, rdStatus, setView, setRegion } = useStore();
   const { isRawModeSupported } = useStdin();
 
   useInput(
     (input, key) => {
-      if (input === "a") {
-        openAccounts();
+      // The search field is always focused on the splash, so it owns every
+      // printable keystroke — no single-key shortcuts here, or typing a query
+      // like "alex" would trigger them. Tab drops into the app's sidebar menu
+      // (where the shortcuts live); esc / ^c quit.
+      if (key.tab) {
+        setView("browser");
+        setRegion("sidebar");
         return;
       }
       if (key.escape || (key.ctrl && input === "c")) quitAll();


### PR DESCRIPTION
## Problem

On the main search landing page (the splash), the search field is **always focused**, but the splash registered its own single-key `a` → Accounts shortcut with no guard. Because Ink dispatches every keystroke to *all* active `useInput` handlers, typing a query like **"alex"** fired the shortcut on the first keystroke and immediately navigated to the Accounts pane.

## Fix

Make the splash **search-only** and adopt the same rule the browser view already follows (a focused search box owns all printable input):

- Remove the `a` → Accounts keypress. Nothing you type can navigate away.
- **Tab** drops into the app's sidebar menu, where the shortcuts and navigation live (`setView("browser")` + focus the sidebar). Accounts/Watchlist/etc. remain reachable from there.
- `↑/↓` history recall, Enter to search, and esc/^c to quit are unchanged.
- Remove the now-dead `openAccounts` store action (and its preview-script stub).

## Tests

Added `src/ui/views/Splash.test.tsx` (drives the real Ink input path via `ink-testing-library`):
- typing the first letter of a query no longer navigates (regression)
- Tab drops into the sidebar menu
- Enter still submits the typed query
- esc still quits

Full suite: 327 tests pass, `tsc --noEmit` clean. Patch version bump to `1.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)