### PR TITLE
chore: sync upstream baairon/torlink (2026-07-13)

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,61 +1,113 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   # dependencies
-  fetchurl,
   nodejs_22,
   wl-clipboard,
   xclip,
+  cmake,
+  openssl,
+  cacert,
 }:
+
+let
+  libdatachannel = fetchFromGitHub {
+    owner = "paullouisageneau";
+    repo = "libdatachannel";
+    tag = "v0.24.5";
+    fetchSubmodules = true;
+    hash = "sha256-0Yrp9cZL8JvBD5YZYbJdmPpPSBHTM/5WXNNK/s+GkDI=";
+  };
+
+  libdatachannelBuildDeps = stdenv.mkDerivation {
+    name = "libdatachannel-build-deps";
+    nativeBuildInputs = [
+      nodejs_22
+      cacert
+    ];
+    # needs cert for registry to resolve
+    buildPhase = ''
+      export HOME=$(mktemp -d)
+      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+      mkdir -p $out
+      npm install --prefix $out --no-save --ignore-scripts \
+        cmake-js@8.0.0 node-addon-api@8.9.0
+    '';
+
+    dontUnpack = true;
+    dontInstall = true;
+    outputHashMode = "recursive";
+    outputHash = "sha256-Haj527mURO7NAy3Xms7LEVvAKm314LDP2IeAYFYKMpw=";
+  };
+in
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
   version = "1.4.0";
-  __structuredAttrs = true;
-  strictDeps = true;
-
   src = fetchFromGitHub {
     owner = "baairon";
     repo = "torlink";
     tag = "v${finalAttrs.version}";
     hash = "sha256-KeszeV9atSvaA9s7iDCl+Q1eDMSx7flnQuBE8t49IPY=";
   };
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nodejs = nodejs_22;
   npmDepsHash = "sha256-nSHunmjZfr9oCygaLnHQxrXv7wuSa5ze7cQL7BrqfwQ=";
-  # ignore-scripts for ip-set broken preinstall
-  npmFlags = [ "--ignore-scripts" ];
+  npmFlags = [ "--ignore-scripts" ]; # ignore-scripts for ip-set broken preinstall
 
-  # node-datachannel binary tarball
-  nodeDatachannelPrebuilt = fetchurl {
-    url = "https://github.com/murat-dogan/node-datachannel/releases/download/v0.32.3/node-datachannel-v0.32.3-napi-v8-linux-x64.tar.gz";
-    sha256 = "4092afc9cd594a3326eb1bd823da452b227b742ea8222689b2cea6f7344cf67a";
-  };
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl ];
+  dontUseCmakeConfigure = true; # override cmake default (no configure script)
 
-  # replicate postbuild from package.json
   postBuild = ''
     node scripts/postbuild.cjs
   '';
 
-  # extract node-datachannel tarball
-  # add wl-copy and xclip to nix readeable path
+  # build node-datachannel, and wrap clipboard
   postInstall = ''
