### PR TITLE
Sync upstream v1.4.0 + ESLint/CI + release v1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ A short, hand-picked list of trusted sources:
 
 Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.
 
+## Headless
+
+torlink also runs without the TUI, for servers and seedboxes:
+
+    torlnk watch <dir>    download anything dropped into a folder
+    torlnk serve          take magnets over HTTP
+    torlnk files          stream finished downloads over HTTP
+    torlnk attach         keep the TUI alive across ssh sessions
+
+Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
+
 ## Contributing
 
 To run or work on torlink locally:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ A short, hand-picked list of trusted sources:
 | Category | Sources |
 | --- | --- |
 | Games | FitGirl |
-| Movies | YTS, The Pirate Bay, 1337x, Torrents.csv |
-| TV | EZTV, The Pirate Bay, 1337x |
+| Movies | YTS, The Pirate Bay, 1337x, Torrents.csv, BitTorrented |
+| TV | EZTV, The Pirate Bay, 1337x, BitTorrented |
 | Anime | Nyaa, SubsPlease |
 | Books | The Pirate Bay, Nyaa |
 | Music | The Pirate Bay, 1337x |
@@ -109,6 +109,17 @@ Prefer an environment variable? Set `TORLINK_DNS` before launching (it takes pre
 ```sh
 TORLINK_DNS=cloudflare npm start
 ```
+
+## Headless
+
+torlink also runs without the TUI, for servers and seedboxes:
+
+    torlnk watch <dir>    download anything dropped into a folder
+    torlnk serve          take magnets over HTTP
+    torlnk files          stream finished downloads over HTTP
+    torlnk attach         keep the TUI alive across ssh sessions
+
+Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ A short, hand-picked list of trusted sources:
 | Category | Sources |
 | --- | --- |
 | Games | FitGirl |
-| Movies | YTS, The Pirate Bay, 1337x |
-| TV | EZTV, The Pirate Bay, 1337x |
+| Movies | YTS, The Pirate Bay, 1337x, BitTorrented |
+| TV | EZTV, The Pirate Bay, 1337x, BitTorrented |
 | Anime | Nyaa, SubsPlease |
 
 Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,56 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
+
+// Flat config (ESLint 9+). Kept deliberately lean so `npm run lint` stays green
+// on the existing tree and is worth running: the recommended TS rules plus the
+// two classic React Hooks rules the codebase already annotates against. We do
+// not pull in eslint-plugin-react-hooks' newer React-Compiler rule set (via its
+// `recommended-latest` config) — those are aggressive for an Ink TUI and would
+// bury the useful signal in noise.
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "**/*.cjs"],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+      // Underscore-prefixed names are an intentional "unused" marker.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+      // This is a terminal UI: several regexes legitimately match ANSI escape
+      // (\x1b) control characters to sanitize or interpret terminal output.
+      "no-control-regex": "off",
+      // Best-effort operations (clipboard, opening a folder, stat-ing a partial
+      // download) intentionally swallow failures with an empty catch.
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      // Flags idiomatic "declare a default, then assign in a try/catch or loop"
+      // initializers; reviewed occurrences and none are bugs.
+      "no-useless-assignment": "off",
+      // A `let` that a closure reads before its single deferred assignment
+      // (e.g. a timer whose own callback references it) genuinely can't be
+      // const; don't flag that pattern.
+      "prefer-const": ["error", { ignoreReadBeforeAssign: true }],
+    },
+  },
+  {
+    // Tests lean on `any` for fixtures and deliberately-malformed input casts.
+    files: ["**/*.test.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+);

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
-  version = "1.3.1";
+  version = "1.4.0";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -19,11 +19,11 @@ buildNpmPackage (finalAttrs: {
     owner = "baairon";
     repo = "torlink";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XMwJ1nVVcwXOhj3moqBMRngOAnAfbOuICHMAYQheeWA=";
+    hash = "sha256-KeszeV9atSvaA9s7iDCl+Q1eDMSx7flnQuBE8t49IPY=";
   };
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-FT4SUjuEKefMG2zzA/QhafZbLab0tUeWHnO30+7smnI=";
+  npmDepsHash = "sha256-nSHunmjZfr9oCygaLnHQxrXv7wuSa5ze7cQL7BrqfwQ=";
   # ignore-scripts for ip-set broken preinstall
   npmFlags = [ "--ignore-scripts" ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "torlnk",
       "version": "1.4.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",
@@ -20,12 +21,17 @@
         "torlnk": "dist/cli.cjs"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^25.9.2",
         "@types/react": "^19.2.17",
+        "eslint": "^10.6.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^17.7.0",
         "ink-testing-library": "^4.0.0",
         "tsup": "^8.5.1",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
+        "typescript-eslint": "^8.63.0",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -43,6 +49,266 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -521,6 +787,200 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -529,6 +989,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -1316,10 +1787,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1341,6 +1826,236 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.63.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1491,6 +2206,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/addr-to-ip-port": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-2.0.0.tgz",
@@ -1498,6 +2223,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1580,6 +2322,16 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bare-addon-resolve": {
@@ -1757,6 +2509,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bencode": {
       "version": "4.0.1",
@@ -1977,6 +2742,53 @@
       "integrity": "sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2064,6 +2876,27 @@
         "lru": "^3.1.0",
         "queue-microtask": "^1.2.3"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2422,6 +3255,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/default-gateway": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
@@ -2442,6 +3282,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2544,6 +3391,16 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2559,6 +3416,184 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2567,6 +3602,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -2656,10 +3701,31 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-readable-async-iterator": {
@@ -2709,6 +3775,19 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
@@ -2716,6 +3795,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2732,6 +3828,27 @@
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2823,6 +3940,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -2865,6 +3992,49 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
@@ -2900,6 +4070,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immediate-chunk-store": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/immediate-chunk-store/-/immediate-chunk-store-2.2.0.tgz",
@@ -2921,6 +4101,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.3"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -3051,6 +4241,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
@@ -3070,6 +4270,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-in-ci": {
@@ -3133,6 +4346,60 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/junk": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
@@ -3183,11 +4450,35 @@
       "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w==",
       "license": "MIT"
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/last-one-wins": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
       "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA==",
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3516,6 +4807,22 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
@@ -3526,6 +4833,16 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lt_donthave": {
@@ -3641,6 +4958,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3718,6 +5051,13 @@
       "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/netmask": {
       "version": "2.1.1",
@@ -3803,6 +5143,16 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -3878,6 +5228,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-torrent": {
       "version": "11.0.21",
       "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-11.0.21.tgz",
@@ -3919,6 +5319,16 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -4084,6 +5494,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4092,6 +5512,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -5019,6 +6449,19 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5602,6 +7045,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
@@ -5629,6 +7085,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
@@ -5675,6 +7155,47 @@
       "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/ut_metadata": {
       "version": "4.0.3",
@@ -6094,6 +7615,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
@@ -6160,11 +7691,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yoga-layout": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3974,7 +3974,7 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",
@@ -3973,7 +3973,7 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "type": "git",
     "url": "git+https://github.com/baairon/torlink.git"
   },
-  "homepage": "https://github.com/baairon/torlink#readme",
+  "homepage": "https://torlink.bairon.dev",
   "bugs": {
     "url": "https://github.com/baairon/torlink/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "dist",
-    "preview"
+    "preview",
+    "scripts/ensure-webrtc.cjs"
   ],
   "engines": {
     "node": ">=22"
@@ -23,6 +24,7 @@
     "test": "vitest run",
     "verify:seeding": "tsx scripts/verify-seeding.ts",
     "previews": "tsx scripts/render-previews.tsx",
+    "postinstall": "node scripts/ensure-webrtc.cjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -49,7 +51,7 @@
     "type": "git",
     "url": "git+https://github.com/baairon/torlink.git"
   },
-  "homepage": "https://github.com/baairon/torlink#readme",
+  "homepage": "https://torlink.bairon.dev",
   "bugs": {
     "url": "https://github.com/baairon/torlink/issues"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "verify:seeding": "tsx scripts/verify-seeding.ts",
     "previews": "tsx scripts/render-previews.tsx",
     "postinstall": "node scripts/ensure-webrtc.cjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "keywords": [
     "torrent",
@@ -67,12 +69,17 @@
     "webtorrent": "^2.4.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
+    "eslint": "^10.6.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^17.7.0",
     "ink-testing-library": "^4.0.0",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "typescript-eslint": "^8.63.0",
     "vitest": "^4.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "dist",
-    "preview"
+    "preview",
+    "scripts/ensure-webrtc.cjs"
   ],
   "engines": {
     "node": ">=22"
@@ -22,6 +23,7 @@
     "test": "vitest run",
     "verify:seeding": "tsx scripts/verify-seeding.ts",
     "previews": "tsx scripts/render-previews.tsx",
+    "postinstall": "node scripts/ensure-webrtc.cjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/ensure-webrtc.cjs
+++ b/scripts/ensure-webrtc.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+// During postinstall the CWD is always torlink's root directory.
+// Check whether the native module actually loads; if prebuild-install
+// succeeded on its own (Node 18/20) there is nothing to do. require()
+// resolves through any node_modules layout, so this check is layout-proof.
+
+try {
+  require('node-datachannel');
+  process.exit(0);
+} catch {
+  // Missing or not built - locate it and rebuild from source.
+}
+
+// npm nests the module under our own node_modules for local dev and npm -g,
+// but hoists it beside us for npx and project installs. Check both layouts
+// (CWD is the package root, so our parent directory is that node_modules).
+const candidates = [
+  resolve('node_modules', 'node-datachannel'),
+  resolve('..', 'node-datachannel'),
+];
+const moduleDir = candidates.find((dir) => existsSync(dir));
+if (!moduleDir) {
+  process.exit(0); // nothing installed, nothing to build
+}
+
+console.error('\ntorlnk: building WebRTC native module from source.\n');
+
+try {
+  execSync('npx --yes cmake-js build', {
+    cwd: moduleDir,
+    stdio: 'inherit',
+    env: { ...process.env, NODE_ENV: 'production' },
+    timeout: 300000,
+  });
+} catch {
+  // Warn but never fail the install: torlink works without WebRTC peers
+  // (TCP/uTP swarms still connect), so a missing toolchain must not brick
+  // `npm install`.
+  console.error('');
+  console.error('torlnk: could not build the WebRTC native module.');
+  console.error('torlnk still works; WebRTC peers just stay unavailable.');
+  console.error('To enable them, install the build tools, then reinstall:');
+  console.error('  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static');
+  console.error('  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev');
+  console.error('  macOS:   xcode-select --install');
+  console.error('  Windows: install CMake and Visual Studio Build Tools');
+  console.error('');
+  console.error('https://github.com/baairon/torlink/issues/60');
+}
+process.exit(0);

--- a/scripts/ensure-webrtc.cjs
+++ b/scripts/ensure-webrtc.cjs
@@ -44,9 +44,9 @@ try {
   console.error('');
   console.error('torlnk: could not build the WebRTC native module.');
   console.error('torlnk still works; WebRTC peers just stay unavailable.');
-  console.error('To enable them, install cmake and a C++ compiler, then reinstall:');
-  console.error('  Fedora:  sudo dnf install cmake gcc-c++');
-  console.error('  Debian / Ubuntu:  sudo apt install cmake g++');
+  console.error('To enable them, install the build tools, then reinstall:');
+  console.error('  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static');
+  console.error('  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev');
   console.error('  macOS:   xcode-select --install');
   console.error('  Windows: install CMake and Visual Studio Build Tools');
   console.error('');

--- a/scripts/ensure-webrtc.cjs
+++ b/scripts/ensure-webrtc.cjs
@@ -6,18 +6,26 @@ const { resolve } = require('node:path');
 
 // During postinstall the CWD is always torlink's root directory.
 // Check whether the native module actually loads; if prebuild-install
-// succeeded on its own (Node 18/20) there is nothing to do.
-
-const moduleDir = resolve('node_modules', 'node-datachannel');
-if (!existsSync(moduleDir)) {
-  process.exit(0); // nothing installed, nothing to build
-}
+// succeeded on its own (Node 18/20) there is nothing to do. require()
+// resolves through any node_modules layout, so this check is layout-proof.
 
 try {
   require('node-datachannel');
   process.exit(0);
 } catch {
-  // Not built - rebuild from source.
+  // Missing or not built - locate it and rebuild from source.
+}
+
+// npm nests the module under our own node_modules for local dev and npm -g,
+// but hoists it beside us for npx and project installs. Check both layouts
+// (CWD is the package root, so our parent directory is that node_modules).
+const candidates = [
+  resolve('node_modules', 'node-datachannel'),
+  resolve('..', 'node-datachannel'),
+];
+const moduleDir = candidates.find((dir) => existsSync(dir));
+if (!moduleDir) {
+  process.exit(0); // nothing installed, nothing to build
 }
 
 console.error('\ntorlnk: building WebRTC native module from source.\n');

--- a/scripts/ensure-webrtc.cjs
+++ b/scripts/ensure-webrtc.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+// During postinstall the CWD is always torlink's root directory.
+// Check whether the native module actually loads; if prebuild-install
+// succeeded on its own (Node 18/20) there is nothing to do.
+
+const moduleDir = resolve('node_modules', 'node-datachannel');
+if (!existsSync(moduleDir)) {
+  process.exit(0); // nothing installed, nothing to build
+}
+
+try {
+  require('node-datachannel');
+  process.exit(0);
+} catch {
+  // Not built - rebuild from source.
+}
+
+console.error('\ntorlnk: building WebRTC native module from source.\n');
+
+try {
+  execSync('npx --yes cmake-js build', {
+    cwd: moduleDir,
+    stdio: 'inherit',
+    env: { ...process.env, NODE_ENV: 'production' },
+    timeout: 300000,
+  });
+} catch {
+  // Warn but never fail the install: torlink works without WebRTC peers
+  // (TCP/uTP swarms still connect), so a missing toolchain must not brick
+  // `npm install`.
+  console.error('');
+  console.error('torlnk: could not build the WebRTC native module.');
+  console.error('torlnk still works; WebRTC peers just stay unavailable.');
+  console.error('To enable them, install cmake and a C++ compiler, then reinstall:');
+  console.error('  Fedora:  sudo dnf install cmake gcc-c++');
+  console.error('  Debian / Ubuntu:  sudo apt install cmake g++');
+  console.error('  macOS:   xcode-select --install');
+  console.error('  Windows: install CMake and Visual Studio Build Tools');
+  console.error('');
+  console.error('https://github.com/baairon/torlink/issues/60');
+}
+process.exit(0);

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -82,4 +82,24 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["serve", "--port", "abc"]).kind).toBe("serve");
     expect((parseCliArgs(["serve", "--port", "abc"]) as { port?: number }).port).toBeUndefined();
   });
+  it("parses files with defaults", () => {
+    expect(parseCliArgs(["files"])).toEqual({
+      kind: "files",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      dir: undefined,
+    });
+  });
+  it("parses files flags", () => {
+    expect(
+      parseCliArgs(["files", "--port", "9160", "--host", "0.0.0.0", "--token", "s3cret", "--dir", "/mnt/media"]),
+    ).toEqual({
+      kind: "files",
+      port: 9160,
+      host: "0.0.0.0",
+      token: "s3cret",
+      dir: "/mnt/media",
+    });
+  });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,4 +33,29 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses watch with a directory", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: undefined,
+    });
+  });
+  it("parses watch with a --to download dir", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--to", "/mnt/media"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+    });
+    expect(parseCliArgs(["watch", "--dir", "/mnt/media", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+    });
+  });
+  it("rejects watch with no directory", () => {
+    expect(parseCliArgs(["watch"])).toEqual({
+      kind: "invalid",
+      arg: "watch (missing directory)",
+    });
+  });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,4 +33,138 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses attach", () => {
+    expect(parseCliArgs(["attach"])).toEqual({ kind: "attach" });
+  });
+  it("parses watch with a directory", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("parses watch with a --to download dir", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--to", "/mnt/media"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+    expect(parseCliArgs(["watch", "--dir", "/mnt/media", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("parses watch --seed-time, --delete-files, and --daemon", () => {
+    expect(
+      parseCliArgs(["watch", "/srv/bh", "--seed-time", "1h", "--delete-files", "--daemon"]),
+    ).toEqual({
+      kind: "watch",
+      dir: "/srv/bh",
+      downloadDir: undefined,
+      seedTimeMs: 3_600_000,
+      deleteFiles: true,
+      daemon: true,
+    });
+  });
+  it("ignores an unparseable --seed-time", () => {
+    expect(parseCliArgs(["watch", "/srv/bh", "--seed-time", "soon"])).toEqual({
+      kind: "watch",
+      dir: "/srv/bh",
+      downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("rejects watch with no directory", () => {
+    expect(parseCliArgs(["watch"])).toEqual({
+      kind: "invalid",
+      arg: "watch (missing directory)",
+    });
+  });
+  it("parses serve with defaults", () => {
+    expect(parseCliArgs(["serve"])).toEqual({
+      kind: "serve",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("parses serve flags", () => {
+    expect(
+      parseCliArgs([
+        "serve",
+        "--port",
+        "9999",
+        "--host",
+        "0.0.0.0",
+        "--token",
+        "s3cret",
+        "--to",
+        "/mnt/media",
+        "--seed-time",
+        "30m",
+      ]),
+    ).toEqual({
+      kind: "serve",
+      port: 9999,
+      host: "0.0.0.0",
+      token: "s3cret",
+      downloadDir: "/mnt/media",
+      seedTimeMs: 1_800_000,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("ignores a bad --port", () => {
+    expect(parseCliArgs(["serve", "--port", "abc"]).kind).toBe("serve");
+    expect((parseCliArgs(["serve", "--port", "abc"]) as { port?: number }).port).toBeUndefined();
+  });
+  it("parses files with defaults", () => {
+    expect(parseCliArgs(["files"])).toEqual({
+      kind: "files",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      dir: undefined,
+      daemon: false,
+    });
+  });
+  it("parses files flags", () => {
+    expect(
+      parseCliArgs([
+        "files",
+        "--port",
+        "9160",
+        "--host",
+        "0.0.0.0",
+        "--token",
+        "s3cret",
+        "--dir",
+        "/mnt/media",
+        "--daemon",
+      ]),
+    ).toEqual({
+      kind: "files",
+      port: 9160,
+      host: "0.0.0.0",
+      token: "s3cret",
+      dir: "/mnt/media",
+      daemon: true,
+    });
+  });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -58,4 +58,28 @@ describe("parseCliArgs", () => {
       arg: "watch (missing directory)",
     });
   });
+  it("parses serve with defaults", () => {
+    expect(parseCliArgs(["serve"])).toEqual({
+      kind: "serve",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      downloadDir: undefined,
+    });
+  });
+  it("parses serve flags", () => {
+    expect(
+      parseCliArgs(["serve", "--port", "9999", "--host", "0.0.0.0", "--token", "s3cret", "--to", "/mnt/media"]),
+    ).toEqual({
+      kind: "serve",
+      port: 9999,
+      host: "0.0.0.0",
+      token: "s3cret",
+      downloadDir: "/mnt/media",
+    });
+  });
+  it("ignores a bad --port", () => {
+    expect(parseCliArgs(["serve", "--port", "abc"]).kind).toBe("serve");
+    expect((parseCliArgs(["serve", "--port", "abc"]) as { port?: number }).port).toBeUndefined();
+  });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,11 +33,17 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses attach", () => {
+    expect(parseCliArgs(["attach"])).toEqual({ kind: "attach" });
+  });
   it("parses watch with a directory", () => {
     expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
       kind: "watch",
       dir: "/srv/blackhole",
       downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
     });
   });
   it("parses watch with a --to download dir", () => {
@@ -45,11 +51,39 @@ describe("parseCliArgs", () => {
       kind: "watch",
       dir: "/srv/blackhole",
       downloadDir: "/mnt/media",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
     });
     expect(parseCliArgs(["watch", "--dir", "/mnt/media", "/srv/blackhole"])).toEqual({
       kind: "watch",
       dir: "/srv/blackhole",
       downloadDir: "/mnt/media",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("parses watch --seed-time, --delete-files, and --daemon", () => {
+    expect(
+      parseCliArgs(["watch", "/srv/bh", "--seed-time", "1h", "--delete-files", "--daemon"]),
+    ).toEqual({
+      kind: "watch",
+      dir: "/srv/bh",
+      downloadDir: undefined,
+      seedTimeMs: 3_600_000,
+      deleteFiles: true,
+      daemon: true,
+    });
+  });
+  it("ignores an unparseable --seed-time", () => {
+    expect(parseCliArgs(["watch", "/srv/bh", "--seed-time", "soon"])).toEqual({
+      kind: "watch",
+      dir: "/srv/bh",
+      downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
     });
   });
   it("rejects watch with no directory", () => {
@@ -65,17 +99,35 @@ describe("parseCliArgs", () => {
       host: undefined,
       token: undefined,
       downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
     });
   });
   it("parses serve flags", () => {
     expect(
-      parseCliArgs(["serve", "--port", "9999", "--host", "0.0.0.0", "--token", "s3cret", "--to", "/mnt/media"]),
+      parseCliArgs([
+        "serve",
+        "--port",
+        "9999",
+        "--host",
+        "0.0.0.0",
+        "--token",
+        "s3cret",
+        "--to",
+        "/mnt/media",
+        "--seed-time",
+        "30m",
+      ]),
     ).toEqual({
       kind: "serve",
       port: 9999,
       host: "0.0.0.0",
       token: "s3cret",
       downloadDir: "/mnt/media",
+      seedTimeMs: 1_800_000,
+      deleteFiles: false,
+      daemon: false,
     });
   });
   it("ignores a bad --port", () => {
@@ -89,17 +141,30 @@ describe("parseCliArgs", () => {
       host: undefined,
       token: undefined,
       dir: undefined,
+      daemon: false,
     });
   });
   it("parses files flags", () => {
     expect(
-      parseCliArgs(["files", "--port", "9160", "--host", "0.0.0.0", "--token", "s3cret", "--dir", "/mnt/media"]),
+      parseCliArgs([
+        "files",
+        "--port",
+        "9160",
+        "--host",
+        "0.0.0.0",
+        "--token",
+        "s3cret",
+        "--dir",
+        "/mnt/media",
+        "--daemon",
+      ]),
     ).toEqual({
       kind: "files",
       port: 9160,
       host: "0.0.0.0",
       token: "s3cret",
       dir: "/mnt/media",
+      daemon: true,
     });
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,22 +5,23 @@ export type CliCommand =
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
   | { kind: "watch"; dir: string; downloadDir?: string }
+  | { kind: "serve"; port?: number; host?: string; token?: string; downloadDir?: string }
   | { kind: "invalid"; arg: string };
 
-// `--to <dir>` (alias `--dir`) overrides where finished files land, for the
-// headless subcommands; returns the value and the remaining args.
-function takeToFlag(rest: string[]): { downloadDir?: string; rest: string[] } {
-  const out: string[] = [];
-  let downloadDir: string | undefined;
-  for (let i = 0; i < rest.length; i++) {
-    const arg = rest[i]!;
-    if ((arg === "--to" || arg === "--dir") && i + 1 < rest.length) {
-      downloadDir = rest[++i];
+// Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
+// left in `rest` so the caller can decide what to do with them.
+function readFlags(args: string[]): { flags: Record<string, string>; rest: string[] } {
+  const flags: Record<string, string> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith("--") && i + 1 < args.length) {
+      flags[arg.slice(2)] = args[++i]!;
     } else {
-      out.push(arg);
+      rest.push(arg);
     }
   }
-  return { downloadDir, rest: out };
+  return { flags, rest };
 }
 
 export function parseCliArgs(argv: string[]): CliCommand {
@@ -30,10 +31,21 @@ export function parseCliArgs(argv: string[]): CliCommand {
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
   if (a === "watch") {
-    const { downloadDir, rest } = takeToFlag(args.slice(1));
+    const { flags, rest } = readFlags(args.slice(1));
     const dir = rest[0];
     if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
-    return { kind: "watch", dir, downloadDir };
+    return { kind: "watch", dir, downloadDir: flags.to ?? flags.dir };
+  }
+  if (a === "serve") {
+    const { flags } = readFlags(args.slice(1));
+    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    return {
+      kind: "serve",
+      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      host: flags.host,
+      token: flags.token,
+      downloadDir: flags.to ?? flags.dir,
+    };
   }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
@@ -48,6 +60,7 @@ usage
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
   torlnk watch <dir>          headless: download torrents dropped into <dir>
+  torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
@@ -57,4 +70,12 @@ tip: quote magnet links (they contain & characters)
 watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
 info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
 where files land. Handled files move to <dir>/.processed (or /.failed).
+
+serve mode (no TUI): a small HTTP API for handing torlink a magnet.
+  POST /add {"magnet":"..."}   queue a magnet or info hash
+  GET  /downloads              list active downloads and seeds
+  GET  /health                 liveness (no auth)
+flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_API_TOKEN),
+--to <dir> (where files land).
 `;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,11 +1,73 @@
 import { logFile } from "../config/paths";
 import { isInfoHash } from "../sources/magnet";
+import { parseDuration } from "../util/duration";
 
 export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
+  | {
+      kind: "watch";
+      dir: string;
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
+  | {
+      kind: "serve";
+      port?: number;
+      host?: string;
+      token?: string;
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
+  | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
+  | { kind: "attach" }
   | { kind: "invalid"; arg: string };
+
+// Valueless boolean flags for the headless subcommands (everything else is a
+// `--flag value` pair).
+const BOOL_FLAGS = new Set(["delete-files", "daemon"]);
+
+function splitBooleans(args: string[]): { bools: Set<string>; rest: string[] } {
+  const bools = new Set<string>();
+  const rest: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith("--") && BOOL_FLAGS.has(arg.slice(2))) bools.add(arg.slice(2));
+    else rest.push(arg);
+  }
+  return { bools, rest };
+}
+
+// Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
+// left in `rest` so the caller can decide what to do with them.
+function readFlags(args: string[]): { flags: Record<string, string>; rest: string[] } {
+  const flags: Record<string, string> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith("--") && i + 1 < args.length) {
+      flags[arg.slice(2)] = args[++i]!;
+    } else {
+      rest.push(arg);
+    }
+  }
+  return { flags, rest };
+}
+
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function seedTimeFrom(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  return parseDuration(raw) ?? undefined;
+}
 
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
@@ -13,6 +75,47 @@ export function parseCliArgs(argv: string[]): CliCommand {
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "attach") return { kind: "attach" };
+  if (a === "watch") {
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags, rest } = readFlags(r0);
+    const dir = rest[0];
+    if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
+    return {
+      kind: "watch",
+      dir,
+      downloadDir: flags.to ?? flags.dir,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
+    };
+  }
+  if (a === "serve") {
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags } = readFlags(r0);
+    return {
+      kind: "serve",
+      port: parsePort(flags.port),
+      host: flags.host,
+      token: flags.token,
+      downloadDir: flags.to ?? flags.dir,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
+    };
+  }
+  if (a === "files") {
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags } = readFlags(r0);
+    return {
+      kind: "files",
+      port: parsePort(flags.port),
+      host: flags.host,
+      token: flags.token,
+      dir: flags.dir,
+      daemon: bools.has("daemon"),
+    };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -25,10 +128,46 @@ usage
   torlnk                      open the search TUI
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk watch <dir>          headless: download torrents dropped into <dir>
+  torlnk serve                headless: HTTP add API (POST /add) on :9161
+  torlnk files                headless: serve downloads over HTTP on :9160
+  torlnk attach               open/reattach the TUI in a persistent tmux session
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
+info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
+where files land. Handled files move to <dir>/.processed (or /.failed).
+
+seed mode (watch/serve): --seed-time <dur> stops seeding a torrent that long
+after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
+--delete-files to also remove the downloaded data when the timer expires.
+
+--daemon (watch/serve/files): background the process (own session, logs to a
+file), so you can log out and it keeps running. Prints the pid and log path.
+
+torlnk attach: run the TUI inside a persistent tmux session. Detach with
+tmux's ctrl-b d, log out, then torlnk attach again to reattach where you
+left off. Downloads and seeds keep running while detached.
+
+serve mode (no TUI): a small HTTP API for handing torlink a magnet.
+  POST /add {"magnet":"..."}   queue a magnet or info hash
+  GET  /downloads              list active downloads and seeds
+  GET  /health                 liveness (no auth)
+flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_API_TOKEN),
+--to <dir> (where files land).
+
+files mode (no TUI): a read-only, range-aware HTTP server over the downloads
+folder, so finished files stream to a browser or media player.
+  GET /            list the folder (JSON)
+  GET /<path>      stream a file (supports Range for seeking/resuming)
+flags: --port <n> (default 9160), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_FILES_TOKEN),
+--dir <dir> (folder to serve; defaults to your downloads folder).
+
 logs: ${logFile}
 `;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,24 @@ export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
+  | { kind: "watch"; dir: string; downloadDir?: string }
   | { kind: "invalid"; arg: string };
+
+// `--to <dir>` (alias `--dir`) overrides where finished files land, for the
+// headless subcommands; returns the value and the remaining args.
+function takeToFlag(rest: string[]): { downloadDir?: string; rest: string[] } {
+  const out: string[] = [];
+  let downloadDir: string | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]!;
+    if ((arg === "--to" || arg === "--dir") && i + 1 < rest.length) {
+      downloadDir = rest[++i];
+    } else {
+      out.push(arg);
+    }
+  }
+  return { downloadDir, rest: out };
+}
 
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
@@ -12,6 +29,12 @@ export function parseCliArgs(argv: string[]): CliCommand {
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "watch") {
+    const { downloadDir, rest } = takeToFlag(args.slice(1));
+    const dir = rest[0];
+    if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
+    return { kind: "watch", dir, downloadDir };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -24,9 +47,14 @@ usage
   torlnk                      open the search TUI
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
+info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
+where files land. Handled files move to <dir>/.processed (or /.failed).
 `;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,6 +6,7 @@ export type CliCommand =
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
   | { kind: "watch"; dir: string; downloadDir?: string }
   | { kind: "serve"; port?: number; host?: string; token?: string; downloadDir?: string }
+  | { kind: "files"; port?: number; host?: string; token?: string; dir?: string }
   | { kind: "invalid"; arg: string };
 
 // Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
@@ -47,6 +48,17 @@ export function parseCliArgs(argv: string[]): CliCommand {
       downloadDir: flags.to ?? flags.dir,
     };
   }
+  if (a === "files") {
+    const { flags } = readFlags(args.slice(1));
+    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    return {
+      kind: "files",
+      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      host: flags.host,
+      token: flags.token,
+      dir: flags.dir,
+    };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -61,6 +73,7 @@ usage
   torlnk path/to/file.torrent open a .torrent file on launch
   torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk serve                headless: HTTP add API (POST /add) on :9161
+  torlnk files                headless: serve downloads over HTTP on :9160
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
@@ -78,4 +91,12 @@ serve mode (no TUI): a small HTTP API for handing torlink a magnet.
 flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),
 --token <secret> (required to bind a public --host; or TORLINK_API_TOKEN),
 --to <dir> (where files land).
+
+files mode (no TUI): a read-only, range-aware HTTP server over the downloads
+folder, so finished files stream to a browser or media player.
+  GET /            list the folder (JSON)
+  GET /<path>      stream a file (supports Range for seeking/resuming)
+flags: --port <n> (default 9160), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_FILES_TOKEN),
+--dir <dir> (folder to serve; defaults to your downloads folder).
 `;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,13 +1,45 @@
 import { isInfoHash } from "../sources/magnet";
+import { parseDuration } from "../util/duration";
 
 export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
-  | { kind: "watch"; dir: string; downloadDir?: string }
-  | { kind: "serve"; port?: number; host?: string; token?: string; downloadDir?: string }
-  | { kind: "files"; port?: number; host?: string; token?: string; dir?: string }
+  | {
+      kind: "watch";
+      dir: string;
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
+  | {
+      kind: "serve";
+      port?: number;
+      host?: string;
+      token?: string;
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
+  | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
+  | { kind: "attach" }
   | { kind: "invalid"; arg: string };
+
+// Valueless boolean flags for the headless subcommands (everything else is a
+// `--flag value` pair).
+const BOOL_FLAGS = new Set(["delete-files", "daemon"]);
+
+function splitBooleans(args: string[]): { bools: Set<string>; rest: string[] } {
+  const bools = new Set<string>();
+  const rest: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith("--") && BOOL_FLAGS.has(arg.slice(2))) bools.add(arg.slice(2));
+    else rest.push(arg);
+  }
+  return { bools, rest };
+}
 
 // Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
 // left in `rest` so the caller can decide what to do with them.
@@ -25,38 +57,62 @@ function readFlags(args: string[]): { flags: Record<string, string>; rest: strin
   return { flags, rest };
 }
 
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function seedTimeFrom(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  return parseDuration(raw) ?? undefined;
+}
+
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
   if (args.length === 0) return { kind: "run" };
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "attach") return { kind: "attach" };
   if (a === "watch") {
-    const { flags, rest } = readFlags(args.slice(1));
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags, rest } = readFlags(r0);
     const dir = rest[0];
     if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
-    return { kind: "watch", dir, downloadDir: flags.to ?? flags.dir };
+    return {
+      kind: "watch",
+      dir,
+      downloadDir: flags.to ?? flags.dir,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
+    };
   }
   if (a === "serve") {
-    const { flags } = readFlags(args.slice(1));
-    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags } = readFlags(r0);
     return {
       kind: "serve",
-      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      port: parsePort(flags.port),
       host: flags.host,
       token: flags.token,
       downloadDir: flags.to ?? flags.dir,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
     };
   }
   if (a === "files") {
-    const { flags } = readFlags(args.slice(1));
-    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags } = readFlags(r0);
     return {
       kind: "files",
-      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      port: parsePort(flags.port),
       host: flags.host,
       token: flags.token,
       dir: flags.dir,
+      daemon: bools.has("daemon"),
     };
   }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
@@ -74,6 +130,7 @@ usage
   torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk files                headless: serve downloads over HTTP on :9160
+  torlnk attach               open/reattach the TUI in a persistent tmux session
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
@@ -83,6 +140,17 @@ tip: quote magnet links (they contain & characters)
 watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
 info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
 where files land. Handled files move to <dir>/.processed (or /.failed).
+
+seed mode (watch/serve): --seed-time <dur> stops seeding a torrent that long
+after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
+--delete-files to also remove the downloaded data when the timer expires.
+
+--daemon (watch/serve/files): background the process (own session, logs to a
+file), so you can log out and it keeps running. Prints the pid and log path.
+
+torlnk attach: run the TUI inside a persistent tmux session. Detach with
+tmux's ctrl-b d, log out, then torlnk attach again to reattach where you
+left off. Downloads and seeds keep running while detached.
 
 serve mode (no TUI): a small HTTP API for handing torlink a magnet.
   POST /add {"magnet":"..."}   queue a magnet or info hash

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -139,7 +139,6 @@ describe("config favourites", () => {
     await saveConfig({
       downloadDir: "/tmp/dl",
       trackers: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       favourites: [
         { id: "", name: "no id", magnet: "m", addedAt: 1 },
         { id: "ok", name: "", magnet: "m", addedAt: 1 },
@@ -158,7 +157,6 @@ describe("config favourites", () => {
       name: `n${i}`,
       magnet: "m",
     }));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await saveConfig({ downloadDir: "/tmp/dl", trackers: [], favourites: many as any });
     const cfg = await loadConfig();
     expect(cfg.favourites?.length).toBe(100);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -30,3 +30,6 @@ export const logFile = path.join(dataDir, "torlink.log");
 // Per-torrent .torrent metadata, captured during download so a re-seed can
 // verify the on-disk file locally instead of re-fetching it from the swarm.
 export const torrentsDir = path.join(dataDir, "torrents");
+
+// Where a --daemon headless run writes its log and pidfile.
+export const logsDir = path.join(dataDir, "logs");

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -26,3 +26,6 @@ export const seedsFile = path.join(dataDir, "seeds.json");
 // Per-torrent .torrent metadata, captured during download so a re-seed can
 // verify the on-disk file locally instead of re-fetching it from the swarm.
 export const torrentsDir = path.join(dataDir, "torrents");
+
+// Where a --daemon headless run writes its log and pidfile.
+export const logsDir = path.join(dataDir, "logs");

--- a/src/daemon/attach.test.ts
+++ b/src/daemon/attach.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { tuiCommand, SESSION } from "./attach";
+
+describe("tuiCommand", () => {
+  it("sh-quotes the node binary and script so tmux runs the plain TUI", () => {
+    expect(tuiCommand("/usr/bin/node", "/opt/torlink/dist/index.js")).toBe(
+      "'/usr/bin/node' '/opt/torlink/dist/index.js'",
+    );
+  });
+  it("escapes single quotes in paths", () => {
+    expect(tuiCommand("/us'r/node", "/a b/x.js")).toBe("'/us'\\''r/node' '/a b/x.js'");
+  });
+  it("names one stable session", () => {
+    expect(SESSION).toBe("torlink");
+  });
+});

--- a/src/daemon/attach.ts
+++ b/src/daemon/attach.ts
@@ -1,0 +1,40 @@
+// Detach / reattach for the TUI, the simple + stable way: run torlink inside a
+// persistent tmux session. `torlnk attach` creates the session (or reattaches to
+// it if it's already running), so you can detach with tmux's ctrl-b d, log out,
+// log back in over ssh/mosh, and `torlnk attach` again to pick up right where
+// you left off. tmux does the heavy lifting, so this stays tiny.
+
+import { spawnSync } from "node:child_process";
+
+export const SESSION = "torlink";
+
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+export function hasTmux(): boolean {
+  try {
+    return spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+// The shell command tmux should run inside the session: this same executable,
+// no args, i.e. the plain TUI. tmux runs it via `sh -c`, so sh-quoting is right.
+export function tuiCommand(execPath: string, scriptPath: string): string {
+  return `${shQuote(execPath)} ${shQuote(scriptPath)}`;
+}
+
+export function runAttach(): never {
+  if (!hasTmux()) {
+    console.error(
+      "torlink attach needs tmux (for detach/reattach). Install tmux, or just run `torlnk`.",
+    );
+    process.exit(1);
+  }
+  const inner = tuiCommand(process.execPath, process.argv[1] ?? "");
+  // -A: attach if the session exists, otherwise create it and run the TUI.
+  const r = spawnSync("tmux", ["new-session", "-A", "-s", SESSION, inner], { stdio: "inherit" });
+  process.exit(r.status ?? 0);
+}

--- a/src/daemon/auth.test.ts
+++ b/src/daemon/auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isAuthorized, hostHeaderOk } from "./auth";
+
+describe("isAuthorized", () => {
+  it("is open when no token is configured", () => {
+    expect(isAuthorized(null, undefined)).toBe(true);
+  });
+  it("accepts a matching bearer token or raw token", () => {
+    expect(isAuthorized("s3cret", "Bearer s3cret")).toBe(true);
+    expect(isAuthorized("s3cret", "s3cret")).toBe(true);
+  });
+  it("rejects a missing, wrong, or different-length token", () => {
+    expect(isAuthorized("s3cret", undefined)).toBe(false);
+    expect(isAuthorized("s3cret", "Bearer nope")).toBe(false);
+    expect(isAuthorized("s3cret", "s3cret-plus-suffix")).toBe(false);
+    expect(isAuthorized("s3cret", "s3cre")).toBe(false);
+  });
+});
+
+describe("hostHeaderOk", () => {
+  it("accepts loopback hosts with or without a port", () => {
+    expect(hostHeaderOk("127.0.0.1")).toBe(true);
+    expect(hostHeaderOk("127.0.0.1:9161")).toBe(true);
+    expect(hostHeaderOk("localhost:9160")).toBe(true);
+    expect(hostHeaderOk("LOCALHOST")).toBe(true);
+    expect(hostHeaderOk("[::1]:9161")).toBe(true);
+    expect(hostHeaderOk("[::1]")).toBe(true);
+  });
+  it("rejects external names and addresses (DNS rebinding)", () => {
+    expect(hostHeaderOk("attacker.example")).toBe(false);
+    expect(hostHeaderOk("attacker.example:9161")).toBe(false);
+    expect(hostHeaderOk("192.168.1.20:9161")).toBe(false);
+    expect(hostHeaderOk("localhost.attacker.example")).toBe(false);
+  });
+  it("rejects a missing or malformed header", () => {
+    expect(hostHeaderOk(undefined)).toBe(false);
+    expect(hostHeaderOk("")).toBe(false);
+    expect(hostHeaderOk("[::1")).toBe(false);
+  });
+});

--- a/src/daemon/auth.ts
+++ b/src/daemon/auth.ts
@@ -1,0 +1,41 @@
+// Shared request guards for the headless HTTP servers (serve, files). Both
+// speak plain node:http on a local port, so they share the same two doors:
+// a bearer token and, when tokenless, a loopback-only Host header.
+
+export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+// Constant-ish comparison — the token isn't a password hash, but don't leak
+// length via early exit on the common prefix.
+function tokenMatches(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i);
+  return diff === 0;
+}
+
+export function isAuthorized(token: string | null, authHeader: string | undefined): boolean {
+  if (!token) return true; // no token configured -> open (loopback only, enforced at bind)
+  if (!authHeader) return false;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
+  return tokenMatches(token, provided);
+}
+
+// A tokenless server only ever binds loopback, but DNS rebinding lets a hostile
+// webpage reach loopback ports through the browser: the request arrives with
+// the attacker's name in the Host header. Requiring a loopback Host defeats it.
+export function hostHeaderOk(hostHeader: string | undefined): boolean {
+  if (!hostHeader) return false;
+  const raw = hostHeader.trim().toLowerCase();
+  let name: string;
+  if (raw.startsWith("[")) {
+    // bracketed IPv6, e.g. [::1]:9161
+    const end = raw.indexOf("]");
+    if (end === -1) return false;
+    name = raw.slice(1, end);
+  } else {
+    const colon = raw.indexOf(":");
+    name = colon === -1 ? raw : raw.slice(0, colon);
+  }
+  return LOOPBACK_HOSTS.has(name);
+}

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -1,0 +1,45 @@
+// Self-backgrounding for the headless commands: `--daemon` re-spawns this exact
+// command detached from the terminal (own session, stdio to a log file), writes
+// a pidfile, and exits the parent. You can then log out and it keeps running.
+//
+// NOTE: on a box with systemd, a `systemctl --user` service with linger is a
+// sturdier way to run these (auto-restart, boot-start). This is the no-systemd
+// convenience path.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { logsDir } from "../config/paths";
+
+const MARKER = "TORLINK_DAEMONIZED";
+
+export function logPathFor(name: string): string {
+  return path.join(logsDir, `${name}.log`);
+}
+export function pidPathFor(name: string): string {
+  return path.join(logsDir, `${name}.pid`);
+}
+
+// In the parent: fork a detached child and exit. In the already-detached child
+// (marker set): return so the caller keeps running normally.
+export function daemonize(name: string): void {
+  if (process.env[MARKER] === "1") return;
+
+  fs.mkdirSync(logsDir, { recursive: true });
+  const logPath = logPathFor(name);
+  const pidPath = pidPathFor(name);
+  const out = fs.openSync(logPath, "a");
+
+  const child = spawn(process.execPath, process.argv.slice(1), {
+    detached: true,
+    stdio: ["ignore", out, out],
+    env: { ...process.env, [MARKER]: "1" },
+  });
+  child.unref();
+  if (child.pid) fs.writeFileSync(pidPath, `${child.pid}\n`);
+
+  console.log(`torlink ${name} daemon started (pid ${child.pid}).`);
+  console.log(`  logs: ${logPath}`);
+  console.log(`  stop: kill ${child.pid}   (or: kill $(cat ${pidPath}))`);
+  process.exit(0);
+}

--- a/src/daemon/files.test.ts
+++ b/src/daemon/files.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { contentType, safeResolve, parseRange } from "./files";
+
+describe("contentType", () => {
+  it("maps known media extensions", () => {
+    expect(contentType("Movie.mp4")).toBe("video/mp4");
+    expect(contentType("track.MP3")).toBe("audio/mpeg");
+    expect(contentType("clip.mkv")).toBe("video/x-matroska");
+  });
+  it("falls back to octet-stream", () => {
+    expect(contentType("archive.xyz")).toBe("application/octet-stream");
+    expect(contentType("noext")).toBe("application/octet-stream");
+  });
+});
+
+describe("safeResolve", () => {
+  const root = path.resolve("/srv/downloads");
+  it("resolves a file beneath the root", () => {
+    expect(safeResolve(root, "/Movie/Movie.mkv")).toBe(path.join(root, "Movie", "Movie.mkv"));
+  });
+  it("maps the empty path to the root itself", () => {
+    expect(safeResolve(root, "/")).toBe(root);
+  });
+  it("rejects traversal, encoded or plain", () => {
+    expect(safeResolve(root, "/../etc/passwd")).toBeNull();
+    expect(safeResolve(root, "/%2e%2e/secret")).toBeNull();
+    expect(safeResolve(root, "/a/../../b")).toBeNull();
+  });
+  it("rejects a malformed percent-encoding", () => {
+    expect(safeResolve(root, "/%")).toBeNull();
+  });
+});
+
+describe("parseRange", () => {
+  const size = 1000;
+  it("returns null with no header (send whole file)", () => {
+    expect(parseRange(undefined, size)).toBeNull();
+    expect(parseRange("bytes=-", size)).toBeNull();
+  });
+  it("parses a closed range", () => {
+    expect(parseRange("bytes=0-499", size)).toEqual({ start: 0, end: 499 });
+  });
+  it("parses an open-ended range", () => {
+    expect(parseRange("bytes=500-", size)).toEqual({ start: 500, end: 999 });
+  });
+  it("parses a suffix range", () => {
+    expect(parseRange("bytes=-200", size)).toEqual({ start: 800, end: 999 });
+  });
+  it("clamps an end past the file", () => {
+    expect(parseRange("bytes=900-5000", size)).toEqual({ start: 900, end: 999 });
+  });
+  it("flags an unsatisfiable range", () => {
+    expect(parseRange("bytes=2000-3000", size)).toBe("unsatisfiable");
+    expect(parseRange("bytes=-0", size)).toBe("unsatisfiable");
+  });
+  it("ignores a malformed header", () => {
+    expect(parseRange("chunks=0-1", size)).toBeNull();
+  });
+});

--- a/src/daemon/files.ts
+++ b/src/daemon/files.ts
@@ -1,0 +1,254 @@
+// Headless HTTP file server: serve the downloads directory over HTTP so finished
+// files can be streamed or fetched from another machine — a browser, a media
+// player, a seedbox front-end. Read-only, range-aware (so video seeks and
+// resumable downloads work), and rooted at the downloads folder with no way out.
+//
+// Default port 9160 sits beside Tor's SOCKS port (9050 / browser 9150); it's
+// deliberately non-standard and overridable with --port.
+
+import http from "node:http";
+import { pipeline } from "node:stream";
+import { createReadStream } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../config/config";
+import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
+
+export const DEFAULT_FILES_PORT = 9160;
+
+const MIME: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".mkv": "video/x-matroska",
+  ".webm": "video/webm",
+  ".avi": "video/x-msvideo",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".flac": "audio/flac",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/opus",
+  ".wav": "audio/wav",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".srt": "text/plain; charset=utf-8",
+  ".vtt": "text/vtt",
+  ".txt": "text/plain; charset=utf-8",
+  ".pdf": "application/pdf",
+  ".nfo": "text/plain; charset=utf-8",
+};
+
+export function contentType(name: string): string {
+  return MIME[path.extname(name).toLowerCase()] ?? "application/octet-stream";
+}
+
+// Resolve a request path against the root, refusing anything that escapes it
+// (traversal, absolute paths, encoded ../). Returns an absolute path inside root
+// or null. The empty path maps to the root itself (directory listing).
+export function safeResolve(root: string, urlPath: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+  const segments = decoded.split("/").filter((s) => s.length > 0);
+  if (segments.some((s) => s === "..")) return null;
+  const resolvedRoot = path.resolve(root);
+  const full = path.resolve(resolvedRoot, ...segments);
+  // Must be the root or strictly beneath it.
+  if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) return null;
+  return full;
+}
+
+export interface Range {
+  start: number;
+  end: number;
+}
+
+// Parse a single-range `bytes=start-end` header against a known size. Returns
+// null for a missing/multi/malformed range (caller sends the whole file) and
+// "unsatisfiable" when the range falls outside the file (caller sends 416).
+export function parseRange(header: string | undefined, size: number): Range | null | "unsatisfiable" {
+  if (!header) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m) return null;
+  const startRaw = m[1];
+  const endRaw = m[2];
+  if (startRaw === "" && endRaw === "") return null;
+  let start: number;
+  let end: number;
+  if (startRaw === "") {
+    // suffix range: last N bytes
+    const n = Number.parseInt(endRaw!, 10);
+    if (n <= 0) return "unsatisfiable";
+    start = Math.max(0, size - n);
+    end = size - 1;
+  } else {
+    start = Number.parseInt(startRaw!, 10);
+    end = endRaw === "" ? size - 1 : Number.parseInt(endRaw!, 10);
+  }
+  if (start > end || start >= size) return "unsatisfiable";
+  if (end >= size) end = size - 1;
+  return { start, end };
+}
+
+function log(message: string): void {
+  console.log(`[torlnk files] ${new Date().toISOString()} ${message}`);
+}
+
+async function sendListing(res: http.ServerResponse, dir: string, method: string): Promise<void> {
+  const names = await fs.readdir(dir).catch(() => [] as string[]);
+  const entries = await Promise.all(
+    names.map(async (name) => {
+      const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+      return {
+        name,
+        type: stat?.isDirectory() ? "dir" : "file",
+        size: stat?.isFile() ? stat.size : undefined,
+      };
+    }),
+  );
+  const payload = JSON.stringify({ entries });
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(method === "HEAD" ? undefined : payload);
+}
+
+function sendFile(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  full: string,
+  size: number,
+): void {
+  const type = contentType(full);
+  const range = parseRange(req.headers.range, size);
+
+  if (range === "unsatisfiable") {
+    res.writeHead(416, { "Content-Range": `bytes */${size}` });
+    res.end();
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": type,
+    "Accept-Ranges": "bytes",
+  };
+
+  if (range) {
+    const length = range.end - range.start + 1;
+    res.writeHead(206, {
+      ...headers,
+      "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+      "Content-Length": String(length),
+    });
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    // pipeline (not pipe) so the read stream is destroyed when the client
+    // disconnects mid-transfer; a media player's seeks abort constantly, and
+    // plain pipe would leak an open handle per aborted request.
+    pipeline(createReadStream(full, { start: range.start, end: range.end }), res, () => {});
+    return;
+  }
+
+  res.writeHead(200, { ...headers, "Content-Length": String(size) });
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+  pipeline(createReadStream(full), res, () => {});
+}
+
+export interface FilesOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  dir?: string;
+}
+
+export async function runFiles(options: FilesOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_FILES_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: don't expose the disk on a public interface tokenless.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_FILES_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const root = path.resolve(
+    options.dir && options.dir.trim() ? options.dir.trim() : (await loadConfig()).downloadDir,
+  );
+  await fs.mkdir(root, { recursive: true }).catch(() => {});
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      if (method !== "GET" && method !== "HEAD") {
+        res.writeHead(405, { "Content-Type": "application/json", Allow: "GET, HEAD" });
+        res.end(JSON.stringify({ error: "method not allowed" }));
+        return;
+      }
+      // Tokenless means loopback-bound; require a loopback Host so a hostile
+      // webpage can't reach us through DNS rebinding.
+      if (!token && !hostHeaderOk(req.headers.host)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden host" }));
+        return;
+      }
+      if (!isAuthorized(token, req.headers.authorization)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "unauthorized" }));
+        return;
+      }
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      const full = safeResolve(root, urlPath);
+      if (!full) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden" }));
+        return;
+      }
+      const stat = await fs.stat(full).catch(() => null);
+      if (!stat) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not found" }));
+        return;
+      }
+      try {
+        if (stat.isDirectory()) await sendListing(res, full, method);
+        else sendFile(req, res, full, stat.size);
+      } catch {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "internal error" }));
+        }
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`serving ${root} on http://${host}:${port}`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/files.ts
+++ b/src/daemon/files.ts
@@ -1,0 +1,252 @@
+// Headless HTTP file server: serve the downloads directory over HTTP so finished
+// files can be streamed or fetched from another machine — a browser, a media
+// player, a seedbox front-end. Read-only, range-aware (so video seeks and
+// resumable downloads work), and rooted at the downloads folder with no way out.
+//
+// Default port 9160 sits beside Tor's SOCKS port (9050 / browser 9150); it's
+// deliberately non-standard and overridable with --port.
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../config/config";
+
+export const DEFAULT_FILES_PORT = 9160;
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+const MIME: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".mkv": "video/x-matroska",
+  ".webm": "video/webm",
+  ".avi": "video/x-msvideo",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".flac": "audio/flac",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/opus",
+  ".wav": "audio/wav",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".srt": "text/plain; charset=utf-8",
+  ".vtt": "text/vtt",
+  ".txt": "text/plain; charset=utf-8",
+  ".pdf": "application/pdf",
+  ".nfo": "text/plain; charset=utf-8",
+};
+
+export function contentType(name: string): string {
+  return MIME[path.extname(name).toLowerCase()] ?? "application/octet-stream";
+}
+
+// Resolve a request path against the root, refusing anything that escapes it
+// (traversal, absolute paths, encoded ../). Returns an absolute path inside root
+// or null. The empty path maps to the root itself (directory listing).
+export function safeResolve(root: string, urlPath: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+  const segments = decoded.split("/").filter((s) => s.length > 0);
+  if (segments.some((s) => s === "..")) return null;
+  const resolvedRoot = path.resolve(root);
+  const full = path.resolve(resolvedRoot, ...segments);
+  // Must be the root or strictly beneath it.
+  if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) return null;
+  return full;
+}
+
+export interface Range {
+  start: number;
+  end: number;
+}
+
+// Parse a single-range `bytes=start-end` header against a known size. Returns
+// null for a missing/multi/malformed range (caller sends the whole file) and
+// "unsatisfiable" when the range falls outside the file (caller sends 416).
+export function parseRange(header: string | undefined, size: number): Range | null | "unsatisfiable" {
+  if (!header) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m) return null;
+  const startRaw = m[1];
+  const endRaw = m[2];
+  if (startRaw === "" && endRaw === "") return null;
+  let start: number;
+  let end: number;
+  if (startRaw === "") {
+    // suffix range: last N bytes
+    const n = Number.parseInt(endRaw!, 10);
+    if (n <= 0) return "unsatisfiable";
+    start = Math.max(0, size - n);
+    end = size - 1;
+  } else {
+    start = Number.parseInt(startRaw!, 10);
+    end = endRaw === "" ? size - 1 : Number.parseInt(endRaw!, 10);
+  }
+  if (start > end || start >= size) return "unsatisfiable";
+  if (end >= size) end = size - 1;
+  return { start, end };
+}
+
+function authHeaderOk(token: string | null, authHeader: string | undefined): boolean {
+  if (!token) return true;
+  if (!authHeader) return false;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
+  return provided === token;
+}
+
+function log(message: string): void {
+  console.log(`[torlnk files] ${new Date().toISOString()} ${message}`);
+}
+
+async function sendListing(res: http.ServerResponse, dir: string, method: string): Promise<void> {
+  const names = await fs.readdir(dir).catch(() => [] as string[]);
+  const entries = await Promise.all(
+    names.map(async (name) => {
+      const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+      return {
+        name,
+        type: stat?.isDirectory() ? "dir" : "file",
+        size: stat?.isFile() ? stat.size : undefined,
+      };
+    }),
+  );
+  const payload = JSON.stringify({ entries });
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(method === "HEAD" ? undefined : payload);
+}
+
+function sendFile(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  full: string,
+  size: number,
+): void {
+  const type = contentType(full);
+  const range = parseRange(req.headers.range, size);
+
+  if (range === "unsatisfiable") {
+    res.writeHead(416, { "Content-Range": `bytes */${size}` });
+    res.end();
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": type,
+    "Accept-Ranges": "bytes",
+  };
+
+  if (range) {
+    const length = range.end - range.start + 1;
+    res.writeHead(206, {
+      ...headers,
+      "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+      "Content-Length": String(length),
+    });
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    createReadStream(full, { start: range.start, end: range.end }).pipe(res);
+    return;
+  }
+
+  res.writeHead(200, { ...headers, "Content-Length": String(size) });
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+  createReadStream(full).pipe(res);
+}
+
+export interface FilesOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  dir?: string;
+}
+
+export async function runFiles(options: FilesOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_FILES_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: don't expose the disk on a public interface tokenless.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_FILES_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const root = path.resolve(
+    options.dir && options.dir.trim() ? options.dir.trim() : (await loadConfig()).downloadDir,
+  );
+  await fs.mkdir(root, { recursive: true }).catch(() => {});
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      if (method !== "GET" && method !== "HEAD") {
+        res.writeHead(405, { "Content-Type": "application/json", Allow: "GET, HEAD" });
+        res.end(JSON.stringify({ error: "method not allowed" }));
+        return;
+      }
+      if (!authHeaderOk(token, req.headers.authorization)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "unauthorized" }));
+        return;
+      }
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      const full = safeResolve(root, urlPath);
+      if (!full) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden" }));
+        return;
+      }
+      const stat = await fs.stat(full).catch(() => null);
+      if (!stat) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not found" }));
+        return;
+      }
+      try {
+        if (stat.isDirectory()) await sendListing(res, full, method);
+        else sendFile(req, res, full, stat.size);
+      } catch {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "internal error" }));
+        }
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`serving ${root} on http://${host}:${port}`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/files.ts
+++ b/src/daemon/files.ts
@@ -7,14 +7,14 @@
 // deliberately non-standard and overridable with --port.
 
 import http from "node:http";
