### PR TITLE
Isolate persisted test state per vitest worker

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,18 @@
+import os from "node:os";
+import path from "node:path";
+
+// Give every vitest worker its own on-disk state directory so concurrent
+// workers never share torlink's persisted files (queue / history / seeds /
+// config / torrents) and race on them.
+//
+// This must run before any module imports src/config/paths.ts, which resolves
+// those paths once at load from TORLINK_STATE_DIR. setupFiles are evaluated
+// before the test module's import graph, so the override lands in time. This
+// file deliberately imports nothing from the app, so paths.ts is not pulled in
+// early.
+//
+// VITEST_WORKER_ID is stable for a worker's lifetime and distinct across
+// concurrent workers; the pid disambiguates the forks pool, where a fresh
+// process can reuse a worker id.
+const workerTag = `${process.pid}-${process.env.VITEST_WORKER_ID ?? "0"}`;
+process.env.TORLINK_STATE_DIR = path.join(os.tmpdir(), "torlink-test-state", workerTag);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,13 @@
-import os from "node:os";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
 
-// Keep tests off the real user data dir: redirect all persisted state (queue /
-// history / seeds / config) into a temp folder via the TORLINK_STATE_DIR
-// override that src/config/paths.ts honors. Applied before test modules import
-// paths.ts, so every write during a run lands here instead.
+// Keep tests off the real user data dir and isolated from each other: each
+// worker gets its own TORLINK_STATE_DIR (which src/config/paths.ts honors) so
+// concurrent workers never share persisted state — queue / history / seeds /
+// config / torrents — and race on it. See src/test-setup.ts for the per-worker
+// path; it must run before any test module imports paths.ts, which setupFiles
+// guarantee.
 export default defineConfig({
   test: {
-    env: {
-      TORLINK_STATE_DIR: path.join(os.tmpdir(), "torlink-test-state"),
-    },
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
Follow-up hardening spotted while fixing the queue-test flake.

## Problem
`vitest.config.ts` pointed `TORLINK_STATE_DIR` at a single fixed temp dir shared by **every** worker. So concurrent workers wrote torlink's persisted files (queue / history / seeds / config / torrents) into the same place and could race on them — a latent flake that would surface as the suite grows and more files touch shared state.

## Fix
Each worker now gets its own state dir. A new `src/test-setup.ts` (vitest `setupFiles`) derives a per-worker path from `pid + VITEST_WORKER_ID` and sets `TORLINK_STATE_DIR` **before** any module imports `src/config/paths.ts` (which resolves those paths once at load — setup files run early enough to satisfy that ordering).

## Verification
- Confirmed the override lands: per-worker `pid-workerid` dirs are created under the temp root during a run (proves the setup beat `paths.ts`).
- 6/6 sequential full-suite runs + 6/6 parallel same-file runs green.
- typecheck: 0 errors · lint: clean · 430/430 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)