-    tar -xzf ${finalAttrs.nodeDatachannelPrebuilt} \
-      -C $out/lib/node_modules/torlnk/node_modules/node-datachannel
-      wrapProgram $out/bin/torlnk \
-        --prefix PATH : ${
-          lib.makeBinPath [
-            wl-clipboard
-            xclip
-          ]
-        }
+    pushd $out/lib/node_modules/torlnk/node_modules/node-datachannel
+
+    # link shared nixpkgs openssl
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+      'set(OPENSSL_USE_STATIC_LIBS TRUE)' \
+      'set(OPENSSL_USE_STATIC_LIBS FALSE)'
+
+    # merge build deps
+    mkdir -p node_modules
+    cp -r ${libdatachannelBuildDeps}/node_modules/. node_modules/
+    patchShebangs --build node_modules
+
+    export npm_config_nodedir=${lib.getDev nodejs_22}
+
+    # redirect node-datachannel
+    node_modules/.bin/cmake-js compile \
+        --CDFETCHCONTENT_SOURCE_DIR_LIBDATACHANNEL=${libdatachannel} \
+        --CDFETCHCONTENT_FULLY_DISCONNECTED=ON
+
+    # trim build tree
+    find build -mindepth 1 -maxdepth 1 -not -name Release -exec rm -rf {} +
+    find build/Release -mindepth 1 -not -name 'node_datachannel.node' -exec rm -rf {} +
+    popd
+
+    # wrap clipboard
+    wrapProgram $out/bin/torlnk \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          wl-clipboard
+          xclip
+        ]
+      }
   '';
 
   meta = {
     description = "Torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure.";
     homepage = "https://github.com/baairon/torlink";
-    changelog = "https://github.com/baairon/torlink/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/baairon/torlink/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ghastrum ];
     mainProgram = "torlnk";

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -113,16 +113,29 @@ export class TorrentEngine {
   stats(id: string): TorrentProgress | null {
     const t = this.torrents.get(id);
     if (!t) return null;
+
+    let progress = 0;
+    let downloaded = 0;
+    let timeRemaining = Infinity;
+
+    try {
+      progress = t.progress;
+      downloaded = t.downloaded;
+      timeRemaining = t.timeRemaining;
+    } catch (err) {
+      // Ignore webtorrent getter errors that occur before metadata is fully parsed
+    }
+
     return {
-      progress: t.progress,
-      downloaded: t.downloaded,
-      total: t.length,
-      speed: t.downloadSpeed,
-      uploadSpeed: t.uploadSpeed,
-      uploaded: t.uploaded,
-      peers: t.numPeers,
-      timeRemaining: t.timeRemaining,
-      name: t.name,
+      progress,
+      downloaded,
+      total: t.length || 0,
+      speed: t.downloadSpeed || 0,
+      uploadSpeed: t.uploadSpeed || 0,
+      uploaded: t.uploaded || 0,
+      peers: t.numPeers || 0,
+      timeRemaining,
+      name: t.name || '',
     };
   }
 

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -158,7 +158,7 @@ export class TorrentEngine {
       progress = t.progress;
       downloaded = t.downloaded;
       timeRemaining = t.timeRemaining;
-    } catch (err) {
+    } catch {
       // Ignore webtorrent getter errors that occur before metadata is fully parsed
     }
 

--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -33,6 +33,7 @@ export function SearchBar({
             <TextField
               defaultValue={value}
               placeholder={placeholder}
+              width={Math.max(1, width - 6)}
               onSubmit={onSubmit}
               onChange={onChange}
               onExitDown={onExitDown}

--- a/src/ui/components/TextField.test.ts
+++ b/src/ui/components/TextField.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { deleteAt, deleteWordAfter, wordLeft, wordRight } from "./TextField";
+
+describe("wordLeft", () => {
+  it("jumps to the start of the previous word, crossing runs of spaces", () => {
+    expect(wordLeft("one two", 7)).toBe(4);
+    expect(wordLeft("one two", 4)).toBe(0);
+    expect(wordLeft("one   two", 6)).toBe(0);
+    expect(wordLeft("one two", 5)).toBe(4);
+  });
+
+  it("stays put at the start of the line", () => {
+    expect(wordLeft("one", 0)).toBe(0);
+    expect(wordLeft("", 0)).toBe(0);
+  });
+});
+
+describe("wordRight", () => {
+  it("jumps past the end of the next word, crossing runs of spaces", () => {
+    expect(wordRight("one two", 0)).toBe(3);
+    expect(wordRight("one two", 3)).toBe(7);
+    expect(wordRight("one   two", 3)).toBe(9);
+    expect(wordRight("one two", 5)).toBe(7);
+  });
+
+  it("stays put at the end of the line", () => {
+    expect(wordRight("one", 3)).toBe(3);
+    expect(wordRight("", 0)).toBe(0);
+  });
+});
+
+describe("deleteWordAfter", () => {
+  it("removes through the end of the next word, keeping the cursor in place", () => {
+    expect(deleteWordAfter("one two", 3)).toEqual({ value: "one", cursor: 3 });
+    expect(deleteWordAfter("one two three", 4)).toEqual({ value: "one  three", cursor: 4 });
+    expect(deleteWordAfter("one   two", 3)).toEqual({ value: "one", cursor: 3 });
+  });
+
+  it("no-ops at the end of the line", () => {
+    expect(deleteWordAfter("one", 3)).toEqual({ value: "one", cursor: 3 });
+    expect(deleteWordAfter("", 0)).toEqual({ value: "", cursor: 0 });
+  });
+});
+
+describe("deleteAt", () => {
+  it("removes the character under the cursor without moving it", () => {
+    expect(deleteAt("abc", 0)).toEqual({ value: "bc", cursor: 0 });
+    expect(deleteAt("abc", 1)).toEqual({ value: "ac", cursor: 1 });
+  });
+
+  it("no-ops at the end of the line", () => {
+    expect(deleteAt("abc", 3)).toEqual({ value: "abc", cursor: 3 });
+    expect(deleteAt("", 0)).toEqual({ value: "", cursor: 0 });
+  });
+});

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -40,6 +40,24 @@ export function deleteWordBefore(value: string, cursor: number): Edit {
   return { value: value.slice(0, i) + value.slice(cursor), cursor: i };
 }
 
+export function wordLeft(value: string, cursor: number): number {
+  let i = cursor;
+  while (i > 0 && value[i - 1] === " ") i--;
+  while (i > 0 && value[i - 1] !== " ") i--;
+  return i;
+}
+
+export function wordRight(value: string, cursor: number): number {
+  let i = cursor;
+  while (i < value.length && value[i] === " ") i++;
+  while (i < value.length && value[i] !== " ") i++;
+  return i;
+}
+
+export function deleteWordAfter(value: string, cursor: number): Edit {
+  return { value: value.slice(0, cursor) + value.slice(wordRight(value, cursor)), cursor };
+}
+
 export function killToEnd(value: string, cursor: number): Edit {
   return { value: value.slice(0, cursor), cursor };
 }
@@ -85,6 +103,47 @@ export function TextField({
         return;
       }
 
+      if (key.home) {
+        setCursor(0);
+        return;
+      }
+      if (key.end) {
+        setCursor(value.length);
+        return;
+      }
+
+      // Modifier+named-key combos must be handled before the ctrl switch:
+      // named keys arrive with an empty input, so they'd hit its default arm
+      // and vanish.
+      if (key.leftArrow) {
+        if (key.ctrl || key.meta) {
+          setCursor(wordLeft(value, cursor));
+          return;
+        }
+        if (cursor === 0) {
+          onExitLeft?.();
+          return;
+        }
+        setCursor(cursor - 1);
+        return;
+      }
+      if (key.rightArrow) {
+        if (key.ctrl || key.meta) {
+          setCursor(wordRight(value, cursor));
+          return;
+        }
+        setCursor(Math.min(value.length, cursor + 1));
+        return;
+      }
+      if (key.delete) {
+        apply(key.ctrl || key.meta ? deleteWordAfter(value, cursor) : deleteAt(value, cursor));
+        return;
+      }
+      if (key.backspace) {
+        apply(key.ctrl || key.meta ? deleteWordBefore(value, cursor) : deleteBefore(value, cursor));
+        return;
+      }
+
       if (key.ctrl) {
         switch (input) {
           case "u":
@@ -102,32 +161,20 @@ export function TextField({
           case "e":
             setCursor(value.length);
             return;
+          // Every other ctrl combo is swallowed so views behind the field
+          // never see it; ctrl+d stays free for view-level bindings.
           default:
             return;
         }
       }
 
-      if (key.leftArrow) {
-        if (cursor === 0) {
-          onExitLeft?.();
-          return;
+      if (key.meta) {
+        if (input === "d") {
+          apply(deleteWordAfter(value, cursor));
         }
-        setCursor(cursor - 1);
         return;
       }
-      if (key.rightArrow) {
-        setCursor(Math.min(value.length, cursor + 1));
-        return;
-      }
-      if (key.delete) {
-        apply(deleteAt(value, cursor));
-        return;
-      }
-      if (key.backspace) {
-        apply(deleteBefore(value, cursor));
-        return;
-      }
-      if (key.meta || !input) return;
+      if (!input) return;
       const text = input
         .replace(/\x1b?\[<\d+;\d+;\d+[Mm]/g, "") // SGR mouse
         .replace(/\x1b\[20[01]~/g, "") // Bracketed paste

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -5,6 +5,7 @@ export interface TextFieldProps {
   isDisabled?: boolean;
   defaultValue?: string;
   placeholder?: string;
+  width?: number;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
   onExitDown?: () => void;
@@ -21,6 +22,14 @@ export function deleteBefore(value: string, cursor: number): Edit {
   return {
     value: value.slice(0, cursor - 1) + value.slice(cursor),
     cursor: cursor - 1,
+  };
+}
+
+export function deleteAt(value: string, cursor: number): Edit {
+  if (cursor === value.length) return { value, cursor };
+  return {
+    value: value.slice(0, cursor) + value.slice(cursor + 1),
+    cursor,
   };
 }
 
@@ -48,6 +57,7 @@ export function TextField({
   isDisabled = false,
   defaultValue = "",
   placeholder = "",
+  width,
   onChange,
   onSubmit,
   onExitDown,
@@ -109,12 +119,19 @@ export function TextField({
         setCursor(Math.min(value.length, cursor + 1));
         return;
       }
-      if (key.backspace || key.delete) {
+      if (key.delete) {
+        apply(deleteAt(value, cursor));
+        return;
+      }
+      if (key.backspace) {
         apply(deleteBefore(value, cursor));
         return;
       }
       if (key.meta || !input) return;
-      const text = input.replace(/\x1b?\[<\d+;\d+;\d+[Mm]/g, "");
+      const text = input
+        .replace(/\x1b?\[<\d+;\d+;\d+[Mm]/g, "") // SGR mouse
+        .replace(/\x1b\[20[01]~/g, "") // Bracketed paste
+        .replace(/[\r\n]+/g, ""); // Newlines
       if (!text) return;
       apply(insertAt(value, cursor, text));
     },
@@ -137,9 +154,24 @@ export function TextField({
     return <Text inverse>{CURSOR}</Text>;
   }
 
-  const before = value.slice(0, cursor);
+  // Compute a viewport window that keeps the cursor visible.
+  // The cursor char itself always occupies 1 column inside the viewport.
+  const viewW = width && width > 0 ? width : Infinity;
+  let viewStart = 0;
+  if (value.length + 1 > viewW) {
+    // Ensure cursor position is visible: keep at least 1 char of context
+    // after the cursor when possible.
+    const cursorScreenPos = cursor; // 0-indexed position in full string
+    if (cursorScreenPos >= viewW - 1) {
+      viewStart = cursorScreenPos - viewW + 2;
+    }
+  }
+  const viewEnd = viewStart + viewW;
+
+  const before = value.slice(Math.max(viewStart, 0), cursor);
   const atChar = value[cursor] ?? CURSOR;
-  const after = cursor < value.length ? value.slice(cursor + 1) : "";
+  const after =
+    cursor < value.length ? value.slice(cursor + 1, Math.min(value.length, viewEnd)) : "";
   return (
     <Text>
       {before}


### PR DESCRIPTION
Catches the fork up with `baairon/torlink` (upstream/main), which we were 4 commits behind.

## Upstream commits brought in
- `a4edc55` build: node-datachannel build from source (#88) — clean (nix/package.nix only)
- `31020f3` fix: safely handle webtorrent getter errors during metadata parsing (#86) — defensive try/catch in `TorrentEngine.stats`, auto-merged cleanly
- `329cb0d` fix: keep the textfield cursor visible on overflow and separate the delete key (#84)
- `2fa2c3d` feat: home/end and word-wise editing in text fields

## Conflicts resolved (all in the text-field UI, which our fork had diverged on)
- **`TextField.tsx`** — kept **both** feature sets: our `mask` (secret bulleting) + `history` recall, and upstream's `width` viewport-scrolling + `meta+d` delete-word-after. Rendering now applies `shown()` masking to the viewport-windowed slices. Renamed our `deleteAfter` → upstream's `deleteAt` for consistency (identical behaviour). Dropped now-duplicate home/end/arrow handlers that upstream had lifted into the shared code path.
- **`SearchBar.tsx`** — passes both `history` and `width` to `TextField`.
- **`TextField.test.ts`** — merged both test suites; dropped the duplicate `deleteAfter` suite (covered by `deleteAt`).

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ 435 passed (61 files)
- `npm run lint` — could not run: eslint isn't installed in this worktree's node_modules (pre-existing; unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)