+import { pipeline } from "node:stream";
 import { createReadStream } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { loadConfig } from "../config/config";
+import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
 
 export const DEFAULT_FILES_PORT = 9160;
-
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 
 const MIME: Record<string, string> = {
   ".mp4": "video/mp4",
@@ -96,14 +96,6 @@ export function parseRange(header: string | undefined, size: number): Range | nu
   return { start, end };
 }
 
-function authHeaderOk(token: string | null, authHeader: string | undefined): boolean {
-  if (!token) return true;
-  if (!authHeader) return false;
-  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
-  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
-  return provided === token;
-}
-
 function log(message: string): void {
   console.log(`[torlnk files] ${new Date().toISOString()} ${message}`);
 }
@@ -156,7 +148,10 @@ function sendFile(
       res.end();
       return;
     }
-    createReadStream(full, { start: range.start, end: range.end }).pipe(res);
+    // pipeline (not pipe) so the read stream is destroyed when the client
+    // disconnects mid-transfer; a media player's seeks abort constantly, and
+    // plain pipe would leak an open handle per aborted request.
+    pipeline(createReadStream(full, { start: range.start, end: range.end }), res, () => {});
     return;
   }
 
@@ -165,7 +160,7 @@ function sendFile(
     res.end();
     return;
   }
