### PR TITLE
chore: publish to npm as 'torlnk-rd' + release 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,14 @@ jobs:
             artifacts/torlnk-*
             artifacts/SHA256SUMS
 
-  # Publish the package to npm on the same tag, so `npm i -g torlink@latest`
+  # Publish the package to npm on the same tag, so `npm i -g torlnk-rd@latest`
   # (and the in-app update check for npm-global installs) tracks releases too.
   # Uses npm Trusted Publishing (OIDC) — no stored token — and gets signed
   # build provenance automatically. Runs after the cross-platform bundles build
   # so a broken release never reaches npm.
   #
   # One-time setup on npmjs.com (package must already exist — see the PR notes
-  # for the first-publish bootstrap): torlink → Settings → Trusted Publisher →
+  # for the first-publish bootstrap): torlnk-rd → Settings → Trusted Publisher →
   # GitHub Actions, org "WarlaxZ", repo "torlink", workflow "release.yml".
   publish-npm:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,19 @@ jobs:
 
   # Publish the package to npm on the same tag, so `npm i -g torlink@latest`
   # (and the in-app update check for npm-global installs) tracks releases too.
-  # Requires an NPM_TOKEN repo secret (an npm automation token). Runs after the
-  # cross-platform bundles build so a broken release never reaches npm.
+  # Uses npm Trusted Publishing (OIDC) — no stored token — and gets signed
+  # build provenance automatically. Runs after the cross-platform bundles build
+  # so a broken release never reaches npm.
+  #
+  # One-time setup on npmjs.com (package must already exist — see the PR notes
+  # for the first-publish bootstrap): torlink → Settings → Trusted Publisher →
+  # GitHub Actions, org "WarlaxZ", repo "torlink", workflow "release.yml".
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token npm exchanges for publish rights
     steps:
       - uses: actions/checkout@v7
         with:
@@ -100,8 +108,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
+      # Trusted publishing needs npm >= 11.5.1; Node 22's bundled npm is older.
+      - run: npm install -g npm@latest
       - run: npm ci
-      # `prepublishOnly` builds dist/; publishConfig sets public access.
+      # `prepublishOnly` builds dist/; publishConfig sets public access; OIDC
+      # supplies auth and provenance — no NODE_AUTH_TOKEN needed.
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,25 @@ jobs:
           files: |
             artifacts/torlnk-*
             artifacts/SHA256SUMS
+
+  # Publish the package to npm on the same tag, so `npm i -g torlink@latest`
+  # (and the in-app update check for npm-global installs) tracks releases too.
+  # Requires an NPM_TOKEN repo secret (an npm automation token). Runs after the
+  # cross-platform bundles build so a broken release never reaches npm.
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      # `prepublishOnly` builds dist/; publishConfig sets public access.
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Download a standalone executable from [Releases](https://github.com/WarlaxZ/torl
 curl -fsSL https://raw.githubusercontent.com/WarlaxZ/torlink/main/scripts/install.sh | sh
 ```
 
+Or, with [Node 22+](https://nodejs.org), install it from npm and run the `torlnk` command anywhere:
+
+```sh
+npm install -g torlink
+torlnk
+```
+
 You can still build from source with [Node 22+](https://nodejs.org):
 
 1. **Clone this repo** and open the folder.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/WarlaxZ/torlink/main/scripts/instal
 Or, with [Node 22+](https://nodejs.org), install it from npm and run the `torlnk` command anywhere:
 
 ```sh
-npm install -g torlink
+npm install -g torlnk-rd
 torlnk
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,20 @@ Download a standalone executable from [Releases](https://github.com/WarlaxZ/torl
 curl -fsSL https://raw.githubusercontent.com/WarlaxZ/torlink/main/scripts/install.sh | sh
 ```
 
-Or, with [Node 22+](https://nodejs.org), install it from npm and run the `torlnk` command anywhere:
+Or, with [Node 22+](https://nodejs.org), install it from npm — the command is `torlnk`:
 
 ```sh
 npm install -g torlnk-rd
 torlnk
 ```
+
+Or run it once, without installing anything:
+
+```sh
+npx torlnk-rd
+```
+
+Globally-installed copies keep themselves current: `torlnk update` pulls the latest release (and `torlnk` quietly points it out when one is available).
 
 You can still build from source with [Node 22+](https://nodejs.org):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "torlnk",
-  "version": "1.5.1",
+  "name": "torlnk-rd",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "torlnk",
-      "version": "1.5.1",
+      "name": "torlnk-rd",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "torlink",
+  "name": "torlnk-rd",
   "version": "1.5.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {
-    "torlnk": "./dist/cli.cjs"
+    "torlnk": "dist/cli.cjs"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk-rd",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "torlnk",
+  "name": "torlink",
   "version": "1.5.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
@@ -47,7 +47,10 @@
     "zero-setup",
     "fitgirl"
   ],
-  "author": "bairon",
+  "author": "WarlaxZ",
+  "contributors": [
+    "bairon <hi@bairon.dev> (original author of torlnk)"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/update/manifest.test.ts
+++ b/src/update/manifest.test.ts
@@ -41,7 +41,7 @@ describe("readManifest", () => {
 
   it("resolves this repo's own manifest from the source tree", () => {
     const m = readManifest();
-    expect(m?.name).toBe("torlnk");
+    expect(m?.name).toBe("torlink");
     expect(m?.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });

--- a/src/update/manifest.test.ts
+++ b/src/update/manifest.test.ts
@@ -41,7 +41,7 @@ describe("readManifest", () => {
 
   it("resolves this repo's own manifest from the source tree", () => {
     const m = readManifest();
-    expect(m?.name).toBe("torlink");
+    expect(m?.name).toBe("torlnk-rd");
     expect(m?.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });


### PR DESCRIPTION
## What and why

Makes the fork installable from npm. `torlnk` on npm is upstream's (`baairon`) package, and npm's similarity filter rejects the unscoped `torlink` (too close to `comlink`), so the fork publishes as **`torlnk-rd`** — unscoped, matches the `torlnk` command, and calls out the Real-Debrid support.

## Changes

- **`package.json`**: `name` → `torlnk-rd`; `author` → `WarlaxZ` with `bairon` kept as a contributor; **bin fixed** to `dist/cli.cjs` (npm 11 strips a leading `./`, which would ship no CLI command). The `torlnk` **command is unchanged** — users `npm i -g torlnk-rd` and run `torlnk`.
- **`release.yml`**: `publish-npm` job publishing on each `v*` tag via **npm Trusted Publishing (OIDC)** — no stored token, automatic signed provenance (`id-token: write`, npm ≥ 11.5.1). Runs after the bundle build.
- **README**: documents `npm install -g torlnk-rd`.
- **`manifest.test.ts`**: name assertion → `torlnk-rd`. The in-app npm-global update path follows automatically (reads the name from the manifest → `npm i -g torlnk-rd@latest`).

## One-time setup

1. **Bootstrap** (creates the package + reserves the name): `npm publish --otp=<code>` from this branch / merged `main`. (Only time a CLI login/OTP is needed.)
2. **Trusted Publishing**: npmjs.com → `torlnk-rd` → Settings → Trusted Publisher → GitHub Actions: org `WarlaxZ`, repo `torlink`, workflow `release.yml`, action `npm publish`.
3. From then on, tags auto-publish tokenlessly.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 521/521 pass
- [x] `npm publish --dry-run` → `torlnk-rd-1.5.1.tgz`, no warnings, bin retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)