### PR TITLE
Fix flaky queue test + fake timers + bump CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
             archive: zip
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -62,7 +62,7 @@ jobs:
           Copy-Item package.json,LICENSE,README.md torlnk-runtime/
           Set-Content torlnk-runtime/torlnk.cmd '@echo off`r`n"%~dp0node.exe" "%~dp0dist\cli.cjs" %*'
           Compress-Archive -Path torlnk-runtime -DestinationPath "${{ matrix.asset }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
@@ -71,12 +71,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
       - run: cd artifacts && sha256sum torlnk-* > SHA256SUMS
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -73,7 +73,9 @@ describe("DownloadQueue seeding", () => {
   it("exports cached .torrent metadata for a history item", async () => {
     const q = new DownloadQueue();
     const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-queue-export-"));
-    const item = h({ id: "h5", name: "Some/Torrent", dir: outDir });
+    // Unique id: saveTorrentMeta writes into the shared torrents dir keyed by id,
+    // so a fixed id would collide with any concurrent run using the same one.
+    const item = h({ id: `export-${path.basename(outDir)}`, name: "Some/Torrent", dir: outDir });
     try {
       q.restoreHistory([item]);
       await saveTorrentMeta(item.id, new Uint8Array([5, 6, 7]));
@@ -166,6 +168,21 @@ describe("DownloadQueue Real-Debrid path", () => {
 
 describe("DownloadQueue Real-Debrid scheduling", () => {
   const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+  // Poll the event loop until `cond` holds, yielding a real macrotask each time
+  // so injected async deps and real fs I/O can settle. Waiting on observable
+  // state instead of a fixed number of ticks keeps these tests deterministic
+  // under load; the generous cap still fails fast on a genuine hang.
+  const waitFor = async (
+    cond: () => boolean | Promise<boolean>,
+    label = "condition",
+  ): Promise<void> => {
+    for (let i = 0; i < 500; i++) {
+      if (await cond()) return;
+      await tick();
+    }
+    throw new Error(`waitFor timed out waiting for ${label}`);
+  };
+  const fileExists = (p: string): Promise<boolean> => fs.access(p).then(() => true, () => false);
 
   it("runs at most two Real-Debrid downloads at once; the rest wait as queued", async () => {
     const q = new DownloadQueue();
@@ -184,8 +201,7 @@ describe("DownloadQueue Real-Debrid scheduling", () => {
     const inputs = [1, 2, 3, 4].map((n) => ({ id: `rd${n}`, name: `M${n}`, magnet: `m${n}` }));
     const all = Promise.all(inputs.map((i) => q.addDebrid(i, "/downloads", "tok", deps)));
 
-    await tick();
-    await tick();
+    await waitFor(() => started === 2, "2 downloads started");
     expect(started).toBe(2);
     expect(q.getItems().filter((it) => it.phase === "queued")).toHaveLength(2);
 
@@ -259,13 +275,11 @@ describe("DownloadQueue Real-Debrid scheduling", () => {
     const inputs = [1, 2, 3].map((n) => ({ id: `rd${n}`, name: `M${n}`, magnet: `m${n}` }));
     const all = Promise.all(inputs.map((i) => q.addDebrid(i, "/downloads", "tok", deps)));
 
-    await tick();
-    await tick();
-    expect(started).toHaveLength(2); // cap = 2; rd3 waiting
+    await waitFor(() => started.length === 2, "cap of 2 started"); // cap = 2; rd3 waiting
+    expect(started).toHaveLength(2);
 
     q.cancel("rd1"); // cancel a running item → its slot should free
-    await tick();
-    await tick();
+    await waitFor(() => started.length === 3, "rd3 starts after slot frees");
     expect(started).toHaveLength(3); // rd3 acquired the freed slot
     expect(q.has("rd1")).toBe(false); // cancelled item is gone
 
@@ -287,10 +301,11 @@ describe("DownloadQueue Real-Debrid scheduling", () => {
         downloadCalls++;
         if (downloadCalls === 1) {
           // First run: block until the pause aborts us, then throw like a real abort.
+          const abortErr = (): Error =>
+            Object.assign(new Error("Download aborted."), { name: "AbortError" });
           await new Promise<void>((_res, rej) => {
-            opts?.signal?.addEventListener("abort", () =>
-              rej(Object.assign(new Error("Download aborted."), { name: "AbortError" })),
-            );
+            if (opts?.signal?.aborted) return rej(abortErr());
+            opts?.signal?.addEventListener("abort", () => rej(abortErr()));
           });
         }
         opts?.onProgress?.({ downloaded: 10, total: 10, speed: 0 });
@@ -300,15 +315,17 @@ describe("DownloadQueue Real-Debrid scheduling", () => {
     };
 
     const p = q.addDebrid({ id: "rd1", name: "M", magnet: "m" }, "/downloads", "tok", deps);
-    await tick();
-    await tick();
+    await waitFor(
+      () => q.getItems().find((i) => i.id === "rd1")?.phase === "downloading",
+      "download in progress",
+    );
 
     q.pause("rd1");
     await p; // driveDebrid returns once the pause abort unwinds
     expect(q.getItems().find((i) => i.id === "rd1")?.status).toBe("paused");
 
     q.resume("rd1");
-    for (let n = 0; n < 5 && q.has("rd1"); n++) await tick();
+    await waitFor(() => !q.has("rd1"), "resumed download completes"); // second run → history
     expect(q.has("rd1")).toBe(false); // second download run completed → history
     expect(downloadCalls).toBe(2);
     q.suspend();
@@ -322,25 +339,28 @@ describe("DownloadQueue Real-Debrid scheduling", () => {
       downloadFiles: async (_files, destDir, opts) => {
         await fs.mkdir(destDir, { recursive: true });
         await fs.writeFile(path.join(destDir, "f.mkv"), "partial");
-        await new Promise<void>((_res, rej) =>
-          opts?.signal?.addEventListener("abort", () =>
-            rej(Object.assign(new Error("Download aborted."), { name: "AbortError" })),
-          ),
-        );
+        const abortErr = (): Error =>
+          Object.assign(new Error("Download aborted."), { name: "AbortError" });
+        await new Promise<void>((_res, rej) => {
+          // The abort may already have fired while the writes above were in
+          // flight; adding a listener after the fact would never see it and the
+          // pipeline would hang. Reject immediately in that case.
+          if (opts?.signal?.aborted) return rej(abortErr());
+          opts?.signal?.addEventListener("abort", () => rej(abortErr()));
+        });
         return [];
       },
       sleep: async () => {},
     };
+    const file = path.join(dir, "f.mkv");
     const p = q.addDebrid({ id: "rd1", name: "M", magnet: "m" }, dir, "tok", deps);
-    await tick();
-    await tick();
+    await waitFor(() => fileExists(file), "partial file written"); // download reached the abort wait
     q.pause("rd1");
     await p;
-    expect(await fs.readFile(path.join(dir, "f.mkv"), "utf8")).toBe("partial"); // kept on pause
+    expect(await fs.readFile(file, "utf8")).toBe("partial"); // kept on pause
 
     q.cancel("rd1");
-    for (let n = 0; n < 5; n++) await tick(); // cleanup is async best-effort
-    await expect(fs.access(path.join(dir, "f.mkv"))).rejects.toBeTruthy(); // gone after cancel
+    await waitFor(async () => !(await fileExists(file)), "partial file deleted"); // async best-effort cleanup
     q.suspend();
   });
 });

--- a/src/util/net.test.ts
+++ b/src/util/net.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { parseRetryAfter, backoffDelay, fetchResilient, HttpError } from "./net";
 
 function fakeRes(status: number, headers: Record<string, string> = {}): Response {
@@ -275,20 +275,27 @@ describe("fetchResilient", () => {
   });
 
   it("cuts a backoff sleep short when the signal aborts", async () => {
-    // No sleepImpl: exercises the real sleep. Retry-After floors the backoff
-    // at 60s, so only an abort-aware sleep lets this settle quickly.
-    const ctrl = new AbortController();
-    setTimeout(() => ctrl.abort(), 20);
-    const started = Date.now();
-    await expect(
-      fetchResilient("http://x", {
-        retries: 2,
-        baseMs: 60_000,
-        capMs: 60_000,
-        signal: ctrl.signal,
-        fetchImpl: async () => fakeRes(503, { "retry-after": "60" }),
-      }),
-    ).rejects.toBeInstanceOf(HttpError);
-    expect(Date.now() - started).toBeLessThan(5_000);
+    // No sleepImpl: exercises the real sleep. Retry-After floors the backoff at
+    // 60s, so only an abort-aware sleep lets this settle. With fake timers we
+    // advance just past the 20ms abort — never the 60s backoff — so a sleep that
+    // ignored the signal would sit unresolved and this test would hang.
+    vi.useFakeTimers();
+    try {
+      const ctrl = new AbortController();
+      setTimeout(() => ctrl.abort(), 20);
+      const rejects = expect(
+        fetchResilient("http://x", {
+          retries: 2,
+          baseMs: 60_000,
+          capMs: 60_000,
+          signal: ctrl.signal,
+          fetchImpl: async () => fakeRes(503, { "retry-after": "60" }),
+        }),
+      ).rejects.toBeInstanceOf(HttpError);
+      await vi.advanceTimersByTimeAsync(20);
+      await rejects;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/util/semaphore.test.ts
+++ b/src/util/semaphore.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Semaphore } from "./semaphore";
 
-const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+// Semaphore itself uses no timers; the one yield below just proves queued
+// waiters stay parked. Drive it with fake timers so it never leans on real
+// wall-clock scheduling.
+const tick = async (): Promise<void> => {
+  await vi.advanceTimersByTimeAsync(0);
+};
 
 describe("Semaphore", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it("admits up to the limit immediately", async () => {
     const s = new Semaphore(2);
     await s.acquire();


### PR DESCRIPTION
Fixes the intermittent CI failure and hardens the timer-dependent tests.

## The flake
CI failed on `queue.test.ts` with a 5s timeout. Root cause: the Real-Debrid `downloadFiles` mock registered its abort listener **after** two real `fs` writes, so a `pause()` that fired first was missed → the pipeline promise never rejected → `await p` hung until the timeout.

## Fixes
- **Abort race**: register the abort listener with an `aborted` guard, so an already-fired abort rejects immediately instead of hanging (structural fix — the abort can no longer be missed regardless of timing).
- **No more fixed tick counts**: added a condition-based `waitFor` helper; tests now gate on observable state (started counts, `phase`, file existence) instead of a guessed number of event-loop turns.
- **Unique export id**: the `.torrent`-export test wrote into the shared torrents dir keyed by a fixed id, so it could collide under concurrency — now uses a unique id.

## Fake timers (clean, timer-driven unit tests)
- `net.test.ts`: the abort-cuts-backoff test advances fake time just past the 20ms abort (never the 60s floor) — no wall-clock wait.
- `semaphore.test.ts`: drives its event-loop yield via fake timers.
- Ink UI tests deliberately keep their real render-flush (fake timers fight ink's renderer).

## CI actions (off deprecated Node 20)
`checkout` v4→v7, `setup-node` v4→v6, `upload-artifact` v4→v7, `download-artifact` v4→v8, `action-gh-release` v2→v3.

## Verification
- **24/24** parallel `queue.test.ts` runs green (previously flaked under contention)
- **12/12** sequential full-suite runs green
- typecheck: 0 errors · lint: clean · 430/430 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)