-  createReadStream(full).pipe(res);
+  pipeline(createReadStream(full), res, () => {});
 }
 
 export interface FilesOptions {
@@ -203,7 +198,14 @@ export async function runFiles(options: FilesOptions = {}): Promise<void> {
         res.end(JSON.stringify({ error: "method not allowed" }));
         return;
       }
-      if (!authHeaderOk(token, req.headers.authorization)) {
+      // Tokenless means loopback-bound; require a loopback Host so a hostile
+      // webpage can't reach us through DNS rebinding.
+      if (!token && !hostHeaderOk(req.headers.host)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden host" }));
+        return;
+      }
+      if (!isAuthorized(token, req.headers.authorization)) {
         res.writeHead(401, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "unauthorized" }));
         return;

--- a/src/daemon/runtime.test.ts
+++ b/src/daemon/runtime.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { addInput, type Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+// A stand-in for DownloadQueue that records adds without spinning up webtorrent.
+function fakeRuntime(dir: string, has = false): { runtime: Runtime; add: ReturnType<typeof vi.fn> } {
+  const add = vi.fn();
+  const runtime = {
+    queue: { has: () => has, add } as unknown as Runtime["queue"],
+    downloadDir: dir,
+  };
+  return { runtime, add };
+}
+
+describe("addInput", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-rt-"));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("adds a magnet keyed by its info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, MAGNET)).toBe("added");
+    expect(add).toHaveBeenCalledWith(
+      { id: HASH, name: "Example", magnet: MAGNET },
+      dir,
+    );
+  });
+
+  it("adds a bare info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, HASH)).toBe("added");
+    expect(add).toHaveBeenCalledOnce();
+  });
+
+  it("reports a duplicate without adding", async () => {
+    const { runtime, add } = fakeRuntime(dir, true);
+    expect(await addInput(runtime, MAGNET)).toBe("duplicate");
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid input without adding or throwing", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, "not a magnet")).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("rejects a .torrent file path unless the caller opts in", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    const file = path.join(dir, "example.torrent");
+    expect(await addInput(runtime, file)).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+    // Opted in (the watch folder), a bad file still fails soft as invalid.
+    expect(await addInput(runtime, file, { allowTorrentPath: true })).toBe("invalid");
+  });
+});

