### PR TITLE
chore: sync upstream baairon/torlink (v1.4.3) into fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .DS_Store
 package-lock.json
+!nix/package-lock.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ torlink also runs without the TUI, for servers and seedboxes:
 
 Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
 
+Set `TORLINK_MAX_DOWNLOADS=N` to cap how many torrents download at once — handy on a bandwidth-limited seedbox so each active download gets a fair share instead of splitting the pipe across everything. Extra torrents wait as `queued` and start automatically as slots free (oldest first). Unset or `0` means unlimited (the default). Seeding is unaffected.
+
 ## Contributing
 
 To run or work on torlink locally:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ torlink also runs without the TUI, for servers and seedboxes:
 
 Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
 
-Set `TORLINK_MAX_DOWNLOADS=N` to cap how many torrents download at once — handy on a bandwidth-limited seedbox so each active download gets a fair share instead of splitting the pipe across everything. Extra torrents wait as `queued` and start automatically as slots free (oldest first). Unset or `0` means unlimited (the default). Seeding is unaffected.
-
 ## Contributing
 
 To run or work on torlink locally:

--- a/nix/package-lock.json
+++ b/nix/package-lock.json
@@ -1,0 +1,450 @@
+{
+  "name": "libdatachannel-build-deps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "libdatachannel-build-deps",
+      "dependencies": {
+        "cmake-js": "8.0.0",
+        "node-addon-api": "8.9.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmake-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-8.0.0.tgz",
+      "integrity": "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.3",
+        "node-api-headers": "^1.8.0",
+        "rc": "1.2.8",
+        "semver": "^7.7.3",
+        "tar": "^7.5.6",
+        "url-join": "^4.0.1",
+        "which": "^6.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.9.0.tgz",
+      "integrity": "sha512-2oNILP4jXwRB4ywnYKjVk1YyJ96n2D4EOVJO6S3oYZ5PtbJrw3Yt9TpAuX3nBLMuzn74rnfGQrv13pS9vC+YiA==",
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/nix/package.json
+++ b/nix/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "libdatachannel-build-deps",
+  "private": true,
+  "dependencies": {
+    "cmake-js": "8.0.0",
+    "node-addon-api": "8.9.0"
+  }
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,36 +27,39 @@ let
       nodejs_22
       cacert
     ];
-    # needs cert for registry to resolve
+
     buildPhase = ''
       export HOME=$(mktemp -d)
-      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt    # needs cert for registry to resolve
+      # copy package.json and package-lock.json to the build directory
+      cp ${./package.json} package.json
+      cp ${./package-lock.json} package-lock.json
+      npm ci --ignore-scripts
       mkdir -p $out
-      npm install --prefix $out --no-save --ignore-scripts \
-        cmake-js@8.0.0 node-addon-api@8.9.0
+      cp -r node_modules $out/
     '';
 
     dontUnpack = true;
     dontInstall = true;
     outputHashMode = "recursive";
-    outputHash = "sha256-Haj527mURO7NAy3Xms7LEVvAKm314LDP2IeAYFYKMpw=";
+    outputHash = "sha256-Psa2R99JFUHGCA3DsrKFYgC1D7KIY+Va/kDGuiRi/CQ=";
   };
 in
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
-  version = "1.4.0";
+  version = "1.4.1";
   src = fetchFromGitHub {
     owner = "baairon";
     repo = "torlink";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KeszeV9atSvaA9s7iDCl+Q1eDMSx7flnQuBE8t49IPY=";
+    hash = "sha256-VXfYzwjhSS+zZCnGoRUCVGgmuRaV5KeYASASM4E9Xj4=";
   };
   __structuredAttrs = true;
   strictDeps = true;
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-nSHunmjZfr9oCygaLnHQxrXv7wuSa5ze7cQL7BrqfwQ=";
+  npmDepsHash = "sha256-y1Q9PvI2PeWxuGuoQRSRN4qXgXFops3jA4QW75wkC80=";
   npmFlags = [ "--ignore-scripts" ]; # ignore-scripts for ip-set broken preinstall
 
   nativeBuildInputs = [ cmake ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ let
     repo = "libdatachannel";
     tag = "v0.24.5";
     fetchSubmodules = true;
-    hash = "sha256-0Yrp9cZL8JvBD5YZYbJdmPpPSBHTM/5WXNNK/s+GkDI=";
+    hash = "sha256-rr3au3JMqLd/sjNtXtXY2mcuW0CeOgG+Xj2RgEQCWys=";
   };
 
   libdatachannelBuildDeps = stdenv.mkDerivation {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/scripts/cli-entry.cjs
+++ b/scripts/cli-entry.cjs
@@ -12,6 +12,50 @@ if (major < 22) {
   process.exit(1);
 }
 
+// The WebRTC stack (webtorrent -> simple-peer -> webrtc-polyfill) eagerly
+// requires node-datachannel's native binary, which only install scripts
+// download; npm 12 skips those scripts by default, so the binary is often
+// absent and the eager import would kill startup. When it cannot load,
+// resolve webrtc-polyfill to an inert stub instead: simple-peer then reports
+// WEBRTC_SUPPORT = false and downloads run on TCP/uTP and DHT peers alone.
+try {
+  require('node-datachannel');
+} catch (err) {
+  var Module = require('node:module');
+  if (typeof Module.registerHooks === 'function') {
+    var stubUrl = require('node:url')
+      .pathToFileURL(require('node:path').join(__dirname, 'webrtc-stub.mjs'))
+      .href;
+    Module.registerHooks({
+      resolve: function (specifier, context, nextResolve) {
+        if (specifier === 'webrtc-polyfill') {
+          return { url: stubUrl, shortCircuit: true };
+        }
+        return nextResolve(specifier, context);
+      },
+    });
+    process.stderr.write(
+      'torlnk: WebRTC peers unavailable (native module not installed); ' +
+        'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
+    );
+  } else {
+    // Node 22.0 to 22.14 has no module.registerHooks, so the eager import
+    // cannot be redirected; a clear explanation beats the raw module error.
+    process.stderr.write(
+      '\ntorlnk needs the WebRTC native module (node-datachannel), and it is\n' +
+        'not installed. Either upgrade to Node 22.15+ (torlnk then runs\n' +
+        'without WebRTC peers), or install the build tools and reinstall:\n' +
+        '  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static\n' +
+        '  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev\n' +
+        '  macOS:   xcode-select --install\n' +
+        '  Windows: install CMake and Visual Studio Build Tools\n' +
+        'On npm 12, also allow install scripts: npm approve-scripts\n\n' +
+        'https://github.com/baairon/torlink/issues/60\n\n'
+    );
+    process.exit(1);
+  }
+}
+
 import('./index.js').catch(function (err) {
   process.stderr.write(String((err && err.message) || err) + '\n');
   process.exit(1);

--- a/scripts/postbuild.cjs
+++ b/scripts/postbuild.cjs
@@ -8,6 +8,9 @@ const src = resolve(root, 'scripts/cli-entry.cjs');
 const dest = resolve(root, 'dist/cli.cjs');
 
 copyFileSync(src, dest);
+// The WebRTC fallback stub must ship beside cli.cjs, which resolves it via
+// __dirname when the node-datachannel binary is unavailable.
+copyFileSync(resolve(root, 'scripts/webrtc-stub.mjs'), resolve(root, 'dist/webrtc-stub.mjs'));
 
 // On Windows chmod is effectively a no-op, and npm re-applies bin permissions on install anyway, so a failure
 // here shouldn't fail the build, but warn rather than swallow the error.
@@ -17,4 +20,4 @@ try {
   console.warn('postbuild: could not set executable bit on dist/cli.cjs:', err.message);
 }
 
-console.log('postbuild: wrote dist/cli.cjs');
+console.log('postbuild: wrote dist/cli.cjs and dist/webrtc-stub.mjs');

--- a/scripts/webrtc-stub.mjs
+++ b/scripts/webrtc-stub.mjs
@@ -1,0 +1,18 @@
+// Runtime stand-in for webrtc-polyfill, used when the node-datachannel native
+// binary is missing or fails to load (npm 12 skips install scripts by default,
+// so the binary is often never fetched). dist/cli.cjs redirects the
+// webrtc-polyfill specifier here; with RTCPeerConnection undefined,
+// simple-peer computes WEBRTC_SUPPORT = false and bittorrent-tracker skips
+// WebRTC peers entirely, so the swarm runs on TCP/uTP and DHT peers alone.
+// The export list mirrors webrtc-polyfill/index.js so named imports link.
+
+export const RTCPeerConnection = undefined;
+export const RTCSessionDescription = undefined;
+export const RTCIceCandidate = undefined;
+export const RTCIceTransport = undefined;
+export const RTCDataChannel = undefined;
+export const RTCSctpTransport = undefined;
+export const RTCDtlsTransport = undefined;
+export const RTCCertificate = undefined;
+
+export default undefined;

--- a/scripts/webrtc-stub.test.mjs
+++ b/scripts/webrtc-stub.test.mjs
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import * as stub from "./webrtc-stub.mjs";
+
+describe("webrtc-stub", () => {
+  it("mirrors the webrtc-polyfill export surface with every value undefined", () => {
+    expect(Object.keys(stub).sort()).toEqual([
+      "RTCCertificate",
+      "RTCDataChannel",
+      "RTCDtlsTransport",
+      "RTCIceCandidate",
+      "RTCIceTransport",
+      "RTCPeerConnection",
+      "RTCSctpTransport",
+      "RTCSessionDescription",
+      "default",
+    ]);
+    for (const value of Object.values(stub)) expect(value).toBeUndefined();
+  });
+
+  it("makes simple-peer's WEBRTC_SUPPORT check compute false", () => {
+    expect(!!stub.RTCPeerConnection).toBe(false);
+  });
+});

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -36,6 +36,10 @@ describe("parseCliArgs", () => {
   it("parses attach", () => {
     expect(parseCliArgs(["attach"])).toEqual({ kind: "attach" });
   });
+  it("parses update, with and without --force", () => {
+    expect(parseCliArgs(["update"])).toEqual({ kind: "update", force: false });
+    expect(parseCliArgs(["update", "--force"])).toEqual({ kind: "update", force: true });
+  });
   it("parses watch with a directory", () => {
     expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
       kind: "watch",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -25,6 +25,7 @@ export type CliCommand =
     }
   | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
   | { kind: "attach" }
+  | { kind: "update"; force?: boolean }
   | { kind: "invalid"; arg: string };
 
 // Valueless boolean flags for the headless subcommands (everything else is a
@@ -75,6 +76,7 @@ export function parseCliArgs(argv: string[]): CliCommand {
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
   if (a === "attach") return { kind: "attach" };
+  if (a === "update") return { kind: "update", force: args.slice(1).includes("--force") };
   if (a === "watch") {
     const { bools, rest: r0 } = splitBooleans(args.slice(1));
     const { flags, rest } = readFlags(r0);
@@ -131,6 +133,8 @@ usage
   torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk files                headless: serve downloads over HTTP on :9160
   torlnk attach               open/reattach the TUI in a persistent tmux session
+  torlnk update [--force]     update to the latest release and restart any daemon
+                              (--force rebuilds/restarts even if already current)
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,

--- a/src/config/trackers.test.ts
+++ b/src/config/trackers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatTrackers, parseTrackers } from "./trackers";
+import { formatTrackers, parseTrackers, trackersStatus } from "./trackers";
 
 describe("parseTrackers", () => {
   it("returns empty for blank input", () => {
@@ -51,5 +51,47 @@ describe("formatTrackers", () => {
 
   it("returns empty string for empty array", () => {
     expect(formatTrackers([])).toBe("");
+  });
+});
+
+describe("trackersStatus", () => {
+  it("shows the idle hint when the field matches what is saved", () => {
+    expect(trackersStatus(["udp://a.example:1337"], "udp://a.example:1337")).toBe(
+      "1 saved · comma or space separated · empty clears",
+    );
+  });
+
+  it("shows the idle hint without the clear tail when nothing is saved", () => {
+    expect(trackersStatus([], "")).toBe("none saved · comma or space separated");
+  });
+
+  it("counts what a paste will save", () => {
+    expect(
+      trackersStatus(["udp://a.example:1337"], "udp://a.example:1337, udp://b.example:80"),
+    ).toBe("1 saved → will save 2");
+  });
+
+  it("announces that an empty field clears the saved list", () => {
+    expect(trackersStatus(["udp://a.example:1337", "udp://b.example:80"], "   ")).toBe(
+      "2 saved → empty clears all",
+    );
+  });
+
+  it("counts invalid tokens as ignored", () => {
+    expect(trackersStatus([], "udp://a.example:1337 garbage")).toBe(
+      "none saved → will save 1 · 1 ignored",
+    );
+  });
+
+  it("counts duplicates as ignored", () => {
+    expect(trackersStatus([], "udp://a.example:1337, udp://a.example:1337")).toBe(
+      "none saved → will save 1 · 1 ignored",
+    );
+  });
+
+  it("surfaces ignored tokens even when the valid list is unchanged", () => {
+    expect(trackersStatus(["udp://a.example:1337"], "udp://a.example:1337 nope")).toBe(
+      "1 saved → will save 1 · 1 ignored",
+    );
   });
 });

--- a/src/config/trackers.ts
+++ b/src/config/trackers.ts
@@ -16,3 +16,24 @@ export function parseTrackers(input: string): string[] {
 export function formatTrackers(trackers: string[]): string {
   return trackers.join(", ");
 }
+
+// One dim status line for the trackers prompt: what is saved now, what the
+// current field text will save, and how many typed tokens get dropped
+// (bad scheme or duplicate), so a paste confirms itself before enter.
+export function trackersStatus(saved: string[], fieldText: string): string {
+  const next = parseTrackers(fieldText);
+  const tokens = fieldText.split(/[\s,]+/).filter((t) => t.trim().length > 0);
+  const ignored = tokens.length - next.length;
+  const savedLabel = saved.length === 0 ? "none saved" : `${saved.length} saved`;
+  const unchanged =
+    ignored === 0 && next.length === saved.length && next.every((t, i) => t === saved[i]);
+  if (unchanged) {
+    return saved.length === 0
+      ? "none saved · comma or space separated"
+      : `${savedLabel} · comma or space separated · empty clears`;
+  }
+  if (tokens.length === 0) return `${savedLabel} → empty clears all`;
+  let line = `${savedLabel} → will save ${next.length}`;
+  if (ignored > 0) line += ` · ${ignored} ignored`;
+  return line;
+}

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -27,6 +27,9 @@ export function runPathFor(name: string): string {
   return path.join(logsDir, `${name}.run.json`);
 }
 
+// Records argv and cwd only, not env: a daemon relaunched after an update
+// inherits the updater's environment, so env-dependent behavior (proxies,
+// TORLINK_* overrides) follows the shell that ran `torlnk update`.
 export interface RunDescriptor {
   name: string;
   pid: number;

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -1,6 +1,10 @@
 // Self-backgrounding for the headless commands: `--daemon` re-spawns this exact
 // command detached from the terminal (own session, stdio to a log file), writes
-// a pidfile, and exits the parent. You can then log out and it keeps running.
+// a pidfile plus a run descriptor, and exits the parent. You can then log out and
+// it keeps running.
+//
+// The run descriptor is what lets `torlnk update` relaunch a daemon on its exact
+// original command after rebuilding.
 //
 // NOTE: on a box with systemd, a `systemctl --user` service with linger is a
 // sturdier way to run these (auto-restart, boot-start). This is the no-systemd
@@ -19,27 +23,52 @@ export function logPathFor(name: string): string {
 export function pidPathFor(name: string): string {
   return path.join(logsDir, `${name}.pid`);
 }
+export function runPathFor(name: string): string {
+  return path.join(logsDir, `${name}.run.json`);
+}
+
+export interface RunDescriptor {
+  name: string;
+  pid: number;
+  argv: string[]; // args to node (script path + subcommand + flags)
+  cwd: string;
+  startedAt: number;
+}
+
+// Spawn `node <argv>` detached with its own session and stdio pointed at the log,
+// then record the pid and enough to relaunch it later. Shared by the initial
+// --daemon fork and by a post-update restart, so both write the pidfile and
+// descriptor the same way.
+export function spawnDaemon(name: string, argv: string[], cwd: string): number {
+  fs.mkdirSync(logsDir, { recursive: true });
+  const out = fs.openSync(logPathFor(name), "a");
+  const child = spawn(process.execPath, argv, {
+    cwd,
+    detached: true,
+    stdio: ["ignore", out, out],
+    env: { ...process.env, [MARKER]: "1" },
+  });
+  child.unref();
+  const pid = child.pid ?? 0;
+  if (pid) {
+    fs.writeFileSync(pidPathFor(name), `${pid}\n`);
+    const desc: RunDescriptor = { name, pid, argv, cwd, startedAt: Date.now() };
+    fs.writeFileSync(runPathFor(name), `${JSON.stringify(desc, null, 2)}\n`);
+  }
+  return pid;
+}
 
 // In the parent: fork a detached child and exit. In the already-detached child
 // (marker set): return so the caller keeps running normally.
 export function daemonize(name: string): void {
   if (process.env[MARKER] === "1") return;
 
-  fs.mkdirSync(logsDir, { recursive: true });
+  const pid = spawnDaemon(name, process.argv.slice(1), process.cwd());
   const logPath = logPathFor(name);
   const pidPath = pidPathFor(name);
-  const out = fs.openSync(logPath, "a");
 
-  const child = spawn(process.execPath, process.argv.slice(1), {
-    detached: true,
-    stdio: ["ignore", out, out],
-    env: { ...process.env, [MARKER]: "1" },
-  });
-  child.unref();
-  if (child.pid) fs.writeFileSync(pidPath, `${child.pid}\n`);
-
-  console.log(`torlink ${name} daemon started (pid ${child.pid}).`);
+  console.log(`torlink ${name} daemon started (pid ${pid}).`);
   console.log(`  logs: ${logPath}`);
-  console.log(`  stop: kill ${child.pid}   (or: kill $(cat ${pidPath}))`);
+  console.log(`  stop: kill ${pid}   (or: kill $(cat ${pidPath}))`);
   process.exit(0);
 }

--- a/src/daemon/restart.test.ts
+++ b/src/daemon/restart.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { isAlive, listRunDescriptors, restartDaemon } from "./restart";
+import type { RunDescriptor } from "./daemonize";
+
+describe("isAlive", () => {
+  it("is true for this process and false for a free pid", () => {
+    expect(isAlive(process.pid)).toBe(true);
+    expect(isAlive(2 ** 30)).toBe(false); // no process owns this
+    expect(isAlive(0)).toBe(false);
+    expect(isAlive(-1)).toBe(false);
+  });
+});
+
+describe("listRunDescriptors", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "torlink-restart-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, body: unknown): void =>
+    fs.writeFileSync(path.join(dir, `${name}.run.json`), JSON.stringify(body));
+
+  it("reads valid descriptors and skips everything else", () => {
+    write("watch", { name: "watch", pid: 111, argv: ["a", "watch", "/srv"], cwd: "/srv", startedAt: 1 });
+    write("serve", { name: "serve", pid: 222, argv: ["a", "serve"], cwd: "/opt" });
+    fs.writeFileSync(path.join(dir, "watch.log"), "noise");
+    fs.writeFileSync(path.join(dir, "broken.run.json"), "{ not json");
+
+    const got = listRunDescriptors(dir).sort((a, b) => a.pid - b.pid);
+    expect(got.map((d) => d.name)).toEqual(["watch", "serve"]);
+    expect(got[0]).toMatchObject({ pid: 111, cwd: "/srv" });
+    expect(got[1]!.startedAt).toBe(0); // missing startedAt defaults to 0
+  });
+
+  it("returns [] when the directory is absent", () => {
+    expect(listRunDescriptors(path.join(dir, "nope"))).toEqual([]);
+  });
+});
+
+describe("restartDaemon", () => {
+  it("returns null when the recorded process is already gone", async () => {
+    const dead: RunDescriptor = {
+      name: "watch",
+      pid: 2 ** 30,
+      argv: ["a", "watch", "/srv"],
+      cwd: "/srv",
+      startedAt: 0,
+    };
+    expect(await restartDaemon(dead)).toBeNull();
+  });
+});

--- a/src/daemon/restart.test.ts
+++ b/src/daemon/restart.test.ts
@@ -44,14 +44,46 @@ describe("listRunDescriptors", () => {
 });
 
 describe("restartDaemon", () => {
-  it("returns null when the recorded process is already gone", async () => {
-    const dead: RunDescriptor = {
-      name: "watch",
-      pid: 2 ** 30,
-      argv: ["a", "watch", "/srv"],
-      cwd: "/srv",
-      startedAt: 0,
-    };
-    expect(await restartDaemon(dead)).toBeNull();
+  const desc = (pid: number): RunDescriptor => ({
+    name: "watch",
+    pid,
+    argv: ["a", "watch", "/srv"],
+    cwd: "/srv",
+    startedAt: 0,
+  });
+
+  it("spawns nothing when the recorded process is already gone", async () => {
+    expect(await restartDaemon(desc(2 ** 30))).toEqual({ newPid: null, stillRunning: false });
+  });
+
+  it("reports stillRunning instead of spawning when the old pid outlives the grace", async () => {
+    const killed: Array<[number, string]> = [];
+    const res = await restartDaemon(desc(4242), {
+      sleep: async () => {},
+      waitMs: 100,
+      graceMs: 500,
+      isAliveImpl: () => true, // never dies
+      killImpl: (pid, signal) => killed.push([pid, signal]),
+    });
+    expect(res).toEqual({ newPid: null, stillRunning: true });
+    expect(killed).toEqual([[4242, "SIGTERM"]]);
+  });
+
+  it("waits out a slow shutdown and then relaunches", async () => {
+    let aliveChecks = 0;
+    const spawned: string[] = [];
+    const res = await restartDaemon(desc(4242), {
+      sleep: async () => {},
+      waitMs: 100,
+      graceMs: 10_000,
+      isAliveImpl: () => ++aliveChecks < 5, // dies on the 5th check
+      killImpl: () => {},
+      spawnImpl: (name) => {
+        spawned.push(name);
+        return 5151;
+      },
+    });
+    expect(res).toEqual({ newPid: 5151, stillRunning: false });
+    expect(spawned).toEqual(["watch"]);
   });
 });

--- a/src/daemon/restart.ts
+++ b/src/daemon/restart.ts
@@ -60,24 +60,42 @@ export function listRunDescriptors(dir: string = logsDir): RunDescriptor[] {
 
 const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+export interface RestartResult {
+  newPid: number | null; // pid of the relaunched daemon, when one was spawned
+  stillRunning: boolean; // the old process outlived the grace; nothing spawned
+}
+
 // Stop a running daemon and start it again from its recorded command so it comes
-// back on the freshly built code. Returns the new pid, or null if it wasn't
-// running (nothing to restart). Waits for the old process to exit first so the
-// two never fight over the same state files.
+// back on the freshly built code. Waits for the old process to exit first, and
+// if it outlives the grace (tearing down a client that seeds many torrents can
+// take a while) reports stillRunning instead of spawning: two daemons must never
+// contend for the same ports and state files.
 export async function restartDaemon(
   desc: RunDescriptor,
-  opts: { sleep?: (ms: number) => Promise<void>; waitMs?: number } = {},
-): Promise<number | null> {
+  opts: {
+    sleep?: (ms: number) => Promise<void>;
+    waitMs?: number;
+    graceMs?: number;
+    isAliveImpl?: (pid: number) => boolean;
+    killImpl?: (pid: number, signal: NodeJS.Signals) => void;
+    spawnImpl?: (name: string, argv: string[], cwd: string) => number;
+  } = {},
+): Promise<RestartResult> {
   const sleep = opts.sleep ?? realSleep;
   const waitMs = opts.waitMs ?? 100;
-  if (!isAlive(desc.pid)) return null;
+  const graceMs = opts.graceMs ?? 10_000;
+  const alive = opts.isAliveImpl ?? isAlive;
+  const kill = opts.killImpl ?? ((pid, signal) => process.kill(pid, signal));
+  const spawnFn = opts.spawnImpl ?? spawnDaemon;
+  if (!alive(desc.pid)) return { newPid: null, stillRunning: false };
 
   try {
-    process.kill(desc.pid, "SIGTERM");
+    kill(desc.pid, "SIGTERM");
   } catch {
     // Already gone between the check and the signal; fine, we'll re-spawn.
   }
-  for (let i = 0; i < 20 && isAlive(desc.pid); i++) await sleep(waitMs);
+  for (let waited = 0; waited < graceMs && alive(desc.pid); waited += waitMs) await sleep(waitMs);
+  if (alive(desc.pid)) return { newPid: null, stillRunning: true };
 
-  return spawnDaemon(desc.name, desc.argv, desc.cwd);
+  return { newPid: spawnFn(desc.name, desc.argv, desc.cwd), stillRunning: false };
 }

--- a/src/daemon/restart.ts
+++ b/src/daemon/restart.ts
@@ -1,0 +1,83 @@
+// Restart the --daemon processes after an update. We only know about daemons that
+// went through daemonize (they leave a run descriptor next to their log); a
+// systemd unit or a foreground run manages its own lifecycle and is left alone.
+
+import fs from "node:fs";
+import path from "node:path";
+import { logsDir } from "../config/paths";
+import { runPathFor, spawnDaemon, type RunDescriptor } from "./daemonize";
+
+// `kill -0` only checks whether we may signal the pid. ESRCH means it's gone;
+// EPERM means it's alive but owned by someone else, so still alive.
+export function isAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readDescriptor(file: string): RunDescriptor | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<RunDescriptor>;
+    if (
+      typeof raw.name === "string" &&
+      typeof raw.pid === "number" &&
+      Array.isArray(raw.argv) &&
+      typeof raw.cwd === "string"
+    ) {
+      return {
+        name: raw.name,
+        pid: raw.pid,
+        argv: raw.argv.filter((a): a is string => typeof a === "string"),
+        cwd: raw.cwd,
+        startedAt: typeof raw.startedAt === "number" ? raw.startedAt : 0,
+      };
+    }
+  } catch {
+    // A partial/corrupt descriptor just means we can't restart that one.
+  }
+  return null;
+}
+
+export function listRunDescriptors(dir: string = logsDir): RunDescriptor[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: RunDescriptor[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".run.json")) continue;
+    const desc = readDescriptor(path.join(dir, file));
+    if (desc) out.push(desc);
+  }
+  return out;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Stop a running daemon and start it again from its recorded command so it comes
+// back on the freshly built code. Returns the new pid, or null if it wasn't
+// running (nothing to restart). Waits for the old process to exit first so the
+// two never fight over the same state files.
+export async function restartDaemon(
+  desc: RunDescriptor,
+  opts: { sleep?: (ms: number) => Promise<void>; waitMs?: number } = {},
+): Promise<number | null> {
+  const sleep = opts.sleep ?? realSleep;
+  const waitMs = opts.waitMs ?? 100;
+  if (!isAlive(desc.pid)) return null;
+
+  try {
+    process.kill(desc.pid, "SIGTERM");
+  } catch {
+    // Already gone between the check and the signal; fine, we'll re-spawn.
+  }
+  for (let i = 0; i < 20 && isAlive(desc.pid); i++) await sleep(waitMs);
+
+  return spawnDaemon(desc.name, desc.argv, desc.cwd);
+}

--- a/src/daemon/seed-reaper.ts
+++ b/src/daemon/seed-reaper.ts
@@ -7,9 +7,11 @@
 // The clock is the download's completion time (history.completedAt), not when
 // this process started, so a restart doesn't reset every torrent's timer.
 
-import { rm } from "node:fs/promises";
-import path from "node:path";
 import type { DownloadQueue } from "../download/queue";
+import { deleteSeedData } from "../download/delete-data";
+
+// Re-exported for backwards compatibility (the reaper's original home for it).
+export { deleteSeedData } from "../download/delete-data";
 
 const DEFAULT_CHECK_MS = 30_000;
 
@@ -36,17 +38,6 @@ export function dueSeeds(queue: ReapableQueue, seedTimeMs: number, now: number):
     if (now - since >= seedTimeMs) out.push({ id: s.id, name: s.name, dir: s.dir });
   }
   return out;
-}
-
-// Best-effort delete of a torrent's on-disk data: only the torrent's own entry
-// directly under its download dir (a file, or the folder named after it). Never
-// walks outside that dir, never throws.
-export async function deleteSeedData(dir: string, name: string): Promise<string | null> {
-  const base = path.basename(name.trim());
-  if (!base || base === "." || base === "..") return null;
-  const target = path.join(dir, base);
-  await rm(target, { recursive: true, force: true }).catch(() => {});
-  return target;
 }
 
 export interface SeedReaperOptions {

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { handleApi, isAuthorized, extractMagnet } from "./serve";
+import { handleApi, isAuthorized, extractMagnet, parseControl, applyControl } from "./serve";
 import type { Runtime } from "./runtime";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef01";
@@ -101,5 +101,93 @@ describe("handleApi", () => {
   it("404s an unknown route", async () => {
     const res = await handleApi(runtime, null, "GET", "/nope", undefined, "");
     expect(res.status).toBe(404);
+  });
+
+  it("400s POST /control with a malformed body", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"x"}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("400s POST /control with an unknown action", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"boom"}`);
+    expect(res.status).toBe(400);
+    expect(String(res.body.error)).toContain("unknown action");
+  });
+
+  it("404s POST /control for an unknown torrent", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"pause"}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("pauses a known download on POST /control", async () => {
+    const pause = vi.fn();
+    runtime.queue = { has: (id: string) => id === HASH, pause } as unknown as Runtime["queue"];
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"pause"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, action: "pause" });
+    expect(pause).toHaveBeenCalledWith(HASH);
+  });
+});
+
+describe("parseControl", () => {
+  it("reads id + action from JSON", () => {
+    expect(parseControl(`{"id":"abc","action":"pause"}`)).toEqual({ id: "abc", action: "pause", deleteFiles: false });
+  });
+  it("reads the deleteFiles flag", () => {
+    expect(parseControl(`{"id":"abc","action":"delete","deleteFiles":true}`)).toEqual({
+      id: "abc",
+      action: "delete",
+      deleteFiles: true,
+    });
+  });
+  it("returns null when id or action is missing/blank or the body isn't JSON", () => {
+    expect(parseControl(`{"id":"abc"}`)).toBeNull();
+    expect(parseControl(`{"action":"pause"}`)).toBeNull();
+    expect(parseControl(`{"id":"  ","action":"pause"}`)).toBeNull();
+    expect(parseControl(`pause abc`)).toBeNull();
+    expect(parseControl("")).toBeNull();
+  });
+});
+
+describe("applyControl", () => {
+  const mkRuntime = (queue: Partial<Record<string, unknown>>): Runtime =>
+    ({ queue: queue as unknown as Runtime["queue"], downloadDir: "/tmp" });
+
+  it("resumes a paused download", async () => {
+    const resume = vi.fn();
+    const rt = mkRuntime({ has: (id: string) => id === "x", resume });
+    expect(await applyControl(rt, { id: "x", action: "resume", deleteFiles: false })).toBe("ok");
+    expect(resume).toHaveBeenCalledWith("x");
+  });
+
+  it("stops seeding but keeps files", async () => {
+    const stopSeeding = vi.fn();
+    const rt = mkRuntime({ getSeed: (id: string) => (id === "s" ? { id } : undefined), stopSeeding });
+    expect(await applyControl(rt, { id: "s", action: "stop-seed", deleteFiles: false })).toBe("ok");
+    expect(stopSeeding).toHaveBeenCalledWith("s");
+  });
+
+  it("starts seeding from a history entry", async () => {
+    const startSeeding = vi.fn();
+    const hist = { id: "h", name: "H", magnet: "m", dir: "/d", sizeBytes: 1, completedAt: 0 };
+    const rt = mkRuntime({ getHistory: () => [hist], startSeeding });
+    expect(await applyControl(rt, { id: "h", action: "start-seed", deleteFiles: false })).toBe("ok");
+    expect(startSeeding).toHaveBeenCalledWith(hist);
+  });
+
+  it("delete forces deleteFiles:true; remove keeps files", async () => {
+    const remove = vi.fn().mockResolvedValue(true);
+    const rt = mkRuntime({ remove });
+    expect(await applyControl(rt, { id: "z", action: "delete", deleteFiles: false })).toBe("ok");
+    expect(remove).toHaveBeenCalledWith("z", { deleteFiles: true });
+    remove.mockClear();
+    await applyControl(rt, { id: "z", action: "remove", deleteFiles: false });
+    expect(remove).toHaveBeenCalledWith("z", { deleteFiles: false });
+  });
+
+  it("reports not-found when remove finds nothing and unknown-action otherwise", async () => {
+    const rt = mkRuntime({ remove: vi.fn().mockResolvedValue(false) });
+    expect(await applyControl(rt, { id: "z", action: "remove", deleteFiles: false })).toBe("not-found");
+    expect(await applyControl(mkRuntime({}), { id: "z", action: "nope", deleteFiles: false })).toBe("unknown-action");
   });
 });

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -53,6 +53,81 @@ export function extractMagnet(bodyText: string): string | null {
   return raw;
 }
 
+// Control actions the headless API accepts (POST /control). A seedbox web app
+// drives per-torrent buttons through these instead of the interactive keymap.
+export const CONTROL_ACTIONS = [
+  "pause", // pause an active/queued download
+  "resume", // resume a paused download
+  "start-seed", // (re)start seeding a finished torrent
+  "stop-seed", // stop seeding but keep the files
+  "remove", // forget the torrent, keep files on disk
+  "delete", // forget the torrent AND delete its files
+] as const;
+export type ControlAction = (typeof CONTROL_ACTIONS)[number];
+
+export interface ControlRequest {
+  id: string;
+  action: string;
+  deleteFiles: boolean;
+}
+
+// Parse a control request body: JSON { id, action, deleteFiles? }. Returns null
+// for anything missing the two required string fields; the action string itself
+// is validated later so an unknown action gets a precise error.
+export function parseControl(bodyText: string): ControlRequest | null {
+  const raw = bodyText.trim();
+  if (!raw.startsWith("{")) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const id = typeof obj.id === "string" ? obj.id.trim() : "";
+  const action = typeof obj.action === "string" ? obj.action.trim() : "";
+  if (!id || !action) return null;
+  return { id, action, deleteFiles: obj.deleteFiles === true };
+}
+
+export type ControlOutcome = "ok" | "not-found" | "unknown-action";
+
+// Apply a parsed control request to the queue. Pure over the runtime so it's
+// unit-testable with a fake queue.
+export async function applyControl(
+  runtime: Runtime,
+  req: ControlRequest,
+): Promise<ControlOutcome> {
+  const q = runtime.queue;
+  const { id, action, deleteFiles } = req;
+  switch (action as ControlAction) {
+    case "pause":
+      if (!q.has(id)) return "not-found";
+      q.pause(id);
+      return "ok";
+    case "resume":
+      if (!q.has(id)) return "not-found";
+      q.resume(id);
+      return "ok";
+    case "stop-seed":
+      if (!q.getSeed(id)) return "not-found";
+      q.stopSeeding(id);
+      return "ok";
+    case "start-seed": {
+      const h = q.getHistory().find((x) => x.id === id);
+      if (!h) return "not-found";
+      q.startSeeding(h);
+      return "ok";
+    }
+    case "remove":
+    case "delete": {
+      const found = await q.remove(id, { deleteFiles: action === "delete" || deleteFiles });
+      return found ? "ok" : "not-found";
+    }
+    default:
+      return "unknown-action";
+  }
+}
+
 function statusPayload(runtime: Runtime): Record<string, unknown> {
   const downloads = runtime.queue.getItems().map((it) => ({
     id: it.id,
@@ -96,6 +171,16 @@ export async function handleApi(
     const outcome = await addInput(runtime, magnet);
     if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
     return { status: 200, body: { ok: true, outcome } };
+  }
+  if (method === "POST" && urlPath === "/control") {
+    const req = parseControl(bodyText);
+    if (!req) return { status: 400, body: { error: "missing or invalid { id, action }" } };
+    const outcome = await applyControl(runtime, req);
+    if (outcome === "unknown-action") {
+      return { status: 400, body: { error: `unknown action: ${req.action}` } };
+    }
+    if (outcome === "not-found") return { status: 404, body: { error: "no such torrent" } };
+    return { status: 200, body: { ok: true, id: req.id, action: req.action } };
   }
   return { status: 404, body: { error: "not found" } };
 }

--- a/src/download/delete-data.ts
+++ b/src/download/delete-data.ts
@@ -1,0 +1,15 @@
+// Best-effort delete of a torrent's on-disk data: only the torrent's own entry
+// directly under its download dir (a file, or the folder named after it). Never
+// walks outside that dir, never throws. Shared by the seed reaper (auto-purge
+// after the seed timer) and the headless control API (manual delete).
+
+import { rm } from "node:fs/promises";
+import path from "node:path";
+
+export async function deleteSeedData(dir: string, name: string): Promise<string | null> {
+  const base = path.basename(name.trim());
+  if (!base || base === "." || base === "..") return null;
+  const target = path.join(dir, base);
+  await rm(target, { recursive: true, force: true }).catch(() => {});
+  return target;
+}

--- a/src/download/queue.concurrency.test.ts
+++ b/src/download/queue.concurrency.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { DownloadQueue } from "./queue";
+
+// Stub the engine (same approach as queue.add.test.ts) so these tests cover the
+// queue's own concurrency bookkeeping without touching webtorrent/the network.
+vi.mock("./engine", () => ({
+  TorrentEngine: class {
+    add(): void {}
+    remove(): void {}
+    stats(): undefined {
+      return undefined;
+    }
+    destroy(): void {}
+  },
+}));
+
+const mk = (n: number) => ({
+  id: String(n).padStart(40, "0"),
+  name: `T${n}`,
+  magnet: `magnet:?xt=urn:btih:${String(n).padStart(40, "0")}`,
+});
+const statuses = (q: DownloadQueue): Record<string, string> =>
+  Object.fromEntries(q.getItems().map((i) => [i.id, i.status]));
+
+describe("DownloadQueue concurrent-download cap (TORLINK_MAX_DOWNLOADS)", () => {
+  it("queues torrents beyond the cap, then promotes the oldest when a slot frees", () => {
+    const q = new DownloadQueue({ maxDownloads: 2 });
+    q.add(mk(1), "/d");
+    q.add(mk(2), "/d");
+    q.add(mk(3), "/d");
+
+    expect(q.activeCount).toBe(2);
+    let s = statuses(q);
+    expect(s[mk(1).id]).toBe("downloading");
+    expect(s[mk(2).id]).toBe("downloading");
+    expect(s[mk(3).id]).toBe("queued");
+
+    // Pausing an active download frees a slot → the queued one starts.
+    q.pause(mk(1).id);
+    expect(q.activeCount).toBe(2);
+    s = statuses(q);
+    expect(s[mk(1).id]).toBe("paused");
+    expect(s[mk(3).id]).toBe("downloading");
+
+    q.suspend();
+  });
+
+  it("defaults to unlimited (maxDownloads 0) — everything downloads at once", () => {
+    const q = new DownloadQueue({ maxDownloads: 0 });
+    q.add(mk(1), "/d");
+    q.add(mk(2), "/d");
+    q.add(mk(3), "/d");
+    expect(q.activeCount).toBe(3);
+    expect(Object.values(statuses(q)).every((v) => v === "downloading")).toBe(true);
+    q.suspend();
+  });
+
+  it("respects the cap when restoring persisted downloads on boot", () => {
+    const persisted = [1, 2, 3].map((n) => ({
+      ...mk(n),
+      source: undefined,
+      dir: "/d",
+      status: "downloading" as const,
+      progress: 0,
+      totalBytes: 0,
+      downloadedBytes: 0,
+      speed: 0,
+      peers: 0,
+      addedAt: n,
+    }));
+    const q = new DownloadQueue({ maxDownloads: 2 });
+    q.restore(persisted);
+    expect(q.activeCount).toBe(2);
+    expect(statuses(q)[mk(3).id]).toBe("queued");
+    q.suspend();
+  });
+});

--- a/src/download/queue.concurrency.test.ts
+++ b/src/download/queue.concurrency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { DownloadQueue } from "./queue";
+import type { QueueItem } from "./types";
 
 // Stub the engine (same approach as queue.add.test.ts) so these tests cover the
 // queue's own concurrency bookkeeping without touching webtorrent/the network.
@@ -72,6 +73,28 @@ describe("DownloadQueue concurrent-download cap (TORLINK_MAX_DOWNLOADS)", () => 
     q.restore(persisted);
     expect(q.activeCount).toBe(2);
     expect(statuses(q)[mk(3).id]).toBe("queued");
+    q.suspend();
+  });
+
+  it("starts persisted queued items on restore when the cap is unset", () => {
+    const persisted = [1, 2, 3].map(
+      (n): QueueItem => ({
+        ...mk(n),
+        source: undefined,
+        dir: "/d",
+        status: n === 1 ? "downloading" : "queued",
+        progress: 0,
+        totalBytes: 0,
+        downloadedBytes: 0,
+        speed: 0,
+        peers: 0,
+        addedAt: n,
+      }),
+    );
+    const q = new DownloadQueue({ maxDownloads: 0 });
+    q.restore(persisted);
+    expect(q.activeCount).toBe(3);
+    expect(Object.values(statuses(q)).every((v) => v === "downloading")).toBe(true);
     q.suspend();
   });
 });

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -150,12 +150,14 @@ export class DownloadQueue extends EventEmitter {
   /**
    * Start queued torrents (oldest first) while download slots are free. Called
    * whenever a slot opens up — a download finishes, fails, is paused, or is
-   * cancelled. No-op when unlimited (this.maxDownloads === 0), since nothing queues.
+   * cancelled. With no cap (maxDownloads 0) nothing queues in-session, but
+   * persisted "queued" items from an earlier capped run must still start, so
+   * 0 means no ceiling here rather than an early return.
    */
   private promote(): void {
-    if (this.maxDownloads === 0) return;
+    const cap = this.maxDownloads === 0 ? Infinity : this.maxDownloads;
     let started = false;
-    while (this.activeCount < this.maxDownloads) {
+    while (this.activeCount < cap) {
       const next = [...this.items.values()]
         .filter((it) => it.status === "queued")
         .sort((a, b) => a.addedAt - b.addedAt)[0];

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -38,6 +38,13 @@ const SEED_GRACE_MS = 10_000;
 const POLL_MS = 500;
 const HISTORY_MAX = 500;
 
+// Max torrents allowed to actively download at once. Overflow waits as "queued"
+// and starts automatically when a slot frees. 0 / unset = unlimited (default).
+function readMaxDownloads(): number {
+  const v = Number(process.env.TORLINK_MAX_DOWNLOADS);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+}
+
 export interface AddInput {
   id: string;
   name: string;
@@ -55,6 +62,14 @@ export class DownloadQueue extends EventEmitter {
   private strayHits = new Map<string, number>();
   private seedStartedAt = new Map<string, number>();
   private trackers: string[] = [];
+
+  // Max torrents allowed to download at once; overflow waits as "queued".
+  private readonly maxDownloads: number;
+
+  constructor(opts?: { maxDownloads?: number }) {
+    super();
+    this.maxDownloads = opts?.maxDownloads ?? readMaxDownloads();
+  }
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
@@ -115,15 +130,46 @@ export class DownloadQueue extends EventEmitter {
           peers: 0,
           addedAt: Date.now(),
         };
+    // Respect the concurrent-download cap: start now if a slot is free, else
+    // hold the torrent as "queued" until one frees (see promote()).
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    item.status = start ? "downloading" : "queued";
     this.items.set(item.id, item);
-    this.startEngine(item);
-    this.ensurePoll();
+    if (start) {
+      this.startEngine(item);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
 
   private startEngine(item: QueueItem): void {
     this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+  }
+
+  /**
+   * Start queued torrents (oldest first) while download slots are free. Called
+   * whenever a slot opens up — a download finishes, fails, is paused, or is
+   * cancelled. No-op when unlimited (this.maxDownloads === 0), since nothing queues.
+   */
+  private promote(): void {
+    if (this.maxDownloads === 0) return;
+    let started = false;
+    while (this.activeCount < this.maxDownloads) {
+      const next = [...this.items.values()]
+        .filter((it) => it.status === "queued")
+        .sort((a, b) => a.addedAt - b.addedAt)[0];
+      if (!next) break;
+      next.status = "downloading";
+      next.speed = 0;
+      this.startEngine(next);
+      started = true;
+    }
+    if (started) {
+      this.ensurePoll();
+      this.changed();
+      void this.persist();
+    }
   }
 
   // One torrent serves an item across its whole life (download -> seed ->
@@ -169,6 +215,7 @@ export class DownloadQueue extends EventEmitter {
           it.peers = 0;
           this.changed();
           void this.persist();
+          this.promote(); // a slot just freed
           this.maybeStopPoll();
           return;
         }
@@ -195,6 +242,7 @@ export class DownloadQueue extends EventEmitter {
     this.emit("completed", it.name);
     this.changed();
     void this.persist();
+    this.promote(); // a slot just freed
     this.maybeStopPoll();
   }
 
@@ -291,23 +339,33 @@ export class DownloadQueue extends EventEmitter {
 
   pause(id: string): void {
     const it = this.items.get(id);
-    if (!it || it.status !== "downloading") return;
+    // A queued (not-yet-started) item can be paused too; only a downloading one
+    // holds a live engine + frees a slot on pause.
+    if (!it || (it.status !== "downloading" && it.status !== "queued")) return;
+    const wasDownloading = it.status === "downloading";
     it.status = "paused";
     it.speed = 0;
     it.peers = 0;
     it.eta = undefined;
-    this.engine.remove(id);
+    if (wasDownloading) this.engine.remove(id);
     this.changed();
     void this.persist();
-    this.maybeStopPoll();
+    if (wasDownloading) {
+      this.promote(); // a slot just freed
+      this.maybeStopPoll();
+    }
   }
 
   resume(id: string): void {
     const it = this.items.get(id);
     if (!it || it.status !== "paused") return;
-    it.status = "downloading";
-    this.startEngine(it);
-    this.ensurePoll();
+    // Respect the cap on manual resume: start if a slot is free, else re-queue.
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    it.status = start ? "downloading" : "queued";
+    if (start) {
+      this.startEngine(it);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
@@ -315,7 +373,7 @@ export class DownloadQueue extends EventEmitter {
   togglePause(id: string): void {
     const it = this.items.get(id);
     if (!it) return;
-    if (it.status === "downloading") this.pause(id);
+    if (it.status === "downloading" || it.status === "queued") this.pause(id);
     else if (it.status === "paused") this.resume(id);
   }
 
@@ -332,16 +390,21 @@ export class DownloadQueue extends EventEmitter {
     deleteTorrentMeta(id);
     this.changed();
     void this.persist();
+    this.promote(); // a slot may have freed
     this.maybeStopPoll();
   }
 
   retry(id: string): void {
     const it = this.items.get(id);
     if (!it || it.status !== "failed") return;
-    it.status = "downloading";
     it.error = undefined;
-    this.startEngine(it);
-    this.ensurePoll();
+    // Respect the cap on retry: start if a slot is free, else queue.
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    it.status = start ? "downloading" : "queued";
+    if (start) {
+      this.startEngine(it);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
@@ -472,12 +535,22 @@ export class DownloadQueue extends EventEmitter {
   }
 
   restore(items: QueueItem[]): void {
+    let active = 0;
     for (const raw of items) {
       this.items.set(raw.id, raw);
-      if (raw.status === "downloading") this.startEngine(raw);
+      if (raw.status !== "downloading") continue;
+      if (this.maxDownloads === 0 || active < this.maxDownloads) {
+        this.startEngine(raw);
+        active++;
+      } else {
+        // Over the cap on boot → hold as queued (promoted as slots free).
+        raw.status = "queued";
+      }
     }
-    if (this.activeCount > 0) this.ensurePoll();
+    if (active > 0) this.ensurePoll();
     this.changed();
+    // Fill any remaining slots from persisted "queued" items.
+    this.promote();
   }
 
   restoreHistory(items: HistoryItem[]): void {

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -13,6 +13,7 @@ import {
   type SeedRecord,
 } from "./persist";
 import { saveHistory, saveHistorySync, type HistoryItem } from "./history";
+import { deleteSeedData } from "./delete-data";
 import type { QueueItem, SeedItem } from "./types";
 import type { SourceId } from "../sources/types";
 
@@ -394,6 +395,43 @@ export class DownloadQueue extends EventEmitter {
     void this.persist();
     this.promote(); // a slot may have freed
     this.maybeStopPoll();
+  }
+
+  // Remove a torrent from the daemon entirely, wherever it lives (active
+  // download, seed, or just history), and optionally delete its on-disk data.
+  // Unlike cancel() (downloads only) or stopSeeding() (which leaves a paused
+  // seed record behind), this forgets the torrent completely. Returns false if
+  // the id is unknown.
+  async remove(id: string, opts: { deleteFiles?: boolean } = {}): Promise<boolean> {
+    const it = this.items.get(id);
+    const seed = this.seeds.get(id);
+    const hist = this.history.find((h) => h.id === id);
+    if (!it && !seed && !hist) return false;
+
+    const dir = it?.dir ?? seed?.dir ?? hist?.dir;
+    const name = it?.name ?? seed?.name ?? hist?.name;
+
+    // Tear down any live engine handle + in-memory record.
+    if (it || seed) this.engine.remove(id);
+    if (it) this.items.delete(id);
+    if (seed) {
+      this.seeds.delete(id);
+      this.strayHits.delete(id);
+      this.seedStartedAt.delete(id);
+    }
+    deleteTorrentMeta(id);
+    this.removeHistory(id); // persists history
+
+    if (opts.deleteFiles && dir && name) {
+      await deleteSeedData(dir, name);
+    }
+
+    this.changed();
+    void this.persist();
+    void this.persistSeeds();
+    if (it) this.promote(); // a download slot may have freed
+    this.maybeStopPoll();
+    return true;
   }
 
   retry(id: string): void {

--- a/src/download/reconcile.ts
+++ b/src/download/reconcile.ts
@@ -8,7 +8,13 @@ export function reconcileQueue(items: QueueItem[]): QueueItem[] {
     seen.add(it.id);
     if (it.status === "completed") continue;
     const status =
-      it.status === "failed" ? "failed" : it.status === "paused" ? "paused" : "downloading";
+      it.status === "failed"
+        ? "failed"
+        : it.status === "paused"
+          ? "paused"
+          : it.status === "queued"
+            ? "queued"
+            : "downloading";
     out.push({ ...it, status, speed: 0, peers: 0, eta: undefined });
   }
   return out;

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -1,6 +1,9 @@
 import type { SourceId } from "../sources/types";
 
-export type DownloadStatus = "downloading" | "paused" | "completed" | "failed";
+// "queued" = waiting for a free download slot (see TORLINK_MAX_DOWNLOADS). Unlike
+// "paused" (an explicit user action) a queued item is started automatically as
+// soon as a slot frees.
+export type DownloadStatus = "downloading" | "queued" | "paused" | "completed" | "failed";
 
 export type SeedStatus = "seeding" | "paused" | "missing";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,9 @@ function failHeadless(err: unknown): never {
   process.exit(1);
 }
 
-if (cmd.kind === "watch") {
+if (cmd.kind === "update") {
+  void import("./update/run").then(({ runUpdate }) => runUpdate({ force: cmd.force }).catch(failHeadless));
+} else if (cmd.kind === "watch") {
   if (cmd.daemon) daemonize("watch"); // parent exits here; the detached child continues
   const { dir, downloadDir, seedTimeMs, deleteFiles } = cmd;
   void import("./daemon/watch").then(({ runWatch }) =>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -23,6 +23,7 @@ import {
   type View,
 } from "./store";
 import { Logo } from "./components/Logo";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { Sidebar, RAIL_WIDTH } from "./components/Sidebar";
 import { Rule } from "./components/Rule";
 import { Footer } from "./components/Footer";
@@ -38,6 +39,8 @@ import { TrackersPrompt } from "./components/TrackersPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
+import { VERSION } from "../version";
+import { fetchLatestVersion, isNewer } from "../update/version";
 import type { SourceId } from "../sources/types";
 
 export function App({
@@ -98,6 +101,7 @@ export function App({
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const booting = useRef(false);
 
   useEffect(() => {
@@ -137,6 +141,20 @@ export function App({
       alive = false;
     };
   }, [initialMagnet, initialTorrent]);
+
+  // Best-effort, once per launch, off the hot path: if a newer release exists,
+  // surface a quiet banner. Any failure (offline, opt-out) just leaves it hidden.
+  useEffect(() => {
+    if (process.env.TORLINK_NO_UPDATE_CHECK) return;
+    let alive = true;
+    void (async () => {
+      const latest = await fetchLatestVersion();
+      if (alive && latest && isNewer(VERSION, latest)) setUpdateVersion(latest);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!queue) return;
@@ -515,7 +533,7 @@ export function App({
     return (
       <StoreContext.Provider value={store}>
         <TabTitle />
-        <Splash />
+        <Splash updateVersion={updateVersion} />
       </StoreContext.Provider>
     );
   }
@@ -527,7 +545,8 @@ export function App({
         <Box justifyContent="space-between">
           {/* The wordmark never shrinks: without these constraints a long notice
               squeezes the logo box and wraps its own text through the art. */}
-          <Box flexShrink={0}>
+          <Box flexShrink={0} flexDirection="column">
+            <UpdateBanner latest={updateVersion} />
             <Logo />
           </Box>
           {notice ? (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -23,7 +23,6 @@ import {
   type View,
 } from "./store";
 import { Logo } from "./components/Logo";
-import { UpdateBanner } from "./components/UpdateBanner";
 import { Sidebar, RAIL_WIDTH } from "./components/Sidebar";
 import { Rule } from "./components/Rule";
 import { Footer } from "./components/Footer";
@@ -545,8 +544,7 @@ export function App({
         <Box justifyContent="space-between">
           {/* The wordmark never shrinks: without these constraints a long notice
               squeezes the logo box and wraps its own text through the art. */}
-          <Box flexShrink={0} flexDirection="column">
-            <UpdateBanner latest={updateVersion} />
+          <Box flexShrink={0}>
             <Logo />
           </Box>
           {notice ? (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -525,8 +525,18 @@ export function App({
       <TabTitle />
       <Box flexDirection="column" paddingX={1}>
         <Box justifyContent="space-between">
-          <Logo />
-          {notice ? <Text color={COLOR.good}>{notice}</Text> : null}
+          {/* The wordmark never shrinks: without these constraints a long notice
+              squeezes the logo box and wraps its own text through the art. */}
+          <Box flexShrink={0}>
+            <Logo />
+          </Box>
+          {notice ? (
+            <Box flexShrink={1} minWidth={0} marginLeft={2}>
+              <Text color={COLOR.good} wrap="truncate-end">
+                {notice}
+              </Text>
+            </Box>
+          ) : null}
         </Box>
         {showTopRule ? <Rule width={ruleWidth} /> : null}
 

--- a/src/ui/components/Downloads.test.tsx
+++ b/src/ui/components/Downloads.test.tsx
@@ -117,3 +117,22 @@ describe("Downloads clear/remove keys", () => {
     expect(u.frame()).toContain("Recently downloaded  (3)");
   });
 });
+
+describe("Downloads queued rows", () => {
+  it("renders a waiting item as queued, not failed", async () => {
+    const queued: QueueItem = {
+      ...activeItem("q2", "kubuntu 25.10 iso"),
+      status: "queued",
+      progress: 0,
+      downloadedBytes: 0,
+      speed: 0,
+      peers: 0,
+      eta: undefined,
+    };
+    const u = mount([queued], []);
+    await vi.waitFor(() => expect(u.frame()).toContain("kubuntu 25.10"));
+    expect(u.frame()).toContain("queued  0%");
+    expect(u.frame()).not.toContain("failed");
+    expect(lineWith(u, "kubuntu 25.10")).toContain("·");
+  });
+});

--- a/src/ui/components/Downloads.test.tsx
+++ b/src/ui/components/Downloads.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StoreContext } from "../store";
+import { fakeQueue, makeTestStore, renderUI, type RenderedUI } from "../testHarness";
+import { Downloads } from "./Downloads";
+import type { QueueItem } from "../../download/types";
+import type { HistoryItem } from "../../download/history";
+
+const NOW_MS = 1_760_000_000_000;
+
+const activeItem = (id: string, name: string): QueueItem => ({
+  id,
+  name,
+  source: "yts",
+  magnet: `magnet:?xt=urn:btih:${id}`,
+  dir: "C:/dl",
+  status: "downloading",
+  progress: 40,
+  totalBytes: 2e9,
+  downloadedBytes: 8e8,
+  speed: 5e6,
+  peers: 12,
+  eta: 240,
+  addedAt: NOW_MS,
+});
+
+const recentItem = (id: string, name: string): HistoryItem => ({
+  id,
+  name,
+  source: "eztv",
+  sizeBytes: 1.5e9,
+  magnet: `magnet:?xt=urn:btih:${id}`,
+  dir: "C:/dl",
+  completedAt: NOW_MS,
+});
+
+const ACTIVE = [activeItem("q1", "fedora workstation 42 iso")];
+const RECENT = [
+  recentItem("h1", "ubuntu 24.04 desktop iso"),
+  recentItem("h2", "debian 12 netinst iso"),
+  recentItem("h3", "arch linux 2026.07 iso"),
+];
+
+let ui: RenderedUI | null = null;
+afterEach(() => {
+  ui?.unmount();
+  ui = null;
+});
+
+function mount(items: QueueItem[] = ACTIVE, history: HistoryItem[] = RECENT): RenderedUI {
+  ui = renderUI(
+    <StoreContext.Provider
+      value={makeTestStore({ queue: fakeQueue(items, history), section: "downloads" })}
+    >
+      <Downloads />
+    </StoreContext.Provider>,
+  );
+  return ui;
+}
+
+const lineWith = (u: RenderedUI, needle: string): string =>
+  u.frame().split("\n").find((l) => l.includes(needle)) ?? "";
+
+// Two immediate press() calls can coalesce into one input chunk, which Ink
+// delivers as a single unmatched keypress; settle between no-op keys instead.
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 25));
+
+describe("Downloads clear/remove keys", () => {
+  it("c removes only the selected recent entry", async () => {
+    const u = mount();
+    await vi.waitFor(() => expect(u.frame()).toContain("Recently downloaded  (3)"));
+    u.press("j");
+    await vi.waitFor(() => expect(lineWith(u, "ubuntu 24.04")).toContain("❯"));
+
+    u.press("c");
+    await vi.waitFor(() => expect(u.frame()).toContain("Recently downloaded  (2)"));
+    expect(u.frame()).not.toContain("ubuntu 24.04");
+    expect(u.frame()).toContain("debian 12");
+    expect(u.frame()).toContain("arch linux");
+  });
+
+  it("shift+c clears all recent entries from recent focus", async () => {
+    const u = mount();
+    await vi.waitFor(() => expect(u.frame()).toContain("Recently downloaded  (3)"));
+    u.press("j");
+    await vi.waitFor(() => expect(lineWith(u, "ubuntu 24.04")).toContain("❯"));
+
+    u.press("C");
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Recently downloaded"));
+    expect(u.frame()).toContain("fedora workstation");
+    expect(u.frame()).not.toContain("ubuntu 24.04");
+  });
+
+  it("shift+c does nothing while an active download is focused", async () => {
+    const u = mount();
+    await vi.waitFor(() => expect(u.frame()).toContain("Recently downloaded  (3)"));
+
+    u.press("C");
+    await tick();
+    u.press("x");
+    await tick();
+    // Navigation still works afterwards, and the history is untouched.
+    u.press("j");
+    await vi.waitFor(() => expect(lineWith(u, "ubuntu 24.04")).toContain("❯"));
+    expect(u.frame()).toContain("Recently downloaded  (3)");
+  });
+
+  it("x is no longer bound anywhere in the panel", async () => {
+    const u = mount();
+    await vi.waitFor(() => expect(u.frame()).toContain("Recently downloaded  (3)"));
+    u.press("j");
+    await vi.waitFor(() => expect(lineWith(u, "ubuntu 24.04")).toContain("❯"));
+
+    u.press("x");
+    await tick();
+    u.press("j");
+    await vi.waitFor(() => expect(lineWith(u, "debian 12")).toContain("❯"));
+    expect(u.frame()).toContain("Recently downloaded  (3)");
+  });
+});

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -23,13 +23,14 @@ const PAUSED = "#7c7785";
 
 function statusColor(status: QueueItem["status"]): string {
   if (status === "failed") return COLOR.bad;
-  if (status === "paused") return PAUSED;
+  if (status === "paused" || status === "queued") return PAUSED;
   return COLOR.accent;
 }
 
 function statusIcon(status: QueueItem["status"]): string {
   if (status === "failed") return ICON.error;
   if (status === "paused") return ICON.pause;
+  if (status === "queued") return ICON.pending;
   return ICON.down;
 }
 
@@ -40,6 +41,7 @@ function rightStats(it: QueueItem): string {
     return `${it.progress}%  ${speed}  ${ICON.peer}${it.peers}${eta}`;
   }
   if (it.status === "paused") return `paused  ${it.progress}%`;
+  if (it.status === "queued") return `queued  ${it.progress}%`;
   return truncate(it.error || "failed", 28);
 }
 

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -69,7 +69,6 @@ export function Downloads() {
       if (key.upArrow || input === "k") setCursor(wrapStep(clamped, -1, total));
       else if (key.downArrow || input === "j") setCursor(wrapStep(clamped, 1, total));
       else if (input === "f") queue.retryFailed();
-      else if (input === "x") queue.clearHistory();
       else if (input === "e") {
         const dir = inActive ? active[clamped]?.dir : recent[recentCursor]?.dir;
         if (dir) openDownloadFolder(dir);
@@ -93,6 +92,9 @@ export function Downloads() {
             sizeBytes: h.sizeBytes,
           });
         else if (input === "c") queue.removeHistory(h.id);
+        // Clear-all lives here, not at the top of the chain, so it can only
+        // fire while the cursor is actually on the recent list.
+        else if (input === "C") queue.clearHistory();
       }
     },
     { isActive: focused && total > 0 },

--- a/src/ui/components/FolderPrompt.tsx
+++ b/src/ui/components/FolderPrompt.tsx
@@ -48,6 +48,7 @@ export function FolderPrompt({
             <TextField
               defaultValue={value}
               placeholder="~/Downloads/torlink"
+              width={Math.max(1, width - 6)}
               onSubmit={onSubmit}
             />
           </Box>

--- a/src/ui/components/Footer.tsx
+++ b/src/ui/components/Footer.tsx
@@ -5,7 +5,9 @@ import type { Hint } from "../keymap";
 export function Footer({ hints }: { hints: Hint[] }) {
   return (
     <Box>
-      <Text>
+      {/* App budgets exactly one row for the footer, so the hints truncate
+          rather than wrapping and pushing the layout past the terminal. */}
+      <Text wrap="truncate-end">
         {hints.map((h, i) => (
           <Text key={h.keys + h.label}>
             {i > 0 ? <Text dimColor>{"   "}</Text> : null}

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SOURCES } from "../../sources/registry";
+import { StoreContext } from "../store";
+import {
+  KEY,
+  makeTestStore,
+  renderUI,
+  TEST_CONTENT_WIDTH,
+  type RenderedUI,
+} from "../testHarness";
+import { Results } from "./Results";
+import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
+import type { TorrentResult } from "../../sources/types";
+
+const searchState = vi.hoisted(() => ({ current: null as unknown }));
+
+vi.mock("../hooks/useConcurrentSearch", () => ({
+  useConcurrentSearch: () => searchState.current,
+}));
+
+const t = (infoHash: string, name: string): TorrentResult => ({
+  infoHash,
+  name,
+  source: "yts",
+  sizeBytes: 2.1e9,
+  seeders: 40,
+  leechers: 6,
+  magnet: `magnet:?xt=urn:btih:${infoHash}`,
+  added: 1_760_000_000,
+});
+
+// Invented names. "ubuntu 24" exercises all three rank tiers: exact substring
+// (a1), tokens in order (b2), tokens scattered (c3).
+const LIST = [
+  t("a1", "ubuntu 24.04 desktop amd64 iso"),
+  t("b2", "ubuntu server 24.04 arm64 iso"),
+  t("c3", "24 hour timelapse of ubuntu builds"),
+  t("d4", "debian 12 netinst iso"),
+  t("e5", "arch linux 2026.07 iso"),
+  t("f6", "fedora workstation 42 iso"),
+  t("g7", "gentoo stage3 tarball"),
+  t("h8", "mint cinnamon 22 iso"),
+];
+
+function settled(results: TorrentResult[]): ConcurrentSearchState {
+  const perSource = Object.fromEntries(
+    SOURCES.map((s) => [s.id, { loading: false, error: null, code: null, count: 0 }]),
+  ) as ConcurrentSearchState["perSource"];
+  return { results, perSource, loading: false, done: SOURCES.length, total: SOURCES.length };
+}
+
+let ui: RenderedUI | null = null;
+afterEach(() => {
+  ui?.unmount();
+  ui = null;
+});
+
+async function mount(results: TorrentResult[] = LIST): Promise<RenderedUI> {
+  searchState.current = settled(results);
+  ui = renderUI(
+    <StoreContext.Provider value={makeTestStore({ query: "linux iso" })}>
+      <Results />
+    </StoreContext.Provider>,
+  );
+  const u = ui;
+  await vi.waitFor(() => expect(u.frame()).toContain(`Results (${results.length})`));
+  return u;
+}
+
+const lines = (u: RenderedUI): string[] => u.frame().split("\n");
+const lineIndex = (u: RenderedUI, needle: string): number =>
+  lines(u).findIndex((l) => l.includes(needle));
+// The TextField cursor renders as SGR inverse; nothing else in this view does.
+const editing = (u: RenderedUI): boolean => u.rawFrame().includes(`${KEY.esc}[7m`);
+
+async function openFilter(u: RenderedUI): Promise<void> {
+  u.press("f");
+  await vi.waitFor(() => expect(editing(u)).toBe(true));
+}
+
+async function type(u: RenderedUI, text: string, expectCount: number): Promise<void> {
+  u.press(text);
+  await vi.waitFor(() => expect(u.frame()).toContain(`(${expectCount})`));
+}
+
+describe("Results filter UI", () => {
+  it("shows no filter bar by default", async () => {
+    const u = await mount();
+    expect(u.frame()).not.toContain("Filter");
+  });
+
+  it("renders the filter bar on its own row below an intact panel", async () => {
+    const u = await mount();
+    await openFilter(u);
+    await type(u, "ubuntu 24", 3);
+
+    const ls = lines(u);
+    const top = ls.findIndex((l) => l.includes("╭─ Results"));
+    const bar = ls.findIndex((l) => l.includes("Filter ❯"));
+    const lastBorder = ls.reduce((acc, l, i) => (l.includes("╰") ? i : acc), -1);
+
+    // The bug this guards against: the bar rendered as a row sibling of the
+    // panel, landing on the top border line and squeezing the title.
+    expect(ls[top]).toMatch(/^╭─ Results \(3\) ─+╮$/);
+    expect(ls[top]).toHaveLength(TEST_CONTENT_WIDTH);
+    expect(bar).toBeGreaterThan(lastBorder);
+    for (const l of ls) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+  });
+
+  it("narrows live and ranks exact > in-order > scattered", async () => {
+    const u = await mount();
+    await openFilter(u);
+    await type(u, "ubuntu 24", 3);
+
+    const exact = lineIndex(u, "ubuntu 24.04 desktop");
+    const inOrder = lineIndex(u, "ubuntu server");
+    const scattered = lineIndex(u, "24 hour timelapse");
+    expect(exact).toBeGreaterThan(-1);
+    expect(inOrder).toBeGreaterThan(exact);
+    expect(scattered).toBeGreaterThan(inOrder);
+    expect(u.frame()).not.toContain("debian 12");
+  });
+
+  it("enter commits the filter and returns keys to the list", async () => {
+    const u = await mount();
+    await openFilter(u);
+    await type(u, "iso", 6);
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+    expect(u.frame()).toContain("Filter ❯ iso");
+
+    u.press("j");
+    await vi.waitFor(() => {
+      const ls = lines(u);
+      expect(ls.find((l) => l.includes("ubuntu server"))).toContain("❯");
+    });
+    expect(lines(u).find((l) => l.includes("ubuntu 24.04 desktop"))).not.toContain("❯");
+  });
+
+  it("esc leaves editing but keeps the filter applied", async () => {
+    const u = await mount();
+    await openFilter(u);
+    await type(u, "iso", 6);
+    u.press(KEY.esc);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+    expect(u.frame()).toContain("Filter ❯ iso");
+    expect(u.frame()).toContain("(6)");
+
+    u.press("j");
+    await vi.waitFor(() => {
+      const ls = lines(u);
+      expect(ls.find((l) => l.includes("ubuntu server"))).toContain("❯");
+    });
+  });
+
+  it("ctrl+u then enter clears the filter and removes the bar", async () => {
+    const u = await mount();
+    await openFilter(u);
+    await type(u, "arch", 1);
+    u.press(KEY.ctrlU);
+    await vi.waitFor(() => expect(u.frame()).toContain("(8)"));
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Filter"));
+    expect(u.frame()).toContain("Results (8)");
+  });
+
+  it("a zero-match filter never traps the user", async () => {
+    const u = await mount();
+    await openFilter(u);
+    u.press("zzz");
+    await vi.waitFor(() => expect(u.frame()).toContain("No results for"));
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+    expect(u.frame()).toContain("Filter ❯ zzz");
+
+    u.press("f");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press(KEY.ctrlU);
+    // Wait between keys: TextField's input closure only refreshes on render,
+    // so a same-batch ctrl+u + enter would still submit the pre-clear value
+    // (pre-existing TextField trait, logged as a follow-up).
+    await vi.waitFor(() => expect(u.frame()).toContain("Results (8)"));
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Filter"));
+    expect(u.frame()).toContain("Results (8)");
+  });
+});

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -477,26 +477,31 @@ export function Results() {
             </>
           )}
         </Panel>
-        {(mode === "filter" || textFilter.trim()) && (
-          <Box marginLeft={1}>
-            <Text color={COLOR.accent}>{`Filter ${ICON.pointer} `}</Text>
-            <Box flexGrow={1} minWidth={0}>
-              {mode === "filter" ? (
-                <TextField
-                  defaultValue={textFilter}
-                  width={Math.max(1, contentWidth - 10)}
-                  onChange={setTextFilter}
-                  onSubmit={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
-                  onExitDown={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
-                  onExitLeft={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
-                />
-              ) : (
-                <Text wrap="truncate-end">{textFilter}</Text>
-              )}
-            </Box>
-          </Box>
-        )}
       </Box>
+      {(mode === "filter" || textFilter.trim()) && (
+        <Box width={contentWidth} paddingLeft={1}>
+          <Box flexShrink={0}>
+            <Text color={COLOR.accent}>{`Filter ${ICON.pointer} `}</Text>
+          </Box>
+          <Box flexGrow={1} minWidth={0}>
+            {mode === "filter" ? (
+              <TextField
+                defaultValue={textFilter}
+                width={Math.max(1, contentWidth - 10)}
+                onChange={setTextFilter}
+                // Commit from the submit value / functional form, not the
+                // render closure: a same-tick burst (ctrl+u then enter) would
+                // otherwise resurrect the pre-clear text.
+                onSubmit={(value) => { setTextFilter(value.trim()); setMode("list"); }}
+                onExitDown={() => { setTextFilter((cur) => cur.trim()); setMode("list"); }}
+                onExitLeft={() => { setTextFilter((cur) => cur.trim()); setMode("list"); }}
+              />
+            ) : (
+              <Text wrap="truncate-end">{textFilter}</Text>
+            )}
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { useStore, CATEGORIES } from "../store";
 import { Spinner } from "./Spinner";
 import { SearchBar } from "./SearchBar";
+import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { Rule } from "./Rule";
 import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
@@ -14,7 +15,7 @@ import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
 
-type Mode = "list" | "search" | "detail";
+type Mode = "list" | "search" | "detail" | "filter";
 
 const PLACEHOLDER = "Search or paste a magnet link…";
 
@@ -128,13 +129,14 @@ export function Results() {
 
   const [sort, setSort] = useState<Sort>("none");
   const [hideDead, setHideDead] = useState(false);
+  const [textFilter, setTextFilter] = useState("");
   const results = useMemo(() => {
     const cat = CATEGORIES.find((c) => c.key === section);
     const base = cat?.group
       ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
       : search.results;
-    return sortResults(filterResults(base, hideDead), sort);
-  }, [search.results, section, sort, hideDead]);
+    return sortResults(filterResults(base, hideDead, textFilter), sort);
+  }, [search.results, section, sort, hideDead, textFilter]);
 
   const focused = region === "content";
   const [mode, setMode] = useState<Mode>("list");
@@ -151,11 +153,12 @@ export function Results() {
   useEffect(() => {
     selRef.current = null;
     setCursor(0);
+    setTextFilter("");
   }, [query, section]);
 
   useEffect(() => {
     if (!focused) return;
-    setCaptureMode(mode === "search" ? "text" : mode === "detail" ? "esc" : "none");
+    setCaptureMode(mode === "search" || mode === "filter" ? "text" : mode === "detail" ? "esc" : "none");
     return () => setCaptureMode("none");
   }, [mode, focused, setCaptureMode]);
 
@@ -166,7 +169,8 @@ export function Results() {
   const clamped = Math.min(cursor, Math.max(0, results.length - 1));
 
   const searchH = 3;
-  const panelOuter = resultsPanelOuter(listRows, searchH);
+  const filterH = mode === "filter" || textFilter.trim() ? 1 : 0;
+  const panelOuter = resultsPanelOuter(listRows, searchH + filterH);
   const listHeight = Math.max(3, panelOuter - 4);
   const pageJump = Math.max(1, listHeight - 1);
 
@@ -207,11 +211,21 @@ export function Results() {
         else setMode("search");
         return;
       }
-      if (results.length === 0) return;
-      if (key.downArrow || input === "j") moveTo(wrapStep(clamped, 1, results.length));
-      else if (key.pageUp) moveTo(Math.max(0, clamped - pageJump));
-      else if (key.pageDown) moveTo(Math.min(results.length - 1, clamped + pageJump));
-      else if (key.return) {
+      if (input === "s") {
+        setSort((cur) => nextSort(cur));
+      } else if (input === "z") {
+        setHideDead((on) => !on);
+      } else if (input === "f") {
+        setMode("filter");
+      } else if (results.length === 0) {
+        return;
+      } else if (key.downArrow || input === "j") {
+        moveTo(wrapStep(clamped, 1, results.length));
+      } else if (key.pageUp) {
+        moveTo(Math.max(0, clamped - pageJump));
+      } else if (key.pageDown) {
+        moveTo(Math.min(results.length - 1, clamped + pageJump));
+      } else if (key.return) {
         const r = results[clamped];
         if (r) {
           setDetail(r);
@@ -226,10 +240,6 @@ export function Results() {
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
-      } else if (input === "s") {
-        setSort((cur) => nextSort(cur));
-      } else if (input === "z") {
-        setHideDead((on) => !on);
       }
     },
     { isActive: focused && mode === "list" },
@@ -251,7 +261,7 @@ export function Results() {
     (_input, key) => {
       if (key.escape) setMode("list");
     },
-    { isActive: focused && mode === "search" },
+    { isActive: focused && (mode === "search" || mode === "filter") },
   );
 
   const onSubmit = (value: string): void => {
@@ -467,6 +477,25 @@ export function Results() {
             </>
           )}
         </Panel>
+        {(mode === "filter" || textFilter.trim()) && (
+          <Box marginLeft={1}>
+            <Text color={COLOR.accent}>{`Filter ${ICON.pointer} `}</Text>
+            <Box flexGrow={1} minWidth={0}>
+              {mode === "filter" ? (
+                <TextField
+                  defaultValue={textFilter}
+                  width={Math.max(1, contentWidth - 10)}
+                  onChange={setTextFilter}
+                  onSubmit={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
+                  onExitDown={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
+                  onExitLeft={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
+                />
+              ) : (
+                <Text wrap="truncate-end">{textFilter}</Text>
+              )}
+            </Box>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -92,11 +92,11 @@ export function TextField({
 
   useInput(
     (input, key) => {
-      if (key.downArrow) {
+      if (key.downArrow || key.tab) {
         onExitDown?.();
         return;
       }
-      if (key.upArrow || key.tab || (key.ctrl && input === "c")) return;
+      if (key.upArrow || (key.ctrl && input === "c")) return;
 
       if (key.return) {
         onSubmit?.(value);

--- a/src/ui/components/TrackersPrompt.tsx
+++ b/src/ui/components/TrackersPrompt.tsx
@@ -1,8 +1,9 @@
+import { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { PromptHints } from "./PromptHints";
-import { formatTrackers, parseTrackers } from "../../config/trackers";
+import { formatTrackers, parseTrackers, trackersStatus } from "../../config/trackers";
 import { COLOR, ICON } from "../theme";
 
 interface TrackersPromptProps {
@@ -13,6 +14,9 @@ interface TrackersPromptProps {
 }
 
 export function TrackersPrompt({ width, value, onSubmit, onCancel }: TrackersPromptProps) {
+  const initial = formatTrackers(value);
+  const [fieldText, setFieldText] = useState(initial);
+
   useInput((_input, key) => {
     if (key.escape) onCancel();
   });
@@ -22,15 +26,17 @@ export function TrackersPrompt({ width, value, onSubmit, onCancel }: TrackersPro
       <Panel title="extra trackers" width={width} focused height={3}>
         <Box>
           <Text dimColor wrap="truncate-end">
-            Comma or space separated. Empty clears. Applies to new adds.
+            {trackersStatus(value, fieldText)}
           </Text>
         </Box>
         <Box>
           <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
           <Box flexGrow={1} minWidth={0}>
             <TextField
-              defaultValue={formatTrackers(value)}
+              defaultValue={initial}
               placeholder="udp://tracker.example:1337/announce, https://..."
+              width={Math.max(1, width - 6)}
+              onChange={setFieldText}
               onSubmit={(raw) => onSubmit(parseTrackers(raw))}
             />
           </Box>

--- a/src/ui/components/UpdateBanner.tsx
+++ b/src/ui/components/UpdateBanner.tsx
@@ -1,0 +1,8 @@
+import { Text } from "ink";
+
+// A quiet one-liner above the wordmark when a newer release exists. Passive by
+// design: it never steals focus or a key, it just points at `torlnk update`.
+export function UpdateBanner({ latest }: { latest: string | null }) {
+  if (!latest) return null;
+  return <Text dimColor>{`↑ torlink v${latest} available · torlnk update`}</Text>;
+}

--- a/src/ui/filter.test.ts
+++ b/src/ui/filter.test.ts
@@ -45,4 +45,19 @@ describe("filterResults", () => {
     filterResults(list, true);
     expect(list.map((x) => x.infoHash)).toEqual(before);
   });
+
+  it("filters by text matching all tokens and ranks exact matches higher", () => {
+    const list = [
+      r({ infoHash: "a", name: "ubuntu 24 desktop" }),
+      r({ infoHash: "b", name: "ubuntu desktop 24.04" }),
+      r({ infoHash: "c", name: "debian 12" }),
+      r({ infoHash: "d", name: "24 ubuntu desktop" }),
+    ];
+    // "ubuntu 24" -> 
+    // a: exact substring "ubuntu 24" (score 60)
+    // b: "ubuntu" before "24" (score 30)
+    // d: "24" before "ubuntu" (out of order, score 10)
+    // c: no match
+    expect(filterResults(list, false, "ubuntu 24").map(x => x.infoHash)).toEqual(["a", "b", "d"]);
+  });
 });

--- a/src/ui/filter.ts
+++ b/src/ui/filter.ts
@@ -4,9 +4,55 @@ import type { TorrentResult } from "../sources/types";
 export function filterResults(
   list: TorrentResult[],
   hideDead: boolean,
+  textFilter: string = "",
 ): TorrentResult[] {
-  if (!hideDead) return list;
-  // Sources without swarm data report seeders: 0 for everything (unknown, not
-  // dead), so the filter only judges rows whose source actually reports health.
-  return list.filter((r) => r.seeders > 0 || !getSource(r.source).reportsHealth);
+  let filtered = list;
+
+  if (hideDead) {
+    // Sources without swarm data report seeders: 0 for everything (unknown, not
+    // dead), so the filter only judges rows whose source actually reports health.
+    filtered = filtered.filter((r) => r.seeders > 0 || !getSource(r.source).reportsHealth);
+  }
+
+  const text = textFilter.trim().toLowerCase();
+  if (text) {
+    const tokens = text.split(/\s+/);
+    const scored = filtered.map((r) => {
+      const name = r.name.toLowerCase();
+      let score = 0;
+
+      // Every token must be present
+      const matchesAll = tokens.every((token) => name.includes(token));
+      if (!matchesAll) return { r, score: 0 };
+
+      score += 10; // Base score for matching all tokens
+
+      const normalizedText = tokens.join(" ");
+      if (name.includes(normalizedText)) {
+        score += 50; // Exact substring gets highest boost
+      } else {
+        // Boost if tokens appear in the same order
+        let lastIndex = -1;
+        let inOrder = true;
+        for (const token of tokens) {
+          const idx = name.indexOf(token, lastIndex + 1);
+          if (idx === -1 || idx < lastIndex) {
+            inOrder = false;
+            break;
+          }
+          lastIndex = idx;
+        }
+        if (inOrder) score += 20;
+      }
+
+      return { r, score };
+    });
+
+    filtered = scored
+      .filter((x) => x.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((x) => x.r);
+  }
+
+  return filtered;
 }

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 12, 16, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 31]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -3,20 +3,19 @@ import { MEASURED, pickLayout } from "./helpLayout";
 
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
-    expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 31]);
+    expect(MEASURED.map((m) => m.width)).toEqual([134, 113, 77, 41]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 30]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {
-    expect(pickLayout(140).layout).toHaveLength(4);
-    expect(pickLayout(124).layout).toHaveLength(4);
-    expect(pickLayout(123).layout).toHaveLength(3);
-    expect(pickLayout(103).layout).toHaveLength(3);
-    expect(pickLayout(102).layout).toHaveLength(2);
+    expect(pickLayout(160).layout).toHaveLength(4);
+    expect(pickLayout(136).layout).toHaveLength(4);
+    expect(pickLayout(135).layout).toHaveLength(3);
+    expect(pickLayout(115).layout).toHaveLength(3);
+    expect(pickLayout(114).layout).toHaveLength(2);
     expect(pickLayout(80).layout).toHaveLength(2);
-    expect(pickLayout(67).layout).toHaveLength(2);
-    expect(pickLayout(66).layout).toHaveLength(1);
-    expect(pickLayout(60).layout).toHaveLength(1);
+    expect(pickLayout(79).layout).toHaveLength(2);
+    expect(pickLayout(78).layout).toHaveLength(1);
     expect(pickLayout(40).layout).toHaveLength(1);
   });
 });

--- a/src/ui/keymap.test.ts
+++ b/src/ui/keymap.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { footerHints, HELP_GROUPS, type Hint } from "./keymap";
+
+// Footer.tsx renders hints as "keys label" joined by a 3-space separator, and
+// the app pads one column each side, so a row must fit 80 - 2 at 80 cols.
+const rowWidth = (hints: Hint[]): number =>
+  hints.reduce((n, h) => n + h.keys.length + 1 + h.label.length, 0) + (hints.length - 1) * 3;
+
+describe("downloads/seeding key vocabulary", () => {
+  it("folds clear-all into shift+c on the c row and drops x", () => {
+    const downloads = HELP_GROUPS.find((g) => g.title === "Downloads")!;
+    expect(downloads.hints.some((h) => h.keys === "x")).toBe(false);
+    expect(downloads.hints.some((h) => h.keys === "shift+c")).toBe(false);
+    expect(downloads.hints.find((h) => h.keys === "c")?.label).toContain("(shift+c");
+  });
+
+  it("labels one-entry removal as list bookkeeping in the footers", () => {
+    const recent = footerHints("content", "downloads", "recent", null);
+    expect(recent.some((h) => h.keys === "x")).toBe(false);
+    expect(recent.find((h) => h.keys === "c")?.label).toBe("Remove from list");
+
+    const seeding = footerHints("content", "seeding", null, "seeding");
+    expect(seeding.find((h) => h.keys === "c")?.label).toBe("Remove from list");
+  });
+
+  // The results row carries a known pre-existing overflow (f Filter), so the
+  // budget is pinned only for the rows this vocabulary owns.
+  it("keeps the downloads and seeding footer rows inside the 80-col budget", () => {
+    const rows = [
+      footerHints("sidebar", "downloads", null, null),
+      footerHints("content", "downloads", "downloading", null),
+      footerHints("content", "downloads", "paused", null),
+      footerHints("content", "downloads", "failed", null),
+      footerHints("content", "downloads", "recent", null),
+      footerHints("content", "seeding", null, "seeding"),
+      footerHints("content", "seeding", null, "missing"),
+      footerHints("content", "seeding", null, null),
+    ];
+    for (const row of rows) expect(rowWidth(row)).toBeLessThanOrEqual(78);
+  });
+});

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -39,12 +39,11 @@ export const HELP_GROUPS: HelpGroup[] = [
     title: "Downloads",
     hints: [
       { keys: "p", label: "Pause/resume" },
-      { keys: "c", label: "Cancel or remove" },
+      { keys: "c", label: "Cancel or remove (shift+c: all)" },
       { keys: "f", label: "Retry failed" },
       { keys: "d", label: "Download again" },
       { keys: "e", label: "Open folder" },
       { keys: "s", label: "Export torrent file" },
-      { keys: "x", label: "Clear recent" },
     ],
   },
   {
@@ -88,7 +87,7 @@ export function footerHints(
   if (section === "seeding") {
     const label =
       seedFocus === "seeding" ? "Pause" : seedFocus === "missing" ? "Retry" : "Resume";
-    return [{ keys: "p", label }, { keys: "c", label: "Remove" }, FOLDER, SWITCH, ALWAYS];
+    return [{ keys: "p", label }, { keys: "c", label: "Remove from list" }, FOLDER, SWITCH, ALWAYS];
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
@@ -98,10 +97,11 @@ export function footerHints(
       return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, FOLDER, TORRENT, SWITCH, ALWAYS];
     }
     if (downloadFocus === "recent") {
+      // Removal is list bookkeeping, never file deletion, and the label says
+      // so. Clear-all (shift+c) stays `?`-only, like D.
       return [
         { keys: "d", label: "Redownload" },
-        { keys: "c", label: "Remove" },
-        { keys: "x", label: "Clear" },
+        { keys: "c", label: "Remove from list" },
         FOLDER,
         TORRENT,
         SWITCH,

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -27,6 +27,7 @@ export const HELP_GROUPS: HelpGroup[] = [
     title: "Search",
     hints: [
       { keys: "/", label: "Edit search" },
+      { keys: "f", label: "Filter list" },
       { keys: "d", label: "Download (shift+d picks folder)" },
       { keys: "s", label: "Sort results" },
       { keys: "z", label: "Hide dead torrents" },
@@ -117,6 +118,7 @@ export function footerHints(
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "/", label: "Search" },
+    { keys: "f", label: "Filter" },
     SWITCH,
     ALWAYS,
   ];

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -1,0 +1,160 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import chalk from "chalk";
+import { render } from "ink";
+import type { ReactNode } from "react";
+
+// Ink styles Text through this shared chalk instance (chalk rides in as ink's
+// own dependency), and chalk mutes every code under vitest's piped stdout.
+// Forcing the level keeps SGR in captured frames, which rawFrame() relies on
+// to see the TextField's inverse cursor.
+chalk.level = 3;
+import type { Config } from "../config/config";
+import type { DownloadQueue } from "../download/queue";
+import type { QueueItem, SeedItem } from "../download/types";
+import type { HistoryItem } from "../download/history";
+import { RAIL_WIDTH } from "./components/Sidebar";
+import type { Store } from "./store";
+
+export const TEST_COLS = 80;
+export const TEST_CONTENT_WIDTH = Math.max(24, TEST_COLS - RAIL_WIDTH - 3);
+
+export const KEY = {
+  enter: "\r",
+  esc: "\u001b",
+  ctrlU: "\u0015",
+} as const;
+
+// SGR/CSI sequences only. util/format's stripControl drops the ESC byte but
+// leaves the sequence text behind, so it cannot clean frames for assertions.
+export function stripAnsi(s: string): string {
+  return s.replace(/\u001b\[[0-9;?]*[A-Za-z]/g, "");
+}
+
+export interface RenderedUI {
+  /** Latest rendered frame, ANSI-stripped. */
+  frame: () => string;
+  /** Latest rendered frame with escape codes intact (inverse cursor = ESC[7m). */
+  rawFrame: () => string;
+  /** Feed raw bytes to the app as if typed. */
+  press: (bytes: string) => void;
+  unmount: () => void;
+}
+
+/**
+ * Renders an Ink tree for tests. Input goes through a real PassThrough stream
+ * because Ink 7 consumes stdin via 'readable' + stdin.read(): bytes emitted on
+ * a plain EventEmitter stub (ink-testing-library's stdin) never reach its
+ * parser. Raw mode is gated on stdin.isTTY plus a callable setRawMode.
+ */
+export function renderUI(node: ReactNode, opts: { cols?: number; rows?: number } = {}): RenderedUI {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (v: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  // Socket-only members Ink calls when input hooks mount; streams lack them.
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+
+  const writes: string[] = [];
+  const stdout = Object.assign(new EventEmitter(), {
+    columns: opts.cols ?? TEST_COLS,
+    rows: opts.rows ?? 24,
+    write(chunk: unknown): boolean {
+      writes.push(String(chunk));
+      return true;
+    },
+  });
+
+  const instance = render(node, {
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    // debug makes every render land as one full standalone frame in `writes`,
+    // instead of incremental repaints that only carry changed lines.
+    debug: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  // A fatal render error makes Ink self-unmount after an empty frame; without
+  // this, tests would only ever see that blank frame, never the cause.
+  let fatal: unknown = null;
+  instance.waitUntilExit().catch((e: unknown) => {
+    fatal = e;
+  });
+  const guard = (): void => {
+    if (fatal) throw fatal;
+  };
+
+  return {
+    frame: () => {
+      guard();
+      return stripAnsi(writes.at(-1) ?? "");
+    },
+    rawFrame: () => writes.at(-1) ?? "",
+    press: (bytes: string) => void stdin.write(bytes),
+    unmount: () => instance.unmount(),
+  };
+}
+
+function fakeQueue(
+  items: QueueItem[] = [],
+  history: HistoryItem[] = [],
+  seeds: SeedItem[] = [],
+): DownloadQueue {
+  const stub = {
+    getItems: () => items,
+    getHistory: () => history,
+    getSeeds: () => seeds,
+    getSeed: (id: string) => seeds.find((s) => s.id === id),
+    activeCount: 0,
+    seedingCount: 0,
+    on: () => stub,
+    off: () => stub,
+  };
+  return stub as unknown as DownloadQueue;
+}
+
+// Mirrors makeStore in scripts/render-previews-impl.tsx, which cannot be
+// imported here: that module generates previews at import time. Typing the
+// literal as Store keeps the same drift guard: a new Store field fails compile.
+export function makeTestStore(overrides: Partial<Store> = {}): Store {
+  const noop = (): void => {};
+  return {
+    config: { downloadDir: "~/Downloads/torlink" } as Config,
+    setConfig: noop,
+    queue: fakeQueue(),
+    view: "browser",
+    setView: noop,
+    query: "",
+    submitQuery: noop,
+    section: "all",
+    setSection: noop,
+    region: "content",
+    setRegion: noop,
+    captureMode: "none",
+    setCaptureMode: noop,
+    downloadFocus: null,
+    setDownloadFocus: noop,
+    seedFocus: null,
+    setSeedFocus: noop,
+    startDownload: noop,
+    requestDownloadTo: noop,
+    copyMagnet: noop,
+    openDownloadFolder: noop,
+    exportTorrent: noop,
+    notice: null,
+    setNotice: noop,
+    quitAll: noop,
+    listRows: 14,
+    compact: false,
+    contentWidth: TEST_CONTENT_WIDTH,
+    cols: TEST_COLS,
+    rows: 24,
+    ...overrides,
+  };
+}

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -101,20 +101,35 @@ export function renderUI(node: ReactNode, opts: { cols?: number; rows?: number }
   };
 }
 
-function fakeQueue(
+// Functional enough for panel tests: history mutations emit "update" so the
+// useQueue* hooks refresh, everything else is a stub.
+export function fakeQueue(
   items: QueueItem[] = [],
   history: HistoryItem[] = [],
   seeds: SeedItem[] = [],
 ): DownloadQueue {
+  const em = new EventEmitter();
+  let hist = [...history];
   const stub = {
     getItems: () => items,
-    getHistory: () => history,
+    getHistory: () => hist,
     getSeeds: () => seeds,
     getSeed: (id: string) => seeds.find((s) => s.id === id),
-    activeCount: 0,
+    activeCount: items.filter((i) => i.status === "downloading").length,
     seedingCount: 0,
-    on: () => stub,
-    off: () => stub,
+    on: (ev: string, cb: () => void) => (em.on(ev, cb), stub),
+    off: (ev: string, cb: () => void) => (em.off(ev, cb), stub),
+    removeHistory: (id: string): void => {
+      hist = hist.filter((h) => h.id !== id);
+      em.emit("update");
+    },
+    clearHistory: (): void => {
+      hist = [];
+      em.emit("update");
+    },
+    cancel: (): void => {},
+    togglePause: (): void => {},
+    retryFailed: (): void => {},
   };
   return stub as unknown as DownloadQueue;
 }

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput, useStdin } from "ink";
 import { Logo } from "../components/Logo";
+import { UpdateBanner } from "../components/UpdateBanner";
 import { SearchBar } from "../components/SearchBar";
 import { LOGO_WIDTH } from "../logo";
 import { useStore } from "../store";
@@ -10,7 +11,7 @@ const CATEGORIES = sourcesByGroup()
   .map((g) => g.group.toLowerCase())
   .join(`  ${ICON.dot}  `);
 
-export function Splash() {
+export function Splash({ updateVersion }: { updateVersion?: string | null } = {}) {
   const { submitQuery, quitAll, cols, rows } = useStore();
   const { isRawModeSupported } = useStdin();
 
@@ -31,6 +32,7 @@ export function Splash() {
       justifyContent="center"
       alignItems="center"
     >
+      <UpdateBanner latest={updateVersion ?? null} />
       {showLogo ? (
         <Logo />
       ) : (

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -54,6 +54,7 @@ export function Splash({ updateVersion }: { updateVersion?: string | null } = {}
           editing
           placeholder="Search or paste a magnet link…"
           onSubmit={submitQuery}
+          onExitDown={() => submitQuery("")}
         />
       </Box>
       <Box marginTop={1}>
@@ -61,8 +62,7 @@ export function Splash({ updateVersion }: { updateVersion?: string | null } = {}
           <Text color={COLOR.alt}>↵</Text>
           <Text dimColor> search</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
-          <Text dimColor>empty </Text>
-          <Text color={COLOR.alt}>↵</Text>
+          <Text color={COLOR.alt}>⇥</Text>
           <Text dimColor> browse</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
           <Text color={COLOR.alt}>^c</Text>

--- a/src/update/manifest.test.ts
+++ b/src/update/manifest.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { readManifest } from "./manifest";
+
+describe("readManifest", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "torlink-manifest-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const urlIn = (...segments: string[]): string =>
+    pathToFileURL(path.join(dir, ...segments, "module.js")).href;
+
+  it("finds the nearest package.json with a name and version", () => {
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "some-pkg", version: "2.3.4" }));
+    fs.mkdirSync(path.join(dir, "dist"), { recursive: true });
+
+    expect(readManifest(urlIn("dist"))).toEqual({ name: "some-pkg", version: "2.3.4", root: dir });
+  });
+
+  it("walks past manifests missing a name or version", () => {
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "outer-pkg", version: "1.0.0" }));
+    const inner = path.join(dir, "a", "b");
+    fs.mkdirSync(inner, { recursive: true });
+    fs.writeFileSync(path.join(inner, "package.json"), JSON.stringify({ type: "module" }));
+
+    expect(readManifest(urlIn("a", "b"))?.name).toBe("outer-pkg");
+  });
+
+  it("resolves this repo's own manifest from the source tree", () => {
+    const m = readManifest();
+    expect(m?.name).toBe("torlnk");
+    expect(m?.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/src/update/manifest.ts
+++ b/src/update/manifest.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The package's own identity, read from the nearest package.json at runtime so
+// nothing about the install is hardcoded: the registry check, the global
+// reinstall target, and the update root all follow whatever manifest this code
+// actually ships in.
+export interface PackageManifest {
+  name: string;
+  version: string;
+  root: string;
+}
+
+// Walk up from `fromUrl` (this module by default) to the first package.json
+// carrying a string name and version. Covers the bundled dist (dist/index.js),
+// the tsx dev tree (src/update), and a global npm install without hardcoding a
+// depth or a package name.
+export function readManifest(fromUrl: string = import.meta.url): PackageManifest | null {
+  let dir = path.dirname(fileURLToPath(fromUrl));
+  for (let i = 0; i < 6; i++) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8")) as {
+        name?: unknown;
+        version?: unknown;
+      };
+      if (typeof raw.name === "string" && typeof raw.version === "string") {
+        return { name: raw.name, version: raw.version, root: dir };
+      }
+    } catch {
+      // no package.json here, or unreadable; keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}

--- a/src/update/run.test.ts
+++ b/src/update/run.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { managedInstallOwner } from "./run";
+
+describe("managedInstallOwner", () => {
+  it("names nix for a store path, whatever the separators", () => {
+    expect(managedInstallOwner("/nix/store/abc123-torlnk-1.4.2")).toBe("nix");
+    expect(managedInstallOwner("\\nix\\store\\abc123-torlnk-1.4.2")).toBe("nix");
+  });
+
+  it("names the package manager when the root is not writable", () => {
+    const denied = (): void => {
+      throw new Error("EACCES");
+    };
+    expect(managedInstallOwner("/usr/lib/node_modules/torlnk", denied)).toBe("your package manager");
+  });
+
+  it("returns null for a writable root we own", () => {
+    expect(managedInstallOwner("/home/u/dev/torlink", () => {})).toBeNull();
+  });
+});

--- a/src/update/run.ts
+++ b/src/update/run.ts
@@ -1,48 +1,47 @@
 // `torlnk update`: fetch the latest release, apply it, and bring any --daemon
 // process back on the new code. Two install shapes are handled: a git checkout
 // (pull, install, build) and a global npm install (npm i -g), chosen by whether
-// the package root is a git working tree.
+// the package root is a git working tree. The package name and root come from
+// the manifest at runtime, never a hardcoded slug.
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { VERSION } from "../version";
 import { fetchLatestVersion, isNewer } from "./version";
+import { readManifest } from "./manifest";
 import { isAlive, listRunDescriptors, restartDaemon } from "../daemon/restart";
 
-// npm is a shell script on Windows (npm.cmd), and spawning a .cmd there needs a
-// shell; git is a real binary everywhere.
+// git is a real binary everywhere and spawns without a shell, so paths with
+// spaces survive as plain argv entries. npm is npm.cmd on Windows and a .cmd
+// needs a shell there; every npm invocation below has space-free args, which
+// keeps that shell safe without hand-quoting.
 const IS_WIN = process.platform === "win32";
 const NPM = IS_WIN ? "npm.cmd" : "npm";
 
-// Walk up from this module to the torlnk package root. Robust across the bundled
-// dist (dist/index.js -> ..), the tsx dev tree (src/update -> ../..), and a
-// global install, instead of hard-coding a depth that only one of them matches.
-function packageRoot(): string {
-  let dir = path.dirname(fileURLToPath(import.meta.url));
-  for (let i = 0; i < 6; i++) {
-    const pkg = path.join(dir, "package.json");
-    try {
-      if ((JSON.parse(fs.readFileSync(pkg, "utf8")) as { name?: string }).name === "torlnk") {
-        return dir;
-      }
-    } catch {
-      // no package.json here, or not ours, so keep walking up
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-}
-
-function run(cmd: string, args: string[], cwd: string): Promise<number> {
+function run(cmd: string, args: string[], cwd: string, useShell = false): Promise<number> {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { cwd, stdio: "inherit", shell: IS_WIN });
+    const child = spawn(cmd, args, { cwd, stdio: "inherit", shell: useShell });
     child.on("error", () => resolve(-1)); // e.g. command not found
     child.on("exit", (code) => resolve(code ?? -1));
   });
+}
+
+// A root the current user cannot write to belongs to a package manager (the
+// nix store is the concrete case today). Updating through npm would fail on
+// the read-only prefix or shadow the managed binary, so name the situation and
+// stop instead. Returns who owns the install, or null when it is ours to touch.
+export function managedInstallOwner(
+  root: string,
+  accessImpl: (p: string) => void = (p) => fs.accessSync(p, fs.constants.W_OK),
+): string | null {
+  if (/^\/nix\/store\//.test(root.replace(/\\/g, "/"))) return "nix";
+  try {
+    accessImpl(root);
+  } catch {
+    return "your package manager";
+  }
+  return null;
 }
 
 async function gitUpdate(root: string, force: boolean): Promise<boolean> {
@@ -55,14 +54,14 @@ async function gitUpdate(root: string, force: boolean): Promise<boolean> {
     console.log("Pull skipped; rebuilding the current checkout (--force).");
   }
   console.log("Installing dependencies…");
-  if ((await run(NPM, ["install"], root)) !== 0) return false;
+  if ((await run(NPM, ["install"], root, IS_WIN)) !== 0) return false;
   console.log("Building…");
-  return (await run(NPM, ["run", "build"], root)) === 0;
+  return (await run(NPM, ["run", "build"], root, IS_WIN)) === 0;
 }
 
-async function npmGlobalUpdate(): Promise<boolean> {
+async function npmGlobalUpdate(name: string): Promise<boolean> {
   console.log("Installing the latest release (npm -g)…");
-  return (await run(NPM, ["install", "-g", "torlnk@latest"], process.cwd())) === 0;
+  return (await run(NPM, ["install", "-g", `${name}@latest`], process.cwd(), IS_WIN)) === 0;
 }
 
 async function restartDaemons(): Promise<void> {
@@ -73,19 +72,43 @@ async function restartDaemons(): Promise<void> {
   }
   for (const d of running) {
     process.stdout.write(`Restarting ${d.name} daemon (pid ${d.pid})… `);
-    const pid = await restartDaemon(d);
-    console.log(pid ? `now pid ${pid}.` : "it had already stopped.");
+    const res = await restartDaemon(d);
+    console.log(
+      res.stillRunning
+        ? "still shutting down; skipped (stop it, then rerun torlnk update --force)."
+        : res.newPid
+          ? `now pid ${res.newPid}.`
+          : "it had already stopped.",
+    );
   }
 }
 
 export async function runUpdate(opts: { force?: boolean } = {}): Promise<void> {
   console.log(`torlink v${VERSION}`);
 
-  const latest = await fetchLatestVersion();
+  const manifest = readManifest();
+  if (!manifest) {
+    console.error("Couldn't locate the package manifest; nothing was updated.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const latest = await fetchLatestVersion({ packageName: manifest.name });
   if (!opts.force && latest && !isNewer(VERSION, latest)) {
     console.log(`Already on the latest release (v${latest}). Use --force to rebuild and restart anyway.`);
     return;
   }
+
+  const root = manifest.root;
+  const isGitCheckout = fs.existsSync(path.join(root, ".git"));
+  if (!isGitCheckout) {
+    const owner = managedInstallOwner(root);
+    if (owner) {
+      console.log(`This install is managed by ${owner}; update it there.`);
+      return;
+    }
+  }
+
   console.log(
     opts.force
       ? "Forcing a reinstall and restart…"
@@ -94,9 +117,7 @@ export async function runUpdate(opts: { force?: boolean } = {}): Promise<void> {
         : "Couldn't reach the registry; updating from source anyway…",
   );
 
-  const root = packageRoot();
-  const isGitCheckout = fs.existsSync(path.join(root, ".git"));
-  const ok = isGitCheckout ? await gitUpdate(root, opts.force ?? false) : await npmGlobalUpdate();
+  const ok = isGitCheckout ? await gitUpdate(root, opts.force ?? false) : await npmGlobalUpdate(manifest.name);
 
   if (!ok) {
     console.error("Update failed; nothing was restarted.");

--- a/src/update/run.ts
+++ b/src/update/run.ts
@@ -1,0 +1,109 @@
+// `torlnk update`: fetch the latest release, apply it, and bring any --daemon
+// process back on the new code. Two install shapes are handled: a git checkout
+// (pull, install, build) and a global npm install (npm i -g), chosen by whether
+// the package root is a git working tree.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { VERSION } from "../version";
+import { fetchLatestVersion, isNewer } from "./version";
+import { isAlive, listRunDescriptors, restartDaemon } from "../daemon/restart";
+
+// npm is a shell script on Windows (npm.cmd), and spawning a .cmd there needs a
+// shell; git is a real binary everywhere.
+const IS_WIN = process.platform === "win32";
+const NPM = IS_WIN ? "npm.cmd" : "npm";
+
+// Walk up from this module to the torlnk package root. Robust across the bundled
+// dist (dist/index.js -> ..), the tsx dev tree (src/update -> ../..), and a
+// global install, instead of hard-coding a depth that only one of them matches.
+function packageRoot(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 6; i++) {
+    const pkg = path.join(dir, "package.json");
+    try {
+      if ((JSON.parse(fs.readFileSync(pkg, "utf8")) as { name?: string }).name === "torlnk") {
+        return dir;
+      }
+    } catch {
+      // no package.json here, or not ours, so keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function run(cmd: string, args: string[], cwd: string): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: "inherit", shell: IS_WIN });
+    child.on("error", () => resolve(-1)); // e.g. command not found
+    child.on("exit", (code) => resolve(code ?? -1));
+  });
+}
+
+async function gitUpdate(root: string, force: boolean): Promise<boolean> {
+  console.log("Pulling latest (git)…");
+  if ((await run("git", ["-C", root, "pull", "--ff-only"], root)) !== 0) {
+    // No upstream, a diverged branch, or a dirty tree. A plain update can't get
+    // latest, so it stops; --force means "rebuild and restart what's here", so
+    // it presses on with the current checkout.
+    if (!force) return false;
+    console.log("Pull skipped; rebuilding the current checkout (--force).");
+  }
+  console.log("Installing dependencies…");
+  if ((await run(NPM, ["install"], root)) !== 0) return false;
+  console.log("Building…");
+  return (await run(NPM, ["run", "build"], root)) === 0;
+}
+
+async function npmGlobalUpdate(): Promise<boolean> {
+  console.log("Installing the latest release (npm -g)…");
+  return (await run(NPM, ["install", "-g", "torlnk@latest"], process.cwd())) === 0;
+}
+
+async function restartDaemons(): Promise<void> {
+  const running = listRunDescriptors().filter((d) => isAlive(d.pid));
+  if (running.length === 0) {
+    console.log("No running daemon to restart.");
+    return;
+  }
+  for (const d of running) {
+    process.stdout.write(`Restarting ${d.name} daemon (pid ${d.pid})… `);
+    const pid = await restartDaemon(d);
+    console.log(pid ? `now pid ${pid}.` : "it had already stopped.");
+  }
+}
+
+export async function runUpdate(opts: { force?: boolean } = {}): Promise<void> {
+  console.log(`torlink v${VERSION}`);
+
+  const latest = await fetchLatestVersion();
+  if (!opts.force && latest && !isNewer(VERSION, latest)) {
+    console.log(`Already on the latest release (v${latest}). Use --force to rebuild and restart anyway.`);
+    return;
+  }
+  console.log(
+    opts.force
+      ? "Forcing a reinstall and restart…"
+      : latest
+        ? `Updating to v${latest}…`
+        : "Couldn't reach the registry; updating from source anyway…",
+  );
+
+  const root = packageRoot();
+  const isGitCheckout = fs.existsSync(path.join(root, ".git"));
+  const ok = isGitCheckout ? await gitUpdate(root, opts.force ?? false) : await npmGlobalUpdate();
+
+  if (!ok) {
+    console.error("Update failed; nothing was restarted.");
+    process.exitCode = 1;
+    return;
+  }
+
+  await restartDaemons();
+  console.log("Update complete.");
+}

--- a/src/update/version.test.ts
+++ b/src/update/version.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { compareVersions, isNewer, fetchLatestVersion } from "./version";
+
+describe("compareVersions", () => {
+  it("orders by major, minor, then patch", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.2.0", "1.1.9")).toBeGreaterThan(0);
+    expect(compareVersions("1.4.1", "1.4.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.4.1", "1.4.1")).toBe(0);
+  });
+  it("tolerates a leading v and uneven lengths", () => {
+    expect(compareVersions("v1.4", "1.4.0")).toBe(0);
+    expect(compareVersions("1.4.1", "1.4")).toBeGreaterThan(0);
+  });
+  it("ignores pre-release and build suffixes", () => {
+    expect(compareVersions("1.4.1-rc.2", "1.4.1")).toBe(0);
+    expect(compareVersions("1.5.0+build9", "1.4.9")).toBeGreaterThan(0);
+  });
+});
+
+describe("isNewer", () => {
+  it("is true only when the candidate is ahead of current", () => {
+    expect(isNewer("1.4.0", "1.4.1")).toBe(true);
+    expect(isNewer("1.4.1", "1.4.1")).toBe(false);
+    expect(isNewer("1.4.1", "1.4.0")).toBe(false);
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  const okResponse = (version: unknown): Response =>
+    ({ ok: true, json: async () => ({ version }) }) as unknown as Response;
+
+  it("returns the version string from the registry", async () => {
+    const v = await fetchLatestVersion({ fetchImpl: async () => okResponse("1.5.0") });
+    expect(v).toBe("1.5.0");
+  });
+  it("returns null on a non-ok response", async () => {
+    const v = await fetchLatestVersion({
+      fetchImpl: async () => ({ ok: false, status: 404 }) as unknown as Response,
+    });
+    expect(v).toBeNull();
+  });
+  it("returns null when the network throws", async () => {
+    const v = await fetchLatestVersion({
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+    });
+    expect(v).toBeNull();
+  });
+  it("returns null when the payload has no version", async () => {
+    const v = await fetchLatestVersion({ fetchImpl: async () => okResponse(undefined) });
+    expect(v).toBeNull();
+  });
+});

--- a/src/update/version.test.ts
+++ b/src/update/version.test.ts
@@ -34,6 +34,27 @@ describe("fetchLatestVersion", () => {
     const v = await fetchLatestVersion({ fetchImpl: async () => okResponse("1.5.0") });
     expect(v).toBe("1.5.0");
   });
+  it("builds the registry URL from the manifest name, not a hardcoded slug", async () => {
+    const urls: string[] = [];
+    await fetchLatestVersion({
+      packageName: "@scope/other-pkg",
+      fetchImpl: async (url) => {
+        urls.push(url);
+        return okResponse("9.9.9");
+      },
+    });
+    expect(urls).toEqual(["https://registry.npmjs.org/%40scope%2Fother-pkg/latest"]);
+  });
+  it("defaults the package name to this repo's own manifest", async () => {
+    const urls: string[] = [];
+    await fetchLatestVersion({
+      fetchImpl: async (url) => {
+        urls.push(url);
+        return okResponse("9.9.9");
+      },
+    });
+    expect(urls).toEqual(["https://registry.npmjs.org/torlnk/latest"]);
+  });
   it("returns null on a non-ok response", async () => {
     const v = await fetchLatestVersion({
       fetchImpl: async () => ({ ok: false, status: 404 }) as unknown as Response,

--- a/src/update/version.ts
+++ b/src/update/version.ts
@@ -1,0 +1,55 @@
+import { fetchResilient, USER_AGENT, type FetchImpl } from "../util/net";
+
+// Compare two dotted versions numerically. Pre-release / build suffixes (-rc.1,
+// +build) are dropped before comparing; torlink ships plain x.y.z releases, and
+// a half-parsed suffix is worse than ignoring it. Returns <0, 0, >0 like a
+// sort comparator (a older, equal, a newer).
+export function compareVersions(a: string, b: string): number {
+  const parts = (v: string): number[] =>
+    v
+      .trim()
+      .replace(/^v/i, "")
+      .split(/[-+]/, 1)[0]!
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const pa = parts(a);
+  const pb = parts(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export function isNewer(current: string, candidate: string): boolean {
+  return compareVersions(candidate, current) > 0;
+}
+
+const REGISTRY_URL = "https://registry.npmjs.org/torlnk/latest";
+
+// Ask the npm registry for the published version. Works no matter how torlink was
+// installed (npm, nix, a git checkout), since they all track the same release.
+// Never throws: the caller is either a background banner or a one-shot command,
+// and neither should care that the network was down.
+export async function fetchLatestVersion(opts: {
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+} = {}): Promise<string | null> {
+  const { fetchImpl, timeoutMs = 4000 } = opts;
+  try {
+    const res = await fetchResilient(REGISTRY_URL, {
+      // One shot: this feeds a background banner and a re-runnable command, so a
+      // flaky moment should fail soft, not sit through a backoff.
+      retries: 0,
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      fetchImpl,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/update/version.ts
+++ b/src/update/version.ts
@@ -1,4 +1,5 @@
 import { fetchResilient, USER_AGENT, type FetchImpl } from "../util/net";
+import { readManifest } from "./manifest";
 
 // Compare two dotted versions numerically. Pre-release / build suffixes (-rc.1,
 // +build) are dropped before comparing; torlink ships plain x.y.z releases, and
@@ -26,19 +27,22 @@ export function isNewer(current: string, candidate: string): boolean {
   return compareVersions(candidate, current) > 0;
 }
 
-const REGISTRY_URL = "https://registry.npmjs.org/torlnk/latest";
-
-// Ask the npm registry for the published version. Works no matter how torlink was
-// installed (npm, nix, a git checkout), since they all track the same release.
-// Never throws: the caller is either a background banner or a one-shot command,
-// and neither should care that the network was down.
+// Ask the npm registry for the published version of whatever package this code
+// ships in: the name comes from the manifest, never a hardcoded slug, so the
+// comparison always runs against the real npm package. Works no matter how
+// torlink was installed (npm, nix, a git checkout), since they all track the
+// same release. Never throws: the caller is either a background banner or a
+// one-shot command, and neither should care that the network was down.
 export async function fetchLatestVersion(opts: {
   fetchImpl?: FetchImpl;
   timeoutMs?: number;
+  packageName?: string;
 } = {}): Promise<string | null> {
   const { fetchImpl, timeoutMs = 4000 } = opts;
+  const name = opts.packageName ?? readManifest()?.name;
+  if (!name) return null;
   try {
-    const res = await fetchResilient(REGISTRY_URL, {
+    const res = await fetchResilient(`https://registry.npmjs.org/${encodeURIComponent(name)}/latest`, {
       // One shot: this feeds a background banner and a re-runnable command, so a
       // flaky moment should fail soft, not sit through a backoff.
       retries: 0,


### PR DESCRIPTION
## What and why

Catches the fork up to upstream `baairon/torlink` (through #105), replacing the
un-resolvable PR #30 (whose head was upstream's own `main`). The merge conflicts
were resolved to keep **both** the fork's features and upstream's new work.

### Conflict resolutions
- **download `types`/`queue`**: unioned the fork's `selecting` state with upstream's
  `queued` concurrency-cap state. Real-Debrid pause/resume/retry short-circuit;
  P2P respects `TORLINK_MAX_DOWNLOADS`, and freeing an RD slot promotes the queue.
- **Downloads / Results / keymap**: adopted upstream's `f` = filter (folder-download
  moved to `shift+D`) and the `shift+c` clear-all fold, layered over the fork's
  Real-Debrid, streaming, saved-search, alive-only and category features.
- **TextField**: kept the fork's history recall; adopted upstream's `tab` → exit.
- **App / Splash**: kept the fork's `RdBadge` + store fields; added upstream's
  update-available banner and overflow-safe header layout.
- **keymap.test**: combined both test suites; dropped the fork-deleted `helpLayout` test.
- **testHarness**: added the fork's `Store` fields so the upstream harness type-checks.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (499 tests)
- [x] `npm run lint` is clean