### PR TITLE
Stream picker: title sort + toggle, taller list; broader Windows player detection

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -605,7 +605,9 @@ export function App({
           }
           prepareAbort.current = null;
           setPreparing(null);
-          const candidates = streamCandidates(session.files).sort((a, b) => b.bytes - a.bytes);
+          // StreamFilePrompt orders the list (title by default, size on toggle),
+          // so the pre-sort here only decided candidates[0] for the single-file case.
+          const candidates = streamCandidates(session.files);
           if (candidates.length === 0) {
             setNotice("This torrent has nothing to stream.");
             void session.stop();
@@ -737,7 +739,8 @@ export function App({
           });
           if (controller.signal.aborted) return;
           prepareAbort.current = null;
-          const candidates = streamCandidates(files).sort((a, b) => b.bytes - a.bytes);
+          // Ordering is handled by StreamFilePrompt; a single candidate needs none.
+          const candidates = streamCandidates(files);
           if (candidates.length === 0) {
             setPreparing(null);
             setNotice("Real-Debrid returned nothing to stream.");
@@ -1426,6 +1429,7 @@ export function App({
           <Box marginTop={1}>
             <StreamFilePrompt
               width={Math.max(24, Math.min(cols - 4, 72))}
+              maxRows={Math.max(3, bodyH - 4)}
               files={streamFiles}
               onSelect={(file) => finishStream(file)}
               onCancel={() => {

--- a/src/ui/components/StreamFilePrompt.tsx
+++ b/src/ui/components/StreamFilePrompt.tsx
@@ -1,43 +1,92 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { Panel } from "./Panel";
 import { COLOR, GUTTER, ICON } from "../theme";
 import { formatBytes, cleanText, truncate } from "../../util/format";
 import type { ResolvedFile } from "../../integrations/realdebrid";
 
+type SortMode = "name" | "size";
+
 interface StreamFilePromptProps {
   width: number;
   files: ResolvedFile[];
   onSelect: (file: ResolvedFile) => void;
   onCancel: () => void;
+  // Max rows the file list body may occupy. The caller sizes this from the
+  // available window height so the list fills most of the screen.
+  maxRows?: number;
 }
 
-// Pick a file to stream when a torrent holds several videos. Files arrive
-// largest-first (sorted by the caller), so cursor 0 is the most likely pick.
-export function StreamFilePrompt({ width, files, onSelect, onCancel }: StreamFilePromptProps) {
-  const [cursor, setCursor] = useState(0);
-  const clamped = Math.min(cursor, Math.max(0, files.length - 1));
+// Order the candidates by title (case/number-aware) or by size, largest-first.
+function sortFiles(files: ResolvedFile[], mode: SortMode): ResolvedFile[] {
+  const copy = [...files];
+  if (mode === "name") {
+    copy.sort((a, b) =>
+      cleanText(a.filename).localeCompare(cleanText(b.filename), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    );
+  } else {
+    copy.sort((a, b) => b.bytes - a.bytes);
+  }
+  return copy;
+}
 
-  useInput((_input, key) => {
+// Pick a file to stream when a torrent holds several videos. Defaults to sorting
+// by title; press "s" to toggle between title and size ordering.
+export function StreamFilePrompt({ width, files, onSelect, onCancel, maxRows = 8 }: StreamFilePromptProps) {
+  const [cursor, setCursor] = useState(0);
+  const [sortMode, setSortMode] = useState<SortMode>("name");
+  const sorted = useMemo(() => sortFiles(files, sortMode), [files, sortMode]);
+  const clamped = Math.min(cursor, Math.max(0, sorted.length - 1));
+
+  useInput((input, key) => {
     if (key.escape) {
       onCancel();
       return;
     }
+    if (input === "s" || input === "S") {
+      // Keep the highlighted file selected across the re-sort.
+      const current = sorted[clamped];
+      const next: SortMode = sortMode === "name" ? "size" : "name";
+      setSortMode(next);
+      if (current) {
+        const idx = sortFiles(files, next).findIndex((f) => f.url === current.url);
+        if (idx >= 0) setCursor(idx);
+      }
+      return;
+    }
     if (key.upArrow) setCursor(Math.max(0, clamped - 1));
-    else if (key.downArrow) setCursor(Math.min(files.length - 1, clamped + 1));
+    else if (key.downArrow) setCursor(Math.min(sorted.length - 1, clamped + 1));
     else if (key.return) {
-      const file = files[clamped];
+      const file = sorted[clamped];
       if (file) onSelect(file);
     }
   });
 
   const nameW = Math.max(10, width - 16);
+  // Scroll a window over the list so the cursor stays visible when the archive
+  // holds more files than fit on screen.
+  const visible = Math.max(1, Math.min(sorted.length, maxRows));
+  const start = Math.min(
+    Math.max(0, clamped - visible + 1),
+    Math.max(0, sorted.length - visible),
+  );
+  const windowFiles = sorted.slice(start, start + visible);
 
   return (
     <Box flexDirection="column" width={width}>
-      <Panel title="choose a file to stream" width={width} focused height={Math.min(files.length, 8)}>
-        {files.slice(0, 8).map((file, i) => {
-          const here = i === clamped;
+      <Panel
+        title="choose a file to stream"
+        width={width}
+        focused
+        count={`${clamped + 1}/${sorted.length}`}
+        height={visible + 1}
+      >
+        {windowFiles.map((file, i) => {
+          const index = start + i;
+          const here = index === clamped;
           return (
             <Box key={file.url}>
               <Box width={GUTTER} flexShrink={0}>
@@ -61,6 +110,9 @@ export function StreamFilePrompt({ width, files, onSelect, onCancel }: StreamFil
         <Text dimColor>{`     ${ICON.dot}     `}</Text>
         <Text color={COLOR.alt}>↵</Text>
         <Text dimColor> stream</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>s</Text>
+        <Text dimColor>{` sort: ${sortMode}`}</Text>
         <Text dimColor>{`     ${ICON.dot}     `}</Text>
         <Text color={COLOR.alt}>esc</Text>
         <Text dimColor> cancel</Text>

--- a/src/util/player.test.ts
+++ b/src/util/player.test.ts
@@ -67,6 +67,58 @@ describe("detectPlayer", () => {
     });
     expect(found).toBeNull();
   });
+
+  it("finds a Windows install path when nothing is on PATH", async () => {
+    const found = await detectPlayer({
+      which: async () => false,
+      winFind: async (paths) => (paths.some((p) => p.includes("VLC")) ? "C:\\VLC\\vlc.exe" : null),
+      platform: "win32",
+    });
+    expect(found).toBe("C:\\VLC\\vlc.exe");
+  });
+
+  it("falls back to Windows Media Player when VLC is absent", async () => {
+    const found = await detectPlayer({
+      which: async () => false,
+      winFind: async (paths) =>
+        paths.some((p) => p.includes("Windows Media Player"))
+          ? "C:\\Program Files\\Windows Media Player\\wmplayer.exe"
+          : null,
+      platform: "win32",
+    });
+    expect(found).toBe("C:\\Program Files\\Windows Media Player\\wmplayer.exe");
+  });
+
+  it("does not probe Windows paths off Windows", async () => {
+    const found = await detectPlayer({
+      which: async () => false,
+      winFind: async () => "C:\\VLC\\vlc.exe",
+      platform: "linux",
+    });
+    expect(found).toBeNull();
+  });
+
+  it("returns null on Windows when no player is installed", async () => {
+    const found = await detectPlayer({
+      which: async () => false,
+      winFind: async () => null,
+      platform: "win32",
+    });
+    expect(found).toBeNull();
+  });
+
+  it("prefers an earlier Windows candidate over a later one", async () => {
+    const found = await detectPlayer({
+      which: async () => false,
+      // Only Windows Media Player is present; VLC etc. are not.
+      winFind: async (paths) =>
+        paths.some((p) => p.includes("Windows Media Player"))
+          ? "C:\\Program Files\\Windows Media Player\\wmplayer.exe"
+          : null,
+      platform: "win32",
+    });
+    expect(found).toBe("C:\\Program Files\\Windows Media Player\\wmplayer.exe");
+  });
 });
 
 describe("streamCandidates", () => {

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -26,17 +26,74 @@ const VIDEO_EXTS = new Set([
 ]);
 
 // Players we probe for, in preference order, when none is configured. Each has
-// a CLI name (looked up on PATH) and, on macOS, an .app bundle name we can
-// launch with `open -a` even when nothing is on PATH.
+// a CLI name (looked up on PATH); on macOS an .app bundle name we can launch
+// with `open -a`, and on Windows a list of known install paths — in both cases
+// so a GUI player still works when nothing is on PATH (the common case).
 interface PlayerCandidate {
   cli: string;
   macApp?: string;
+  // Absolute-path templates checked on Windows. May contain %ENV% tokens
+  // (e.g. %ProgramFiles%), expanded against process.env; a path whose tokens
+  // are undefined is skipped.
+  winPaths?: string[];
 }
 
 const PLAYER_CANDIDATES: PlayerCandidate[] = [
   { cli: "mpv" },
+  {
+    cli: "mpvnet",
+    winPaths: [
+      "%ProgramFiles%\\mpv.net\\mpvnet.exe",
+      "%LocalAppData%\\Programs\\mpv.net\\mpvnet.exe",
+    ],
+  },
   { cli: "iina", macApp: "IINA" },
-  { cli: "vlc", macApp: "VLC" },
+  {
+    cli: "vlc",
+    macApp: "VLC",
+    winPaths: [
+      "%ProgramFiles%\\VideoLAN\\VLC\\vlc.exe",
+      "%ProgramFiles(x86)%\\VideoLAN\\VLC\\vlc.exe",
+      "%ProgramW6432%\\VideoLAN\\VLC\\vlc.exe",
+    ],
+  },
+  {
+    cli: "mpc-hc64",
+    winPaths: [
+      "%ProgramFiles%\\MPC-HC\\mpc-hc64.exe",
+      "%ProgramFiles%\\MPC-HC64\\mpc-hc64.exe",
+      "%ProgramFiles(x86)%\\K-Lite Codec Pack\\MPC-HC64\\mpc-hc64.exe",
+    ],
+  },
+  {
+    cli: "mpc-hc",
+    winPaths: [
+      "%ProgramFiles(x86)%\\MPC-HC\\mpc-hc.exe",
+      "%ProgramFiles(x86)%\\K-Lite Codec Pack\\MPC-HC\\mpc-hc.exe",
+    ],
+  },
+  {
+    cli: "mpc-be64",
+    winPaths: [
+      "%ProgramFiles%\\MPC-BE\\mpc-be64.exe",
+      "%ProgramFiles(x86)%\\MPC-BE\\mpc-be.exe",
+    ],
+  },
+  {
+    cli: "potplayer",
+    winPaths: [
+      "%ProgramFiles%\\DAUM\\PotPlayer64\\PotPlayerMini64.exe",
+      "%ProgramFiles%\\DAUM\\PotPlayer\\PotPlayerMini64.exe",
+      "%ProgramFiles(x86)%\\DAUM\\PotPlayer\\PotPlayerMini.exe",
+    ],
+  },
+  {
+    cli: "wmplayer",
+    winPaths: [
+      "%ProgramFiles%\\Windows Media Player\\wmplayer.exe",
+      "%ProgramFiles(x86)%\\Windows Media Player\\wmplayer.exe",
+    ],
+  },
 ];
 
 function ext(name: string): string {
@@ -109,24 +166,64 @@ async function macAppExists(app: string): Promise<boolean> {
   return false;
 }
 
+// Expand %ENV% tokens in a Windows path template. Returns null if any token is
+// undefined (e.g. %ProgramFiles(x86)% on a 32-bit-only system), so callers skip
+// paths they can't resolve rather than probing a half-built string.
+function expandWinPath(template: string): string | null {
+  let missing = false;
+  const expanded = template.replace(/%([^%]+)%/g, (_, name: string) => {
+    const value = process.env[name];
+    if (value === undefined || value === "") {
+      missing = true;
+      return "";
+    }
+    return value;
+  });
+  return missing ? null : expanded;
+}
+
+// The first of these Windows install paths that exists on disk, or null. GUI
+// players (VLC, Windows Media Player) usually aren't on PATH, so we look where
+// their installers put them.
+async function winPlayerPath(paths: string[]): Promise<string | null> {
+  for (const template of paths) {
+    const full = expandWinPath(template);
+    if (!full) continue;
+    try {
+      await fs.access(full);
+      return full;
+    } catch {
+      /* not here */
+    }
+  }
+  return null;
+}
+
 export interface DetectDeps {
   which?: WhichImpl;
   appExists?: (app: string) => Promise<boolean>;
+  winFind?: (paths: string[]) => Promise<string | null>;
   platform?: NodeJS.Platform;
 }
 
 /**
- * Find the first available player, or null. On macOS this also matches an
- * installed .app bundle (VLC, IINA) even when nothing is on PATH — common,
- * since GUI players usually aren't. Deps are injectable for testing.
+ * Find the first available player, or null. When nothing is on PATH — the usual
+ * case for GUI players — this also matches an installed macOS .app bundle (VLC,
+ * IINA) or a known Windows install path (VLC, Windows Media Player). Deps are
+ * injectable for testing.
  */
 export async function detectPlayer(deps: DetectDeps = {}): Promise<string | null> {
   const which = deps.which ?? commandExists;
   const appExists = deps.appExists ?? macAppExists;
+  const winFind = deps.winFind ?? winPlayerPath;
   const platform = deps.platform ?? process.platform;
   for (const c of PLAYER_CANDIDATES) {
     if (await which(c.cli)) return c.cli;
     if (platform === "darwin" && c.macApp && (await appExists(c.macApp))) return c.macApp;
+    if (platform === "win32" && c.winPaths) {
+      const found = await winFind(c.winPaths);
+      if (found) return found;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Two improvements to the streaming experience.

### Stream file picker (multi-video archives)
- **Sorts by title by default** (numeric-aware, so `E02` comes before `E10`) instead of by file size.
- **`s` toggles the sort** between title and size; the footer shows the active mode and the highlighted file stays selected across the re-sort.
- **Fills most of the window** — the list is now sized from the available window height instead of a fixed 8-row cap, with a scroll window and a `n/total` position counter so large archives stay navigable.
- Fixes a pre-existing off-by-one where the panel's bottom border clipped the last file.
- Ordering now lives in the component (single source of truth); the redundant caller-side size sort was removed.

### Windows media player detection
On Windows, GUI players are almost never on `PATH`, so `where vlc` always failed and no player could be found even when one was installed. Detection now probes known install paths (mirroring the existing macOS `.app` fallback) for:

- VLC
- Windows Media Player
- mpv.net
- MPC-HC / MPC-HC64 (including K-Lite Codec Pack locations)
- MPC-BE
- PotPlayer

`%ENV%` tokens (`%ProgramFiles%`, etc.) are expanded from the environment; a path is skipped if a token is undefined.

> Note: the newer Windows 11 UWP "Media Player" / "Films & TV" apps are intentionally **not** targeted — stream URLs are `http(s)://`, which Windows routes to the default browser rather than a video app, and those apps can't reliably be handed a URL from the command line. A dedicated player (VLC/mpv/etc.) is the right tool, and all the common ones are now detected.

## Testing
- `tsc --noEmit` clean
- Full test suite green (348 passing), including new `detectPlayer` tests for the Windows install-path branch
- Manually rendered `StreamFilePrompt` to confirm title/size sorting, the `s` toggle, the taller layout, and scroll behaviour
- Verified the real (non-mocked) Windows path expansion + on-disk check end-to-end with a temp file

🤖 Generated with [Claude Code](https://claude.com/claude-code)