--- a/src/daemon/runtime.test.ts
+++ b/src/daemon/runtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { addInput, type Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+// A stand-in for DownloadQueue that records adds without spinning up webtorrent.
+function fakeRuntime(dir: string, has = false): { runtime: Runtime; add: ReturnType<typeof vi.fn> } {
+  const add = vi.fn();
+  const runtime = {
+    queue: { has: () => has, add } as unknown as Runtime["queue"],
+    downloadDir: dir,
+  };
+  return { runtime, add };
+}
+
+describe("addInput", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-rt-"));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("adds a magnet keyed by its info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, MAGNET)).toBe("added");
+    expect(add).toHaveBeenCalledWith(
+      { id: HASH, name: "Example", magnet: MAGNET },
+      dir,
+    );
+  });
+
+  it("adds a bare info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, HASH)).toBe("added");
+    expect(add).toHaveBeenCalledOnce();
+  });
+
+  it("reports a duplicate without adding", async () => {
+    const { runtime, add } = fakeRuntime(dir, true);
+    expect(await addInput(runtime, MAGNET)).toBe("duplicate");
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid input without adding or throwing", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, "not a magnet")).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/runtime.test.ts
+++ b/src/daemon/runtime.test.ts
@@ -52,4 +52,13 @@ describe("addInput", () => {
     expect(await addInput(runtime, "not a magnet")).toBe("invalid");
     expect(add).not.toHaveBeenCalled();
   });
+
+  it("rejects a .torrent file path unless the caller opts in", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    const file = path.join(dir, "example.torrent");
+    expect(await addInput(runtime, file)).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+    // Opted in (the watch folder), a bad file still fails soft as invalid.
+    expect(await addInput(runtime, file, { allowTorrentPath: true })).toBe("invalid");
+  });
 });

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,0 +1,55 @@
+// Headless runtime: drive the download queue without the Ink TUI.
+//
+// The TUI is one front-end over DownloadQueue; a seedbox needs another that has
+// no terminal at all. This mirrors App.tsx's boot sequence (load config, restore
+// queue/history/seeds) so a headless run resumes exactly what an interactive one
+// would, then exposes a single addInput() the watch folder and HTTP API share.
+
+import { promises as fs } from "node:fs";
+import { loadConfig } from "../config/config";
+import { DownloadQueue } from "../download/queue";
+import { loadQueue, loadSeeds } from "../download/persist";
+import { loadHistory } from "../download/history";
+import { reconcileQueue } from "../download/reconcile";
+import { parseInput } from "../sources/magnet";
+import { magnetFromTorrentFile } from "../sources/torrentFile";
+
+export interface Runtime {
+  queue: DownloadQueue;
+  downloadDir: string;
+}
+
+// Build a queue and restore persisted state, matching the TUI's boot order
+// (history before seeds — seeds resolve against history). `downloadDir` falls
+// back to the saved config's dir when the caller doesn't override it.
+export async function startRuntime(overrideDir?: string): Promise<Runtime> {
+  const cfg = await loadConfig();
+  const queue = new DownloadQueue();
+  queue.setTrackers(cfg.trackers);
+  queue.restore(reconcileQueue(await loadQueue()));
+  queue.restoreHistory(await loadHistory());
+  queue.restoreSeeds(await loadSeeds());
+  const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
+  return { queue, downloadDir };
+}
+
+export type AddOutcome = "added" | "duplicate" | "invalid";
+
+// Turn a magnet URI, bare info hash, or a path to a .torrent file into a queued
+// download. Deduplicates by info hash (the queue's own id), so re-submitting the
+// same torrent is a no-op rather than a restart. Never throws — bad input is
+// reported as "invalid" so callers (a watcher, an HTTP handler) can fail soft.
+export async function addInput(runtime: Runtime, input: string): Promise<AddOutcome> {
+  const trimmed = input.trim();
+  const parsed = /\.torrent$/i.test(trimmed)
+    ? await magnetFromTorrentFile(trimmed)
+    : parseInput(trimmed);
+  if (!parsed) return "invalid";
+  if (runtime.queue.has(parsed.infoHash)) return "duplicate";
+  await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});
+  runtime.queue.add(
+    { id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet },
+    runtime.downloadDir,
+  );
+  return "added";
+}

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,0 +1,70 @@
+// Headless runtime: drive the download queue without the Ink TUI.
+//
+// The TUI is one front-end over DownloadQueue; a seedbox needs another that has
+// no terminal at all. This mirrors App.tsx's boot sequence (load config, restore
+// queue/history/seeds) so a headless run resumes exactly what an interactive one
+// would, then exposes a single addInput() the watch folder and HTTP API share.
+
+import { promises as fs } from "node:fs";
+import { loadConfig } from "../config/config";
+import { DownloadQueue } from "../download/queue";
+import { loadQueue, loadSeeds } from "../download/persist";
+import { loadHistory } from "../download/history";
+import { reconcileQueue } from "../download/reconcile";
+import { parseInput } from "../sources/magnet";
+import { magnetFromTorrentFile } from "../sources/torrentFile";
+
+export interface Runtime {
+  queue: DownloadQueue;
+  downloadDir: string;
+}
+
+// Build a queue and restore persisted state, matching the TUI's boot order
+// (history before seeds — seeds resolve against history). `downloadDir` falls
+// back to the saved config's dir when the caller doesn't override it.
+export async function startRuntime(overrideDir?: string): Promise<Runtime> {
+  const cfg = await loadConfig();
+  const queue = new DownloadQueue();
+  queue.setTrackers(cfg.trackers);
+  queue.restore(reconcileQueue(await loadQueue()));
+  queue.restoreHistory(await loadHistory());
+  queue.restoreSeeds(await loadSeeds());
+  const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
+  return { queue, downloadDir };
+}
+
+export type AddOutcome = "added" | "duplicate" | "invalid";
+
+// Turn a magnet URI, bare info hash, or a path to a .torrent file into a queued
+// download. Deduplicates by info hash (the queue's own id), so re-submitting the
+// same torrent is a no-op rather than a restart. Never throws — bad input is
+// reported as "invalid" so callers (a watcher, an HTTP handler) can fail soft.
+export interface AddInputOptions {
+  // Treat an input ending in .torrent as a local file path and read it. Only
+  // the watch folder opts in; a network caller (the HTTP add API) must never
+  // be able to point the daemon at the local filesystem.
+  allowTorrentPath?: boolean;
+}
+
+export async function addInput(
+  runtime: Runtime,
+  input: string,
+  options: AddInputOptions = {},
+): Promise<AddOutcome> {
+  const trimmed = input.trim();
+  let parsed;
+  if (/\.torrent$/i.test(trimmed)) {
+    if (!options.allowTorrentPath) return "invalid";
+    parsed = await magnetFromTorrentFile(trimmed);
+  } else {
+    parsed = parseInput(trimmed);
+  }
+  if (!parsed) return "invalid";
+  if (runtime.queue.has(parsed.infoHash)) return "duplicate";
+  await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});
+  runtime.queue.add(
+    { id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet },
+    runtime.downloadDir,
+  );
+  return "added";
+}

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -39,11 +39,26 @@ export type AddOutcome = "added" | "duplicate" | "invalid";
 // download. Deduplicates by info hash (the queue's own id), so re-submitting the
 // same torrent is a no-op rather than a restart. Never throws — bad input is
 // reported as "invalid" so callers (a watcher, an HTTP handler) can fail soft.
-export async function addInput(runtime: Runtime, input: string): Promise<AddOutcome> {
+export interface AddInputOptions {
+  // Treat an input ending in .torrent as a local file path and read it. Only
+  // the watch folder opts in; a network caller (the HTTP add API) must never
+  // be able to point the daemon at the local filesystem.
+  allowTorrentPath?: boolean;
+}
+
+export async function addInput(
+  runtime: Runtime,
+  input: string,
+  options: AddInputOptions = {},
+): Promise<AddOutcome> {
   const trimmed = input.trim();
-  const parsed = /\.torrent$/i.test(trimmed)
-    ? await magnetFromTorrentFile(trimmed)
-    : parseInput(trimmed);
+  let parsed;
+  if (/\.torrent$/i.test(trimmed)) {
+    if (!options.allowTorrentPath) return "invalid";
+    parsed = await magnetFromTorrentFile(trimmed);
+  } else {
+    parsed = parseInput(trimmed);
+  }
   if (!parsed) return "invalid";
   if (runtime.queue.has(parsed.infoHash)) return "duplicate";
   await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});

