### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump to **1.4.0** ahead of the release tag.

Includes the changes from #22:
- Stream file picker: title-sort by default with `s` toggle, taller scrolling list, off-by-one fix
- Broader Windows media player detection (VLC, Windows Media Player, mpv.net, MPC-HC/BE, PotPlayer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)