### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release bump to **1.5.1**, cutting a release off the upstream sync (#31) that
brought the fork up to `baairon/torlink` v1.4.3 plus the fork's own features.

Once merged, tag `v1.5.1` on main to trigger `release.yml` (cross-platform
bundles + GitHub Release).

## Checklist
- [x] `npm run typecheck` clean
- [x] `npm test` passes
- [x] `npm run lint` clean