--- a/src/daemon/seed-reaper.test.ts
+++ b/src/daemon/seed-reaper.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { dueSeeds, type ReapableQueue } from "./seed-reaper";
+
+const HOUR = 3_600_000;
+
+function queue(
+  seeds: { id: string; name: string; dir: string; status: string }[],
+  history: { id: string; completedAt: number }[],
+): ReapableQueue {
+  return {
+    getSeeds: () => seeds,
+    getHistory: () => history,
+    stopSeeding: () => {},
+  };
+}
+
+describe("dueSeeds", () => {
+  const now = 10 * HOUR;
+
+  it("returns seeds finished longer ago than the limit", () => {
+    const q = queue(
+      [
+        { id: "a", name: "Old", dir: "/d", status: "seeding" },
+        { id: "b", name: "Fresh", dir: "/d", status: "seeding" },
+      ],
+      [
+        { id: "a", completedAt: now - 2 * HOUR },
+        { id: "b", completedAt: now - 10 * 60_000 }, // 10 min ago
+      ],
+    );
+    expect(dueSeeds(q, HOUR, now).map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("ignores non-seeding entries (paused/missing)", () => {
+    const q = queue(
+      [{ id: "a", name: "Paused", dir: "/d", status: "paused" }],
+      [{ id: "a", completedAt: 0 }],
+    );
+    expect(dueSeeds(q, HOUR, now)).toEqual([]);
+  });
+
+  it("treats unknown completion time as just-finished (not due)", () => {
+    const q = queue([{ id: "a", name: "NoHist", dir: "/d", status: "seeding" }], []);
+    expect(dueSeeds(q, HOUR, now)).toEqual([]);
+  });
+
+  it("carries the dir/name through for optional file deletion", () => {
+    const q = queue(
+      [{ id: "a", name: "Movie", dir: "/downloads", status: "seeding" }],
+      [{ id: "a", completedAt: now - 5 * HOUR }],
+    );
+    expect(dueSeeds(q, HOUR, now)).toEqual([{ id: "a", name: "Movie", dir: "/downloads" }]);
+  });
+});

--- a/src/daemon/seed-reaper.ts
+++ b/src/daemon/seed-reaper.ts
@@ -1,0 +1,80 @@
+// Auto-stop seeding after a time limit (headless "seed mode"). Once a torrent
+// has been finished for `seedTimeMs`, stop seeding it. By default the files are
+// kept (it becomes a paused seed you can resume) — the point is to stop sharing,
+// e.g. to stay ahead of DMCA notices, without losing your library. With
+// `deleteFiles` it also removes the downloaded data to reclaim space.
+//
+// The clock is the download's completion time (history.completedAt), not when
+// this process started, so a restart doesn't reset every torrent's timer.
+
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import type { DownloadQueue } from "../download/queue";
+
+const DEFAULT_CHECK_MS = 30_000;
+
+// The slice of DownloadQueue the reaper needs — keeps it trivially testable.
+export interface ReapableQueue {
+  getSeeds(): { id: string; name: string; dir: string; status: string }[];
+  getHistory(): { id: string; completedAt: number }[];
+  stopSeeding(id: string): void;
+}
+
+export interface DueSeed {
+  id: string;
+  name: string;
+  dir: string;
+}
+
+// The actively-seeding torrents whose completion is older than the limit.
+export function dueSeeds(queue: ReapableQueue, seedTimeMs: number, now: number): DueSeed[] {
+  const completedAt = new Map(queue.getHistory().map((h) => [h.id, h.completedAt]));
+  const out: DueSeed[] = [];
+  for (const s of queue.getSeeds()) {
+    if (s.status !== "seeding") continue;
+    const since = completedAt.get(s.id) ?? now; // unknown completion → treat as just finished
+    if (now - since >= seedTimeMs) out.push({ id: s.id, name: s.name, dir: s.dir });
+  }
+  return out;
+}
+
+// Best-effort delete of a torrent's on-disk data: only the torrent's own entry
+// directly under its download dir (a file, or the folder named after it). Never
+// walks outside that dir, never throws.
+export async function deleteSeedData(dir: string, name: string): Promise<string | null> {
+  const base = path.basename(name.trim());
+  if (!base || base === "." || base === "..") return null;
+  const target = path.join(dir, base);
+  await rm(target, { recursive: true, force: true }).catch(() => {});
+  return target;
+}
+
+export interface SeedReaperOptions {
+  deleteFiles?: boolean;
+  log?: (message: string) => void;
+  intervalMs?: number;
+}
+
+export function startSeedReaper(
+  queue: DownloadQueue,
+  seedTimeMs: number,
+  options: SeedReaperOptions = {},
+): () => void {
+  const { deleteFiles = false, log = () => {}, intervalMs = DEFAULT_CHECK_MS } = options;
+  const tick = (): void => {
+    for (const s of dueSeeds(queue, seedTimeMs, Date.now())) {
+      queue.stopSeeding(s.id);
+      if (deleteFiles) {
+        void deleteSeedData(s.dir, s.name).then((target) => {
+          log(`seed time reached, stopped seeding + deleted files: ${target ?? s.name}`);
+        });
+      } else {
+        log(`seed time reached, stopped seeding (files kept): ${s.name}`);
+      }
+    }
+  };
+  tick();
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { handleApi, isAuthorized, extractMagnet } from "./serve";
+import type { Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+describe("isAuthorized", () => {
+  it("is open when no token is configured", () => {
+    expect(isAuthorized(null, undefined)).toBe(true);
+  });
+  it("accepts a matching bearer token or raw token", () => {
+    expect(isAuthorized("s3cret", "Bearer s3cret")).toBe(true);
+    expect(isAuthorized("s3cret", "s3cret")).toBe(true);
+  });
+  it("rejects a missing or wrong token", () => {
+    expect(isAuthorized("s3cret", undefined)).toBe(false);
+    expect(isAuthorized("s3cret", "Bearer nope")).toBe(false);
+  });
+});
+
+describe("extractMagnet", () => {
+  it("reads a magnet from JSON", () => {
+    expect(extractMagnet(`{"magnet":"${MAGNET}"}`)).toBe(MAGNET);
+  });
+  it("reads an infohash field", () => {
+    expect(extractMagnet(`{"infohash":"${HASH}"}`)).toBe(HASH);
+  });
+  it("accepts a raw magnet body", () => {
+    expect(extractMagnet(MAGNET)).toBe(MAGNET);
+  });
+  it("returns null for empty or unusable bodies", () => {
+    expect(extractMagnet("")).toBeNull();
+    expect(extractMagnet("{bad json")).toBeNull();
+    expect(extractMagnet(`{"other":1}`)).toBeNull();
+  });
+});
+
+describe("handleApi", () => {
+  let dir: string;
+  let add: ReturnType<typeof vi.fn>;
+  let runtime: Runtime;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-serve-"));
+    add = vi.fn();
+    runtime = {
+      queue: {
+        has: () => false,
+        add,
+        getItems: () => [],
+        getSeeds: () => [],
+      } as unknown as Runtime["queue"],
+      downloadDir: dir,
+    };
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("serves /health without auth", async () => {
+    const res = await handleApi(runtime, "tok", "GET", "/health", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("401s a protected route without a token", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", undefined, `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(401);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("adds a magnet on POST /add", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", "Bearer tok", `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, outcome: "added" });
+    expect(add).toHaveBeenCalledWith({ id: HASH, name: "Example", magnet: MAGNET }, dir);
+  });
+
+  it("400s an invalid magnet", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"nope"}`);
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("lists downloads on GET /downloads", async () => {
+    const res = await handleApi(runtime, null, "GET", "/downloads", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ downloads: [], seeds: [] });
+  });
+
+  it("404s an unknown route", async () => {
+    const res = await handleApi(runtime, null, "GET", "/nope", undefined, "");
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { handleApi, isAuthorized, extractMagnet } from "./serve";
+import type { Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+describe("isAuthorized", () => {
+  it("is open when no token is configured", () => {
+    expect(isAuthorized(null, undefined)).toBe(true);
+  });
+  it("accepts a matching bearer token or raw token", () => {
+    expect(isAuthorized("s3cret", "Bearer s3cret")).toBe(true);
+    expect(isAuthorized("s3cret", "s3cret")).toBe(true);
+  });
+  it("rejects a missing or wrong token", () => {
+    expect(isAuthorized("s3cret", undefined)).toBe(false);
+    expect(isAuthorized("s3cret", "Bearer nope")).toBe(false);
+  });
+});
+
+describe("extractMagnet", () => {
+  it("reads a magnet from JSON", () => {
+    expect(extractMagnet(`{"magnet":"${MAGNET}"}`)).toBe(MAGNET);
+  });
+  it("reads an infohash field", () => {
+    expect(extractMagnet(`{"infohash":"${HASH}"}`)).toBe(HASH);
+  });
+  it("accepts a raw magnet body", () => {
+    expect(extractMagnet(MAGNET)).toBe(MAGNET);
+  });
+  it("returns null for empty or unusable bodies", () => {
+    expect(extractMagnet("")).toBeNull();
+    expect(extractMagnet("{bad json")).toBeNull();
+    expect(extractMagnet(`{"other":1}`)).toBeNull();
+  });
+});
+
+describe("handleApi", () => {
+  let dir: string;
+  let add: ReturnType<typeof vi.fn>;
+  let runtime: Runtime;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-serve-"));
+    add = vi.fn();
+    runtime = {
+      queue: {
+        has: () => false,
+        add,
+        getItems: () => [],
+        getSeeds: () => [],
+      } as unknown as Runtime["queue"],
+      downloadDir: dir,
+    };
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("serves /health without auth", async () => {
+    const res = await handleApi(runtime, "tok", "GET", "/health", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("401s a protected route without a token", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", undefined, `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(401);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("adds a magnet on POST /add", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", "Bearer tok", `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, outcome: "added" });
+    expect(add).toHaveBeenCalledWith({ id: HASH, name: "Example", magnet: MAGNET }, dir);
+  });
+
+  it("400s an invalid magnet", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"nope"}`);
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("400s a .torrent file path (no filesystem reach over HTTP)", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, "C:/secrets/x.torrent");
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("lists downloads on GET /downloads", async () => {
+    const res = await handleApi(runtime, null, "GET", "/downloads", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ downloads: [], seeds: [] });
+  });
+
+  it("404s an unknown route", async () => {
+    const res = await handleApi(runtime, null, "GET", "/nope", undefined, "");
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -86,6 +86,12 @@ describe("handleApi", () => {
     expect(add).not.toHaveBeenCalled();
   });
 
+  it("400s a .torrent file path (no filesystem reach over HTTP)", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, "C:/secrets/x.torrent");
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
   it("lists downloads on GET /downloads", async () => {
     const res = await handleApi(runtime, null, "GET", "/downloads", undefined, "");
     expect(res.status).toBe(200);

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -1,0 +1,212 @@
+// Headless HTTP add API: torlnk exposes a tiny local server so another program
+// (a seedbox web app, a script, curl) can hand it a torrent over HTTP instead of
+// a keypress. It complements the watch folder — same headless runtime, a
+// different doorway.
+//
+// Default port 9161 sits next to Tor's control port (9051 / browser 9151); it's
+// deliberately non-standard and overridable with --port. Binds 127.0.0.1 by
+// default; exposing it on a public interface requires a token.
+
+import http from "node:http";
+import { startRuntime, addInput, type Runtime } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
+import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
+import { VERSION } from "../version";
+
+export { isAuthorized } from "./auth";
+
+export const DEFAULT_API_PORT = 9161;
+
+const MAX_BODY_BYTES = 64 * 1024; // a magnet is small; cap the body hard
+
+export interface ApiResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export interface ServeOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  downloadDir?: string;
+  /** Stop seeding each torrent this long after it finishes (ms). */
+  seedTimeMs?: number;
+  /** With seedTimeMs, also delete the files when the timer expires. */
+  deleteFiles?: boolean;
+}
+
+// Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
+// { infohash }) or a raw body that is itself a magnet or info hash — forgiving,
+// so callers don't have to guess the exact envelope.
+export function extractMagnet(bodyText: string): string | null {
+  const raw = bodyText.trim();
+  if (!raw) return null;
+  if (raw.startsWith("{")) {
+    try {
+      const obj = JSON.parse(raw) as Record<string, unknown>;
+      const val = obj.magnet ?? obj.infohash ?? obj.infoHash ?? obj.hash;
+      return typeof val === "string" && val.trim() ? val.trim() : null;
+    } catch {
+      return null;
+    }
+  }
+  return raw;
+}
+
+function statusPayload(runtime: Runtime): Record<string, unknown> {
+  const downloads = runtime.queue.getItems().map((it) => ({
+    id: it.id,
+    name: it.name,
+    status: it.status,
+    progress: it.progress,
+    peers: it.peers,
+    speed: it.speed,
+  }));
+  const seeds = runtime.queue.getSeeds().map((s) => ({
+    id: s.id,
+    name: s.name,
+    status: s.status,
+    peers: s.peers,
+    uploaded: s.uploaded,
+  }));
+  return { downloads, seeds };
+}
+
+// Pure request router — no node:http types, so it's trivially testable.
+export async function handleApi(
+  runtime: Runtime,
+  token: string | null,
+  method: string,
+  urlPath: string,
+  authHeader: string | undefined,
+  bodyText: string,
+): Promise<ApiResponse> {
+  if (method === "GET" && urlPath === "/health") {
+    return { status: 200, body: { ok: true, version: VERSION } };
+  }
+  if (!isAuthorized(token, authHeader)) {
+    return { status: 401, body: { error: "unauthorized" } };
+  }
+  if (method === "GET" && (urlPath === "/downloads" || urlPath === "/status")) {
+    return { status: 200, body: statusPayload(runtime) };
+  }
+  if (method === "POST" && urlPath === "/add") {
+    const magnet = extractMagnet(bodyText);
+    if (!magnet) return { status: 400, body: { error: "missing magnet or info hash" } };
+    const outcome = await addInput(runtime, magnet);
+    if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
+    return { status: 200, body: { ok: true, outcome } };
+  }
+  return { status: 404, body: { error: "not found" } };
+}
+
+// Read the body up to the size cap. On overflow resolve tooLarge immediately
+// (further chunks are ignored) so the caller can answer 413 on a live socket
+// and close the connection afterwards, instead of writing to a destroyed one.
+function readBody(req: http.IncomingMessage): Promise<{ text: string; tooLarge: boolean }> {
+  return new Promise((resolve) => {
+    let size = 0;
+    let settled = false;
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => {
+      if (settled) return;
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        settled = true;
+        resolve({ text: "", tooLarge: true });
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => {
+      if (settled) return;
+      settled = true;
+      resolve({ text: Buffer.concat(chunks).toString("utf8"), tooLarge: false });
+    });
+    req.on("error", () => {
+      if (settled) return;
+      settled = true;
+      resolve({ text: "", tooLarge: false });
+    });
+  });
+}
+
+function log(message: string): void {
+  console.log(`[torlnk serve] ${new Date().toISOString()} ${message}`);
+}
+
+export async function runServe(options: ServeOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_API_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: never expose a public interface without a token.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_API_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const runtime = await startRuntime(options.downloadDir);
+
+  if (options.seedTimeMs && options.seedTimeMs > 0) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
+  }
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      // Tokenless means loopback-bound; require a loopback Host so a hostile
+      // webpage can't reach us through DNS rebinding.
+      if (!token && !hostHeaderOk(req.headers.host)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden host" }));
+        log(`${method} ${urlPath} -> 403 (host)`);
+        return;
+      }
+      const body = method === "POST" ? await readBody(req) : { text: "", tooLarge: false };
+      if (body.tooLarge) {
+        res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
+        res.end(JSON.stringify({ error: "body too large" }));
+        res.once("finish", () => req.destroy());
+        log(`${method} ${urlPath} -> 413`);
+        return;
+      }
+      const bodyText = body.text;
+      let out: ApiResponse;
+      try {
+        out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);
+      } catch {
+        out = { status: 500, body: { error: "internal error" } };
+      }
+      const payload = JSON.stringify(out.body);
+      res.writeHead(out.status, { "Content-Type": "application/json" });
+      res.end(payload);
+      if (method !== "GET" || urlPath !== "/health") {
+        log(`${method} ${urlPath} -> ${out.status}`);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -1,0 +1,189 @@
+// Headless HTTP add API: torlnk exposes a tiny local server so another program
+// (a seedbox web app, a script, curl) can hand it a torrent over HTTP instead of
+// a keypress. It complements the watch folder — same headless runtime, a
+// different doorway.
+//
+// Default port 9161 sits next to Tor's control port (9051 / browser 9151); it's
+// deliberately non-standard and overridable with --port. Binds 127.0.0.1 by
+// default; exposing it on a public interface requires a token.
+
+import http from "node:http";
+import { startRuntime, addInput, type Runtime } from "./runtime";
+import { VERSION } from "../version";
+
+export const DEFAULT_API_PORT = 9161;
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const MAX_BODY_BYTES = 64 * 1024; // a magnet is small; cap the body hard
+
+export interface ApiResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export interface ServeOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  downloadDir?: string;
+}
+
+// Constant-ish comparison — the token isn't a password hash, but don't leak
+// length via early exit on the common prefix.
+function tokenMatches(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i);
+  return diff === 0;
+}
+
+export function isAuthorized(token: string | null, authHeader: string | undefined): boolean {
+  if (!token) return true; // no token configured -> open (loopback only, enforced at bind)
+  if (!authHeader) return false;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
+  return tokenMatches(token, provided);
+}
+
+// Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
+// { infohash }) or a raw body that is itself a magnet or info hash — forgiving,
+// so callers don't have to guess the exact envelope.
+export function extractMagnet(bodyText: string): string | null {
+  const raw = bodyText.trim();
+  if (!raw) return null;
+  if (raw.startsWith("{")) {
+    try {
+      const obj = JSON.parse(raw) as Record<string, unknown>;
+      const val = obj.magnet ?? obj.infohash ?? obj.infoHash ?? obj.hash;
+      return typeof val === "string" && val.trim() ? val.trim() : null;
+    } catch {
+      return null;
+    }
+  }
+  return raw;
+}
+
+function statusPayload(runtime: Runtime): Record<string, unknown> {
+  const downloads = runtime.queue.getItems().map((it) => ({
+    id: it.id,
+    name: it.name,
+    status: it.status,
+    progress: it.progress,
+    peers: it.peers,
+    speed: it.speed,
+  }));
+  const seeds = runtime.queue.getSeeds().map((s) => ({
+    id: s.id,
+    name: s.name,
+    status: s.status,
+    peers: s.peers,
+    uploaded: s.uploaded,
+  }));
+  return { downloads, seeds };
+}
+
+// Pure request router — no node:http types, so it's trivially testable.
+export async function handleApi(
+  runtime: Runtime,
+  token: string | null,
+  method: string,
+  urlPath: string,
+  authHeader: string | undefined,
+  bodyText: string,
+): Promise<ApiResponse> {
+  if (method === "GET" && urlPath === "/health") {
+    return { status: 200, body: { ok: true, version: VERSION } };
+  }
+  if (!isAuthorized(token, authHeader)) {
+    return { status: 401, body: { error: "unauthorized" } };
+  }
+  if (method === "GET" && (urlPath === "/downloads" || urlPath === "/status")) {
+    return { status: 200, body: statusPayload(runtime) };
+  }
+  if (method === "POST" && urlPath === "/add") {
+    const magnet = extractMagnet(bodyText);
+    if (!magnet) return { status: 400, body: { error: "missing magnet or info hash" } };
+    const outcome = await addInput(runtime, magnet);
+    if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
+    return { status: 200, body: { ok: true, outcome } };
+  }
+  return { status: 404, body: { error: "not found" } };
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        req.destroy();
+        resolve("");
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", () => resolve(""));
+  });
+}
+
+function log(message: string): void {
+  console.log(`[torlnk serve] ${new Date().toISOString()} ${message}`);
+}
+
+export async function runServe(options: ServeOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_API_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: never expose a public interface without a token.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_API_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const runtime = await startRuntime(options.downloadDir);
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      const bodyText = method === "POST" ? await readBody(req) : "";
+      let out: ApiResponse;
+      try {
+        out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);
+      } catch {
+        out = { status: 500, body: { error: "internal error" } };
+      }
+      const payload = JSON.stringify(out.body);
+      res.writeHead(out.status, { "Content-Type": "application/json" });
+      res.end(payload);
+      if (method !== "GET" || urlPath !== "/health") {
+        log(`${method} ${urlPath} -> ${out.status}`);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -9,6 +9,7 @@
 
 import http from "node:http";
 import { startRuntime, addInput, type Runtime } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
 import { VERSION } from "../version";
 
 export const DEFAULT_API_PORT = 9161;
@@ -26,6 +27,10 @@ export interface ServeOptions {
   host?: string;
   token?: string;
   downloadDir?: string;
+  /** Stop seeding each torrent this long after it finishes (ms). */
+  seedTimeMs?: number;
+  /** With seedTimeMs, also delete the files when the timer expires. */
+  deleteFiles?: boolean;
 }
 
 // Constant-ish comparison — the token isn't a password hash, but don't leak
@@ -148,6 +153,10 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
   }
 
   const runtime = await startRuntime(options.downloadDir);
+
+  if (options.seedTimeMs && options.seedTimeMs > 0) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
+  }
 
   const server = http.createServer((req, res) => {
     void (async () => {

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -10,11 +10,13 @@
 import http from "node:http";
 import { startRuntime, addInput, type Runtime } from "./runtime";
 import { startSeedReaper } from "./seed-reaper";
+import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
 import { VERSION } from "../version";
+
+export { isAuthorized } from "./auth";
 
 export const DEFAULT_API_PORT = 9161;
 
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 const MAX_BODY_BYTES = 64 * 1024; // a magnet is small; cap the body hard
 
 export interface ApiResponse {
@@ -31,23 +33,6 @@ export interface ServeOptions {
   seedTimeMs?: number;
   /** With seedTimeMs, also delete the files when the timer expires. */
   deleteFiles?: boolean;
-}
-
-// Constant-ish comparison — the token isn't a password hash, but don't leak
-// length via early exit on the common prefix.
-function tokenMatches(expected: string, provided: string): boolean {
-  if (expected.length !== provided.length) return false;
-  let diff = 0;
-  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i);
-  return diff === 0;
-}
-
-export function isAuthorized(token: string | null, authHeader: string | undefined): boolean {
-  if (!token) return true; // no token configured -> open (loopback only, enforced at bind)
-  if (!authHeader) return false;
-  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
-  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
-  return tokenMatches(token, provided);
 }
 
 // Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
@@ -115,21 +100,34 @@ export async function handleApi(
   return { status: 404, body: { error: "not found" } };
 }
 
-function readBody(req: http.IncomingMessage): Promise<string> {
+// Read the body up to the size cap. On overflow resolve tooLarge immediately
+// (further chunks are ignored) so the caller can answer 413 on a live socket
+// and close the connection afterwards, instead of writing to a destroyed one.
+function readBody(req: http.IncomingMessage): Promise<{ text: string; tooLarge: boolean }> {
   return new Promise((resolve) => {
     let size = 0;
+    let settled = false;
     const chunks: Buffer[] = [];
     req.on("data", (c: Buffer) => {
+      if (settled) return;
       size += c.length;
       if (size > MAX_BODY_BYTES) {
-        req.destroy();
-        resolve("");
+        settled = true;
+        resolve({ text: "", tooLarge: true });
         return;
       }
       chunks.push(c);
     });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", () => resolve(""));
+    req.on("end", () => {
+      if (settled) return;
+      settled = true;
+      resolve({ text: Buffer.concat(chunks).toString("utf8"), tooLarge: false });
+    });
+    req.on("error", () => {
+      if (settled) return;
+      settled = true;
+      resolve({ text: "", tooLarge: false });
+    });
   });
 }
 
@@ -162,7 +160,23 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
     void (async () => {
       const method = req.method ?? "GET";
       const urlPath = (req.url ?? "/").split("?")[0]!;
-      const bodyText = method === "POST" ? await readBody(req) : "";
+      // Tokenless means loopback-bound; require a loopback Host so a hostile
+      // webpage can't reach us through DNS rebinding.
+      if (!token && !hostHeaderOk(req.headers.host)) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden host" }));
+        log(`${method} ${urlPath} -> 403 (host)`);
+        return;
+      }
+      const body = method === "POST" ? await readBody(req) : { text: "", tooLarge: false };
+      if (body.tooLarge) {
+        res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
+        res.end(JSON.stringify({ error: "body too large" }));
+        res.once("finish", () => req.destroy());
+        log(`${method} ${urlPath} -> 413`);
+        return;
+      }
+      const bodyText = body.text;
       let out: ApiResponse;
       try {
         out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);

--- a/src/daemon/watch.test.ts
+++ b/src/daemon/watch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import {
+  isWatchCandidate,
+  firstMeaningfulLine,
+  processFile,
+  PROCESSED_DIR,
+  FAILED_DIR,
+} from "./watch";
+import type { Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+describe("isWatchCandidate", () => {
+  it("accepts torrent/magnet/txt files", () => {
+    expect(isWatchCandidate("Foo.torrent")).toBe(true);
+    expect(isWatchCandidate("Foo.magnet")).toBe(true);
+    expect(isWatchCandidate("Foo.txt")).toBe(true);
+    expect(isWatchCandidate("Foo.MAGNET")).toBe(true);
+  });
+  it("ignores partial writes, dotfiles, and other extensions", () => {
+    expect(isWatchCandidate("Foo.torrent.part")).toBe(false);
+    expect(isWatchCandidate(".hidden.magnet")).toBe(false);
+    expect(isWatchCandidate("movie.mkv")).toBe(false);
+  });
+});
+
+describe("firstMeaningfulLine", () => {
+  it("returns the first non-blank, non-comment line", () => {
+    expect(firstMeaningfulLine("\n\n# a comment\n  magnet:?x  \nsecond")).toBe("magnet:?x");
+  });
+  it("returns null when there is nothing usable", () => {
+    expect(firstMeaningfulLine("\n  \n# only a comment\n")).toBeNull();
+  });
+});
+
+describe("processFile", () => {
+  let dir: string;
+  let downloadDir: string;
+  let add: ReturnType<typeof vi.fn>;
+  let runtime: Runtime;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-watch-"));
+    downloadDir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-dl-"));
+    add = vi.fn();
+    runtime = {
+      queue: { has: () => false, add } as unknown as Runtime["queue"],
+      downloadDir,
+    };
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(downloadDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("adds a magnet from a .magnet file and archives it to .processed", async () => {
+    await fs.writeFile(path.join(dir, "drop.magnet"), `${MAGNET}\n`);
+    const outcome = await processFile(runtime, dir, "drop.magnet");
+    expect(outcome).toBe("added");
+    expect(add).toHaveBeenCalledOnce();
+    // Original is gone; a timestamped copy lands in .processed.
+    expect(await fs.readdir(dir)).not.toContain("drop.magnet");
+    const archived = await fs.readdir(path.join(dir, PROCESSED_DIR));
+    expect(archived.some((f) => f.endsWith("drop.magnet"))).toBe(true);
+  });
+
+  it("routes an unparseable file to .failed without adding", async () => {
+    await fs.writeFile(path.join(dir, "junk.txt"), "not a magnet at all");
+    const outcome = await processFile(runtime, dir, "junk.txt");
+    expect(outcome).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+    const failed = await fs.readdir(path.join(dir, FAILED_DIR));
+    expect(failed.some((f) => f.endsWith("junk.txt"))).toBe(true);
+  });
+});

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -1,0 +1,130 @@
+// Headless watch-folder mode: torlnk watches a directory and downloads any
+// torrent dropped into it. This is the "blackhole" pattern torrent clients use
+// so other tools (a seedbox web app, a script, curl) can hand off a torrent by
+// writing a file — no keypress, no TUI. Drop a `.torrent` file, or a `.magnet`
+// / `.txt` file whose contents are a magnet URI or a bare info hash.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { startRuntime, addInput, type Runtime, type AddOutcome } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
+
+// Subfolders the watcher moves handled files into, so each is processed once and
+// the drop folder stays tidy. Leading dots keep them out of the way and out of
+// its own scans.
+export const PROCESSED_DIR = ".processed";
+export const FAILED_DIR = ".failed";
+
+// Files we act on. A `.torrent` is handed off by path; `.magnet` / `.txt` hold a
+// magnet URI or bare info hash as text. Everything else (partial writes ending
+// in `.part`, the move-target subfolders, dotfiles) is ignored.
+export function isWatchCandidate(name: string): boolean {
+  if (name.startsWith(".")) return false;
+  if (/\.part$/i.test(name)) return false;
+  return /\.(torrent|magnet|txt)$/i.test(name);
+}
+
+// A dropped text file may have a trailing newline, comments, or blank lines.
+// Take the first non-empty, non-comment line as the magnet / info hash.
+export function firstMeaningfulLine(text: string): string | null {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line && !line.startsWith("#")) return line;
+  }
+  return null;
+}
+
+function log(message: string): void {
+  const stamp = new Date().toISOString();
+  console.log(`[torlnk watch] ${stamp} ${message}`);
+}
+
+async function moveInto(dir: string, sub: string, name: string): Promise<void> {
+  const destDir = path.join(dir, sub);
+  await fs.mkdir(destDir, { recursive: true }).catch(() => {});
+  // Prefix with a timestamp so re-dropping a same-named file never clobbers a
+  // previous one in the archive folder.
+  const dest = path.join(destDir, `${Date.now()}-${name}`);
+  await fs.rename(path.join(dir, name), dest).catch(() => {});
+}
+
+async function resolveInput(dir: string, name: string): Promise<string | null> {
+  const full = path.join(dir, name);
+  if (/\.torrent$/i.test(name)) return full; // handed off by path
+  const text = await fs.readFile(full, "utf8").catch(() => "");
+  return firstMeaningfulLine(text);
+}
+
+// Process one candidate file: add it, then archive it by outcome. Returns the
+// outcome for logging/tests. Never throws — a bad file must not stop the loop.
+export async function processFile(runtime: Runtime, dir: string, name: string): Promise<AddOutcome> {
+  const input = await resolveInput(dir, name);
+  let outcome: AddOutcome;
+  try {
+    outcome = input ? await addInput(runtime, input, { allowTorrentPath: true }) : "invalid";
+  } catch {
+    outcome = "invalid";
+  }
+  await moveInto(dir, outcome === "invalid" ? FAILED_DIR : PROCESSED_DIR, name);
+  return outcome;
+}
+
+async function scanOnce(runtime: Runtime, dir: string): Promise<void> {
+  const entries = await fs.readdir(dir).catch(() => [] as string[]);
+  for (const name of entries) {
+    if (!isWatchCandidate(name)) continue;
+    const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+    if (!stat || !stat.isFile() || stat.size === 0) continue; // skip dirs / in-flight writes
+    const outcome = await processFile(runtime, dir, name);
+    log(`${outcome}: ${name}`);
+  }
+}
+
+const POLL_MS = 2000;
+
+// fs.watch is unreliable across platforms (misses events, fires twice, no
+// recursion guarantees), so we poll — dead simple and identical on every OS.
+export interface WatchOptions {
+  seedTimeMs?: number;
+  deleteFiles?: boolean;
+}
+
+export async function runWatch(
+  watchDir: string,
+  downloadDir?: string,
+  options: WatchOptions = {},
+): Promise<void> {
+  const dir = path.resolve(watchDir);
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+
+  const runtime = await startRuntime(downloadDir);
+  runtime.queue.on("completed", (name: string) => log(`done, now seeding: ${name}`));
+
+  if (options.seedTimeMs && options.seedTimeMs > 0) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
+  }
+
+  log(`watching ${dir}`);
+  log(`downloads -> ${runtime.downloadDir}`);
+
+  await scanOnce(runtime, dir);
+  // Serialize scans: one in flight at a time so a slow add never overlaps itself.
+  let scanning = false;
+  const timer = setInterval(() => {
+    if (scanning) return;
+    scanning = true;
+    void scanOnce(runtime, dir).finally(() => {
+      scanning = false;
+    });
+  }, POLL_MS);
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      clearInterval(timer);
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -1,0 +1,116 @@
+// Headless watch-folder mode: torlnk watches a directory and downloads any
+// torrent dropped into it. This is the "blackhole" pattern torrent clients use
+// so other tools (a seedbox web app, a script, curl) can hand off a torrent by
+// writing a file — no keypress, no TUI. Drop a `.torrent` file, or a `.magnet`
+// / `.txt` file whose contents are a magnet URI or a bare info hash.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { startRuntime, addInput, type Runtime, type AddOutcome } from "./runtime";
+
+// Subfolders the watcher moves handled files into, so each is processed once and
+// the drop folder stays tidy. Leading dots keep them out of the way and out of
+// its own scans.
+export const PROCESSED_DIR = ".processed";
+export const FAILED_DIR = ".failed";
+
+// Files we act on. A `.torrent` is handed off by path; `.magnet` / `.txt` hold a
+// magnet URI or bare info hash as text. Everything else (partial writes ending
+// in `.part`, the move-target subfolders, dotfiles) is ignored.
+export function isWatchCandidate(name: string): boolean {
+  if (name.startsWith(".")) return false;
+  if (/\.part$/i.test(name)) return false;
+  return /\.(torrent|magnet|txt)$/i.test(name);
+}
+
+// A dropped text file may have a trailing newline, comments, or blank lines.
+// Take the first non-empty, non-comment line as the magnet / info hash.
+export function firstMeaningfulLine(text: string): string | null {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line && !line.startsWith("#")) return line;
+  }
+  return null;
+}
+
+function log(message: string): void {
+  const stamp = new Date().toISOString();
+  console.log(`[torlnk watch] ${stamp} ${message}`);
+}
+
+async function moveInto(dir: string, sub: string, name: string): Promise<void> {
+  const destDir = path.join(dir, sub);
+  await fs.mkdir(destDir, { recursive: true }).catch(() => {});
+  // Prefix with a timestamp so re-dropping a same-named file never clobbers a
+  // previous one in the archive folder.
+  const dest = path.join(destDir, `${Date.now()}-${name}`);
+  await fs.rename(path.join(dir, name), dest).catch(() => {});
+}
+
+async function resolveInput(dir: string, name: string): Promise<string | null> {
+  const full = path.join(dir, name);
+  if (/\.torrent$/i.test(name)) return full; // handed off by path
+  const text = await fs.readFile(full, "utf8").catch(() => "");
+  return firstMeaningfulLine(text);
+}
+
+// Process one candidate file: add it, then archive it by outcome. Returns the
+// outcome for logging/tests. Never throws — a bad file must not stop the loop.
+export async function processFile(runtime: Runtime, dir: string, name: string): Promise<AddOutcome> {
+  const input = await resolveInput(dir, name);
+  let outcome: AddOutcome;
+  try {
+    outcome = input ? await addInput(runtime, input) : "invalid";
+  } catch {
+    outcome = "invalid";
+  }
+  await moveInto(dir, outcome === "invalid" ? FAILED_DIR : PROCESSED_DIR, name);
+  return outcome;
+}
+
+async function scanOnce(runtime: Runtime, dir: string): Promise<void> {
+  const entries = await fs.readdir(dir).catch(() => [] as string[]);
+  for (const name of entries) {
+    if (!isWatchCandidate(name)) continue;
+    const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+    if (!stat || !stat.isFile() || stat.size === 0) continue; // skip dirs / in-flight writes
+    const outcome = await processFile(runtime, dir, name);
+    log(`${outcome}: ${name}`);
+  }
+}
+
+const POLL_MS = 2000;
+
+// fs.watch is unreliable across platforms (misses events, fires twice, no
+// recursion guarantees), so we poll — dead simple and identical on every OS.
+export async function runWatch(watchDir: string, downloadDir?: string): Promise<void> {
+  const dir = path.resolve(watchDir);
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+
+  const runtime = await startRuntime(downloadDir);
+  runtime.queue.on("completed", (name: string) => log(`done, now seeding: ${name}`));
+
+  log(`watching ${dir}`);
+  log(`downloads -> ${runtime.downloadDir}`);
+
+  await scanOnce(runtime, dir);
+  // Serialize scans: one in flight at a time so a slow add never overlaps itself.
+  let scanning = false;
+  const timer = setInterval(() => {
+    if (scanning) return;
+    scanning = true;
+    void scanOnce(runtime, dir).finally(() => {
+      scanning = false;
+    });
+  }, POLL_MS);
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      clearInterval(timer);
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -7,6 +7,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { startRuntime, addInput, type Runtime, type AddOutcome } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
 
 // Subfolders the watcher moves handled files into, so each is processed once and
 // the drop folder stays tidy. Leading dots keep them out of the way and out of
@@ -83,12 +84,25 @@ const POLL_MS = 2000;
 
 // fs.watch is unreliable across platforms (misses events, fires twice, no
 // recursion guarantees), so we poll — dead simple and identical on every OS.
-export async function runWatch(watchDir: string, downloadDir?: string): Promise<void> {
+export interface WatchOptions {
+  seedTimeMs?: number;
+  deleteFiles?: boolean;
+}
+
+export async function runWatch(
+  watchDir: string,
+  downloadDir?: string,
+  options: WatchOptions = {},
+): Promise<void> {
   const dir = path.resolve(watchDir);
   await fs.mkdir(dir, { recursive: true }).catch(() => {});
 
   const runtime = await startRuntime(downloadDir);
   runtime.queue.on("completed", (name: string) => log(`done, now seeding: ${name}`));
+
+  if (options.seedTimeMs && options.seedTimeMs > 0) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
+  }
 
   log(`watching ${dir}`);
   log(`downloads -> ${runtime.downloadDir}`);

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -61,7 +61,7 @@ export async function processFile(runtime: Runtime, dir: string, name: string): 
   const input = await resolveInput(dir, name);
   let outcome: AddOutcome;
   try {
-    outcome = input ? await addInput(runtime, input) : "invalid";
+    outcome = input ? await addInput(runtime, input, { allowTorrentPath: true }) : "invalid";
   } catch {
     outcome = "invalid";
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import { render } from "ink";
 import { parseCliArgs, HELP_TEXT } from "./cli/args";
+import { daemonize } from "./daemon/daemonize";
+import { runAttach } from "./daemon/attach";
 import { VERSION } from "./version";
 import { log } from "./util/logger";
 import { App } from "./ui/App";
@@ -21,6 +23,48 @@ if (cmd.kind === "invalid") {
   console.error(HELP_TEXT);
   process.exit(1);
 }
+
+// Run/reattach the TUI inside a persistent tmux session (execs tmux, then exits).
+if (cmd.kind === "attach") {
+  runAttach();
+}
+
+// Headless subcommands: run the download queue with no terminal UI (for
+// seedboxes and servers). Kept above the alt-screen setup below — these paths
+// never touch the TUI. Each is dynamically imported so a plain `torlnk` launch
+// pays nothing for them.
+function failHeadless(err: unknown): never {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
+if (cmd.kind === "watch") {
+  if (cmd.daemon) daemonize("watch"); // parent exits here; the detached child continues
+  const { dir, downloadDir, seedTimeMs, deleteFiles } = cmd;
+  void import("./daemon/watch").then(({ runWatch }) =>
+    runWatch(dir, downloadDir, { seedTimeMs, deleteFiles }).catch(failHeadless),
+  );
+} else if (cmd.kind === "serve") {
+  if (cmd.daemon) daemonize("serve");
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_API_TOKEN,
+    downloadDir: cmd.downloadDir,
+    seedTimeMs: cmd.seedTimeMs,
+    deleteFiles: cmd.deleteFiles,
+  };
+  void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
+} else if (cmd.kind === "files") {
+  if (cmd.daemon) daemonize("files");
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_FILES_TOKEN,
+    dir: cmd.dir,
+  };
+  void import("./daemon/files").then(({ runFiles }) => runFiles(options).catch(failHeadless));
+} else {
 
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own
 // cursor (the search field block, list pointers), so the terminal's should
@@ -82,3 +126,5 @@ process.on("uncaughtException", (err) => {
   console.error(err);
   process.exit(1);
 });
+
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,18 +21,28 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
-// Headless subcommand: run the download queue with no terminal UI (for seedboxes
-// and servers). Kept above the alt-screen setup below — this path never touches
-// the TUI. Loaded dynamically so a plain `torlnk` launch pays nothing for it.
+// Headless subcommands: run the download queue with no terminal UI (for
+// seedboxes and servers). Kept above the alt-screen setup below — these paths
+// never touch the TUI. Each is dynamically imported so a plain `torlnk` launch
+// pays nothing for them.
+function failHeadless(err: unknown): never {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
 if (cmd.kind === "watch") {
-  const dir = cmd.dir;
-  const downloadDir = cmd.downloadDir;
+  const { dir, downloadDir } = cmd;
   void import("./daemon/watch").then(({ runWatch }) =>
-    runWatch(dir, downloadDir).catch((err: unknown) => {
-      console.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }),
+    runWatch(dir, downloadDir).catch(failHeadless),
   );
+} else if (cmd.kind === "serve") {
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_API_TOKEN,
+    downloadDir: cmd.downloadDir,
+  };
+  void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
 } else {
 
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,14 @@ if (cmd.kind === "watch") {
     downloadDir: cmd.downloadDir,
   };
   void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
+} else if (cmd.kind === "files") {
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_FILES_TOKEN,
+    dir: cmd.dir,
+  };
+  void import("./daemon/files").then(({ runFiles }) => runFiles(options).catch(failHeadless));
 } else {
 
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,20 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
+// Headless subcommand: run the download queue with no terminal UI (for seedboxes
+// and servers). Kept above the alt-screen setup below — this path never touches
+// the TUI. Loaded dynamically so a plain `torlnk` launch pays nothing for it.
+if (cmd.kind === "watch") {
+  const dir = cmd.dir;
+  const downloadDir = cmd.downloadDir;
+  void import("./daemon/watch").then(({ runWatch }) =>
+    runWatch(dir, downloadDir).catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }),
+  );
+} else {
+
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own
 // cursor (the search field block, list pointers), so the terminal's should
 // stay hidden. restoreTerminal shows it again on exit.
@@ -80,3 +94,5 @@ process.on("uncaughtException", (err) => {
   console.error(err);
   process.exit(1);
 });
+
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import { render } from "ink";
 import { parseCliArgs, HELP_TEXT } from "./cli/args";
+import { daemonize } from "./daemon/daemonize";
+import { runAttach } from "./daemon/attach";
 import { VERSION } from "./version";
 import { App } from "./ui/App";
 
@@ -21,6 +23,11 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
+// Run/reattach the TUI inside a persistent tmux session (execs tmux, then exits).
+if (cmd.kind === "attach") {
+  runAttach();
+}
+
 // Headless subcommands: run the download queue with no terminal UI (for
 // seedboxes and servers). Kept above the alt-screen setup below — these paths
 // never touch the TUI. Each is dynamically imported so a plain `torlnk` launch
@@ -31,19 +38,24 @@ function failHeadless(err: unknown): never {
 }
 
 if (cmd.kind === "watch") {
-  const { dir, downloadDir } = cmd;
+  if (cmd.daemon) daemonize("watch"); // parent exits here; the detached child continues
+  const { dir, downloadDir, seedTimeMs, deleteFiles } = cmd;
   void import("./daemon/watch").then(({ runWatch }) =>
-    runWatch(dir, downloadDir).catch(failHeadless),
+    runWatch(dir, downloadDir, { seedTimeMs, deleteFiles }).catch(failHeadless),
   );
 } else if (cmd.kind === "serve") {
+  if (cmd.daemon) daemonize("serve");
   const options = {
     port: cmd.port,
     host: cmd.host,
     token: cmd.token ?? process.env.TORLINK_API_TOKEN,
     downloadDir: cmd.downloadDir,
+    seedTimeMs: cmd.seedTimeMs,
+    deleteFiles: cmd.deleteFiles,
   };
   void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
 } else if (cmd.kind === "files") {
+  if (cmd.daemon) daemonize("files");
   const options = {
     port: cmd.port,
     host: cmd.host,

--- a/src/sources/bittorrented.test.ts
+++ b/src/sources/bittorrented.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { mapBittorrentedResults, bittorrented } from "./bittorrented";
+
+describe("mapBittorrentedResults", () => {
+  it("maps an API row to a torrent result with a built magnet, tagged by source id", () => {
+    const [r] = mapBittorrentedResults(
+      [
+        {
+          torrent_infohash: "4E60BE2D0B87C93EA6FC20D123D74BF9E9379999",
+          torrent_name: "Old School (2003)",
+          torrent_total_size: 733698385,
+          torrent_seeders: 41,
+          torrent_leechers: 5,
+          torrent_file_count: 6,
+          torrent_created_at: "2026-01-23T22:28:03.159398+00:00",
+        },
+      ],
+      "bittorrented",
+    );
+    expect(r).toMatchObject({
+      infoHash: "4e60be2d0b87c93ea6fc20d123d74bf9e9379999",
+      name: "Old School (2003)",
+      sizeBytes: 733698385,
+      seeders: 41,
+      leechers: 5,
+      numFiles: 6,
+      source: "bittorrented",
+    });
+    expect(r!.magnet).toContain("xt=urn:btih:4e60be2d0b87c93ea6fc20d123d74bf9e9379999");
+    expect(r!.added).toBe(Math.floor(Date.parse("2026-01-23T22:28:03.159398+00:00") / 1000));
+  });
+
+  it("defaults missing seeders/size to 0", () => {
+    const [r] = mapBittorrentedResults(
+      [{ torrent_infohash: "a".repeat(40), torrent_name: "x", torrent_seeders: null }],
+      "bittorrented",
+    );
+    expect(r).toMatchObject({ seeders: 0, leechers: 0, sizeBytes: 0 });
+  });
+
+  it("drops rows without a valid 40-char info hash", () => {
+    expect(
+      mapBittorrentedResults(
+        [{ torrent_name: "no hash" }, { torrent_infohash: "tooshort", torrent_name: "bad" }],
+        "bittorrented",
+      ),
+    ).toEqual([]);
+  });
+
+  it("falls back to the info hash when the name is missing", () => {
+    const [r] = mapBittorrentedResults([{ torrent_infohash: "b".repeat(40) }], "bittorrented");
+    expect(r!.name).toBe("b".repeat(40));
+  });
+});
+
+describe("bittorrented", () => {
+  it("feeds Movies and TV only, never Games or Anime", () => {
+    expect(bittorrented.id).toBe("bittorrented");
+    expect(bittorrented.groups).toEqual(["Movies", "TV"]);
+    expect(bittorrented.groups).not.toContain("Games");
+    expect(bittorrented.groups).not.toContain("Anime");
+    expect(bittorrented.reportsHealth).toBe(true);
+  });
+});

--- a/src/sources/bittorrented.ts
+++ b/src/sources/bittorrented.ts
@@ -1,0 +1,91 @@
+import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
+import { buildMagnet } from "./magnet";
+import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
+
+// BitTorrented is a general index (its own library plus a large DHT crawl).
+// torlink takes its video type only and feeds it to Movies and TV. Anime stays
+// with its dedicated sources (the API can't tell anime from any other video)
+// and Games stays FitGirl's alone. Its JSON API returns real swarm counts, so
+// reportsHealth is true.
+const BASE = "https://bittorrented.com";
+
+// The index requires a real query (the API rejects fewer than 3 characters), so
+// an empty browse returns nothing rather than erroring.
+const MIN_QUERY = 3;
+
+interface BtResult {
+  torrent_infohash?: string;
+  torrent_name?: string;
+  torrent_total_size?: number;
+  torrent_seeders?: number | null;
+  torrent_leechers?: number | null;
+  torrent_file_count?: number;
+  torrent_created_at?: string;
+}
+
+interface BtResponse {
+  results?: BtResult[];
+}
+
+function toUnixSeconds(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
+}
+
+// Map the API rows to torlink results. Pure and exported so the mapping is tested
+// without a live request. Rows without a valid 40-char info hash are dropped (a
+// magnet needs one).
+export function mapBittorrentedResults(results: BtResult[], id: SourceId): TorrentResult[] {
+  const out: TorrentResult[] = [];
+  for (const r of results) {
+    const infoHash = r.torrent_infohash?.toLowerCase();
+    if (!infoHash || !/^[a-f0-9]{40}$/.test(infoHash)) continue;
+    const name = r.torrent_name || infoHash;
+    out.push({
+      infoHash,
+      name,
+      sizeBytes: r.torrent_total_size ?? 0,
+      seeders: r.torrent_seeders ?? 0,
+      leechers: r.torrent_leechers ?? 0,
+      numFiles: r.torrent_file_count,
+      source: id,
+      magnet: buildMagnet(infoHash, name),
+      added: toUnixSeconds(r.torrent_created_at),
+    });
+  }
+  return out;
+}
+
+async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
+  const q = query.trim();
+  if (q.length < MIN_QUERY) return [];
+
+  // Video only: keeps the category tabs plain video and structurally excludes
+  // the index's other media types. One request per search.
+  const params = new URLSearchParams({
+    q,
+    type: "video",
+    limit: "50",
+    sortBy: "seeders",
+    sortOrder: "desc",
+  });
+  const res = await fetchResilient(`${BASE}/api/search/torrents?${params.toString()}`, {
+    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    signal: opts.signal,
+    retries: 1,
+  });
+  if (!res.ok) throw new HttpError(res.status, `BitTorrented returned ${res.status}`);
+
+  const json = (await res.json()) as BtResponse;
+  return mapBittorrentedResults(json.results ?? [], "bittorrented");
+}
+
+export const bittorrented: Source = {
+  id: "bittorrented",
+  label: "BitTorrented",
+  groups: ["Movies", "TV"],
+  homepage: BASE,
+  reportsHealth: true,
+  search,
+};

--- a/src/sources/books.test.ts
+++ b/src/sources/books.test.ts
@@ -5,11 +5,11 @@ import { TPB_BOOK_CATEGORIES, tpbBooks } from "./piratebay";
 describe("Books sources", () => {
   it("uses TPB's audiobook, ebook, and comics categories", () => {
     expect([...TPB_BOOK_CATEGORIES]).toEqual([102, 601, 602]);
-    expect(tpbBooks).toMatchObject({ id: "tpb-books", group: "Books" });
+    expect(tpbBooks).toMatchObject({ id: "tpb-books", groups: ["Books"] });
   });
 
   it("uses Nyaa's Literature category", () => {
     expect(NYAA_LITERATURE_CATEGORY).toBe("3_0");
-    expect(nyaaLiterature).toMatchObject({ id: "nyaa-literature", group: "Books" });
+    expect(nyaaLiterature).toMatchObject({ id: "nyaa-literature", groups: ["Books"] });
   });
 });

--- a/src/sources/eztv.ts
+++ b/src/sources/eztv.ts
@@ -52,7 +52,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
 export const eztv: Source = {
   id: "eztv",
   label: "EZTV",
-  group: "TV",
+  groups: ["TV"],
   homepage: "https://eztvx.to",
   reportsHealth: true,
   search,

--- a/src/sources/fitgirl.ts
+++ b/src/sources/fitgirl.ts
@@ -6,7 +6,7 @@ const HOME = "https://fitgirl-repacks.site";
 export const fitgirl: Source = {
   id: "fitgirl",
   label: "FitGirl",
-  group: "Games",
+  groups: ["Games"],
   homepage: HOME,
   // WordPress RSS carries no swarm data; every result reports seeders: 0.
   reportsHealth: false,

--- a/src/sources/magnet.test.ts
+++ b/src/sources/magnet.test.ts
@@ -46,6 +46,8 @@ describe("buildMagnet", () => {
     expect(out).toContain("xt=urn:btih:abc123");
     expect(out).toContain("dn=My%20Movie%202024");
     expect(out).toContain("&tr=");
+    // At least one non-UDP tracker, so UDP-blocked networks can still announce.
+    expect(out).toContain(encodeURIComponent("http://tracker.opentrackr.org:1337/announce"));
   });
 });
 

--- a/src/sources/magnet.ts
+++ b/src/sources/magnet.ts
@@ -6,6 +6,12 @@ const TRACKERS = [
   "udp://exodus.desync.com:6969/announce",
   "udp://open.stealth.si:80/announce",
   "udp://tracker.dler.org:6969/announce",
+  // HTTP(S) endpoints so peer discovery still works where UDP is blocked or
+  // mangled (VPN exit nodes, strict NATs): DHT and udp:// are both UDP.
+  "http://tracker.opentrackr.org:1337/announce",
+  "http://tracker.openbittorrent.com:80/announce",
+  "http://tracker.dler.org:6969/announce",
+  "https://tracker.tamersunion.org:443/announce",
 ];
 
 export function buildMagnet(infoHash: string, name: string): string {

--- a/src/sources/nyaa.ts
+++ b/src/sources/nyaa.ts
@@ -50,7 +50,7 @@ async function search(
 export const nyaa: Source = {
   id: "nyaa",
   label: "Nyaa",
-  group: "Anime",
+  groups: ["Anime"],
   homepage: "https://nyaa.si",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "0_0", "nyaa", opts),
@@ -59,7 +59,7 @@ export const nyaa: Source = {
 export const nyaaLiterature: Source = {
   id: "nyaa-literature",
   label: "Nyaa",
-  group: "Books",
+  groups: ["Books"],
   homepage: "https://nyaa.si/?c=3_0",
   reportsHealth: true,
   search: (query, opts = {}) =>

--- a/src/sources/nyaa.ts
+++ b/src/sources/nyaa.ts
@@ -44,7 +44,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
 export const nyaa: Source = {
   id: "nyaa",
   label: "Nyaa",
-  group: "Anime",
+  groups: ["Anime"],
   homepage: "https://nyaa.si",
   reportsHealth: true,
   search,

--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -5,18 +5,18 @@ describe("Pirate Bay sources", () => {
   it("should have tpbMovies", () => {
     expect(tpbMovies).toBeDefined();
     expect(tpbMovies.id).toBe("tpb-movies");
-    expect(tpbMovies.group).toBe("Movies");
+    expect(tpbMovies.groups).toContain("Movies");
   });
 
   it("should have tpbTv", () => {
     expect(tpbTv).toBeDefined();
     expect(tpbTv.id).toBe("tpb-tv");
-    expect(tpbTv.group).toBe("TV");
+    expect(tpbTv.groups).toContain("TV");
   });
 
   it("should have tpbMusic", () => {
     expect(tpbMusic).toBeDefined();
     expect(tpbMusic.id).toBe("tpb-music");
-    expect(tpbMusic.group).toBe("Music");
+    expect(tpbMusic.groups).toContain("Music");
   });
 });

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -77,7 +77,7 @@ async function search(
 export const tpbMovies: Source = {
   id: "tpb-movies",
   label: "TPB",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, MOVIE_CATS, TOP_MOVIES, "tpb-movies", opts),
@@ -86,7 +86,7 @@ export const tpbMovies: Source = {
 export const tpbTv: Source = {
   id: "tpb-tv",
   label: "TPB",
-  group: "TV",
+  groups: ["TV"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -83,7 +83,7 @@ async function search(
 export const tpbMovies: Source = {
   id: "tpb-movies",
   label: "TPB",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, MOVIE_CATS, TOP_MOVIES, "tpb-movies", opts),
@@ -92,7 +92,7 @@ export const tpbMovies: Source = {
 export const tpbTv: Source = {
   id: "tpb-tv",
   label: "TPB",
-  group: "TV",
+  groups: ["TV"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),
@@ -101,7 +101,7 @@ export const tpbTv: Source = {
 export const tpbBooks: Source = {
   id: "tpb-books",
   label: "TPB",
-  group: "Books",
+  groups: ["Books"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) =>
@@ -111,7 +111,7 @@ export const tpbBooks: Source = {
 export const tpbMusic: Source = {
   id: "tpb-music",
   label: "TPB",
-  group: "Music",
+  groups: ["Music"],
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, MUSIC_CATS, TOP_MUSIC, "tpb-music", opts),

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -52,7 +52,7 @@ describe("RuTracker sources", () => {
 
 describe("Books sources", () => {
   it("registers dedicated TPB, Nyaa, and RuTracker sources", () => {
-    const books = SOURCES.filter((source) => source.group === "Books");
+    const books = SOURCES.filter((source) => source.groups?.includes("Books"));
     expect(books.map((source) => source.id)).toEqual([
       "tpb-books",
       "nyaa-literature",
@@ -63,7 +63,7 @@ describe("Books sources", () => {
 
 describe("Music sources", () => {
   it("registers dedicated TPB and 1337x sources", () => {
-    const music = SOURCES.filter((source) => source.group === "Music");
+    const music = SOURCES.filter((source) => source.groups?.includes("Music"));
     expect(music.map((source) => source.id)).toEqual([
       "tpb-music",
       "x1337-music",

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,3 +1,4 @@
+import { bittorrented } from "./bittorrented";
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
 import { nyaa, nyaaLiterature } from "./nyaa";
@@ -37,6 +38,7 @@ export const SOURCES: readonly Source[] = [
   rutrackerAnime,
   rutrackerMusic,
   rutrackerBooks,
+  bittorrented,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -65,6 +67,6 @@ const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime", "
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({
     group,
-    sources: SOURCES.filter((s) => s.group === group),
+    sources: SOURCES.filter((s) => s.groups?.includes(group)),
   })).filter((g) => g.sources.length > 0);
 }

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,3 +1,4 @@
+import { bittorrented } from "./bittorrented";
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
 import { nyaa } from "./nyaa";
@@ -17,6 +18,7 @@ export const SOURCES: readonly Source[] = [
   x1337Tv,
   nyaa,
   subsplease,
+  bittorrented,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -30,6 +32,6 @@ const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime"];
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({
     group,
-    sources: SOURCES.filter((s) => s.group === group),
+    sources: SOURCES.filter((s) => s.groups?.includes(group)),
   })).filter((g) => g.sources.length > 0);
 }

--- a/src/sources/rutracker/index.ts
+++ b/src/sources/rutracker/index.ts
@@ -316,7 +316,7 @@ function makeSource(id: SourceId, group: SourceGroup): Source {
   return {
     id,
     label: "RuTracker",
-    group,
+    groups: [group],
     homepage: "https://rutracker.org",
     reportsHealth: true,
     search: async (query, opts = {}) => {

--- a/src/sources/subsplease.ts
+++ b/src/sources/subsplease.ts
@@ -69,7 +69,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
 export const subsplease: Source = {
   id: "subsplease",
   label: "SubsPlease",
-  group: "Anime",
+  groups: ["Anime"],
   homepage: "https://subsplease.org",
   // The SubsPlease API has no swarm data; every result reports seeders: 0.
   reportsHealth: false,

--- a/src/sources/torrentscsv.ts
+++ b/src/sources/torrentscsv.ts
@@ -60,7 +60,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
 export const torrentsCsv: Source = {
   id: "torrents-csv",
   label: "Torrents.csv",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://torrents-csv.com",
   reportsHealth: true,
   search,

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -18,7 +18,8 @@ export type SourceId =
   | "rt-tv"
   | "rt-anime"
   | "rt-music"
-  | "rt-books";
+  | "rt-books"
+  | "bittorrented";
 
 export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music" | "Books";
 
@@ -43,7 +44,9 @@ export interface SearchOptions {
 export interface Source {
   id: SourceId;
   label: string;
-  group: SourceGroup;
+  // The category tabs a source feeds. Most sources belong to one; a general
+  // index can feed several. A source with none shows under the All tab only.
+  groups?: readonly SourceGroup[];
   homepage: string;
   // True when the source returns real swarm counts. False when its feed has
   // none, so seeders: 0 means unknown, not dead (the alive-only filter must

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -7,7 +7,8 @@ export type SourceId =
   | "tpb-movies"
   | "tpb-tv"
   | "x1337-movies"
-  | "x1337-tv";
+  | "x1337-tv"
+  | "bittorrented";
 
 export type SourceGroup = "Games" | "Movies" | "TV" | "Anime";
 
@@ -30,7 +31,9 @@ export interface SearchOptions {
 export interface Source {
   id: SourceId;
   label: string;
-  group: SourceGroup;
+  // The category tabs a source feeds. Most sources belong to one; a general
+  // index can feed several. A source with none shows under the All tab only.
+  groups?: readonly SourceGroup[];
   homepage: string;
   // True when the source returns real swarm counts. False when its feed has
   // none, so seeders: 0 means unknown, not dead (the alive-only filter must

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -140,7 +140,7 @@ async function search(
 export const x1337Movies: Source = {
   id: "x1337-movies",
   label: "1337x",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "Movies", "x1337-movies", opts),
@@ -149,7 +149,7 @@ export const x1337Movies: Source = {
 export const x1337Tv: Source = {
   id: "x1337-tv",
   label: "1337x",
-  group: "TV",
+  groups: ["TV"],
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "TV", "x1337-tv", opts),

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -4,8 +4,9 @@ import { parseSize } from "../util/format";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 const HOSTS = ["1337x.to", "1337x.st", "x1337x.ws", "1337xx.to"];
+let workingHostIndex = 0;
 
-const MAX_DETAILS = 8;
+const MAX_DETAILS = 4;
 
 const STOP = new Set(["the", "a", "an", "of", "and", "or", "to"]);
 
@@ -94,11 +95,14 @@ async function search(
   let base = "";
   let html = "";
   let lastError: unknown;
-  for (const host of HOSTS) {
+  for (let i = 0; i < HOSTS.length; i++) {
+    const hostIdx = (workingHostIndex + i) % HOSTS.length;
+    const host = HOSTS[hostIdx];
     try {
       const candidate = `https://${host}`;
-      html = await fetchText(`${candidate}${path}`, opts, 2);
+      html = await fetchText(`${candidate}${path}`, opts, i === 0 ? 2 : 0);
       base = candidate;
+      workingHostIndex = hostIdx;
       break;
     } catch (e) {
       if (opts.signal?.aborted) throw e;
@@ -142,7 +146,7 @@ async function search(
 export const x1337Movies: Source = {
   id: "x1337-movies",
   label: "1337x",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "Movies", "x1337-movies", opts),
@@ -151,7 +155,7 @@ export const x1337Movies: Source = {
 export const x1337Tv: Source = {
   id: "x1337-tv",
   label: "1337x",
-  group: "TV",
+  groups: ["TV"],
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "TV", "x1337-tv", opts),
@@ -160,7 +164,7 @@ export const x1337Tv: Source = {
 export const x1337Music: Source = {
   id: "x1337-music",
   label: "1337x",
-  group: "Music",
+  groups: ["Music"],
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "Music", "x1337-music", opts),

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -4,8 +4,9 @@ import { parseSize } from "../util/format";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 const HOSTS = ["1337x.to", "1337x.st", "x1337x.ws", "1337xx.to"];
+let workingHostIndex = 0;
 
-const MAX_DETAILS = 8;
+const MAX_DETAILS = 4;
 
 const STOP = new Set(["the", "a", "an", "of", "and", "or", "to"]);
 
@@ -92,11 +93,14 @@ async function search(
   let base = "";
   let html = "";
   let lastError: unknown;
-  for (const host of HOSTS) {
+  for (let i = 0; i < HOSTS.length; i++) {
+    const hostIdx = (workingHostIndex + i) % HOSTS.length;
+    const host = HOSTS[hostIdx];
     try {
       const candidate = `https://${host}`;
-      html = await fetchText(`${candidate}${path}`, opts, 2);
+      html = await fetchText(`${candidate}${path}`, opts, i === 0 ? 2 : 0);
       base = candidate;
+      workingHostIndex = hostIdx;
       break;
     } catch (e) {
       if (opts.signal?.aborted) throw e;

--- a/src/sources/yts.ts
+++ b/src/sources/yts.ts
@@ -74,7 +74,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
 export const yts: Source = {
   id: "yts",
   label: "YTS",
-  group: "Movies",
+  groups: ["Movies"],
   homepage: "https://yts.mx",
   reportsHealth: true,
   search,

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -131,7 +131,7 @@ export function Results() {
   const results = useMemo(() => {
     const cat = CATEGORIES.find((c) => c.key === section);
     const base = cat?.group
-      ? search.results.filter((r) => getSource(r.source).group === cat.group)
+      ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
       : search.results;
     return sortResults(filterResults(base, hideDead), sort);
   }, [search.results, section, sort, hideDead]);
@@ -265,7 +265,9 @@ export function Results() {
     [search.perSource],
   );
   const activeCat = CATEGORIES.find((c) => c.key === section);
-  const tabSources = activeCat?.group ? SOURCES.filter((s) => s.group === activeCat.group) : SOURCES;
+  const tabSources = activeCat?.group
+    ? SOURCES.filter((s) => s.groups?.includes(activeCat.group!))
+    : SOURCES;
   const tabErrored =
     tabSources.length > 0 && tabSources.every((s) => search.perSource[s.id]?.error);
   // Only the active tab's sources hold its spinner; other groups' stragglers
@@ -324,7 +326,7 @@ export function Results() {
       if (hideDead) {
         const cat = CATEGORIES.find((c) => c.key === section);
         const base = cat?.group
-          ? search.results.filter((r) => getSource(r.source).group === cat.group)
+          ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
           : search.results;
         if (base.length > 0 && base.every((r) => r.seeders <= 0)) {
           return (

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -220,7 +220,7 @@ export function Results() {
   const results = useMemo(() => {
     const cat = CATEGORIES.find((c) => c.key === section);
     const base = cat?.group
-      ? search.results.filter((r) => getSource(r.source).group === cat.group)
+      ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
       : search.results;
     const filtered = aliveOnly ? base.filter((result) => result.seeders > 0) : base;
     return sortResults(filtered, sort);
@@ -302,8 +302,8 @@ export function Results() {
 
   // Favourites are for video content only (Movies / TV / Anime).
   const canFavourite = (r: TorrentResult): boolean => {
-    const g = getSource(r.source).group;
-    return g === "Movies" || g === "TV" || g === "Anime";
+    const groups = getSource(r.source).groups ?? [];
+    return groups.some((g) => g === "Movies" || g === "TV" || g === "Anime");
   };
 
   const favInput = (r: TorrentResult) => ({
@@ -401,7 +401,9 @@ export function Results() {
     [search.perSource],
   );
   const activeCat = CATEGORIES.find((c) => c.key === section);
-  const tabSources = activeCat?.group ? enabled.filter((s) => s.group === activeCat.group) : enabled;
+  const tabSources = activeCat?.group
+    ? enabled.filter((s) => s.groups?.includes(activeCat.group!))
+    : enabled;
   const tabErrored =
     tabSources.length > 0 && tabSources.every((s) => search.perSource[s.id]?.error);
   // Only the active tab's sources hold its spinner; other groups' stragglers
@@ -464,7 +466,7 @@ export function Results() {
       if (aliveOnly) {
         const cat = CATEGORIES.find((c) => c.key === section);
         const base = cat?.group
-          ? search.results.filter((r) => getSource(r.source).group === cat.group)
+          ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
           : search.results;
         if (base.length > 0 && base.every((r) => r.seeders <= 0)) {
           return (

--- a/src/ui/components/SourcesPrompt.tsx
+++ b/src/ui/components/SourcesPrompt.tsx
@@ -33,16 +33,23 @@ export function SourcesPrompt({ width, disabled, onToggle, onCancel }: SourcesPr
     }
   });
 
-  const onCount = flat.length - disabled.length;
+  // A source can belong to several groups (e.g. a general index under both
+  // Movies and TV), so it renders once per group. Count each source once.
+  const total = new Set(flat.map((s) => s.id)).size;
+  const onCount = total - disabled.length;
+  // Global row index across all groups, matching `flat`'s order, so a source
+  // shown under two headers is two independently selectable rows.
+  let rowIndex = -1;
 
   return (
     <Box flexDirection="column" width={width}>
-      <Panel title="sources" width={width} focused count={`${onCount}/${flat.length}`}>
+      <Panel title="sources" width={width} focused count={`${onCount}/${total}`}>
         {groups.map((g) => (
           <Box key={g.group} flexDirection="column">
             <Text dimColor>{g.group}</Text>
             {g.sources.map((src) => {
-              const i = flat.indexOf(src);
+              rowIndex += 1;
+              const i = rowIndex;
               const on = !disabled.includes(src.id);
               const selected = i === clamped;
               const ss = SOURCE_STYLE[src.id];
@@ -50,7 +57,7 @@ export function SourcesPrompt({ width, disabled, onToggle, onCancel }: SourcesPr
               // source is otherwise enabled).
               const skipped = on && isSkipped(sourceHealth, src.id, Date.now());
               return (
-                <Box key={src.id}>
+                <Box key={`${g.group}-${src.id}`}>
                   <Text color={selected ? COLOR.accent : undefined}>
                     {selected ? `${ICON.pointer} ` : "  "}
                   </Text>

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -76,6 +76,13 @@ function idleState(sources: readonly Source[]): ConcurrentSearchState {
   };
 }
 
+// Coalesce interval for streaming result updates. Sources finish in bursts (a
+// cache hit or a couple of fast hosts land almost together), and each update
+// re-sorts and re-renders the whole list. Flushing at most once per this window
+// keeps a burst from flooding Ink with re-renders and blocking stdin — the same
+// leading-throttle the queue hooks in store.ts use for `update` events.
+const RESULT_FLUSH_MS = 150;
+
 export function useConcurrentSearch(
   query: string,
   disabled: readonly SourceId[] = [],
@@ -96,6 +103,35 @@ export function useConcurrentSearch(
     const active = sources.filter((s) => !isSkipped(sourceHealth, s.id, Date.now()));
     const per = blankPerSource(active, true);
     let done = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = (): void => {
+      setState({
+        results: defaultOrder(mergeDuplicateResults(collected.slice())),
+        perSource: { ...per },
+        loading: done < active.length,
+        done,
+        total: active.length,
+      });
+    };
+
+    // Push the accumulated state to the UI, but no more than once per window.
+    // The final source flushes immediately so "done" / loading:false is prompt.
+    const scheduleFlush = (): void => {
+      if (done >= active.length) {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        flush();
+        return;
+      }
+      if (timer) return;
+      timer = setTimeout(() => {
+        timer = null;
+        if (alive) flush();
+      }, RESULT_FLUSH_MS);
+    };
 
     setState({
       results: [],
@@ -109,7 +145,7 @@ export function useConcurrentSearch(
       const sc = new AbortController();
       const onAbort = (): void => sc.abort();
       ctrl.signal.addEventListener("abort", onAbort);
-      const timer = setTimeout(() => sc.abort(), PER_SOURCE_TIMEOUT_MS);
+      const abortTimer = setTimeout(() => sc.abort(), PER_SOURCE_TIMEOUT_MS);
 
       cachedSearch(source, query, { signal: sc.signal })
         .then((res) => {
@@ -133,23 +169,18 @@ export function useConcurrentSearch(
           }
         })
         .finally(() => {
-          clearTimeout(timer);
+          clearTimeout(abortTimer);
           ctrl.signal.removeEventListener("abort", onAbort);
           if (!alive) return;
           done += 1;
-          setState({
-            results: defaultOrder(mergeDuplicateResults(collected.slice())),
-            perSource: { ...per },
-            loading: done < active.length,
-            done,
-            total: active.length,
-          });
+          scheduleFlush();
         });
     }
 
     return () => {
       alive = false;
       ctrl.abort();
+      if (timer) clearTimeout(timer);
     };
   }, [query, sources]);
 

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -58,6 +58,13 @@ function idleState(): ConcurrentSearchState {
   };
 }
 
+// Coalesce interval for streaming result updates. Sources finish in bursts (a
+// cache hit or a couple of fast hosts land almost together), and each update
+// re-sorts and re-renders the whole list. Flushing at most once per this window
+// keeps a burst from flooding Ink with re-renders and blocking stdin — the same
+// leading-throttle the queue hooks in store.ts use for `update` events.
+const RESULT_FLUSH_MS = 150;
+
 export function useConcurrentSearch(query: string): ConcurrentSearchState {
   const [state, setState] = useState<ConcurrentSearchState>(idleState);
 
@@ -67,6 +74,35 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
     const collected: TorrentResult[] = [];
     const per = blankPerSource(true);
     let done = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = (): void => {
+      setState({
+        results: defaultOrder(dedupe(collected.slice())),
+        perSource: { ...per },
+        loading: done < SOURCES.length,
+        done,
+        total: SOURCES.length,
+      });
+    };
+
+    // Push the accumulated state to the UI, but no more than once per window.
+    // The final source flushes immediately so "done" / loading:false is prompt.
+    const scheduleFlush = (): void => {
+      if (done >= SOURCES.length) {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        flush();
+        return;
+      }
+      if (timer) return;
+      timer = setTimeout(() => {
+        timer = null;
+        if (alive) flush();
+      }, RESULT_FLUSH_MS);
+    };
 
     setState({
       results: [],
@@ -95,19 +131,14 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
         .finally(() => {
           if (!alive) return;
           done += 1;
-          setState({
-            results: defaultOrder(dedupe(collected.slice())),
-            perSource: { ...per },
-            loading: done < SOURCES.length,
-            done,
-            total: SOURCES.length,
-          });
+          scheduleFlush();
         });
     }
 
     return () => {
       alive = false;
       ctrl.abort();
+      if (timer) clearTimeout(timer);
     };
   }, [query]);
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -52,6 +52,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "rt-anime": { tag: "RUT", color: "#8fce5a" },
   "rt-music": { tag: "RUT", color: "#8fce5a" },
   "rt-books": { tag: "RUT", color: "#8fce5a" },
+  bittorrented: { tag: "BT", color: "#7db8f0" },
 };
 
 // Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -38,6 +38,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
+  bittorrented: { tag: "BT", color: "#7db8f0" },
 };
 
 // Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or

--- a/src/util/duration.test.ts
+++ b/src/util/duration.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { parseDuration } from "./duration";
+
+describe("parseDuration", () => {
+  it("parses units s/m/h/d", () => {
+    expect(parseDuration("90s")).toBe(90_000);
+    expect(parseDuration("30m")).toBe(1_800_000);
+    expect(parseDuration("1h")).toBe(3_600_000);
+    expect(parseDuration("2d")).toBe(172_800_000);
+  });
+  it("treats a bare number as seconds", () => {
+    expect(parseDuration("3600")).toBe(3_600_000);
+  });
+  it("is case-insensitive and trims", () => {
+    expect(parseDuration("  1H ")).toBe(3_600_000);
+  });
+  it("returns null for junk", () => {
+    expect(parseDuration("")).toBeNull();
+    expect(parseDuration("1w")).toBeNull();
+    expect(parseDuration("abc")).toBeNull();
+    expect(parseDuration("1.5h")).toBeNull();
+  });
+});

--- a/src/util/duration.ts
+++ b/src/util/duration.ts
@@ -1,0 +1,11 @@
+// Parse a short human duration like "1h", "30m", "90s", "2d" into milliseconds.
+// A bare number is seconds. Returns null for anything unparseable.
+export function parseDuration(input: string): number | null {
+  const s = input.trim().toLowerCase();
+  const m = /^(\d+)(s|m|h|d)?$/.exec(s);
+  if (!m) return null;
+  const n = Number.parseInt(m[1]!, 10);
+  const unit = m[2] ?? "s";
+  const mult = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[unit]!;
+  return n * mult;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,16 @@
-export const VERSION = "1.0.0";
+import { readFileSync } from "node:fs";
+
+// Read the version from package.json so it can never drift from a release.
+// Works from both src/ (tsx dev) and dist/ (bundled): each sits one level
+// below the package root, where npm installs keep package.json too.
+function readVersion(): string {
+  try {
+    const raw = readFileSync(new URL("../package.json", import.meta.url), "utf8");
+    const version = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof version === "string" ? version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export const VERSION = readVersion();


### PR DESCRIPTION
Brings the fork up to date with upstream **baairon/torlink v1.4.0**, adds the linting/CI tooling the codebase was already written for, and bumps to **v1.5.0**.

## Upstream sync (baairon/torlink → v1.4.0)
Merged 12 upstream commits:
- **Headless modes**: `torlnk watch <dir>` (watch-folder), `torlnk serve` (HTTP add API), `torlnk files` (HTTP file server), plus `--daemon` and `torlnk attach` (tmux).
- **Seed reaper** + `--seed-time` / `--delete-files`.
- **BitTorrented** search source (Movies + TV).
- 1337x scraper speedup, `node-datachannel` source-rebuild fallback for Node 22+, streaming-search flush coalescing, HTTP tracker endpoints, headless-server lockdown, dynamic version reporting.

### Merge reconciliation
- **`useConcurrentSearch`**: kept our source-filtering + `mergeDuplicateResults` provenance and layered upstream's 150ms flush coalescing on top.
- **Source categories**: upstream and the fork independently invented grouping after the fork point with different shapes. Adopted upstream's `groups?: SourceGroup[]` (array) model over the fork's singular `group`, migrating all fork sources, UI reads, and tests. Fixed `SourcesPrompt` to count/select/key multi-group sources (e.g. BitTorrented in both Movies+TV) instead of duplicating them.

## Tooling
- **ESLint** (flat config): `@eslint/js` + `typescript-eslint` recommended + the two classic React Hooks rules. The code already carried `eslint-disable` directives with no config committed — this wires up the linter they assume. Tuned to a green baseline with each deviation documented. Adds `npm run lint` / `lint:fix`.
- **CI** (`.github/workflows/ci.yml`): typecheck + lint + test on PRs and pushes to `main` (repo previously had no PR CI — release.yml only builds on tag).

## Release
- Bumps `package.json` to **1.5.0**.

## Verification
- `tsc --noEmit`: 0 errors
- `eslint .`: clean
- **430/430 tests pass**
- production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)