### PR TITLE
feat: reccd recommendations integration (activity events + For You UI)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-recommendation-engine-phase1.md
+++ b/docs/superpowers/plans/2026-07-09-recommendation-engine-phase1.md
@@ -1,0 +1,2339 @@
+# Recommendation Engine (reccd) — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a standalone `reccd` service that ingests torlink activity events, canonicalizes them against a local IMDb-backed catalog, and returns content-based recommendations (genre overlap + recency + quality priors) via a small HTTP API — plus the minimal torlink changes to feed it and surface like/dislike.
+
+**Architecture:** `reccd` is a new Node/TypeScript repo (`~/projects/reccd`) using `better-sqlite3` for two local databases (`catalog.db`, `activity.db`) and `fastify` for the HTTP API. torlink gains a fire-and-forget HTTP client and a handful of call sites (stream start, stream end/favourite/abandon, like/dislike keypress). No embeddings, no CF, no TMDB in this phase — those are Phase 2/3 per the spec.
+
+**Tech Stack:** TypeScript, Node ≥22, `better-sqlite3`, `fastify`, `parse-torrent-title`, `undici` (torlink client side), `vitest`.
+
+**Reference:** `docs/superpowers/specs/2026-07-09-recommendation-engine-design.md`
+
+---
+
+## Part A — `reccd` service (new repo)
+
+### Task 1: Scaffold the reccd project
+
+**Files:**
+- Create: `~/projects/reccd/package.json`
+- Create: `~/projects/reccd/tsconfig.json`
+- Create: `~/projects/reccd/vitest.config.ts`
+- Create: `~/projects/reccd/.gitignore`
+- Create: `~/projects/reccd/src/config.ts`
+- Test: `~/projects/reccd/src/config.test.ts`
+
+- [ ] **Step 1: Create the directory and initialize git**
+
+```bash
+mkdir -p ~/projects/reccd/src
+cd ~/projects/reccd
+git init
+```
+
+- [ ] **Step 2: Write `package.json`**
+
+```json
+{
+  "name": "reccd",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run",
+    "import:imdb": "tsx src/catalog/importImdb.ts"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.11.1",
+    "fastify": "^5.10.0",
+    "parse-torrent-title": "^3.0.1",
+    "undici": "^8.6.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+- [ ] **Step 3: Write `tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 4: Write `vitest.config.ts`**
+
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});
+```
+
+- [ ] **Step 5: Write `.gitignore`**
+
+```
+node_modules/
+dist/
+data/
+*.db
+```
+
+- [ ] **Step 6: Write the failing test for config**
+
+```typescript
+// src/config.test.ts
+import { describe, it, expect } from "vitest";
+import { loadConfig } from "./config.js";
+
+describe("loadConfig", () => {
+  it("reads port, token, and db paths from env", () => {
+    const cfg = loadConfig({
+      RECCD_PORT: "4100",
+      RECCD_TOKEN: "secret123",
+      RECCD_DATA_DIR: "/tmp/reccd-test",
+    });
+    expect(cfg.port).toBe(4100);
+    expect(cfg.token).toBe("secret123");
+    expect(cfg.catalogDbPath).toBe("/tmp/reccd-test/catalog.db");
+    expect(cfg.activityDbPath).toBe("/tmp/reccd-test/activity.db");
+  });
+
+  it("defaults port to 4100 and data dir to ./data when unset", () => {
+    const cfg = loadConfig({});
+    expect(cfg.port).toBe(4100);
+    expect(cfg.catalogDbPath).toBe("data/catalog.db");
+  });
+
+  it("throws if RECCD_TOKEN is missing", () => {
+    expect(() => loadConfig({})).toThrow(/RECCD_TOKEN/);
+  });
+});
+```
+
+- [ ] **Step 7: Install deps and run test to verify it fails**
+
+```bash
+npm install
+npm test
+```
+Expected: FAIL with "Cannot find module './config.js'" or similar.
+
+- [ ] **Step 8: Implement `src/config.ts`**
+
+```typescript
+import path from "node:path";
+
+export interface ReccdConfig {
+  port: number;
+  token: string;
+  dataDir: string;
+  catalogDbPath: string;
+  activityDbPath: string;
+  minVotesForEnrichment: number;
+}
+
+export function loadConfig(env: Record<string, string | undefined>): ReccdConfig {
+  const token = env.RECCD_TOKEN;
+  if (!token) {
+    throw new Error("RECCD_TOKEN environment variable is required");
+  }
+  const dataDir = env.RECCD_DATA_DIR ?? "data";
+  return {
+    port: env.RECCD_PORT ? Number(env.RECCD_PORT) : 4100,
+    token,
+    dataDir,
+    catalogDbPath: path.join(dataDir, "catalog.db"),
+    activityDbPath: path.join(dataDir, "activity.db"),
+    minVotesForEnrichment: env.RECCD_MIN_VOTES ? Number(env.RECCD_MIN_VOTES) : 1000,
+  };
+}
+```
+
+Note: test 2 asserts `RECCD_TOKEN` throws when missing, but test 1/2 both call `loadConfig({})` — reorder so the throw test doesn't get shadowed. Fix the test file: move the "throws" case to use `{}` and the "defaults" case to pass a token:
+
+```typescript
+// corrected src/config.test.ts (replace previous version)
+import { describe, it, expect } from "vitest";
+import { loadConfig } from "./config.js";
+
+describe("loadConfig", () => {
+  it("reads port, token, and db paths from env", () => {
+    const cfg = loadConfig({
+      RECCD_PORT: "4100",
+      RECCD_TOKEN: "secret123",
+      RECCD_DATA_DIR: "/tmp/reccd-test",
+    });
+    expect(cfg.port).toBe(4100);
+    expect(cfg.token).toBe("secret123");
+    expect(cfg.catalogDbPath).toBe("/tmp/reccd-test/catalog.db");
+    expect(cfg.activityDbPath).toBe("/tmp/reccd-test/activity.db");
+  });
+
+  it("defaults port to 4100 and data dir to ./data when a token is set", () => {
+    const cfg = loadConfig({ RECCD_TOKEN: "x" });
+    expect(cfg.port).toBe(4100);
+    expect(cfg.catalogDbPath).toBe("data/catalog.db");
+  });
+
+  it("throws if RECCD_TOKEN is missing", () => {
+    expect(() => loadConfig({})).toThrow(/RECCD_TOKEN/);
+  });
+});
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+```bash
+npm test
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "chore: scaffold reccd project with config loader"
+```
+
+---
+
+### Task 2: Catalog database schema and open helper
+
+**Files:**
+- Create: `~/projects/reccd/src/db/catalog.ts`
+- Test: `~/projects/reccd/src/db/catalog.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/db/catalog.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle, getTitleByImdbId, findTitlesByYearRange } from "./catalog.js";
+
+const TEST_DB = "/tmp/reccd-catalog-test.db";
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe("catalog db", () => {
+  it("creates the titles table and round-trips a row", () => {
+    const db = openCatalogDb(TEST_DB);
+    upsertTitle(db, {
+      imdbId: "tt0111161",
+      title: "The Shawshank Redemption",
+      year: 1994,
+      type: "movie",
+      genres: ["Drama"],
+      rating: 9.3,
+      votes: 2900000,
+    });
+    const row = getTitleByImdbId(db, "tt0111161");
+    expect(row?.title).toBe("The Shawshank Redemption");
+    expect(row?.genres).toEqual(["Drama"]);
+    db.close();
+  });
+
+  it("finds titles within a year range", () => {
+    const db = openCatalogDb(TEST_DB);
+    upsertTitle(db, { imdbId: "tt1", title: "Old Movie", year: 1980, type: "movie", genres: ["Drama"], rating: 7, votes: 5000 });
+    upsertTitle(db, { imdbId: "tt2", title: "New Movie", year: 2025, type: "movie", genres: ["Drama"], rating: 7, votes: 5000 });
+    const results = findTitlesByYearRange(db, 2020, 2026);
+    expect(results.map((r) => r.imdbId)).toEqual(["tt2"]);
+    db.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- catalog
+```
+Expected: FAIL with "Cannot find module './catalog.js'"
+
+- [ ] **Step 3: Implement `src/db/catalog.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+
+export type TitleType = "movie" | "tv";
+
+export interface CatalogTitle {
+  imdbId: string;
+  title: string;
+  year: number;
+  type: TitleType;
+  genres: string[];
+  rating: number;
+  votes: number;
+}
+
+export function openCatalogDb(path: string): Database.Database {
+  const db = new Database(path);
+  db.pragma("journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS titles (
+      imdb_id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      year INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      genres TEXT NOT NULL,
+      rating REAL NOT NULL,
+      votes INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_titles_year ON titles(year);
+    CREATE INDEX IF NOT EXISTS idx_titles_title_year ON titles(title, year);
+  `);
+  return db;
+}
+
+export function upsertTitle(db: Database.Database, t: CatalogTitle): void {
+  db.prepare(
+    `INSERT INTO titles (imdb_id, title, year, type, genres, rating, votes)
+     VALUES (@imdbId, @title, @year, @type, @genres, @rating, @votes)
+     ON CONFLICT(imdb_id) DO UPDATE SET
+       title = excluded.title, year = excluded.year, type = excluded.type,
+       genres = excluded.genres, rating = excluded.rating, votes = excluded.votes`
+  ).run({ ...t, genres: JSON.stringify(t.genres) });
+}
+
+function rowToTitle(row: any): CatalogTitle {
+  return {
+    imdbId: row.imdb_id,
+    title: row.title,
+    year: row.year,
+    type: row.type,
+    genres: JSON.parse(row.genres),
+    rating: row.rating,
+    votes: row.votes,
+  };
+}
+
+export function getTitleByImdbId(db: Database.Database, imdbId: string): CatalogTitle | undefined {
+  const row = db.prepare(`SELECT * FROM titles WHERE imdb_id = ?`).get(imdbId);
+  return row ? rowToTitle(row) : undefined;
+}
+
+export function findTitlesByYearRange(db: Database.Database, fromYear: number, toYear: number): CatalogTitle[] {
+  const rows = db.prepare(`SELECT * FROM titles WHERE year BETWEEN ? AND ?`).all(fromYear, toYear);
+  return rows.map(rowToTitle);
+}
+
+export function findTitlesByTitleAndYear(db: Database.Database, title: string, year: number, tolerance = 1): CatalogTitle[] {
+  const rows = db
+    .prepare(`SELECT * FROM titles WHERE title = ? COLLATE NOCASE AND year BETWEEN ? AND ?`)
+    .all(title, year - tolerance, year + tolerance);
+  return rows.map(rowToTitle);
+}
+
+export function allTitles(db: Database.Database): CatalogTitle[] {
+  const rows = db.prepare(`SELECT * FROM titles`).all();
+  return rows.map(rowToTitle);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- catalog
+```
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add catalog database schema and helpers"
+```
+
+---
+
+### Task 3: IMDb TSV importer
+
+**Files:**
+- Create: `~/projects/reccd/src/catalog/importImdb.ts`
+- Test: `~/projects/reccd/src/catalog/importImdb.test.ts`
+
+- [ ] **Step 1: Write the failing test using in-memory TSV fixtures (no network)**
+
+```typescript
+// src/catalog/importImdb.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { parseBasicsLine, parseRatingsLine, importFromLines } from "./importImdb.js";
+import { openCatalogDb, getTitleByImdbId } from "../db/catalog.js";
+
+const TEST_DB = "/tmp/reccd-import-test.db";
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe("parseBasicsLine", () => {
+  it("parses a movie row", () => {
+    const line = "tt0111161\tmovie\tThe Shawshank Redemption\tThe Shawshank Redemption\t0\t1994\t\\N\t142\tDrama";
+    const row = parseBasicsLine(line);
+    expect(row).toEqual({ imdbId: "tt0111161", type: "movie", title: "The Shawshank Redemption", year: 1994, genres: ["Drama"] });
+  });
+
+  it("returns null for non movie/tvSeries types", () => {
+    const line = "tt0000001\tshort\tCarmencita\tCarmencita\t0\t1894\t\\N\t1\tDocumentary,Short";
+    expect(parseBasicsLine(line)).toBeNull();
+  });
+
+  it("returns null when year is missing", () => {
+    const line = "tt9999999\tmovie\tUnreleased\tUnreleased\t0\t\\N\t\\N\t\\N\tDrama";
+    expect(parseBasicsLine(line)).toBeNull();
+  });
+
+  it("maps tvSeries to type tv", () => {
+    const line = "tt0903747\ttvSeries\tBreaking Bad\tBreaking Bad\t0\t2008\t2013\t45\tCrime,Drama,Thriller";
+    const row = parseBasicsLine(line);
+    expect(row?.type).toBe("tv");
+  });
+});
+
+describe("parseRatingsLine", () => {
+  it("parses rating and votes", () => {
+    const row = parseRatingsLine("tt0111161\t9.3\t2900000");
+    expect(row).toEqual({ imdbId: "tt0111161", rating: 9.3, votes: 2900000 });
+  });
+});
+
+describe("importFromLines", () => {
+  it("joins basics and ratings into the catalog db", () => {
+    const db = openCatalogDb(TEST_DB);
+    const basicsLines = [
+      "tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres",
+      "tt0111161\tmovie\tThe Shawshank Redemption\tThe Shawshank Redemption\t0\t1994\t\\N\t142\tDrama",
+    ];
+    const ratingsLines = [
+      "tconst\taverageRating\tnumVotes",
+      "tt0111161\t9.3\t2900000",
+    ];
+    importFromLines(db, basicsLines, ratingsLines);
+    const row = getTitleByImdbId(db, "tt0111161");
+    expect(row).toMatchObject({ title: "The Shawshank Redemption", year: 1994, rating: 9.3, votes: 2900000 });
+    db.close();
+  });
+
+  it("skips titles with no matching ratings row", () => {
+    const db = openCatalogDb(TEST_DB);
+    const basicsLines = [
+      "tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres",
+      "tt0000002\tmovie\tNo Ratings\tNo Ratings\t0\t2000\t\\N\t90\tDrama",
+    ];
+    const ratingsLines = ["tconst\taverageRating\tnumVotes"];
+    importFromLines(db, basicsLines, ratingsLines);
+    expect(getTitleByImdbId(db, "tt0000002")).toBeUndefined();
+    db.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- importImdb
+```
+Expected: FAIL with "Cannot find module './importImdb.js'"
+
+- [ ] **Step 3: Implement `src/catalog/importImdb.ts`**
+
+```typescript
+import readline from "node:readline";
+import fs from "node:fs";
+import zlib from "node:zlib";
+import { openCatalogDb, upsertTitle, type TitleType } from "../db/catalog.js";
+
+const IMDB_TYPE_MAP: Record<string, TitleType> = {
+  movie: "movie",
+  tvMovie: "movie",
+  tvSeries: "tv",
+  tvMiniSeries: "tv",
+};
+
+export interface BasicsRow {
+  imdbId: string;
+  type: TitleType;
+  title: string;
+  year: number;
+  genres: string[];
+}
+
+export interface RatingsRow {
+  imdbId: string;
+  rating: number;
+  votes: number;
+}
+
+export function parseBasicsLine(line: string): BasicsRow | null {
+  const cols = line.split("\t");
+  const [imdbId, titleType, primaryTitle, , , startYear, , , genresCol] = cols;
+  const type = IMDB_TYPE_MAP[titleType];
+  if (!type) return null;
+  if (startYear === "\\N" || !startYear) return null;
+  const year = Number(startYear);
+  if (!Number.isFinite(year)) return null;
+  const genres = genresCol && genresCol !== "\\N" ? genresCol.split(",") : [];
+  return { imdbId, type, title: primaryTitle, year, genres };
+}
+
+export function parseRatingsLine(line: string): RatingsRow {
+  const [imdbId, rating, votes] = line.split("\t");
+  return { imdbId, rating: Number(rating), votes: Number(votes) };
+}
+
+export function importFromLines(db: ReturnType<typeof openCatalogDb>, basicsLines: string[], ratingsLines: string[]): void {
+  const ratingsByImdbId = new Map<string, RatingsRow>();
+  for (const line of ratingsLines.slice(1)) {
+    if (!line) continue;
+    const row = parseRatingsLine(line);
+    ratingsByImdbId.set(row.imdbId, row);
+  }
+
+  const insertMany = db.transaction((rows: BasicsRow[]) => {
+    for (const basics of rows) {
+      const ratings = ratingsByImdbId.get(basics.imdbId);
+      if (!ratings) continue;
+      upsertTitle(db, {
+        imdbId: basics.imdbId,
+        title: basics.title,
+        year: basics.year,
+        type: basics.type,
+        genres: basics.genres,
+        rating: ratings.rating,
+        votes: ratings.votes,
+      });
+    }
+  });
+
+  const parsed: BasicsRow[] = [];
+  for (const line of basicsLines.slice(1)) {
+    if (!line) continue;
+    const row = parseBasicsLine(line);
+    if (row) parsed.push(row);
+  }
+  insertMany(parsed);
+}
+
+async function readGzipLines(path: string): Promise<string[]> {
+  const stream = fs.createReadStream(path).pipe(zlib.createGunzip());
+  const rl = readline.createInterface({ input: stream });
+  const lines: string[] = [];
+  for await (const line of rl) lines.push(line);
+  return lines;
+}
+
+export async function importFromFiles(dbPath: string, basicsGzPath: string, ratingsGzPath: string): Promise<void> {
+  const db = openCatalogDb(dbPath);
+  try {
+    const [basicsLines, ratingsLines] = await Promise.all([readGzipLines(basicsGzPath), readGzipLines(ratingsGzPath)]);
+    importFromLines(db, basicsLines, ratingsLines);
+  } finally {
+    db.close();
+  }
+}
+
+async function downloadGz(url: string, destPath: string): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to download ${url}: HTTP ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  await fs.promises.writeFile(destPath, buf);
+}
+
+export async function refreshCatalogFromImdb(dbPath: string, tmpDir = "/tmp"): Promise<void> {
+  const basicsPath = `${tmpDir}/title.basics.tsv.gz`;
+  const ratingsPath = `${tmpDir}/title.ratings.tsv.gz`;
+  await Promise.all([
+    downloadGz("https://datasets.imdbws.com/title.basics.tsv.gz", basicsPath),
+    downloadGz("https://datasets.imdbws.com/title.ratings.tsv.gz", ratingsPath),
+  ]);
+  await importFromFiles(dbPath, basicsPath, ratingsPath);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const dbPath = process.env.RECCD_CATALOG_DB ?? "data/catalog.db";
+  refreshCatalogFromImdb(dbPath)
+    .then(() => console.log("Catalog refreshed"))
+    .catch((err) => {
+      console.error("Catalog refresh failed:", err);
+      process.exit(1);
+    });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- importImdb
+```
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add IMDb TSV importer for the catalog"
+```
+
+---
+
+### Task 4: Activity database (event store)
+
+**Files:**
+- Create: `~/projects/reccd/src/db/activity.ts`
+- Test: `~/projects/reccd/src/db/activity.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/db/activity.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openActivityDb, insertEvent, getUnresolvedEvents, resolveEvent, getResolvedEvents, EVENT_TYPES } from "./activity.js";
+
+const TEST_DB = "/tmp/reccd-activity-test.db";
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe("activity db", () => {
+  it("inserts an event unresolved by default", () => {
+    const db = openActivityDb(TEST_DB);
+    const id = insertEvent(db, { type: "watched", rawName: "The.Matrix.1999.1080p", ts: 1000, source: "torlink" });
+    const unresolved = getUnresolvedEvents(db);
+    expect(unresolved).toHaveLength(1);
+    expect(unresolved[0].id).toBe(id);
+    expect(unresolved[0].resolvedImdbId).toBeNull();
+    db.close();
+  });
+
+  it("resolves an event and it no longer shows as unresolved", () => {
+    const db = openActivityDb(TEST_DB);
+    const id = insertEvent(db, { type: "watched", rawName: "The.Matrix.1999.1080p", ts: 1000, source: "torlink" });
+    resolveEvent(db, id, "tt0133093", 0.95);
+    expect(getUnresolvedEvents(db)).toHaveLength(0);
+    const resolved = getResolvedEvents(db);
+    expect(resolved[0].resolvedImdbId).toBe("tt0133093");
+    expect(resolved[0].confidence).toBe(0.95);
+    db.close();
+  });
+
+  it("rejects an unknown event type", () => {
+    const db = openActivityDb(TEST_DB);
+    expect(() =>
+      // @ts-expect-error intentional invalid type for the test
+      insertEvent(db, { type: "bogus", rawName: "x", ts: 1, source: "torlink" })
+    ).toThrow();
+    db.close();
+  });
+
+  it("exposes the known event type list", () => {
+    expect(EVENT_TYPES).toEqual(["started", "watched", "favourited", "unfavourited", "liked", "disliked", "abandoned"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- activity
+```
+Expected: FAIL with "Cannot find module './activity.js'"
+
+- [ ] **Step 3: Implement `src/db/activity.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+
+export const EVENT_TYPES = [
+  "started",
+  "watched",
+  "favourited",
+  "unfavourited",
+  "liked",
+  "disliked",
+  "abandoned",
+] as const;
+
+export type EventType = (typeof EVENT_TYPES)[number];
+
+export interface NewEvent {
+  type: EventType;
+  rawName: string;
+  ts: number;
+  source: string;
+}
+
+export interface StoredEvent extends NewEvent {
+  id: number;
+  resolvedImdbId: string | null;
+  confidence: number | null;
+}
+
+export function openActivityDb(path: string): Database.Database {
+  const db = new Database(path);
+  db.pragma("journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      raw_name TEXT NOT NULL,
+      ts INTEGER NOT NULL,
+      source TEXT NOT NULL,
+      resolved_imdb_id TEXT,
+      confidence REAL
+    );
+    CREATE INDEX IF NOT EXISTS idx_events_resolved ON events(resolved_imdb_id);
+  `);
+  return db;
+}
+
+function assertValidType(type: string): asserts type is EventType {
+  if (!EVENT_TYPES.includes(type as EventType)) {
+    throw new Error(`Unknown event type: ${type}`);
+  }
+}
+
+export function insertEvent(db: Database.Database, event: NewEvent): number {
+  assertValidType(event.type);
+  const result = db
+    .prepare(`INSERT INTO events (type, raw_name, ts, source) VALUES (@type, @rawName, @ts, @source)`)
+    .run(event);
+  return Number(result.lastInsertRowid);
+}
+
+function rowToEvent(row: any): StoredEvent {
+  return {
+    id: row.id,
+    type: row.type,
+    rawName: row.raw_name,
+    ts: row.ts,
+    source: row.source,
+    resolvedImdbId: row.resolved_imdb_id,
+    confidence: row.confidence,
+  };
+}
+
+export function getUnresolvedEvents(db: Database.Database): StoredEvent[] {
+  const rows = db.prepare(`SELECT * FROM events WHERE resolved_imdb_id IS NULL`).all();
+  return rows.map(rowToEvent);
+}
+
+export function getResolvedEvents(db: Database.Database): StoredEvent[] {
+  const rows = db.prepare(`SELECT * FROM events WHERE resolved_imdb_id IS NOT NULL`).all();
+  return rows.map(rowToEvent);
+}
+
+export function resolveEvent(db: Database.Database, id: number, imdbId: string, confidence: number): void {
+  db.prepare(`UPDATE events SET resolved_imdb_id = ?, confidence = ? WHERE id = ?`).run(imdbId, confidence, id);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- activity
+```
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add activity event store"
+```
+
+---
+
+### Task 5: Release name parsing
+
+**Files:**
+- Create: `~/projects/reccd/src/canonicalize/parseRelease.ts`
+- Test: `~/projects/reccd/src/canonicalize/parseRelease.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/canonicalize/parseRelease.test.ts
+import { describe, it, expect } from "vitest";
+import { parseReleaseName } from "./parseRelease.js";
+
+describe("parseReleaseName", () => {
+  it("extracts title and year from a typical movie release name", () => {
+    const result = parseReleaseName("The.Matrix.1999.1080p.BluRay.x264-GROUP");
+    expect(result).toEqual({ title: "The Matrix", year: 1999 });
+  });
+
+  it("extracts title and year from a TV release name, dropping episode info", () => {
+    const result = parseReleaseName("Breaking.Bad.S01E01.2008.720p.WEB-DL");
+    expect(result?.title).toBe("Breaking Bad");
+    expect(result?.year).toBe(2008);
+  });
+
+  it("returns null title/year gracefully when no year is present", () => {
+    const result = parseReleaseName("Some.Random.Video.mkv");
+    expect(result?.title).toBeTruthy();
+    expect(result?.year).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- parseRelease
+```
+Expected: FAIL with "Cannot find module './parseRelease.js'"
+
+- [ ] **Step 3: Implement `src/canonicalize/parseRelease.ts`**
+
+```typescript
+import parse from "parse-torrent-title";
+
+export interface ParsedRelease {
+  title: string;
+  year: number | null;
+}
+
+export function parseReleaseName(rawName: string): ParsedRelease {
+  const result = parse(rawName) as { title?: string; year?: number };
+  return {
+    title: (result.title ?? rawName).trim(),
+    year: result.year ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- parseRelease
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add release name parser"
+```
+
+---
+
+### Task 6: Canonicalizer (resolve release name to catalog title)
+
+**Files:**
+- Create: `~/projects/reccd/src/canonicalize/resolve.ts`
+- Test: `~/projects/reccd/src/canonicalize/resolve.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/canonicalize/resolve.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle } from "../db/catalog.js";
+import { resolveReleaseName } from "./resolve.js";
+
+const TEST_DB = "/tmp/reccd-resolve-test.db";
+
+afterEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe("resolveReleaseName", () => {
+  it("resolves an exact title+year match with high confidence", () => {
+    const db = openCatalogDb(TEST_DB);
+    upsertTitle(db, { imdbId: "tt0133093", title: "The Matrix", year: 1999, type: "movie", genres: ["Action"], rating: 8.7, votes: 2000000 });
+    const result = resolveReleaseName(db, "The.Matrix.1999.1080p.BluRay.x264-GROUP");
+    expect(result).toEqual({ imdbId: "tt0133093", confidence: 1 });
+    db.close();
+  });
+
+  it("resolves within a 1-year tolerance at reduced confidence", () => {
+    const db = openCatalogDb(TEST_DB);
+    upsertTitle(db, { imdbId: "tt1", title: "Some Movie", year: 2000, type: "movie", genres: ["Drama"], rating: 7, votes: 1000 });
+    const result = resolveReleaseName(db, "Some.Movie.2001.720p.WEB-DL");
+    expect(result).toEqual({ imdbId: "tt1", confidence: 0.7 });
+    db.close();
+  });
+
+  it("returns null when nothing matches", () => {
+    const db = openCatalogDb(TEST_DB);
+    const result = resolveReleaseName(db, "Totally.Unknown.Title.2099.1080p");
+    expect(result).toBeNull();
+    db.close();
+  });
+
+  it("returns null and does not throw when multiple equally-good matches exist", () => {
+    const db = openCatalogDb(TEST_DB);
+    upsertTitle(db, { imdbId: "tt1", title: "Alpha", year: 2000, type: "movie", genres: ["Drama"], rating: 7, votes: 1000 });
+    upsertTitle(db, { imdbId: "tt2", title: "Alpha", year: 2000, type: "tv", genres: ["Drama"], rating: 7, votes: 1000 });
+    const result = resolveReleaseName(db, "Alpha.2000.1080p");
+    expect(result).toBeNull();
+    db.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- resolve
+```
+Expected: FAIL with "Cannot find module './resolve.js'"
+
+- [ ] **Step 3: Implement `src/canonicalize/resolve.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+import { findTitlesByTitleAndYear } from "../db/catalog.js";
+import { parseReleaseName } from "./parseRelease.js";
+
+export interface ResolvedMatch {
+  imdbId: string;
+  confidence: number;
+}
+
+export function resolveReleaseName(db: Database.Database, rawName: string): ResolvedMatch | null {
+  const parsed = parseReleaseName(rawName);
+  if (!parsed.year) return null;
+
+  const exact = findTitlesByTitleAndYear(db, parsed.title, parsed.year, 0);
+  if (exact.length === 1) return { imdbId: exact[0].imdbId, confidence: 1 };
+  if (exact.length > 1) return null;
+
+  const nearby = findTitlesByTitleAndYear(db, parsed.title, parsed.year, 1);
+  if (nearby.length === 1) return { imdbId: nearby[0].imdbId, confidence: 0.7 };
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- resolve
+```
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add release name canonicalizer"
+```
+
+---
+
+### Task 7: Resolver job (drain unresolved events)
+
+**Files:**
+- Create: `~/projects/reccd/src/canonicalize/resolveQueue.ts`
+- Test: `~/projects/reccd/src/canonicalize/resolveQueue.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/canonicalize/resolveQueue.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle } from "../db/catalog.js";
+import { openActivityDb, insertEvent, getResolvedEvents, getUnresolvedEvents } from "../db/activity.js";
+import { drainUnresolvedEvents } from "./resolveQueue.js";
+
+const CATALOG_DB = "/tmp/reccd-rq-catalog-test.db";
+const ACTIVITY_DB = "/tmp/reccd-rq-activity-test.db";
+
+afterEach(() => {
+  for (const p of [CATALOG_DB, ACTIVITY_DB]) if (fs.existsSync(p)) fs.unlinkSync(p);
+});
+
+describe("drainUnresolvedEvents", () => {
+  it("resolves matchable events and leaves unmatchable ones for retry", () => {
+    const catalogDb = openCatalogDb(CATALOG_DB);
+    upsertTitle(catalogDb, { imdbId: "tt0133093", title: "The Matrix", year: 1999, type: "movie", genres: ["Action"], rating: 8.7, votes: 2000000 });
+
+    const activityDb = openActivityDb(ACTIVITY_DB);
+    insertEvent(activityDb, { type: "watched", rawName: "The.Matrix.1999.1080p.BluRay.x264-GROUP", ts: 1, source: "torlink" });
+    insertEvent(activityDb, { type: "watched", rawName: "Totally.Unknown.2099", ts: 2, source: "torlink" });
+
+    const summary = drainUnresolvedEvents(catalogDb, activityDb);
+
+    expect(summary).toEqual({ resolved: 1, stillUnresolved: 1 });
+    expect(getResolvedEvents(activityDb)).toHaveLength(1);
+    expect(getUnresolvedEvents(activityDb)).toHaveLength(1);
+
+    catalogDb.close();
+    activityDb.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- resolveQueue
+```
+Expected: FAIL with "Cannot find module './resolveQueue.js'"
+
+- [ ] **Step 3: Implement `src/canonicalize/resolveQueue.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+import { getUnresolvedEvents, resolveEvent } from "../db/activity.js";
+import { resolveReleaseName } from "./resolve.js";
+
+export interface DrainSummary {
+  resolved: number;
+  stillUnresolved: number;
+}
+
+export function drainUnresolvedEvents(catalogDb: Database.Database, activityDb: Database.Database): DrainSummary {
+  const pending = getUnresolvedEvents(activityDb);
+  let resolved = 0;
+  for (const event of pending) {
+    const match = resolveReleaseName(catalogDb, event.rawName);
+    if (match) {
+      resolveEvent(activityDb, event.id, match.imdbId, match.confidence);
+      resolved += 1;
+    }
+  }
+  return { resolved, stillUnresolved: pending.length - resolved };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- resolveQueue
+```
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add job to drain unresolved events against the catalog"
+```
+
+---
+
+### Task 8: Taste profile builder
+
+**Files:**
+- Create: `~/projects/reccd/src/scoring/tasteProfile.ts`
+- Test: `~/projects/reccd/src/scoring/tasteProfile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/scoring/tasteProfile.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle } from "../db/catalog.js";
+import { openActivityDb, insertEvent, resolveEvent } from "../db/activity.js";
+import { buildTasteProfile } from "./tasteProfile.js";
+
+const CATALOG_DB = "/tmp/reccd-tp-catalog-test.db";
+const ACTIVITY_DB = "/tmp/reccd-tp-activity-test.db";
+
+afterEach(() => {
+  for (const p of [CATALOG_DB, ACTIVITY_DB]) if (fs.existsSync(p)) fs.unlinkSync(p);
+});
+
+describe("buildTasteProfile", () => {
+  it("weights genres positively for favourited/liked/watched and negatively for disliked/abandoned", () => {
+    const catalogDb = openCatalogDb(CATALOG_DB);
+    upsertTitle(catalogDb, { imdbId: "tt1", title: "Heat", year: 1995, type: "movie", genres: ["Crime", "Thriller"], rating: 8.2, votes: 500000 });
+    upsertTitle(catalogDb, { imdbId: "tt2", title: "Ronin", year: 1998, type: "movie", genres: ["Action", "Thriller"], rating: 7.1, votes: 150000 });
+    upsertTitle(catalogDb, { imdbId: "tt3", title: "Fluffy Bunnies", year: 2010, type: "movie", genres: ["Comedy"], rating: 5.0, votes: 2000 });
+
+    const activityDb = openActivityDb(ACTIVITY_DB);
+    const e1 = insertEvent(activityDb, { type: "favourited", rawName: "Heat", ts: 1, source: "torlink" });
+    resolveEvent(activityDb, e1, "tt1", 1);
+    const e2 = insertEvent(activityDb, { type: "watched", rawName: "Ronin", ts: 2, source: "torlink" });
+    resolveEvent(activityDb, e2, "tt2", 1);
+    const e3 = insertEvent(activityDb, { type: "disliked", rawName: "Fluffy Bunnies", ts: 3, source: "torlink" });
+    resolveEvent(activityDb, e3, "tt3", 1);
+
+    const profile = buildTasteProfile(catalogDb, activityDb);
+
+    expect(profile.genreWeights["Thriller"]).toBeGreaterThan(0);
+    expect(profile.genreWeights["Crime"]).toBeGreaterThan(profile.genreWeights["Action"]);
+    expect(profile.genreWeights["Comedy"]).toBeLessThan(0);
+    expect(profile.seenImdbIds.has("tt1")).toBe(true);
+    expect(profile.seenImdbIds.has("tt2")).toBe(true);
+
+    catalogDb.close();
+    activityDb.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- tasteProfile
+```
+Expected: FAIL with "Cannot find module './tasteProfile.js'"
+
+- [ ] **Step 3: Implement `src/scoring/tasteProfile.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+import { getTitleByImdbId } from "../db/catalog.js";
+import { getResolvedEvents, type EventType } from "../db/activity.js";
+
+export interface TasteProfile {
+  genreWeights: Record<string, number>;
+  seenImdbIds: Set<string>;
+}
+
+const EVENT_WEIGHTS: Record<EventType, number> = {
+  favourited: 3,
+  liked: 2,
+  watched: 1,
+  started: 0,
+  unfavourited: -1,
+  abandoned: -1,
+  disliked: -2,
+};
+
+const SEEN_EVENT_TYPES: EventType[] = ["watched", "favourited", "liked", "disliked", "abandoned"];
+
+export function buildTasteProfile(catalogDb: Database.Database, activityDb: Database.Database): TasteProfile {
+  const events = getResolvedEvents(activityDb);
+  const genreWeights: Record<string, number> = {};
+  const seenImdbIds = new Set<string>();
+
+  for (const event of events) {
+    if (!event.resolvedImdbId) continue;
+    if (SEEN_EVENT_TYPES.includes(event.type)) seenImdbIds.add(event.resolvedImdbId);
+
+    const weight = EVENT_WEIGHTS[event.type] * (event.confidence ?? 1);
+    if (weight === 0) continue;
+
+    const title = getTitleByImdbId(catalogDb, event.resolvedImdbId);
+    if (!title) continue;
+
+    for (const genre of title.genres) {
+      genreWeights[genre] = (genreWeights[genre] ?? 0) + weight;
+    }
+  }
+
+  return { genreWeights, seenImdbIds };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- tasteProfile
+```
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: build taste profile from resolved activity events"
+```
+
+---
+
+### Task 9: Scoring (content match + recency + quality)
+
+**Files:**
+- Create: `~/projects/reccd/src/scoring/score.ts`
+- Test: `~/projects/reccd/src/scoring/score.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/scoring/score.test.ts
+import { describe, it, expect } from "vitest";
+import { scoreCandidate } from "./score.js";
+import type { CatalogTitle } from "../db/catalog.js";
+import type { TasteProfile } from "./tasteProfile.js";
+
+const profile: TasteProfile = {
+  genreWeights: { Thriller: 5, Crime: 3, Comedy: -2 },
+  seenImdbIds: new Set(["tt-seen"]),
+};
+
+function title(overrides: Partial<CatalogTitle>): CatalogTitle {
+  return {
+    imdbId: "tt-x",
+    title: "Placeholder",
+    year: 2020,
+    type: "movie",
+    genres: ["Thriller"],
+    rating: 7,
+    votes: 10000,
+    ...overrides,
+  };
+}
+
+describe("scoreCandidate", () => {
+  it("scores higher for genre overlap with the taste profile", () => {
+    const thriller = scoreCandidate(title({ genres: ["Thriller"] }), profile, 2026);
+    const comedy = scoreCandidate(title({ genres: ["Comedy"] }), profile, 2026);
+    expect(thriller.score).toBeGreaterThan(comedy.score);
+  });
+
+  it("gives a recency boost to newer titles over older ones with identical genre/quality", () => {
+    const newer = scoreCandidate(title({ year: 2025, genres: ["Thriller"] }), profile, 2026);
+    const older = scoreCandidate(title({ year: 1990, genres: ["Thriller"] }), profile, 2026);
+    expect(newer.score).toBeGreaterThan(older.score);
+  });
+
+  it("lets a high quality-prior old title still score reasonably (cult-classic gate)", () => {
+    const oldButGreat = scoreCandidate(title({ year: 1975, genres: [], rating: 9.2, votes: 1000000 }), profile, 2026);
+    const newButMediocre = scoreCandidate(title({ year: 2025, genres: [], rating: 4.0, votes: 500 }), profile, 2026);
+    expect(oldButGreat.score).toBeGreaterThan(newButMediocre.score);
+  });
+
+  it("returns null for a title already in seenImdbIds", () => {
+    const result = scoreCandidate(title({ imdbId: "tt-seen" }), profile, 2026);
+    expect(result).toBeNull();
+  });
+
+  it("includes human-readable reasons", () => {
+    const result = scoreCandidate(title({ genres: ["Thriller", "Crime"] }), profile, 2026);
+    expect(result?.reasons.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- score
+```
+Expected: FAIL with "Cannot find module './score.js'"
+
+- [ ] **Step 3: Implement `src/scoring/score.ts`**
+
+```typescript
+import type { CatalogTitle } from "../db/catalog.js";
+import type { TasteProfile } from "./tasteProfile.js";
+
+export interface ScoreWeights {
+  content: number;
+  recency: number;
+  quality: number;
+  recencyHalfLifeYears: number;
+}
+
+export const DEFAULT_WEIGHTS: ScoreWeights = {
+  content: 1.0,
+  recency: 1.0,
+  quality: 0.5,
+  recencyHalfLifeYears: 8,
+};
+
+export interface ScoredCandidate {
+  imdbId: string;
+  score: number;
+  reasons: string[];
+}
+
+function contentMatch(title: CatalogTitle, profile: TasteProfile): number {
+  return title.genres.reduce((sum, genre) => sum + (profile.genreWeights[genre] ?? 0), 0);
+}
+
+function recencyPrior(year: number, currentYear: number, halfLifeYears: number): number {
+  const age = Math.max(0, currentYear - year);
+  return Math.pow(0.5, age / halfLifeYears);
+}
+
+function qualityPrior(rating: number, votes: number): number {
+  return rating * Math.log10(Math.max(votes, 1));
+}
+
+export function scoreCandidate(
+  title: CatalogTitle,
+  profile: TasteProfile,
+  currentYear: number,
+  weights: ScoreWeights = DEFAULT_WEIGHTS
+): ScoredCandidate | null {
+  if (profile.seenImdbIds.has(title.imdbId)) return null;
+
+  const content = contentMatch(title, profile);
+  const recency = recencyPrior(title.year, currentYear, weights.recencyHalfLifeYears);
+  const quality = qualityPrior(title.rating, title.votes);
+
+  const score = weights.content * content + weights.recency * recency * 10 + weights.quality * quality;
+
+  const reasons: string[] = [];
+  const likedGenres = title.genres.filter((g) => (profile.genreWeights[g] ?? 0) > 0);
+  if (likedGenres.length > 0) reasons.push(`matches genres you like: ${likedGenres.join(", ")}`);
+  if (recency > 0.7) reasons.push("recent release");
+  if (title.rating >= 8 && title.votes >= 50000) reasons.push("highly rated classic");
+  if (reasons.length === 0) reasons.push("unseen title in the catalog");
+
+  return { imdbId: title.imdbId, score, reasons };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- score
+```
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add candidate scoring (content match, recency, quality priors)"
+```
+
+---
+
+### Task 10: Recommend (rank candidates with diversity pass)
+
+**Files:**
+- Create: `~/projects/reccd/src/scoring/recommend.ts`
+- Test: `~/projects/reccd/src/scoring/recommend.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/scoring/recommend.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle } from "../db/catalog.js";
+import { openActivityDb } from "../db/activity.js";
+import { recommend } from "./recommend.js";
+
+const CATALOG_DB = "/tmp/reccd-rec-catalog-test.db";
+const ACTIVITY_DB = "/tmp/reccd-rec-activity-test.db";
+
+afterEach(() => {
+  for (const p of [CATALOG_DB, ACTIVITY_DB]) if (fs.existsSync(p)) fs.unlinkSync(p);
+});
+
+describe("recommend", () => {
+  it("returns ranked titles with title/year/reasons, most relevant first", () => {
+    const catalogDb = openCatalogDb(CATALOG_DB);
+    upsertTitle(catalogDb, { imdbId: "tt1", title: "Great Thriller", year: 2025, type: "movie", genres: ["Thriller"], rating: 8, votes: 100000 });
+    upsertTitle(catalogDb, { imdbId: "tt2", title: "Old Comedy", year: 1970, type: "movie", genres: ["Comedy"], rating: 5, votes: 500 });
+    const activityDb = openActivityDb(ACTIVITY_DB);
+
+    const results = recommend(catalogDb, activityDb, { type: "movie", limit: 10, currentYear: 2026 });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].imdbId).toBe("tt1");
+    expect(results[0].title).toBe("Great Thriller");
+    expect(results[0].year).toBe(2025);
+    expect(Array.isArray(results[0].reasons)).toBe(true);
+  });
+
+  it("filters by genre when requested", () => {
+    const catalogDb = openCatalogDb(CATALOG_DB);
+    upsertTitle(catalogDb, { imdbId: "tt1", title: "A Thriller", year: 2025, type: "movie", genres: ["Thriller"], rating: 8, votes: 100000 });
+    upsertTitle(catalogDb, { imdbId: "tt2", title: "A Comedy", year: 2025, type: "movie", genres: ["Comedy"], rating: 8, votes: 100000 });
+    const activityDb = openActivityDb(ACTIVITY_DB);
+
+    const results = recommend(catalogDb, activityDb, { type: "movie", genre: "Comedy", limit: 10, currentYear: 2026 });
+
+    expect(results.every((r) => r.imdbId === "tt2")).toBe(true);
+  });
+
+  it("respects the limit", () => {
+    const catalogDb = openCatalogDb(CATALOG_DB);
+    for (let i = 0; i < 5; i++) {
+      upsertTitle(catalogDb, { imdbId: `tt${i}`, title: `Movie ${i}`, year: 2025, type: "movie", genres: ["Drama"], rating: 7, votes: 10000 });
+    }
+    const activityDb = openActivityDb(ACTIVITY_DB);
+
+    const results = recommend(catalogDb, activityDb, { type: "movie", limit: 3, currentYear: 2026 });
+
+    expect(results).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- recommend
+```
+Expected: FAIL with "Cannot find module './recommend.js'"
+
+- [ ] **Step 3: Implement `src/scoring/recommend.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+import { allTitles, type TitleType } from "../db/catalog.js";
+import { buildTasteProfile } from "./tasteProfile.js";
+import { scoreCandidate } from "./score.js";
+
+export interface RecommendOptions {
+  type?: TitleType;
+  genre?: string;
+  limit: number;
+  currentYear: number;
+}
+
+export interface Recommendation {
+  imdbId: string;
+  title: string;
+  year: number;
+  score: number;
+  reasons: string[];
+}
+
+export function recommend(catalogDb: Database.Database, activityDb: Database.Database, opts: RecommendOptions): Recommendation[] {
+  const profile = buildTasteProfile(catalogDb, activityDb);
+  const candidates = allTitles(catalogDb).filter((t) => {
+    if (opts.type && t.type !== opts.type) return false;
+    if (opts.genre && !t.genres.includes(opts.genre)) return false;
+    return true;
+  });
+
+  const scored: Recommendation[] = [];
+  for (const candidate of candidates) {
+    const result = scoreCandidate(candidate, profile, opts.currentYear);
+    if (!result) continue;
+    scored.push({ imdbId: candidate.imdbId, title: candidate.title, year: candidate.year, score: result.score, reasons: result.reasons });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, opts.limit);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- recommend
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add recommend function ranking scored candidates"
+```
+
+Note: diversity re-ranking (MMR-style spread across genres) is deliberately deferred — with a small personal catalog subset, a straightforward genre filter plus sort is sufficient for Phase 1. Revisit if Phase 1 usage shows homogeneous results.
+
+---
+
+### Task 11: Backfill importer (torlink history + favourites)
+
+**Files:**
+- Create: `~/projects/reccd/src/events/backfill.ts`
+- Test: `~/projects/reccd/src/events/backfill.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/events/backfill.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import { openActivityDb, getUnresolvedEvents } from "../db/activity.js";
+import { backfillFromTorlink } from "./backfill.js";
+
+const ACTIVITY_DB = "/tmp/reccd-backfill-activity-test.db";
+
+afterEach(() => {
+  if (fs.existsSync(ACTIVITY_DB)) fs.unlinkSync(ACTIVITY_DB);
+});
+
+describe("backfillFromTorlink", () => {
+  it("imports history.json completed downloads as watched events", () => {
+    const db = openActivityDb(ACTIVITY_DB);
+    const history = [
+      { id: "abc123", name: "The.Matrix.1999.1080p", completedAt: 1000 },
+      { id: "def456", name: "Some.Show.S01E01.2020.720p", completedAt: 2000 },
+    ];
+    const count = backfillFromTorlink(db, { history, favourites: [] });
+    expect(count).toBe(2);
+    const events = getUnresolvedEvents(db);
+    expect(events.map((e) => e.rawName)).toEqual(["The.Matrix.1999.1080p", "Some.Show.S01E01.2020.720p"]);
+    expect(events.every((e) => e.type === "watched")).toBe(true);
+    db.close();
+  });
+
+  it("imports favourites as favourited events", () => {
+    const db = openActivityDb(ACTIVITY_DB);
+    const favourites = [{ id: "xyz", name: "Heat.1995.1080p", magnet: "magnet:?xt=1", addedAt: 3000 }];
+    backfillFromTorlink(db, { history: [], favourites });
+    const events = getUnresolvedEvents(db);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("favourited");
+    expect(events[0].rawName).toBe("Heat.1995.1080p");
+    db.close();
+  });
+
+  it("is idempotent: re-running does not duplicate events for the same source", () => {
+    const db = openActivityDb(ACTIVITY_DB);
+    const history = [{ id: "abc123", name: "The.Matrix.1999.1080p", completedAt: 1000 }];
+    backfillFromTorlink(db, { history, favourites: [] });
+    backfillFromTorlink(db, { history, favourites: [] });
+    expect(getUnresolvedEvents(db)).toHaveLength(1);
+    db.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- backfill
+```
+Expected: FAIL with "Cannot find module './backfill.js'"
+
+- [ ] **Step 3: Implement `src/events/backfill.ts`**
+
+```typescript
+import Database from "better-sqlite3";
+import { insertEvent } from "../db/activity.js";
+
+export interface TorlinkHistoryItem {
+  id: string;
+  name: string;
+  completedAt: number;
+}
+
+export interface TorlinkFavouriteItem {
+  id: string;
+  name: string;
+  addedAt: number;
+}
+
+export interface TorlinkSnapshot {
+  history: TorlinkHistoryItem[];
+  favourites: TorlinkFavouriteItem[];
+}
+
+const BACKFILL_SOURCE = "torlink-backfill";
+
+export function backfillFromTorlink(db: Database.Database, snapshot: TorlinkSnapshot): number {
+  const alreadyImported = new Set(
+    db
+      .prepare(`SELECT raw_name || ':' || type AS k FROM events WHERE source = ?`)
+      .all(BACKFILL_SOURCE)
+      .map((r: any) => r.k)
+  );
+
+  let count = 0;
+  for (const item of snapshot.history) {
+    const key = `${item.name}:watched`;
+    if (alreadyImported.has(key)) continue;
+    insertEvent(db, { type: "watched", rawName: item.name, ts: item.completedAt, source: BACKFILL_SOURCE });
+    alreadyImported.add(key);
+    count += 1;
+  }
+  for (const item of snapshot.favourites) {
+    const key = `${item.name}:favourited`;
+    if (alreadyImported.has(key)) continue;
+    insertEvent(db, { type: "favourited", rawName: item.name, ts: item.addedAt, source: BACKFILL_SOURCE });
+    alreadyImported.add(key);
+    count += 1;
+  }
+  return count;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- backfill
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add torlink history/favourites backfill importer"
+```
+
+---
+
+### Task 12: HTTP API server
+
+**Files:**
+- Create: `~/projects/reccd/src/api/server.ts`
+- Test: `~/projects/reccd/src/api/server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/api/server.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import { openCatalogDb, upsertTitle } from "../db/catalog.js";
+import { openActivityDb } from "../db/activity.js";
+import { buildServer } from "./server.js";
+
+const CATALOG_DB = "/tmp/reccd-api-catalog-test.db";
+const ACTIVITY_DB = "/tmp/reccd-api-activity-test.db";
+const TOKEN = "test-token";
+
+let app: ReturnType<typeof buildServer>;
+
+beforeEach(() => {
+  const catalogDb = openCatalogDb(CATALOG_DB);
+  upsertTitle(catalogDb, { imdbId: "tt1", title: "Great Thriller", year: 2025, type: "movie", genres: ["Thriller"], rating: 8, votes: 100000 });
+  const activityDb = openActivityDb(ACTIVITY_DB);
+  app = buildServer({ catalogDb, activityDb, token: TOKEN, currentYear: 2026 });
+});
+
+afterEach(() => {
+  app.close();
+  for (const p of [CATALOG_DB, ACTIVITY_DB]) if (fs.existsSync(p)) fs.unlinkSync(p);
+});
+
+describe("API auth", () => {
+  it("rejects requests without a bearer token", async () => {
+    const res = await app.inject({ method: "GET", url: "/recommendations" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects requests with the wrong token", async () => {
+    const res = await app.inject({ method: "GET", url: "/recommendations", headers: { authorization: "Bearer wrong" } });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /recommendations", () => {
+  it("returns ranked recommendations", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/recommendations?type=movie&limit=5",
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body[0].imdbId).toBe("tt1");
+    expect(body[0].title).toBe("Great Thriller");
+  });
+});
+
+describe("POST /events", () => {
+  it("accepts a batch of events and returns 202", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/events",
+      headers: { authorization: `Bearer ${TOKEN}` },
+      payload: { events: [{ type: "watched", rawName: "Great.Thriller.2025.1080p", ts: 1000, source: "torlink" }] },
+    });
+    expect(res.statusCode).toBe(202);
+  });
+
+  it("rejects a malformed payload with 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/events",
+      headers: { authorization: `Bearer ${TOKEN}` },
+      payload: { notEvents: true },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("GET /resolve", () => {
+  it("returns the canonicalization result for a name", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/resolve?name=Great.Thriller.2025.1080p",
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ imdbId: "tt1", confidence: 1 });
+  });
+});
+
+describe("GET /profile", () => {
+  it("returns the current taste profile", async () => {
+    const res = await app.inject({ method: "GET", url: "/profile", headers: { authorization: `Bearer ${TOKEN}` } });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty("genreWeights");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- api/server
+```
+Expected: FAIL with "Cannot find module './server.js'"
+
+- [ ] **Step 3: Implement `src/api/server.ts`**
+
+```typescript
+import Fastify from "fastify";
+import type Database from "better-sqlite3";
+import { insertEvent, EVENT_TYPES, type EventType } from "../db/activity.js";
+import { resolveReleaseName } from "../canonicalize/resolve.js";
+import { drainUnresolvedEvents } from "../canonicalize/resolveQueue.js";
+import { buildTasteProfile } from "../scoring/tasteProfile.js";
+import { recommend } from "../scoring/recommend.js";
+import type { TitleType } from "../db/catalog.js";
+
+export interface ServerDeps {
+  catalogDb: Database.Database;
+  activityDb: Database.Database;
+  token: string;
+  currentYear: number;
+}
+
+interface IncomingEvent {
+  type: EventType;
+  rawName: string;
+  ts: number;
+  source: string;
+}
+
+function isIncomingEvent(value: unknown): value is IncomingEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.type === "string" &&
+    (EVENT_TYPES as readonly string[]).includes(v.type) &&
+    typeof v.rawName === "string" &&
+    typeof v.ts === "number" &&
+    typeof v.source === "string"
+  );
+}
+
+export function buildServer(deps: ServerDeps) {
+  const app = Fastify();
+
+  app.addHook("onRequest", async (req, reply) => {
+    const header = req.headers.authorization;
+    const expected = `Bearer ${deps.token}`;
+    if (header !== expected) {
+      reply.code(401).send({ error: "unauthorized" });
+    }
+  });
+
+  app.get("/recommendations", async (req) => {
+    const query = req.query as { type?: string; genre?: string; limit?: string };
+    return recommend(deps.catalogDb, deps.activityDb, {
+      type: query.type as TitleType | undefined,
+      genre: query.genre,
+      limit: query.limit ? Number(query.limit) : 20,
+      currentYear: deps.currentYear,
+    });
+  });
+
+  app.get("/profile", async () => {
+    return buildTasteProfile(deps.catalogDb, deps.activityDb);
+  });
+
+  app.get("/resolve", async (req, reply) => {
+    const query = req.query as { name?: string };
+    if (!query.name) {
+      reply.code(400);
+      return { error: "missing name query param" };
+    }
+    const match = resolveReleaseName(deps.catalogDb, query.name);
+    return match ?? { imdbId: null, confidence: 0 };
+  });
+
+  app.post("/events", async (req, reply) => {
+    const body = req.body as { events?: unknown };
+    if (!Array.isArray(body.events) || body.events.length === 0 || !body.events.every(isIncomingEvent)) {
+      reply.code(400);
+      return { error: "invalid events payload" };
+    }
+    for (const event of body.events as IncomingEvent[]) {
+      insertEvent(deps.activityDb, event);
+    }
+    drainUnresolvedEvents(deps.catalogDb, deps.activityDb);
+    reply.code(202);
+    return { accepted: body.events.length };
+  });
+
+  return app;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- api/server
+```
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add HTTP API server with bearer auth"
+```
+
+---
+
+### Task 13: Entrypoint wiring
+
+**Files:**
+- Create: `~/projects/reccd/src/index.ts`
+
+- [ ] **Step 1: Implement `src/index.ts`**
+
+```typescript
+import { loadConfig } from "./config.js";
+import { openCatalogDb } from "./db/catalog.js";
+import { openActivityDb } from "./db/activity.js";
+import { buildServer } from "./api/server.js";
+
+const config = loadConfig(process.env);
+const catalogDb = openCatalogDb(config.catalogDbPath);
+const activityDb = openActivityDb(config.activityDbPath);
+
+const app = buildServer({
+  catalogDb,
+  activityDb,
+  token: config.token,
+  currentYear: new Date().getFullYear(),
+});
+
+app.listen({ port: config.port, host: "0.0.0.0" }, (err, address) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log(`reccd listening on ${address}`);
+});
+```
+
+- [ ] **Step 2: Verify it starts locally**
+
+```bash
+RECCD_TOKEN=dev-token npm run dev
+```
+Expected: console prints `reccd listening on http://0.0.0.0:4100` and the process stays up (Ctrl+C to stop).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat: wire up reccd entrypoint"
+```
+
+---
+
+## Part B — torlink integration
+
+### Task 14: torlink config fields for reccd
+
+**Files:**
+- Modify: `src/config/config.ts:20-62` (interface), near line 25
+- Test: `src/config/config.test.ts`
+
+- [ ] **Step 1: Read the existing test file to find the right location for a new test**
+
+Look at how `realDebridToken` round-trips through `loadConfig`/`saveConfig` in `src/config/config.test.ts` and add an equivalent test near it:
+
+```typescript
+it("round-trips reccUrl and reccToken", async () => {
+  const cfg = await loadConfig();
+  cfg.reccUrl = "http://localhost:4100";
+  cfg.reccToken = "dev-token";
+  await saveConfig(cfg);
+  const reloaded = await loadConfig();
+  expect(reloaded.reccUrl).toBe("http://localhost:4100");
+  expect(reloaded.reccToken).toBe("dev-token");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- config
+```
+Expected: FAIL with a TypeScript error — `reccUrl`/`reccToken` do not exist on `Config`.
+
+- [ ] **Step 3: Add the fields to the `Config` interface**
+
+In `src/config/config.ts`, alongside the existing `realDebridToken?: string;` declaration (around line 25), add:
+
+```typescript
+  /** Base URL of the reccd recommendation service, e.g. http://localhost:4100 */
+  reccUrl?: string;
+  /** Bearer token for authenticating with reccd */
+  reccToken?: string;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- config
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/config.ts src/config/config.test.ts
+git commit -m "feat: add reccUrl/reccToken config fields"
+```
+
+---
+
+### Task 15: recc event client
+
+**Files:**
+- Create: `src/recc/client.ts`
+- Test: `src/recc/client.test.ts`
+
+- [ ] **Step 1: Write the failing test, following the fetchImpl-injection pattern from `src/integrations/realdebrid.test.ts`**
+
+```typescript
+// src/recc/client.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { postEvent } from "./client.js";
+
+function jsonRes(status: number, body: unknown = {}) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("postEvent", () => {
+  it("posts to {reccUrl}/events with a bearer token and the event payload", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(202, { accepted: 1 }));
+    await postEvent(
+      { reccUrl: "http://localhost:4100", reccToken: "dev-token" },
+      { type: "watched", rawName: "The.Matrix.1999.1080p", ts: 1000, source: "torlink" },
+      { fetchImpl }
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://localhost:4100/events",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ authorization: "Bearer dev-token" }),
+      })
+    );
+  });
+
+  it("does nothing when reccUrl is not configured", async () => {
+    const fetchImpl = vi.fn();
+    await postEvent({}, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("swallows network errors without throwing", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(
+      postEvent({ reccUrl: "http://localhost:4100", reccToken: "t" }, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl })
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows non-2xx responses without throwing", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500));
+    await expect(
+      postEvent({ reccUrl: "http://localhost:4100", reccToken: "t" }, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl })
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- recc/client
+```
+Expected: FAIL with "Cannot find module './client.js'"
+
+- [ ] **Step 3: Implement `src/recc/client.ts`**
+
+```typescript
+export type ReccEventType = "started" | "watched" | "favourited" | "unfavourited" | "liked" | "disliked" | "abandoned";
+
+export interface ReccEvent {
+  type: ReccEventType;
+  rawName: string;
+  ts: number;
+  source: string;
+}
+
+export interface ReccClientConfig {
+  reccUrl?: string;
+  reccToken?: string;
+}
+
+export interface PostEventOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function postEvent(config: ReccClientConfig, event: ReccEvent, opts: PostEventOptions = {}): Promise<void> {
+  if (!config.reccUrl) return;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/events`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${config.reccToken ?? ""}`,
+      },
+      body: JSON.stringify({ events: [event] }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 3000),
+    });
+    if (!res.ok) return;
+  } catch {
+    // Fire-and-forget: reccd being unreachable must never affect torlink.
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- recc/client
+```
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add fire-and-forget reccd event client"
+```
+
+---
+
+### Task 16: Wire event posts into App.tsx
+
+**Files:**
+- Modify: `src/ui/App.tsx` (see line references below)
+- Test: manual verification (see Step 5) — this task is UI wiring in an already-tested client; no new unit tests are added here, matching how other App.tsx call-site wiring is handled in this codebase.
+
+- [ ] **Step 1: Post a `started` event when a torrent stream begins**
+
+In `src/ui/App.tsx`, inside `startTorrentStream(input)` (around lines 653-703), right after `setActiveStream(...)` (line 686), add:
+
+```typescript
+void postEvent(
+  { reccUrl: config.reccUrl, reccToken: config.reccToken },
+  { type: "started", rawName: input.name, ts: Date.now(), source: "torlink" }
+);
+```
+
+Add the import at the top of `App.tsx`:
+
+```typescript
+import { postEvent } from "../recc/client.js";
+```
+
+(Confirm the exact relative path from `src/ui/App.tsx` to `src/recc/client.ts` — it is `../recc/client.js` since both `ui/` and `recc/` are direct children of `src/`.)
+
+- [ ] **Step 2: Post a `watched` event when playback completes**
+
+In `playFromPicker(file)` (around lines 632-641), alongside the existing `markWatchedInFavourite(streamSource.id, file.filename)` call (line 637), add:
+
+```typescript
+void postEvent(
+  { reccUrl: config.reccUrl, reccToken: config.reccToken },
+  { type: "watched", rawName: streamSource.name, ts: Date.now(), source: "torlink" }
+);
+```
+
+Also add the same call in `playStream(url, name)` (lines 598-617) right before/after `launchPlayer` — use the `name` parameter passed into `playStream` as `rawName`, so single-file streams (not just multi-file picker streams) count as watched too.
+
+- [ ] **Step 3: Post `favourited`/`unfavourited` events from the favourite toggle**
+
+In App's `toggleFavourite(item: FavouriteItem)` wrapper (around lines 405-414), after computing whether the item was added or removed (the existing logic already knows this to persist config), add:
+
+```typescript
+void postEvent(
+  { reccUrl: config.reccUrl, reccToken: config.reccToken },
+  { type: wasAdded ? "favourited" : "unfavourited", rawName: item.name, ts: Date.now(), source: "torlink" }
+);
+```
+
+(`wasAdded` should reuse whatever boolean the existing function already derives to decide the toast/notice message — do not add a second favourites-array scan.)
+
+- [ ] **Step 4: Post an `abandoned` event on queue cancel**
+
+In `src/download/queue.ts`, `DownloadQueue.cancel(id)` (around lines 717-731), the function already loads `it = this.items.get(id)` (line 718). Since `queue.ts` doesn't have access to `config` or `postEvent` directly (it's a download-layer module, not UI), instead wire this at the call site in `src/ui/components/Downloads.tsx` line 148:
+
+```typescript
+if (input === "c") {
+  void postEvent(
+    { reccUrl: config.reccUrl, reccToken: config.reccToken },
+    { type: "abandoned", rawName: it.name, ts: Date.now(), source: "torlink" }
+  );
+  queue.cancel(it.id);
+}
+```
+
+This requires `Downloads.tsx` to receive `config` as a prop — check how `App.tsx` already renders `<Downloads .../>` and pass `config={config}` alongside existing props, then add `config: Config` to `DownloadsProps` and import `postEvent` + `Config` type at the top of `Downloads.tsx`.
+
+- [ ] **Step 5: Manual verification**
+
+```bash
+cd /home/ash/projects/torlink/.claude/worktrees/squishy-snuggling-bengio
+RECCD_TOKEN=dev-token npm run dev --prefix ~/projects/reccd &
+npm run dev
+```
+In torlink: set `reccUrl`/`reccToken` in config.json (or add a quick manual edit), start a stream, favourite an item, cancel a download. Confirm via `curl -H "Authorization: Bearer dev-token" http://localhost:4100/profile` that `genreWeights` is non-empty after resolving (may need to run the resolver — events auto-drain on each `/events` POST per Task 12's server wiring).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: post activity events to reccd from stream/favourite/abandon flows"
+```
+
+---
+
+### Task 17: Like/dislike prompt after streaming
+
+**Files:**
+- Create: `src/ui/components/RatePrompt.tsx`
+- Modify: `src/ui/App.tsx` (state + useInput guard + render, see line references)
+- Test: `src/ui/components/RatePrompt.test.tsx`
+
+- [ ] **Step 1: Write the failing test using `ink-testing-library`, following the pattern of any existing component test in `src/ui/components/`**
+
+```typescript
+// src/ui/components/RatePrompt.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import React from "react";
+import { RatePrompt } from "./RatePrompt.js";
+
+describe("RatePrompt", () => {
+  it("calls onLike when 'l' is pressed", () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(<RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />);
+    stdin.write("l");
+    expect(onLike).toHaveBeenCalled();
+  });
+
+  it("calls onDislike when 'd' is pressed", () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(<RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />);
+    stdin.write("d");
+    expect(onDislike).toHaveBeenCalled();
+  });
+
+  it("calls onDismiss on escape", () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(<RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />);
+    stdin.write("");
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- RatePrompt
+```
+Expected: FAIL with "Cannot find module './RatePrompt.js'"
+
+- [ ] **Step 3: Implement `src/ui/components/RatePrompt.tsx`, mirroring `src/ui/components/ConfirmPrompt.tsx`'s structure**
+
+```typescript
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface RatePromptProps {
+  name: string;
+  onLike: () => void;
+  onDislike: () => void;
+  onDismiss: () => void;
+}
+
+export function RatePrompt({ name, onLike, onDislike, onDismiss }: RatePromptProps) {
+  useInput((input, key) => {
+    if (input === "l") onLike();
+    else if (input === "d") onDislike();
+    else if (key.escape) onDismiss();
+  });
+
+  return (
+    <Box borderStyle="round" paddingX={1}>
+      <Text>
+        How was <Text bold>{name}</Text>? (l) like  (d) dislike  (esc) skip
+      </Text>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- RatePrompt
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Wire `RatePrompt` into `App.tsx`**
+
+Add state near the other prompt states (alongside `keepPrompt`, `torrentPrompt` — search for `useState` calls near line 190-192):
+
+```typescript
+const [ratePrompt, setRatePrompt] = useState<{ name: string } | null>(null);
+```
+
+In `stopStream()` (lines 731-743), after the existing clear/complete logic, add:
+
+```typescript
+setRatePrompt({ name: active.input.name });
+```
+
+(where `active` is whatever local variable `stopStream` already uses to reference the outgoing `activeStream` before clearing it — reuse it rather than re-reading state.)
+
+Add an early-return guard in the top-level `useInput` dispatcher (around line 1303-1321, alongside the other prompt guards):
+
+```typescript
+if (ratePrompt) return;
+```
+
+Render the prompt conditionally near where `keepPrompt`/`torrentPrompt` are rendered (around lines 1613-1681):
+
+```tsx
+{ratePrompt && (
+  <RatePrompt
+    name={ratePrompt.name}
+    onLike={() => {
+      void postEvent(
+        { reccUrl: config.reccUrl, reccToken: config.reccToken },
+        { type: "liked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" }
+      );
+      setRatePrompt(null);
+    }}
+    onDislike={() => {
+      void postEvent(
+        { reccUrl: config.reccUrl, reccToken: config.reccToken },
+        { type: "disliked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" }
+      );
+      setRatePrompt(null);
+    }}
+    onDismiss={() => setRatePrompt(null)}
+  />
+)}
+```
+
+Add the import at the top of `App.tsx`:
+
+```typescript
+import { RatePrompt } from "./components/RatePrompt.js";
+```
+
+Register `ratePrompt` in the two `region: "help"` gate lists (lines 1208 and 1738) and the footer gate (line 1791), following the exact pattern the other prompt state variables use in those three spots (each existing prompt appears as one more `||`-chained boolean condition — add `!!ratePrompt` alongside them).
+
+- [ ] **Step 6: Run the full torlink test suite**
+
+```bash
+npm test
+```
+Expected: PASS, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat: prompt for like/dislike after a stream ends"
+```
+
+---
+
+## Part C — Wrap-up
+
+### Task 18: README for reccd
+
+**Files:**
+- Create: `~/projects/reccd/README.md`
+
+- [ ] **Step 1: Write a minimal operational README**
+
+```markdown
+# reccd
+
+Self-hosted, single-user recommendation service for torlink. Tracks watch/favourite/like/dislike/abandon
+activity, canonicalizes it against a local IMDb-backed catalog, and serves genre+recency+quality-based
+recommendations. Returns IMDb/TMDB IDs and titles only — no metadata redistribution.
+
+## Setup
+
+    npm install
+    RECCD_TOKEN=<pick-a-secret> npm run import:imdb   # populates data/catalog.db (~10-20 min)
+    RECCD_TOKEN=<pick-a-secret> npm run dev             # starts the API on :4100
+
+## Environment variables
+
+- `RECCD_TOKEN` (required) — bearer token clients must send
+- `RECCD_PORT` (default 4100)
+- `RECCD_DATA_DIR` (default `./data`)
+- `RECCD_MIN_VOTES` (default 1000) — reserved for Phase 2 TMDB enrichment threshold
+
+## Recurring maintenance
+
+Re-run `npm run import:imdb` periodically (e.g. nightly via cron) to refresh the catalog from IMDb's
+daily dataset exports.
+
+## API
+
+- `POST /events` — `{ events: [{ type, rawName, ts, source }] }` → 202
+- `GET /recommendations?type=movie|tv&genre=&limit=` → `[{ imdbId, title, year, score, reasons }]`
+- `GET /profile` → inferred taste profile
+- `GET /resolve?name=` → canonicalization debug
+
+All endpoints require `Authorization: Bearer <RECCD_TOKEN>`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -A
+git commit -m "docs: add reccd README"
+```
+
+---
+
+## Self-review notes (for the plan author, already applied above)
+
+- **Spec coverage:** catalog (Task 2-3), activity/events (Task 4), canonicalizer (Task 5-7), taste profile + scoring (Task 8-10), backfill (Task 11), API (Task 12-13), torlink client + wiring + like/dislike (Task 14-17) — all Phase 1 spec items are covered. CF/embeddings/TMDB are explicitly out of scope (Phase 2/3).
+- **Diversity pass** from the spec is deliberately simplified to genre filtering in Task 10, with a note explaining why (small personal catalog subset makes MMR-style re-ranking premature complexity for Phase 1).
+- **Type consistency:** `EventType` (activity.ts) matches `ReccEventType` (client.ts) string-for-string; `CatalogTitle`/`TasteProfile`/`ScoredCandidate`/`Recommendation` field names are consistent across Tasks 2, 8, 9, 10, 12.
+- Task 16/17 App.tsx line numbers are drawn from the Explore agent's research and should be re-confirmed against the actual file at execution time since line numbers shift as the file is edited task-to-task — treat them as strong hints, not guarantees.

--- a/docs/superpowers/plans/2026-07-22-reccd-account-setup.md
+++ b/docs/superpowers/plans/2026-07-22-reccd-account-setup.md
@@ -1,0 +1,831 @@
+# reccd Account Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user configure the reccd connection (URL + token) from within torlink's Accounts pane, persisted to `config.json` (no env vars needed), with a live reachability status, framed as a private/self-hosted service.
+
+**Architecture:** Mirrors the Real-Debrid account flow. A `src/recc/status.ts` module pings reccd's `GET /profile` and classifies the connection. A `ReccdPrompt` two-field prompt (modeled on `RutrackerPrompt`) captures URL + token. The `Accounts` pane gains a third row. `App.tsx` wires prompt lifecycle, config save, and status refresh exactly like the token/rutracker prompts.
+
+**Tech Stack:** TypeScript, React + Ink, Vitest, `ink-testing-library`, `undici` fetch. Tests: `npx vitest run <path>`; typecheck: `npx tsc --noEmit`. Run from the worktree.
+
+**Working directory:** `/home/ash/projects/torlink/.claude/worktrees/squishy-snuggling-bengio` (branch `docs/recommendation-engine-spec`).
+
+**Spec:** `docs/superpowers/specs/2026-07-22-reccd-account-setup-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/recc/status.ts` (create) | `checkReccConnection` (pings `/profile`) + `formatReccStatus` + types. |
+| `src/recc/status.test.ts` (create) | Classification + formatting tests. |
+| `src/ui/components/ReccdPrompt.tsx` (create) | Two-field (URL + token) setup prompt. |
+| `src/ui/components/ReccdPrompt.test.tsx` (create) | Prompt render/submit/cancel tests. |
+| `src/ui/components/Accounts.tsx` (modify) | Add the reccd row + props; parametrize row labels/status icon. |
+| `src/ui/components/Accounts.test.tsx` (modify) | Cover the reccd row. |
+| `src/ui/App.tsx` (modify) | reccd status state, prompt lifecycle, config save/clear, input suppression, Accounts props. |
+| `src/ui/components/ForYou.tsx` (modify) | Point the not-configured hint at the Accounts pane. |
+| `src/ui/components/ForYou.test.tsx` (modify) | Update the hint assertion. |
+
+---
+
+## Task 1: reccd connection status module
+
+**Files:**
+- Create: `src/recc/status.ts`
+- Test: `src/recc/status.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/recc/status.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { checkReccConnection, formatReccStatus } from "./status";
+import type { FetchImpl } from "../util/net";
+
+function fakeFetch(handler: (url: string) => { status: number; throwErr?: boolean }): FetchImpl {
+  return (async (url: string) => {
+    const r = handler(String(url));
+    if (r.throwErr) throw new Error("network down");
+    return { ok: r.status >= 200 && r.status < 300, status: r.status, json: async () => ({}) } as unknown as Response;
+  }) as unknown as FetchImpl;
+}
+
+const CFG = { reccUrl: "http://192.168.0.98:4100", reccToken: "tok" };
+
+describe("checkReccConnection", () => {
+  it("returns unconfigured when reccUrl is missing", async () => {
+    expect(await checkReccConnection({ reccToken: "t" })).toEqual({ state: "unconfigured" });
+  });
+
+  it("returns connected on 200", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 200 })) });
+    expect(res).toEqual({ state: "connected", host: "192.168.0.98:4100" });
+  });
+
+  it("returns badToken on 401", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 401 })) });
+    expect(res).toEqual({ state: "badToken", host: "192.168.0.98:4100" });
+  });
+
+  it("returns unreachable on other non-2xx", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 500 })) });
+    expect(res).toEqual({ state: "unreachable", host: "192.168.0.98:4100" });
+  });
+
+  it("returns unreachable on a network error", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 0, throwErr: true })) });
+    expect(res).toEqual({ state: "unreachable", host: "192.168.0.98:4100" });
+  });
+
+  it("hits the /profile endpoint with a bearer header", async () => {
+    let seen = "";
+    const impl = (async (url: string, init: { headers?: Record<string, string> }) => {
+      seen = String(url);
+      expect(init.headers?.authorization).toBe("Bearer tok");
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }) as unknown as FetchImpl;
+    await checkReccConnection(CFG, { fetchImpl: impl });
+    expect(seen).toBe("http://192.168.0.98:4100/profile");
+  });
+});
+
+describe("formatReccStatus", () => {
+  it("formats each state", () => {
+    expect(formatReccStatus(null)).toBe("Not configured");
+    expect(formatReccStatus({ state: "unconfigured" })).toBe("Not configured");
+    expect(formatReccStatus({ state: "connected", host: "h:4100" })).toBe("Connected · h:4100");
+    expect(formatReccStatus({ state: "badToken", host: "h:4100" })).toBe("Token rejected");
+    expect(formatReccStatus({ state: "unreachable", host: "h:4100" })).toBe("Unreachable · h:4100");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/recc/status.test.ts`
+Expected: FAIL — `./status` does not exist.
+
+- [ ] **Step 3: Implement `src/recc/status.ts`**
+
+```ts
+import type { FetchImpl } from "../util/net";
+import type { ReccClientConfig } from "./client";
+
+export type ReccConnection = "unconfigured" | "connected" | "badToken" | "unreachable";
+
+export interface ReccStatus {
+  state: ReccConnection;
+  host?: string;
+}
+
+function hostOf(reccUrl: string): string {
+  try {
+    return new URL(reccUrl).host || reccUrl;
+  } catch {
+    return reccUrl;
+  }
+}
+
+// Pings reccd's authenticated GET /profile to classify the connection for the
+// Accounts pane. Never throws — network/timeout/other errors map to
+// "unreachable". /profile is a cheap authenticated GET that cleanly separates
+// 200 (connected) from 401 (bad token).
+export async function checkReccConnection(
+  config: ReccClientConfig,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<ReccStatus> {
+  if (!config.reccUrl) return { state: "unconfigured" };
+  const host = hostOf(config.reccUrl);
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/profile`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 6000),
+    });
+    if (res.status === 401) return { state: "badToken", host };
+    if (!res.ok) return { state: "unreachable", host };
+    return { state: "connected", host };
+  } catch {
+    return { state: "unreachable", host };
+  }
+}
+
+// One-line status for the Accounts row / setup prompt.
+export function formatReccStatus(status: ReccStatus | null): string {
+  if (!status || status.state === "unconfigured") return "Not configured";
+  switch (status.state) {
+    case "connected":
+      return `Connected · ${status.host}`;
+    case "badToken":
+      return "Token rejected";
+    case "unreachable":
+      return `Unreachable · ${status.host}`;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/recc/status.test.ts` → PASS. Then `npx tsc --noEmit` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/recc/status.ts src/recc/status.test.ts
+git commit -m "feat(recc): add reccd connection status check"
+```
+
+---
+
+## Task 2: `ReccdPrompt` two-field setup prompt
+
+**Files:**
+- Create: `src/ui/components/ReccdPrompt.tsx`
+- Test: `src/ui/components/ReccdPrompt.test.tsx`
+
+Note: this mirrors `src/ui/components/RutrackerPrompt.tsx` (two fields, a `Field` helper, ↑↓ to move, esc to cancel). READ that file first to match the exact `TextField`/`Panel`/`Field` usage before implementing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/ui/components/ReccdPrompt.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ReccdPrompt } from "./ReccdPrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+
+describe("ReccdPrompt", () => {
+  it("renders URL and Token fields and the status line", () => {
+    const { lastFrame } = render(
+      <ReccdPrompt width={60} url="" token="" status={{ state: "unconfigured" }} onSubmit={() => {}} onCancel={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("URL");
+    expect(frame).toContain("Token");
+    expect(frame).toContain("Not configured");
+  });
+
+  it("cancels on escape", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <ReccdPrompt width={60} url="" token="" status={null} onSubmit={() => {}} onCancel={onCancel} />,
+    );
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("submits the entered url and token", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <ReccdPrompt width={60} url="" token="" status={null} onSubmit={onSubmit} onCancel={() => {}} />,
+    );
+    await flush();
+    stdin.write("http://h:4100"); // typed into the focused URL field
+    await flush();
+    stdin.write("\r"); // enter on URL advances to the Token field
+    await flush();
+    stdin.write("tok"); // typed into the Token field
+    await flush();
+    stdin.write("\r"); // enter on Token submits
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("http://h:4100", "tok");
+  });
+});
+```
+
+If the exact keystroke flow in the third test doesn't line up with how `TextField` reports `onChange`/`onSubmit` (read `TextField.tsx` and `RutrackerPrompt` behaviour), adjust the *interaction* (how fields are advanced) so it passes — but keep the assertion that `onSubmit` receives the entered URL and token. Do not weaken it to a render-only check.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/ui/components/ReccdPrompt.test.tsx`
+Expected: FAIL — cannot find `./ReccdPrompt`.
+
+- [ ] **Step 3: Implement `src/ui/components/ReccdPrompt.tsx`**
+
+```tsx
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+import { formatReccStatus, type ReccStatus } from "../../recc/status";
+
+type FieldKey = "url" | "token";
+
+interface ReccdPromptProps {
+  width: number;
+  url: string;
+  token: string;
+  status: ReccStatus | null;
+  onSubmit: (url: string, token: string) => void;
+  onCancel: () => void;
+}
+
+function Field({
+  label,
+  active,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box>
+      <Box width={8} flexShrink={0}>
+        <Text color={active ? COLOR.accent : undefined} dimColor={!active}>
+          {label}
+        </Text>
+      </Box>
+      <Text color={active ? COLOR.accent : COLOR.alt}>{`${ICON.pointer} `}</Text>
+      <Box flexGrow={1} minWidth={0}>
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+// A private, self-hosted service — reccd is a single URL + bearer token the user
+// stands up themselves. Two fields, modeled on RutrackerPrompt.
+export function ReccdPrompt({ width, url, token, status, onSubmit, onCancel }: ReccdPromptProps) {
+  const [field, setField] = useState<FieldKey>("url");
+  const [urlVal, setUrlVal] = useState(url);
+  const [tokenVal, setTokenVal] = useState(token);
+
+  const submit = (): void => onSubmit(urlVal.trim(), tokenVal);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (key.upArrow) setField("url");
+    else if (key.downArrow) setField("token");
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="reccd — private, self-hosted recommendations" width={width} focused height={4}>
+        <Field label="URL" active={field === "url"}>
+          <TextField
+            isDisabled={field !== "url"}
+            defaultValue={url}
+            placeholder="http://localhost:4100"
+            onChange={setUrlVal}
+            onSubmit={() => setField("token")}
+            onExitDown={() => setField("token")}
+          />
+        </Field>
+        <Field label="Token" active={field === "token"}>
+          <TextField
+            isDisabled={field !== "token"}
+            mask
+            defaultValue={token}
+            placeholder="bearer token from reccd `user:add`"
+            onChange={setTokenVal}
+            onSubmit={submit}
+          />
+        </Field>
+        <Box marginTop={1}>
+          <Text dimColor>{`status: ${formatReccStatus(status)}`}</Text>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <Text color={COLOR.alt}>↵</Text>
+        <Text dimColor> next / save</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>↑↓</Text>
+        <Text dimColor> field</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>esc</Text>
+        <Text dimColor> cancel</Text>
+      </Box>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/ui/components/ReccdPrompt.test.tsx` → PASS. Then `npx tsc --noEmit` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/components/ReccdPrompt.tsx src/ui/components/ReccdPrompt.test.tsx
+git commit -m "feat(ui): add ReccdPrompt setup prompt (url + token)"
+```
+
+---
+
+## Task 3: reccd row in the Accounts pane
+
+**Files:**
+- Modify: `src/ui/components/Accounts.tsx`
+- Test: `src/ui/components/Accounts.test.tsx`
+
+- [ ] **Step 1: Update the test first**
+
+Replace the whole contents of `src/ui/components/Accounts.test.tsx` with:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render } from "ink-testing-library";
+import { StoreContext, type Store } from "../store";
+import { Accounts } from "./Accounts";
+import type { ReccStatus } from "../../recc/status";
+
+function storeStub(): Store {
+  return { region: "content", section: "accounts" } as unknown as Store;
+}
+
+const noop = () => {};
+const baseProps = {
+  rdToken: "",
+  rdStatus: null,
+  rutrackerUser: undefined as string | undefined,
+  reccConfigured: false,
+  reccStatus: null as ReccStatus | null,
+  reccEnvOverride: false,
+  onManageRd: noop,
+  onSignOutRd: noop,
+  onManageRutracker: noop,
+  onSignOutRutracker: noop,
+  onManageRecc: noop,
+  onSignOutRecc: noop,
+};
+
+function renderAccounts(overrides: Partial<typeof baseProps> = {}) {
+  return render(
+    <StoreContext.Provider value={storeStub()}>
+      <Accounts {...baseProps} {...overrides} />
+    </StoreContext.Provider>,
+  );
+}
+
+describe("Accounts", () => {
+  it("lists Real-Debrid, RuTracker and reccd", () => {
+    const frame = renderAccounts().lastFrame() ?? "";
+    expect(frame).toContain("Real-Debrid");
+    expect(frame).toContain("RuTracker");
+    expect(frame).toContain("reccd");
+  });
+
+  it("shows Not configured for reccd when unconfigured", () => {
+    expect(renderAccounts().lastFrame() ?? "").toContain("Not configured");
+  });
+
+  it("shows the RuTracker username when signed in", () => {
+    const frame = renderAccounts({ rutrackerUser: "alice" }).lastFrame() ?? "";
+    expect(frame).toContain("alice");
+  });
+
+  it("shows connected status when reccd is configured and reachable", () => {
+    const frame = renderAccounts({
+      reccConfigured: true,
+      reccStatus: { state: "connected", host: "192.168.0.98:4100" },
+    }).lastFrame() ?? "";
+    expect(frame).toContain("Connected");
+  });
+
+  it("notes an env override when reccEnvOverride is set", () => {
+    const frame = renderAccounts({
+      reccConfigured: true,
+      reccStatus: { state: "connected", host: "h:4100" },
+      reccEnvOverride: true,
+    }).lastFrame() ?? "";
+    expect(frame).toContain("env override");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/ui/components/Accounts.test.tsx`
+Expected: FAIL — new props/row not present yet.
+
+- [ ] **Step 3: Replace `src/ui/components/Accounts.tsx`**
+
+Replace the whole file with (adds the reccd row and parametrizes per-row labels + a status `ok` flag; Real-Debrid/RuTracker output is unchanged because their defaults match the previous hardcoded strings):
+
+```tsx
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { useStore } from "../store";
+import { Panel } from "./Panel";
+import { wrapStep } from "../move";
+import { COLOR, GUTTER, ICON } from "../theme";
+import { truncate } from "../../util/format";
+import { formatAccountStatus, type RdStatus } from "../../integrations/rdStatus";
+import { formatReccStatus, type ReccStatus } from "../../recc/status";
+
+interface AccountsProps {
+  rdToken: string;
+  rdStatus: RdStatus | null;
+  rutrackerUser?: string;
+  reccConfigured: boolean;
+  reccStatus: ReccStatus | null;
+  reccEnvOverride?: boolean;
+  // True while a torrent stream is active; "x" is reserved for stopping it
+  // globally, so sign-out must not also fire on the same keystroke.
+  streamActive?: boolean;
+  onManageRd: () => void;
+  onSignOutRd: () => void;
+  onManageRutracker: () => void;
+  onSignOutRutracker: () => void;
+  onManageRecc: () => void;
+  onSignOutRecc: () => void;
+}
+
+interface Row {
+  tag: string;
+  color: string;
+  label: string;
+  homepage: string;
+  signedIn: boolean;
+  // Drives the status icon/colour when signedIn: green tick when true, a warn
+  // marker otherwise (e.g. reccd configured but unreachable / bad token).
+  ok: boolean;
+  status: string;
+  emptyStatus: string;
+  verbSignedIn: string;
+  verbSignOut: string;
+  verbSignedOut: string;
+  onManage: () => void;
+  onSignOut: () => void;
+}
+
+export function Accounts({
+  rdToken,
+  rdStatus,
+  rutrackerUser,
+  reccConfigured,
+  reccStatus,
+  reccEnvOverride = false,
+  streamActive = false,
+  onManageRd,
+  onSignOutRd,
+  onManageRutracker,
+  onSignOutRutracker,
+  onManageRecc,
+  onSignOutRecc,
+}: AccountsProps) {
+  const { region, section, contentWidth, listRows } = useStore();
+  const focused = region === "content" && section === "accounts";
+  const [cursor, setCursor] = useState(0);
+
+  const rows: Row[] = [
+    {
+      tag: "RD",
+      color: COLOR.good,
+      label: "Real-Debrid",
+      homepage: "real-debrid.com",
+      signedIn: rdToken !== "",
+      ok: rdToken !== "",
+      status: formatAccountStatus(rdStatus, new Date()),
+      emptyStatus: "Not connected",
+      verbSignedIn: "switch",
+      verbSignOut: "sign out",
+      verbSignedOut: "sign in",
+      onManage: onManageRd,
+      onSignOut: onSignOutRd,
+    },
+    {
+      tag: "RUT",
+      color: "#8fce5a",
+      label: "RuTracker",
+      homepage: "rutracker.org",
+      signedIn: !!rutrackerUser,
+      ok: !!rutrackerUser,
+      status: rutrackerUser ? `Signed in as ${truncate(rutrackerUser, 24)}` : "Not signed in",
+      emptyStatus: "Not signed in",
+      verbSignedIn: "switch",
+      verbSignOut: "sign out",
+      verbSignedOut: "sign in",
+      onManage: onManageRutracker,
+      onSignOut: onSignOutRutracker,
+    },
+    {
+      tag: "RCD",
+      color: COLOR.accent,
+      label: "reccd",
+      homepage: "self-hosted · private service",
+      signedIn: reccConfigured,
+      ok: reccStatus?.state === "connected",
+      status: `${formatReccStatus(reccStatus)}${reccEnvOverride ? "  ·  env override active" : ""}`,
+      emptyStatus: "Not configured",
+      verbSignedIn: "edit",
+      verbSignOut: "clear",
+      verbSignedOut: "set up",
+      onManage: onManageRecc,
+      onSignOut: onSignOutRecc,
+    },
+  ];
+
+  const clamped = Math.min(cursor, rows.length - 1);
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow) setCursor(wrapStep(clamped, -1, rows.length));
+      else if (key.downArrow) setCursor(wrapStep(clamped, 1, rows.length));
+      else if (key.return) rows[clamped]!.onManage();
+      else if (input === "x" && !streamActive && rows[clamped]!.signedIn) rows[clamped]!.onSignOut();
+    },
+    { isActive: focused },
+  );
+
+  const panelH = Math.max(5, listRows - 1);
+
+  return (
+    <Panel title="accounts" width={contentWidth} focused={focused} height={panelH}>
+      <Box>
+        <Text dimColor>Sign in to services that need an account to search or stream.</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {rows.map((r, i) => {
+          const here = i === clamped && focused;
+          return (
+            <Box key={r.label} marginTop={i > 0 ? 1 : 0}>
+              <Box width={GUTTER} flexShrink={0}>
+                <Text color={COLOR.accent} bold>{here ? ICON.pointer : ""}</Text>
+              </Box>
+              <Box width={5} flexShrink={0}>
+                <Text color={r.color} bold={here}>{r.tag}</Text>
+              </Box>
+              <Box flexGrow={1} minWidth={0} marginLeft={1} flexDirection="column">
+                <Text bold={here} color={here ? COLOR.accent : undefined} dimColor={!here}>
+                  {r.label}
+                  <Text dimColor>{`  ${ICON.dot} ${r.homepage}`}</Text>
+                </Text>
+                {r.signedIn ? (
+                  <Text>
+                    <Text color={r.ok ? COLOR.good : COLOR.warn}>{`${r.ok ? ICON.done : ICON.warn} `}</Text>
+                    <Text dimColor>{r.status}</Text>
+                  </Text>
+                ) : (
+                  <Text dimColor>{`${ICON.dot} ${r.emptyStatus}`}</Text>
+                )}
+              </Box>
+              <Box flexShrink={0} marginLeft={1}>
+                {r.signedIn ? (
+                  <Text>
+                    <Text color={COLOR.alt}>↵</Text>
+                    <Text dimColor>{` ${r.verbSignedIn}`}</Text>
+                    <Text dimColor>{`  ${ICON.dot}  `}</Text>
+                    <Text color={COLOR.alt}>x</Text>
+                    <Text dimColor>{` ${r.verbSignOut}`}</Text>
+                  </Text>
+                ) : (
+                  <Text>
+                    <Text color={COLOR.alt}>↵</Text>
+                    <Text dimColor>{` ${r.verbSignedOut}`}</Text>
+                  </Text>
+                )}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Panel>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/ui/components/Accounts.test.tsx` → PASS. Then `npx tsc --noEmit` (App.tsx will now have type errors because it doesn't pass the new required `Accounts` props yet — that's expected and fixed in Task 4; if you want a clean tsc for this task alone, note it and proceed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/components/Accounts.tsx src/ui/components/Accounts.test.tsx
+git commit -m "feat(ui): add reccd row to the Accounts pane"
+```
+
+---
+
+## Task 4: Wire the reccd prompt, status, and config save into App
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+- Modify: `src/ui/components/ForYou.tsx`
+- Modify: `src/ui/components/ForYou.test.tsx`
+
+This task follows the existing Real-Debrid token / RuTracker prompt patterns exactly. READ these regions of `App.tsx` first: the imports block, the `editingToken` state + `openTokenPrompt`/`setRealDebridToken`/`clearRealDebridToken` handlers, the `<TokenPrompt/>` render block, the `<Accounts/>` block, the `persistConfig` helper, the `store` `useMemo` (region computation), and the two `display` conditions (body + footer). Mirror the token prompt for reccd.
+
+- [ ] **Step 1: Add imports**
+
+In `src/ui/App.tsx`, add:
+```tsx
+import { ReccdPrompt } from "./components/ReccdPrompt";
+import { checkReccConnection, type ReccStatus } from "../recc/status";
+```
+
+- [ ] **Step 2: Add state**
+
+Near the other prompt/state declarations (e.g. beside `const [editingToken, setEditingToken] = useState(false);`):
+```tsx
+  const [editingRecc, setEditingRecc] = useState(false);
+  const [reccStatus, setReccStatus] = useState<ReccStatus | null>(null);
+```
+
+- [ ] **Step 3: Add a status refresher + a refresh effect**
+
+Add this callback near the other `useCallback` handlers:
+```tsx
+  const refreshReccStatus = useCallback((cfg: Config | null) => {
+    const rc = cfg ? resolveReccConfig(cfg) : {};
+    if (!rc.reccUrl) {
+      setReccStatus(null);
+      return;
+    }
+    void checkReccConnection(rc).then(setReccStatus);
+  }, []);
+```
+
+Add this effect (near other effects) so status is checked on load and whenever the reccd config changes:
+```tsx
+  useEffect(() => {
+    refreshReccStatus(config);
+  }, [config?.reccUrl, config?.reccToken, refreshReccStatus]);
+```
+
+- [ ] **Step 4: Add open / save / clear handlers**
+
+Mirror `openTokenPrompt` / `setRealDebridToken` / `clearRealDebridToken`:
+```tsx
+  const closeReccPrompt = useCallback(() => setEditingRecc(false), []);
+
+  const openReccPrompt = useCallback(() => {
+    setView("browser");
+    setShowHelp(false);
+    setEditingRecc(true);
+    refreshReccStatus(config);
+  }, [config, refreshReccStatus]);
+
+  const saveReccConfig = useCallback(
+    (rawUrl: string, rawToken: string) => {
+      closeReccPrompt();
+      const url = rawUrl.trim().replace(/\/+$/, "");
+      const token = rawToken.trim();
+      persistConfig({ reccUrl: url || undefined, reccToken: token || undefined });
+      setNotice(url ? `${ICON.done} reccd set to ${url}` : "reccd connection cleared.");
+    },
+    [closeReccPrompt],
+  );
+
+  const clearReccConfig = useCallback(() => {
+    closeReccPrompt();
+    if (process.env["TORLINK_RECC_URL"]?.trim() || process.env["TORLINK_RECC_TOKEN"]?.trim()) {
+      setNotice("reccd is set via TORLINK_RECC_* env vars — unset them to clear it.");
+      return;
+    }
+    persistConfig({ reccUrl: undefined, reccToken: undefined });
+    setNotice("reccd connection cleared.");
+  }, [closeReccPrompt],
+  );
+```
+(`persistConfig` triggers a config change, which fires the effect from Step 3 and refreshes the status automatically. `setNotice`, `ICON`, `persistConfig`, `resolveReccConfig`, `setView`, `setShowHelp` are all already in scope/imported.)
+
+- [ ] **Step 5: Suppress global input while the reccd prompt is open**
+
+The reccd prompt contains editable `TextField`s, so the global `useInput` and the focused content pane must NOT react while it's open (otherwise typing a URL/token triggers global shortcuts — the same class of bug that hit the genre prompt). Replicate EXACTLY how `editingToken` does this: grep `editingToken` across `App.tsx` and add `editingRecc` in the same way at each site. Concretely, that means adding `editingRecc` to:
+- the `store` `useMemo` `region` condition (so `region` becomes `"help"` while editing, gating the content panes' `useInput`),
+- the **body** region `display` condition,
+- the **footer** `display` condition,
+- and any early-return guard for prompts inside the global `useInput` handler (if `editingToken` has one there; match it).
+
+After editing, reason through: while `editingRecc` is true, does any global single-letter binding still fire on a keystroke? It must not. (If `editingToken` relies on a `captureMode === "text"` guard rather than an explicit early return, do NOT try to replicate that — `ReccdPrompt` owns its own input; the region+display gating plus mirroring editingToken's sites is what's needed. If unsure whether suppression is complete, report it rather than guessing.)
+
+- [ ] **Step 6: Render the prompt**
+
+Next to the `{editingToken ? (…<TokenPrompt/>…) : null}` block, add:
+```tsx
+{editingRecc ? (
+  <Box marginTop={1}>
+    <ReccdPrompt
+      width={Math.max(24, Math.min(cols - 4, 62))}
+      url={store.config.reccUrl ?? ""}
+      token={store.config.reccToken ?? ""}
+      status={reccStatus}
+      onSubmit={saveReccConfig}
+      onCancel={closeReccPrompt}
+    />
+  </Box>
+) : null}
+```
+
+- [ ] **Step 7: Pass the new props to `<Accounts/>`**
+
+Update the `<Accounts …/>` element to add:
+```tsx
+        reccConfigured={store.reccConfigured}
+        reccStatus={reccStatus}
+        reccEnvOverride={Boolean(process.env["TORLINK_RECC_URL"]?.trim() || process.env["TORLINK_RECC_TOKEN"]?.trim())}
+        onManageRecc={openReccPrompt}
+        onSignOutRecc={clearReccConfig}
+```
+(`store.reccConfigured` already exists from earlier work.)
+
+- [ ] **Step 8: Point the For You not-configured hint at Accounts**
+
+In `src/ui/components/ForYou.tsx`, replace the not-configured hint block:
+```tsx
+      <Box flexDirection="column">
+        <Text color={COLOR.text}>Recommendations aren't set up yet.</Text>
+        <Text dimColor>To set up, add reccUrl and reccToken to config.json,</Text>
+        <Text dimColor>or set TORLINK_RECC_URL / TORLINK_RECC_TOKEN.</Text>
+      </Box>
+```
+with:
+```tsx
+      <Box flexDirection="column">
+        <Text color={COLOR.text}>Recommendations aren't set up yet.</Text>
+        <Text dimColor>Set up reccd in the Accounts pane (↵ on reccd),</Text>
+        <Text dimColor>or set TORLINK_RECC_URL / TORLINK_RECC_TOKEN.</Text>
+      </Box>
+```
+Then in `src/ui/components/ForYou.test.tsx`, update the setup-hint assertion (which currently checks `"set up"`) to match the new copy:
+```tsx
+    expect(lastFrame()).toContain("Accounts");
+```
+
+- [ ] **Step 9: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit` → no errors.
+Run: `npx vitest run` → whole suite green. (Ignore the KNOWN-FLAKY `src/download/queue.test.ts` RD test that fails only in full runs and passes alone — pre-existing/unrelated; confirm by running it in isolation if it fails.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/App.tsx src/ui/components/ForYou.tsx src/ui/components/ForYou.test.tsx
+git commit -m "feat(ui): wire reccd account setup (prompt, status, config save) into App"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Accounts row (tag RCD, "self-hosted · private service", manage/clear) → Task 3. ✓
+- Two-field setup prompt saving to config.json → Task 2 + Task 4 (save handler). ✓
+- Live reachability status (`connected`/`badToken`/`unreachable`/`unconfigured`) → Task 1, surfaced in Task 3 row + Task 2 prompt + Task 4 refresh. ✓
+- Env-override note → Task 3 row + Task 4 prop. ✓
+- Persistence to config.json (no env vars); env still wins → Task 4 (`persistConfig`), `resolveReccConfig` unchanged. ✓
+- For You hint points at Accounts → Task 4 Step 8. ✓
+- Input suppression while prompt open → Task 4 Step 5. ✓
+
+**Type consistency:** `ReccStatus`/`ReccConnection` defined in Task 1 and imported unchanged by `ReccdPrompt` (Task 2), `Accounts` (Task 3), and `App` (Task 4). `AccountsProps` gains `reccConfigured`/`reccStatus`/`reccEnvOverride`/`onManageRecc`/`onSignOutRecc` in Task 3 and App passes exactly those in Task 4. `checkReccConnection`/`formatReccStatus` signatures are stable across tasks.
+
+**Placeholder scan:** none — every code/test step is complete.
+
+**Ordering note for the implementer:** after Task 3, `tsc` over the whole project will error until Task 4 wires the new `Accounts` props — this is expected; Task 3's own test still passes. Do the tasks in order.

--- a/docs/superpowers/plans/2026-07-22-recommendations-ui.md
+++ b/docs/superpowers/plans/2026-07-22-recommendations-ui.md
@@ -877,14 +877,14 @@ git commit -m "feat(ui): wire For You section into nav, App, and keymap"
 
 - [ ] **Step 1: Point torlink at the live reccd**
 
-Add `reccUrl`/`reccToken` to the runtime config (NOT the repo). The token is local-network only and rotatable:
+Add `reccUrl`/`reccToken` to the runtime config (NOT the repo — this is a real secret, keep it out of git). Substitute your own reccd host and the bearer token printed by reccd's `user:add`:
 
 ```bash
 node -e '
 const fs=require("fs"),os=require("os"),p=require("path");
 const f=p.join(os.homedir(),".config","torlink","config.json");
 const c=JSON.parse(fs.readFileSync(f,"utf8"));
-c.reccUrl="http://192.168.0.98:4100";
+c.reccUrl="http://<RECCD_HOST>:4100";
 c.reccToken="<YOUR_RECCD_TOKEN>";
 fs.writeFileSync(f,JSON.stringify(c,null,2));
 console.log("updated",f);
@@ -896,7 +896,7 @@ console.log("updated",f);
 Run:
 ```bash
 curl -s -H "Authorization: Bearer <YOUR_RECCD_TOKEN>" \
-  "http://192.168.0.98:4100/recommendations?limit=3"
+  "http://<RECCD_HOST>:4100/recommendations?limit=3"
 ```
 Expected: a JSON array of `{ imdbId, title, year, score, reasons }`.
 

--- a/docs/superpowers/plans/2026-07-22-recommendations-ui.md
+++ b/docs/superpowers/plans/2026-07-22-recommendations-ui.md
@@ -1,0 +1,932 @@
+# "For You" Recommendations UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "For You" section to torlink that fetches ranked picks from the reccd service (`GET /recommendations`) and lets the user launch a torrent search for any pick, closing the loop with the existing event-posting integration.
+
+**Architecture:** A blocking `fetchRecommendations` client method (sibling to the fire-and-forget `postEvent`) returns a discriminated result. A `useRecommendations` hook owns fetch state + filters. A presentational `ForYou` component renders the list, cycles filters, and on Enter calls `setSection` + `submitQuery` to start a torrent search. A small `GenrePrompt` handles free-text genre entry. A `resolveReccConfig` helper adds env overrides and replaces the six inline reccd-config literals in `App.tsx`.
+
+**Tech Stack:** TypeScript, React + Ink (terminal UI), Vitest, `ink-testing-library`, `undici` fetch. Tests run with `npx vitest run <path>`; typecheck with `npx tsc --noEmit`.
+
+**Working directory:** `/home/ash/projects/torlink/.claude/worktrees/squishy-snuggling-bengio` (branch `docs/recommendation-engine-spec`). Run all commands there.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-recommendations-ui-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/recc/client.ts` (modify) | Add `Recommendation`, `RecommendationQuery`, `FetchRecommendationsResult` types + `fetchRecommendations`. |
+| `src/recc/client.test.ts` (modify) | Tests for `fetchRecommendations`. |
+| `src/config/config.ts` (modify) | Add `resolveReccConfig(config)` with env overrides. |
+| `src/config/config.test.ts` (modify) | Tests for `resolveReccConfig`. |
+| `src/ui/components/GenrePrompt.tsx` (create) | Free-text genre filter prompt. |
+| `src/ui/components/GenrePrompt.test.tsx` (create) | Tests for GenrePrompt. |
+| `src/ui/hooks/useRecommendations.ts` (create) | Fetch state + filters for the For You view. |
+| `src/ui/components/ForYou.tsx` (create) | Presentational recommendations list + input handling. |
+| `src/ui/components/ForYou.test.tsx` (create) | Tests for ForYou (also exercises the hook). |
+| `src/ui/store.ts` (modify) | Add `"forYou"` to `Section`; exclude it in `isCategory`. |
+| `src/ui/components/Sidebar.tsx` (modify) | Add "For You" nav item. |
+| `src/ui/App.tsx` (modify) | Render `<ForYou/>`; replace inline reccd-config literals with `resolveReccConfig`. |
+| `src/ui/keymap.ts` (modify) | For You footer hints + help group. |
+
+---
+
+## Task 1: `fetchRecommendations` client method
+
+**Files:**
+- Modify: `src/recc/client.ts`
+- Test: `src/recc/client.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/recc/client.test.ts` (keep existing imports; add `fetchRecommendations` to the import from `./client` and add `import type { FetchImpl } from "../util/net";` if not present):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { fetchRecommendations } from "./client";
+import type { FetchImpl } from "../util/net";
+
+function fakeFetch(
+  handler: (url: string) => { status: number; body?: unknown; throwErr?: boolean },
+): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    const r = handler(String(url));
+    if (r.throwErr) throw new Error("network down");
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+const CONFIG = { reccUrl: "http://host:4100", reccToken: "tok" };
+const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
+
+describe("fetchRecommendations", () => {
+  it("returns ok with parsed items on 200", async () => {
+    const { impl } = fakeFetch(() => ({ status: 200, body: [REC] }));
+    const res = await fetchRecommendations(CONFIG, { limit: 5 }, { fetchImpl: impl });
+    expect(res).toEqual({ ok: true, items: [REC] });
+  });
+
+  it("builds the query string from provided filters", async () => {
+    const { impl, urls } = fakeFetch(() => ({ status: 200, body: [] }));
+    await fetchRecommendations(CONFIG, { type: "movie", genre: "Western", explore: true, limit: 5 }, { fetchImpl: impl });
+    expect(urls[0]).toContain("/recommendations?");
+    expect(urls[0]).toContain("type=movie");
+    expect(urls[0]).toContain("genre=Western");
+    expect(urls[0]).toContain("explore=true");
+    expect(urls[0]).toContain("limit=5");
+  });
+
+  it("omits type/genre/explore when unset and defaults limit to 20", async () => {
+    const { impl, urls } = fakeFetch(() => ({ status: 200, body: [] }));
+    await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(urls[0]).not.toContain("type=");
+    expect(urls[0]).not.toContain("genre=");
+    expect(urls[0]).not.toContain("explore=");
+    expect(urls[0]).toContain("limit=20");
+  });
+
+  it("maps 401 to a token error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 401, body: { error: "unauthorized" } }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "reccd rejected the token — check reccToken" });
+  });
+
+  it("maps other non-2xx to an unavailable error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 500 }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "recommendations unavailable (HTTP 500)" });
+  });
+
+  it("maps a network throw to an unreachable error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 0, throwErr: true }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "couldn't reach reccd" });
+  });
+
+  it("rejects a malformed body", async () => {
+    const { impl } = fakeFetch(() => ({ status: 200, body: [{ imdbId: 1 }] }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "unexpected response from reccd" });
+  });
+
+  it("returns a not-configured error when reccUrl is missing", async () => {
+    const res = await fetchRecommendations({ reccToken: "t" }, {});
+    expect(res).toEqual({ ok: false, error: "recommendations not configured" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/recc/client.test.ts`
+Expected: FAIL — `fetchRecommendations` is not exported.
+
+- [ ] **Step 3: Implement `fetchRecommendations`**
+
+Append to `src/recc/client.ts` (after `postEvent`; `FetchImpl` is already imported at the top):
+
+```ts
+export interface Recommendation {
+  imdbId: string;
+  title: string;
+  year: number;
+  score: number;
+  reasons: string[];
+}
+
+export interface RecommendationQuery {
+  type?: "movie" | "tv";
+  genre?: string;
+  explore?: boolean;
+  limit?: number;
+}
+
+export type FetchRecommendationsResult =
+  | { ok: true; items: Recommendation[] }
+  | { ok: false; error: string };
+
+function isRecommendation(v: unknown): v is Recommendation {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.imdbId === "string" &&
+    typeof r.title === "string" &&
+    typeof r.year === "number" &&
+    typeof r.score === "number" &&
+    Array.isArray(r.reasons) &&
+    r.reasons.every((x) => typeof x === "string")
+  );
+}
+
+// A blocking read, unlike the fire-and-forget postEvent: the user is waiting on
+// these results, so failures are surfaced as a discriminated result rather than
+// swallowed. reccd returns no magnet — the caller starts a torrent search from
+// the returned title.
+export async function fetchRecommendations(
+  config: ReccClientConfig,
+  query: RecommendationQuery,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchRecommendationsResult> {
+  if (!config.reccUrl) return { ok: false, error: "recommendations not configured" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  const params = new URLSearchParams();
+  if (query.type) params.set("type", query.type);
+  if (query.genre && query.genre.trim()) params.set("genre", query.genre.trim());
+  if (query.explore) params.set("explore", "true");
+  params.set("limit", String(query.limit ?? 20));
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/recommendations?${params.toString()}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 10000),
+    });
+    if (res.status === 401) return { ok: false, error: "reccd rejected the token — check reccToken" };
+    if (!res.ok) return { ok: false, error: `recommendations unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!Array.isArray(body) || !body.every(isRecommendation)) {
+      return { ok: false, error: "unexpected response from reccd" };
+    }
+    return { ok: true, items: body };
+  } catch {
+    return { ok: false, error: "couldn't reach reccd" };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/recc/client.test.ts`
+Expected: PASS (all `fetchRecommendations` tests + existing `postEvent` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/recc/client.ts src/recc/client.test.ts
+git commit -m "feat(recc): add blocking fetchRecommendations client method"
+```
+
+---
+
+## Task 2: `resolveReccConfig` env-aware helper
+
+**Files:**
+- Modify: `src/config/config.ts`
+- Test: `src/config/config.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/config/config.test.ts` (add `resolveReccConfig` to the existing import from `./config`):
+
+```ts
+describe("resolveReccConfig", () => {
+  const base = { downloadDir: "/tmp/dl", trackers: [] as string[] };
+
+  it("uses config values when no env override is set", () => {
+    delete process.env.TORLINK_RECC_URL;
+    delete process.env.TORLINK_RECC_TOKEN;
+    expect(resolveReccConfig({ ...base, reccUrl: "http://host:4100", reccToken: "tok" })).toEqual({
+      reccUrl: "http://host:4100",
+      reccToken: "tok",
+    });
+  });
+
+  it("prefers env vars over config values", () => {
+    process.env.TORLINK_RECC_URL = "http://env:4100";
+    process.env.TORLINK_RECC_TOKEN = "envtok";
+    try {
+      expect(resolveReccConfig({ ...base, reccUrl: "http://host:4100", reccToken: "tok" })).toEqual({
+        reccUrl: "http://env:4100",
+        reccToken: "envtok",
+      });
+    } finally {
+      delete process.env.TORLINK_RECC_URL;
+      delete process.env.TORLINK_RECC_TOKEN;
+    }
+  });
+
+  it("returns undefined fields when neither env nor config is set", () => {
+    delete process.env.TORLINK_RECC_URL;
+    delete process.env.TORLINK_RECC_TOKEN;
+    expect(resolveReccConfig({ ...base })).toEqual({ reccUrl: undefined, reccToken: undefined });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/config/config.test.ts`
+Expected: FAIL — `resolveReccConfig` is not exported.
+
+- [ ] **Step 3: Implement `resolveReccConfig`**
+
+Add to `src/config/config.ts`. At the top with the other imports:
+
+```ts
+import type { ReccClientConfig } from "../recc/client";
+```
+
+After the existing `resolveDnsServers` function (near line 112), add:
+
+```ts
+const RECC_URL_ENV = "TORLINK_RECC_URL";
+const RECC_TOKEN_ENV = "TORLINK_RECC_TOKEN";
+
+// The effective reccd connection (env wins over config, matching the other
+// resolve* helpers). An undefined reccUrl means "recommendations not
+// configured" — the For You view then shows a setup hint instead of fetching.
+export function resolveReccConfig(config: Config): ReccClientConfig {
+  const url = process.env[RECC_URL_ENV]?.trim() || config.reccUrl?.trim() || undefined;
+  const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
+  return { reccUrl: url, reccToken: token };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/config/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/config.ts src/config/config.test.ts
+git commit -m "feat(config): add resolveReccConfig with env overrides"
+```
+
+---
+
+## Task 3: `GenrePrompt` component
+
+**Files:**
+- Create: `src/ui/components/GenrePrompt.tsx`
+- Test: `src/ui/components/GenrePrompt.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/ui/components/GenrePrompt.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { GenrePrompt } from "./GenrePrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+
+describe("GenrePrompt", () => {
+  it("submits the typed genre on enter", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const { stdin } = render(<GenrePrompt width={40} value="" onSubmit={onSubmit} onCancel={onCancel} />);
+    await flush();
+    stdin.write("Western");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("Western");
+  });
+
+  it("cancels on escape", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const { stdin } = render(<GenrePrompt width={40} value="" onSubmit={onSubmit} onCancel={onCancel} />);
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onCancel).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/ui/components/GenrePrompt.test.tsx`
+Expected: FAIL — cannot find `./GenrePrompt`.
+
+- [ ] **Step 3: Implement `GenrePrompt`**
+
+Create `src/ui/components/GenrePrompt.tsx` (mirrors `FolderPrompt.tsx`):
+
+```tsx
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { COLOR, ICON } from "../theme";
+
+interface GenrePromptProps {
+  width: number;
+  value: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+// Free-text genre filter for the For You view. reccd treats genre as an open
+// string, so this is a plain text field; an empty submission clears the filter.
+export function GenrePrompt({ width, value, onSubmit, onCancel }: GenrePromptProps) {
+  useInput((_input, key) => {
+    if (key.escape) onCancel();
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="filter by genre" width={width} focused height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField defaultValue={value} placeholder="e.g. Western — empty clears" onSubmit={onSubmit} />
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <PromptHints submitLabel="filter" />
+      </Box>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/ui/components/GenrePrompt.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/components/GenrePrompt.tsx src/ui/components/GenrePrompt.test.tsx
+git commit -m "feat(ui): add GenrePrompt free-text filter component"
+```
+
+---
+
+## Task 4: `useRecommendations` hook + `ForYou` view
+
+**Files:**
+- Create: `src/ui/hooks/useRecommendations.ts`
+- Create: `src/ui/components/ForYou.tsx`
+- Test: `src/ui/components/ForYou.test.tsx` (drives the hook through the component)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/ui/components/ForYou.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ForYou } from "./ForYou";
+import type { FetchImpl } from "../../util/net";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+
+const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
+const CONFIG = { reccUrl: "http://host:4100", reccToken: "tok" };
+
+function fetchStub(): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    return { ok: true, status: 200, json: async () => [REC] } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+describe("ForYou", () => {
+  it("fetches and renders picks once active", async () => {
+    const { impl } = fetchStub();
+    const { lastFrame } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("Chernobyl");
+    expect(lastFrame()).toContain("2019");
+  });
+
+  it("shows a setup hint when reccUrl is unset", async () => {
+    const { impl } = fetchStub();
+    const { lastFrame } = render(
+      <ForYou reccConfig={{}} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("set up");
+  });
+
+  it("cycles the type filter with 't' and refetches", async () => {
+    const { impl, urls } = fetchStub();
+    const { stdin } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    stdin.write("t");
+    await flush();
+    expect(urls.some((u) => u.includes("type=movie"))).toBe(true);
+  });
+
+  it("searches the selected title on enter", async () => {
+    const { impl } = fetchStub();
+    const setSection = vi.fn();
+    const submitQuery = vi.fn();
+    const { stdin } = render(
+      <ForYou reccConfig={CONFIG} active setSection={setSection} submitQuery={submitQuery} fetchImpl={impl} />,
+    );
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(submitQuery).toHaveBeenCalledWith("Chernobyl");
+    expect(setSection).toHaveBeenCalledWith("all");
+  });
+
+  it("shows an error when the fetch fails", async () => {
+    const impl = (async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response) as unknown as FetchImpl;
+    const { lastFrame } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("unavailable");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/ui/components/ForYou.test.tsx`
+Expected: FAIL — cannot find `./ForYou`.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/ui/hooks/useRecommendations.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FetchImpl } from "../../util/net";
+import {
+  fetchRecommendations,
+  type ReccClientConfig,
+  type Recommendation,
+  type RecommendationQuery,
+} from "../../recc/client";
+
+export type ReccType = "all" | "movie" | "tv";
+
+export interface RecommendationsState {
+  items: Recommendation[];
+  loading: boolean;
+  error: string | null;
+  type: ReccType;
+  genre: string;
+  explore: boolean;
+  refresh: () => void;
+  setType: (t: ReccType) => void;
+  setGenre: (g: string) => void;
+  toggleExplore: () => void;
+}
+
+// Owns the For You view's fetch state and filters. Fetches lazily — only once
+// the section is first visited (`enabled`), then again on refresh or any filter
+// change. A request counter guards against an older in-flight response landing
+// after a newer one.
+export function useRecommendations(
+  config: ReccClientConfig,
+  enabled: boolean,
+  fetchImpl?: FetchImpl,
+): RecommendationsState {
+  const [items, setItems] = useState<Recommendation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [type, setTypeState] = useState<ReccType>("all");
+  const [genre, setGenreState] = useState("");
+  const [explore, setExplore] = useState(false);
+  const loadedRef = useRef(false);
+  const reqRef = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!config.reccUrl) {
+      setItems([]);
+      setError(null);
+      return;
+    }
+    const req = ++reqRef.current;
+    setLoading(true);
+    setError(null);
+    const query: RecommendationQuery = {
+      type: type === "all" ? undefined : type,
+      genre: genre.trim() || undefined,
+      explore,
+      limit: 20,
+    };
+    const result = await fetchRecommendations(config, query, { fetchImpl });
+    if (req !== reqRef.current) return; // superseded by a newer request
+    if (result.ok) {
+      setItems(result.items);
+      setError(null);
+    } else {
+      setItems([]);
+      setError(result.error);
+    }
+    setLoading(false);
+  }, [config, type, genre, explore, fetchImpl]);
+
+  // Lazy first load: once, on first activation.
+  useEffect(() => {
+    if (enabled && !loadedRef.current && config.reccUrl) {
+      loadedRef.current = true;
+      void load();
+    }
+  }, [enabled, config.reccUrl, load]);
+
+  // Refetch on filter change, but only after the first load has happened.
+  useEffect(() => {
+    if (loadedRef.current) void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, genre, explore]);
+
+  const refresh = useCallback(() => void load(), [load]);
+  const setType = useCallback((t: ReccType) => setTypeState(t), []);
+  const setGenre = useCallback((g: string) => setGenreState(g), []);
+  const toggleExplore = useCallback(() => setExplore((v) => !v), []);
+
+  return { items, loading, error, type, genre, explore, refresh, setType, setGenre, toggleExplore };
+}
+```
+
+- [ ] **Step 4: Implement the `ForYou` component**
+
+Create `src/ui/components/ForYou.tsx`:
+
+```tsx
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import type { FetchImpl } from "../../util/net";
+import type { ReccClientConfig } from "../../recc/client";
+import type { Section } from "../store";
+import { useRecommendations, type ReccType } from "../hooks/useRecommendations";
+import { GenrePrompt } from "./GenrePrompt";
+import { COLOR, ICON } from "../theme";
+import { cleanText, truncate } from "../../util/format";
+
+interface ForYouProps {
+  reccConfig: ReccClientConfig;
+  active: boolean;
+  setSection: (s: Section) => void;
+  submitQuery: (q: string) => void;
+  fetchImpl?: FetchImpl;
+  width?: number;
+}
+
+const NEXT_TYPE: Record<ReccType, ReccType> = { all: "movie", movie: "tv", tv: "all" };
+const TYPE_SECTION: Record<ReccType, Section> = { all: "all", movie: "movies", tv: "tv" };
+
+export function ForYou({ reccConfig, active, setSection, submitQuery, fetchImpl, width = 60 }: ForYouProps) {
+  const recs = useRecommendations(reccConfig, active, fetchImpl);
+  const [selected, setSelected] = useState(0);
+  const [editingGenre, setEditingGenre] = useState(false);
+
+  const configured = Boolean(reccConfig.reccUrl);
+  const count = recs.items.length;
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow || input === "k") setSelected((i) => (count ? (i - 1 + count) % count : 0));
+      else if (key.downArrow || input === "j") setSelected((i) => (count ? (i + 1) % count : 0));
+      else if (input === "t") { setSelected(0); recs.setType(NEXT_TYPE[recs.type]); }
+      else if (input === "e") { setSelected(0); recs.toggleExplore(); }
+      else if (input === "g") setEditingGenre(true);
+      else if (input === "r") recs.refresh();
+      else if (key.return) {
+        const item = recs.items[selected];
+        if (item) {
+          setSection(TYPE_SECTION[recs.type]);
+          submitQuery(item.title);
+        }
+      }
+    },
+    { isActive: active && configured && !editingGenre },
+  );
+
+  if (editingGenre) {
+    return (
+      <GenrePrompt
+        width={width}
+        value={recs.genre}
+        onSubmit={(g) => {
+          setEditingGenre(false);
+          setSelected(0);
+          recs.setGenre(g.trim());
+        }}
+        onCancel={() => setEditingGenre(false)}
+      />
+    );
+  }
+
+  if (!configured) {
+    return (
+      <Box flexDirection="column">
+        <Text color={COLOR.text}>Recommendations aren't set up yet.</Text>
+        <Text dimColor>To set up, add reccUrl and reccToken to config.json,</Text>
+        <Text dimColor>or set TORLINK_RECC_URL / TORLINK_RECC_TOKEN.</Text>
+      </Box>
+    );
+  }
+
+  const filterLine = `type: ${recs.type}${recs.genre ? ` · genre: ${recs.genre}` : ""}${recs.explore ? " · explore" : ""}`;
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={COLOR.alt}>For You  </Text>
+        <Text dimColor>{filterLine}</Text>
+      </Box>
+      {recs.loading ? (
+        <Text dimColor>Finding recommendations…</Text>
+      ) : recs.error ? (
+        <Box flexDirection="column">
+          <Text color={COLOR.text}>{recs.error}</Text>
+          <Text dimColor>press r to retry</Text>
+        </Box>
+      ) : count === 0 ? (
+        <Text dimColor>No picks yet — stream something and they'll show up here.</Text>
+      ) : (
+        recs.items.map((item, i) => {
+          const tag = item.reasons[0] ?? "";
+          const isSel = i === selected;
+          return (
+            <Box key={item.imdbId}>
+              <Box width={2} flexShrink={0}>
+                {isSel ? <Text color={COLOR.accent}>{ICON.pointer}</Text> : null}
+              </Box>
+              <Box flexGrow={1} minWidth={0}>
+                <Text color={isSel ? COLOR.accent : COLOR.text} wrap="truncate-end">
+                  {truncate(cleanText(item.title), 40)}
+                </Text>
+              </Box>
+              <Text dimColor>{`  ${item.year}  `}</Text>
+              <Text dimColor>{tag}</Text>
+            </Box>
+          );
+        })
+      )}
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/ui/components/ForYou.test.tsx`
+Expected: PASS (all five tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/hooks/useRecommendations.ts src/ui/components/ForYou.tsx src/ui/components/ForYou.test.tsx
+git commit -m "feat(ui): add useRecommendations hook and ForYou view"
+```
+
+---
+
+## Task 5: Wire "For You" into navigation, App, and keymap
+
+**Files:**
+- Modify: `src/ui/store.ts`
+- Modify: `src/ui/components/Sidebar.tsx`
+- Modify: `src/ui/App.tsx`
+- Modify: `src/ui/keymap.ts`
+
+- [ ] **Step 1: Add `"forYou"` to the `Section` type and exclude it in `isCategory`**
+
+In `src/ui/store.ts`, change the `Section` type (line ~14) to include `"forYou"`:
+
+```ts
+export type Section = Category | "watchlist" | "library" | "downloads" | "seeding" | "accounts" | "forYou";
+```
+
+And add one line to `isCategory` so the Results view is not shown for it:
+
+```ts
+export function isCategory(section: Section): boolean {
+  return (
+    section !== "watchlist" &&
+    section !== "library" &&
+    section !== "downloads" &&
+    section !== "seeding" &&
+    section !== "accounts" &&
+    section !== "forYou"
+  );
+}
+```
+
+- [ ] **Step 2: Add the "For You" nav item**
+
+In `src/ui/components/Sidebar.tsx`, add it at the top of the `LIBRARY` array:
+
+```ts
+const LIBRARY: NavItem[] = [
+  { key: "forYou", label: "For You" },
+  { key: "watchlist", label: "Watchlist" },
+  { key: "library", label: "Library" },
+  { key: "downloads", label: "Downloads" },
+  { key: "seeding", label: "Seeding" },
+  { key: "accounts", label: "Accounts" },
+];
+```
+
+- [ ] **Step 3: Render `<ForYou/>` and replace inline reccd-config literals in App.tsx**
+
+In `src/ui/App.tsx`:
+
+(a) Add `resolveReccConfig` to the existing import from `../config/config`, and import the component:
+
+```tsx
+import { ForYou } from "./components/ForYou";
+```
+
+(b) Replace all six inline `{ reccUrl: config.reccUrl, reccToken: config.reccToken }` literals passed as the first argument to `postEvent(...)` with `resolveReccConfig(config)`. For example the favourite handler becomes:
+
+```tsx
+    void postEvent(
+      resolveReccConfig(config),
+      {
+        type: wasFavourited ? "unfavourited" : "favourited",
+        rawName: item.name,
+        ts: Date.now(),
+        source: "torlink",
+      },
+    );
+```
+
+Do the same at the other five call sites (watched, the two `started` sites, and the two RatePrompt like/dislike handlers).
+
+(c) Add a content block immediately after the `library`/`<Favourites />` block:
+
+```tsx
+            <Box display={section === "forYou" ? "flex" : "none"} flexDirection="column">
+              <ForYou
+                reccConfig={resolveReccConfig(store.config)}
+                active={store.region === "content" && section === "forYou"}
+                setSection={store.setSection}
+                submitQuery={store.submitQuery}
+              />
+            </Box>
+```
+
+- [ ] **Step 4: Add For You footer hints and help group in keymap.ts**
+
+In `src/ui/keymap.ts`, add a branch at the start of the `footerHints(region, section, ...)` function body (before the other `section === ...` branches):
+
+```ts
+  if (section === "forYou") {
+    return [
+      NAVIGATE,
+      { keys: "↵", label: "Search title" },
+      { keys: "t", label: "Type" },
+      { keys: "g", label: "Genre" },
+      { keys: "e", label: "Explore" },
+      { keys: "r", label: "Refresh" },
+      SWITCH,
+      ALWAYS,
+    ];
+  }
+```
+
+And add a help group to the `HELP_GROUPS` array (after the "Search" group):
+
+```ts
+  {
+    title: "For You",
+    hints: [
+      { keys: "↑ ↓", label: "Move between picks" },
+      { keys: "↵", label: "Search this title" },
+      { keys: "t", label: "Cycle movie / TV / all" },
+      { keys: "g", label: "Filter by genre" },
+      { keys: "e", label: "Toggle explore mode" },
+      { keys: "r", label: "Refresh recommendations" },
+    ],
+  },
+```
+
+- [ ] **Step 5: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+Run: `npx vitest run`
+Expected: PASS (whole suite, including the existing Sidebar/keymap tests — update any snapshot/label assertions those tests make about nav items or hints if they now include "For You").
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/store.ts src/ui/components/Sidebar.tsx src/ui/App.tsx src/ui/keymap.ts
+git commit -m "feat(ui): wire For You section into nav, App, and keymap"
+```
+
+---
+
+## Task 6: End-to-end verification against the live reccd
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Point torlink at the live reccd**
+
+Add `reccUrl`/`reccToken` to the runtime config (NOT the repo). The token is local-network only and rotatable:
+
+```bash
+node -e '
+const fs=require("fs"),os=require("os"),p=require("path");
+const f=p.join(os.homedir(),".config","torlink","config.json");
+const c=JSON.parse(fs.readFileSync(f,"utf8"));
+c.reccUrl="http://192.168.0.98:4100";
+c.reccToken="<YOUR_RECCD_TOKEN>";
+fs.writeFileSync(f,JSON.stringify(c,null,2));
+console.log("updated",f);
+'
+```
+
+- [ ] **Step 2: Confirm the endpoint answers with the token**
+
+Run:
+```bash
+curl -s -H "Authorization: Bearer <YOUR_RECCD_TOKEN>" \
+  "http://192.168.0.98:4100/recommendations?limit=3"
+```
+Expected: a JSON array of `{ imdbId, title, year, score, reasons }`.
+
+- [ ] **Step 3: Manual smoke test**
+
+Launch torlink (per the repo's run instructions), open the **For You** section from the sidebar, and confirm:
+- Picks render; the footer shows the For You hints.
+- `t` cycles type (all → movie → tv) and the list refetches.
+- `g` opens the genre prompt; typing a genre filters; empty submission clears it.
+- `e` toggles explore.
+- `↵` on a pick switches to the matching category and runs a search for that title.
+- With `reccUrl` removed, the pane shows the setup hint instead of erroring.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- reccd client `fetchRecommendations` (blocking, discriminated result, error mapping) → Task 1. ✓
+- Env overrides + `resolveReccConfig` → Task 2, wired in Task 5 Step 3b. ✓
+- `useRecommendations` hook (filters, lazy load, refetch) → Task 4. ✓
+- `ForYou` view (rows, reason tag, states, controls `t`/`g`/`e`/`r`/`↵`/nav) → Task 4. ✓
+- Free-text genre prompt → Task 3. ✓
+- Selection → search bridge (`setSection` type→category + `submitQuery` title-only) → Task 4 + Task 5. ✓
+- Nav entry, `Section`/`isCategory`, App content block, footer hints + help group → Task 5. ✓
+- Config-unset setup hint; 401 / network / empty / malformed states → Tasks 1 & 4. ✓
+- Group "movie night", `/similar`, setup wizard, caching → explicitly out of scope. ✓
+
+**Type consistency:** `ReccClientConfig`, `Recommendation`, `RecommendationQuery`, `FetchRecommendationsResult` defined in Task 1 and imported unchanged in Tasks 2/4. `ReccType` (`"all"|"movie"|"tv"`) defined in the hook (Task 4) and used by `ForYou`. `TYPE_SECTION` maps to `Category` members (`all`/`movies`/`tv`) that exist in `store.ts`. `Section` gains `"forYou"` in Task 5 before `ForYou` (which imports `Section`) is wired in.
+
+**Placeholder scan:** none — every code and test step contains complete content.
+
+**Note for the implementer:** the hook is unit-tested *through* the `ForYou` component test (Task 4), matching this repo's component-test convention (`ink-testing-library`, no `renderHook` utility); there is intentionally no standalone `useRecommendations.test.ts`.

--- a/docs/superpowers/specs/2026-07-09-recommendation-engine-design.md
+++ b/docs/superpowers/specs/2026-07-09-recommendation-engine-design.md
@@ -1,0 +1,133 @@
+# Recommendation Engine (`reccd`) — Design
+
+**Date:** 2026-07-09
+**Status:** Approved (brainstorm complete)
+**Scope:** Standalone, self-hosted recommendation service for movies + TV (incl. anime), with torlink as its first client. Personal use only — licensing constraints of upstream data sources are accepted on that basis.
+
+## Goals
+
+- Track what a single user watches, likes, favourites, starts, and abandons.
+- Maintain a local, auto-updating catalog of the universe of movies/TV.
+- Return "you should check out these items" via an HTTP API, biased toward newer releases but still surfacing unseen high-quality classics.
+- Run 24/7 on low-power hardware; occasional heavy jobs run on a beefier machine and ship their outputs over.
+- No frontend. API responses carry only IDs, title, year, score, and reasons — downstream clients fetch artwork/details themselves.
+
+## Non-goals (v1)
+
+- Music and book recommendations.
+- Multi-user cohorts (the scoring pipeline leaves room for it as a future component).
+- Any UI beyond torlink's minimal event hooks.
+- Redistribution of upstream metadata via the API.
+
+## Decisions made during brainstorm
+
+| Decision | Choice |
+|---|---|
+| Where it lives | Standalone service, own repo; torlink is a client |
+| Signals | Implicit events + explicit like/dislike keypress in torlink |
+| Hardware | Low-power always-on host; beefy machine for offline jobs |
+| Content scope | Movies + TV (anime included); music/books out of scope |
+| Stack | TypeScript/Node HTTP service; Python offline jobs; SQLite everywhere |
+| API payload | IDs + title only; no metadata redistribution |
+
+## Architecture
+
+```
+beefy machine (occasional)                 always-on box (24/7)
+┌──────────────────────────┐   scp/rsync   ┌─────────────────────────────┐
+│ build_cf.py → cf.db      │ ────────────▶ │ reccd (Node/TS HTTP API)    │
+│ build_embeddings.py →    │               │  catalog.db  activity.db    │
+│   vectors.db             │               │  cf.db*  vectors.db*        │
+└──────────────────────────┘               └─────────────▲───────────────┘
+                                             POST /events │ GET /recommendations
+                                           ┌──────────────┴──────────────┐
+                                           │ torlink (event client)      │
+                                           └─────────────────────────────┘
+* optional — missing model files zero-out their score component
+```
+
+## Components
+
+### 1. Catalog (`catalog.db`)
+
+The universe of content, in SQLite:
+
+- **Skeleton — IMDb non-commercial TSVs** (`title.basics`, `title.ratings`): every movie/TV title with `imdb_id`, title, year, runtime, genres (≤3, coarse), rating, vote count. A nightly job downloads the dumps, rebuilds into a fresh table, and atomically swaps. Adult titles and non-movie/TV title types are filtered out at import. ~1–2 GB.
+- **Enrichment — TMDB**: keywords, plot overview, popularity, `tmdb_id`↔`imdb_id` mapping. Applied only to the *active subset*: titles above a configurable vote-count threshold plus anything the user interacts with (order of a few hundred thousand titles). Kept fresh incrementally via TMDB's `/changes` feed; initial fill is a rate-limited batch crawl.
+- **Candidate pool**: recommendations are scored over the enriched/pruned subset, not all ~12M rows, keeping runtime cheap.
+
+### 2. Activity store (`activity.db`)
+
+Append-only event log. Event: `{type, raw_name, resolved_imdb_id?, confidence?, ts, source}` where `type ∈ {started, watched, favourited, unfavourited, liked, disliked, abandoned}`.
+
+**Canonicalizer:** parses the raw torrent release name into title + year (release-name parsing library / logic shared with the torlink ecosystem), then resolves against the catalog by exact-then-fuzzy title+year match, storing the IMDb ID and a confidence score. Unresolved events are retained and retried after catalog refreshes — never dropped.
+
+**TV handling:** resolution targets the *show*; episode-level watches aggregate into show-level engagement (many episodes ≈ strong like; one episode then nothing ≈ mild negative).
+
+**Backfill:** on first run, an importer ingests torlink's existing `history.json` and `config.json` favourites (including per-episode `watched` lists) so the engine starts with the user's existing taste.
+
+### 3. Scoring engine
+
+For every unseen candidate:
+
+```
+score = w1·content_match        # genre/keyword/people overlap with taste profile
+      + w2·cf_similarity        # MovieLens-derived item-item ("liked X → try Y"), movies only
+      + w3·embedding_similarity # plot/keyword vector closeness to taste vector
+      + w4·recency_prior        # newer release date → boost
+      + w5·quality_prior        # rating × log(votes) — the cult-classic gate
+      − penalties               # already seen; similar to disliked/abandoned items
+```
+
+- **Taste profile:** weighted feature counts (genres, keywords, people) from events — likes/favourites/rewatches weigh positive, dislikes/abandons negative — with time decay so taste can drift.
+- **Weights** (`w1..w5`, penalty magnitudes, recency half-life) live in config; the newness bias is tuned by editing one number.
+- **Diversity pass:** a simple MMR-style re-rank so the top N spans genres rather than returning fifteen near-identical titles.
+- **Explainability:** every recommendation returns human-readable `reasons` (e.g. "because you liked Heat and Ronin; high rating; unseen").
+- **Graceful degradation:** each component reads its own data file; a missing `cf.db`/`vectors.db` (or un-enriched title) contributes 0 rather than erroring. Phase 1 ships with only `content_match + recency + quality`.
+
+### 4. HTTP API
+
+Bearer-token auth, JSON, deliberately small:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /events` | Ingest one or more activity events (fire-and-forget from clients) |
+| `GET /recommendations?type=movie\|tv&genre=…&limit=…` | Ranked `[{imdb_id, tmdb_id?, title, year, score, reasons[]}]` |
+| `GET /profile` | Inferred taste summary (top genres/keywords/people) — sanity-checking |
+| `GET /resolve?name=…` | Dry-run canonicalization of a release name — debugging |
+
+### 5. Offline jobs (Python, beefy machine)
+
+- **`build_cf.py`** (one-off): MovieLens ml-32M ratings → item-item similarity (top-K per title) → `cf.db`, keyed to IMDb IDs via MovieLens `links.csv`. Movies only; dataset snapshot ends 2023, which is acceptable because CF is one component among several.
+- **`build_embeddings.py`** (roughly monthly): sentence-transformers over `overview + keywords + genres` for the enriched subset → vectors stored via sqlite-vec in `vectors.db`.
+
+Outputs are copied to the always-on box; the service picks them up on restart (or file-watch).
+
+### 6. torlink integration
+
+A small client module inside torlink:
+
+- POSTs events on stream start/finish, favourite toggle, and queue-item removal (abandon signal).
+- One new keypress pair offering like/dislike after a stream ends.
+- Config additions: `reccUrl`, `reccToken`. Unconfigured or unreachable service = silent no-op; torlink behaviour never degrades.
+
+## Phasing
+
+1. **Phase 1 — useful on its own:** service skeleton, IMDb catalog + nightly refresh, event ingestion + canonicalizer, content-based scoring with recency/quality priors, torlink event client + like/dislike keys, backfill importer.
+2. **Phase 2 — biggest quality jump:** TMDB enrichment (keywords/popularity/overviews, ID mapping) + embedding pipeline and score component.
+3. **Phase 3:** MovieLens CF table and score component.
+4. **Later, maybe:** multi-user cohorts as an additional score component; a "Recommended for you" view in torlink.
+
+## Testing
+
+- **Vitest** unit coverage for the scoring pipeline (fixture catalog + synthetic event histories → assert ranking properties: recency bias works, seen items excluded, cult-classic gate admits old-but-great titles).
+- **Canonicalizer** gets the heaviest fixture suite — real-world release-name strings are where bugs will live.
+- Offline jobs validated by spot-checking known-similar pairs (e.g. Heat → Ronin) in their output tables.
+- API integration tests against a temp SQLite fixture set.
+
+## Failure posture
+
+- Catalog refresh failure → keep serving from the previous snapshot; log and retry next night.
+- TMDB unreachable → enrichment pauses; skeleton catalog still serves.
+- Model files absent/corrupt → component disabled, warning logged, recommendations still returned.
+- Event ingestion is fire-and-forget from the client side; the service persists events before acking.

--- a/docs/superpowers/specs/2026-07-22-reccd-account-setup-design.md
+++ b/docs/superpowers/specs/2026-07-22-reccd-account-setup-design.md
@@ -1,0 +1,119 @@
+# reccd Account Setup — Design
+
+**Date:** 2026-07-22
+**Status:** Approved (design)
+**Depends on:** the reccd integration and "For You" UI already on branch `docs/recommendation-engine-spec`
+(config fields `reccUrl`/`reccToken`, `resolveReccConfig`, the `ForYou` view).
+
+## Problem
+
+reccd's connection (`reccUrl` + `reccToken`) can currently only be set by hand-editing
+`config.json` or via `TORLINK_RECC_URL` / `TORLINK_RECC_TOKEN` env vars. There's no in-app way to
+configure it, so it doesn't persist conveniently and isn't discoverable. Since the "For You" nav
+item is hidden until reccd is configured, a first-time user has no obvious path to set it up.
+
+This adds an in-TUI setup for reccd in the existing **Accounts** pane, persisted to `config.json`
+(no env vars needed), with a live connection status. reccd is framed as a **private, self-hosted
+service** — appropriate until it's deployed somewhere shared.
+
+## Architecture
+
+Mirrors the existing Real-Debrid account flow (a status module + an Accounts row + a token prompt),
+adapted to reccd's two required values (URL + token).
+
+### 1. Connection status — `src/recc/status.ts`
+
+```
+type ReccConnection = "unconfigured" | "connected" | "badToken" | "unreachable";
+
+interface ReccStatus { state: ReccConnection; host?: string; }
+
+async function checkReccConnection(
+  config: ReccClientConfig,
+  opts?: { fetchImpl?: FetchImpl; timeoutMs?: number },
+): Promise<ReccStatus>;
+
+function formatReccStatus(status: ReccStatus): string;
+```
+
+- `checkReccConnection` returns `unconfigured` immediately when `reccUrl` is unset. Otherwise it
+  does `GET ${reccUrl}/profile` with `Bearer ${reccToken ?? ""}` and a short timeout (~6s):
+  - 200 → `connected`
+  - 401 → `badToken`
+  - any other status, network error, or timeout → `unreachable`
+  - `host` is the URL's host:port (best-effort parse; falls back to the raw `reccUrl`).
+- `formatReccStatus`: `connected` → `Connected · <host>`; `badToken` → `Token rejected`;
+  `unreachable` → `Unreachable · <host>`; `unconfigured` → `Not configured`.
+- Uses the same injected-`FetchImpl` pattern as `fetchRecommendations`/`postEvent` so it's testable
+  without a network. `/profile` is chosen because it's a cheap authenticated GET that cleanly
+  distinguishes 200 vs 401.
+
+### 2. Setup prompt — `src/ui/components/ReccdPrompt.tsx`
+
+A two-field prompt modeled on the existing RuTracker login prompt (`RutrackerPrompt.tsx`):
+
+- Field 1: **URL** — `TextField`, `defaultValue` = current `reccUrl`, placeholder `http://localhost:4100`.
+- Field 2: **Token** — `TextField` with `mask`, `defaultValue` = current `reccToken`.
+- Tab / ↑↓ move between fields; `↵` submits `(url, token)`; `esc` cancels. Uses `PromptHints`.
+- Title: `reccd — private, self-hosted recommendations`.
+- Props: `{ width; url: string; token: string; onSubmit: (url: string, token: string) => void; onCancel: () => void }`.
+- Trimming/normalization (e.g. stripping a trailing slash from the URL) happens in the App handler,
+  not the prompt, so the prompt stays presentational.
+
+### 3. Accounts row — `src/ui/components/Accounts.tsx`
+
+Add a third `Row`:
+- `tag: "RCD"`, `label: "reccd"`, `homepage: "self-hosted · private service"`.
+- `signedIn` = `reccUrl` is configured.
+- `status` = `formatReccStatus(reccStatus)` (from a new prop).
+- `onManage` = open the ReccdPrompt; `onSignOut` = clear reccUrl/reccToken.
+- New props on `AccountsProps`: `reccConfigured: boolean`, `reccStatus: ReccStatus | null`,
+  `reccEnvOverride?: boolean`, `onManageRecc: () => void`, `onSignOutRecc: () => void`.
+- When `reccEnvOverride` is true, append a dim note to the row (e.g. `(env override active)`) so a
+  value typed here that "doesn't take" isn't confusing — env still wins, matching Real-Debrid.
+
+### 4. App wiring — `src/ui/App.tsx`
+
+- State: `editingRecc: boolean`, `reccStatus: ReccStatus | null`.
+- Open handler (`onManageRecc`): set `editingRecc = true`. Render `<ReccdPrompt … />` hoisted like
+  the other prompts (added to the body/footer `display`-none guards and its own render block).
+- Submit handler: normalize the URL (trim, strip trailing slash; empty → undefined), write
+  `reccUrl`/`reccToken` into config via the existing `setConfigState` + `saveConfig` path, close the
+  prompt, and re-check status.
+- Clear handler (`onSignOutRecc`): set `reccUrl`/`reccToken` to undefined in config, save, re-check.
+- Status lifecycle: compute `checkReccConnection(resolveReccConfig(config))` on load and whenever the
+  reccd config changes (mirrors how `rdStatus` is refreshed). Pass `reccStatus`, `reccConfigured`
+  (`store.reccConfigured`), and `reccEnvOverride` (whether a `TORLINK_RECC_*` env var is set) to
+  `Accounts`.
+- Because saving updates `config`, `store.reccConfigured` flips true and the "For You" nav item
+  appears immediately (already wired).
+
+### 5. For You fallback copy
+
+Update the `ForYou` not-configured hint to point at the Accounts pane
+("Set up reccd in Accounts (↵)") instead of "edit config.json". This branch is normally
+unreachable (the nav item is hidden until configured) but remains as a runtime fallback.
+
+## Persistence & precedence
+
+- Values are saved to `config.json` (`reccUrl`/`reccToken`) — no env vars required.
+- `resolveReccConfig` precedence is unchanged: `TORLINK_RECC_URL`/`TORLINK_RECC_TOKEN` env vars still
+  win over config, consistent with `resolveRealDebridToken`. The Accounts row surfaces when an env
+  override is active.
+
+## Testing
+
+- `src/recc/status.test.ts`: `checkReccConnection` classification (unconfigured / 200 / 401 /
+  non-2xx / network-throw) with an injected fetch; `formatReccStatus` for each state; host parsing.
+- `src/ui/components/ReccdPrompt.test.tsx`: renders two fields; typing URL + token and submitting
+  calls `onSubmit(url, token)`; `esc` calls `onCancel`.
+- `src/ui/components/Accounts.test.tsx` (extend if present, else add): the reccd row renders with its
+  status, `↵` calls `onManageRecc`, `x` calls `onSignOutRecc` when configured, and the env-override
+  note shows when `reccEnvOverride`.
+- Full suite + `tsc --noEmit` green.
+
+## Out of scope
+
+- Multi-user / choosing which reccd user (single token per install, as today).
+- A discovery/onboarding wizard beyond the Accounts row.
+- Changing `resolveReccConfig` precedence.

--- a/docs/superpowers/specs/2026-07-22-recommendations-ui-design.md
+++ b/docs/superpowers/specs/2026-07-22-recommendations-ui-design.md
@@ -130,7 +130,12 @@ existing `postEvent` wiring records the resulting activity back to reccd — clo
 
 - `Section` type: add `"forYou"`. `isCategory()` already excludes non-category sections by
   explicit checks; add `"forYou"` to that exclusion list.
-- `Sidebar.tsx`: add `{ key: "forYou", label: "For You" }` at the **top of the `LIBRARY` group**.
+- `Sidebar.tsx`: add `{ key: "forYou", label: "For You" }` at the **top of the `LIBRARY` group**,
+  but **only when reccd is configured** — the item is filtered out entirely when `reccConfigured`
+  is false, so an unconfigured install never shows it. A `reccConfigured: boolean` field is added
+  to the store (computed as `Boolean(resolveReccConfig(config).reccUrl)`, mirroring the existing
+  `debridConfigured`) and read by the sidebar. The rail width (`RAIL_WIDTH`) is still derived from
+  the full nav list so it stays stable regardless.
 - `App.tsx`: render a `display`-toggled content block
   `display={section === "forYou" ? "flex" : "none"}` wrapping `<ForYou … />`, passing reccd
   config, `submitQuery`, and `setSection`.
@@ -148,7 +153,7 @@ existing `postEvent` wiring records the resulting activity back to reccd — clo
 
 | Situation | Behaviour |
 |---|---|
-| `reccUrl` unset | View shows setup hint; no fetch. |
+| `reccUrl` unset | The "For You" nav item is hidden entirely; no fetch. The in-pane setup hint remains only as a defensive fallback for the rare case where config is removed at runtime while the section is open. |
 | 401 from reccd | Error row: "reccd rejected the token — check reccToken", `r` retries. |
 | Network/timeout | Error row: "couldn't reach reccd", `r` retries. |
 | Empty array | Friendly empty state, not an error. |

--- a/docs/superpowers/specs/2026-07-22-recommendations-ui-design.md
+++ b/docs/superpowers/specs/2026-07-22-recommendations-ui-design.md
@@ -1,0 +1,174 @@
+# "For You" Recommendations UI — Design
+
+**Date:** 2026-07-22
+**Status:** Approved (design)
+**Depends on:** the existing reccd event-posting integration (`src/recc/client.ts`, config fields `reccUrl`/`reccToken`, event wiring in `App.tsx`) already present on branch `docs/recommendation-engine-spec`.
+
+## Problem
+
+torlink's reccd integration is currently one-directional: it *sends* activity events
+(`started`/`watched`/`favourited`/`liked`/`disliked`/`abandoned`) to the self-hosted reccd
+service, but it never *fetches or displays* recommendations. The "smart recommendations"
+payoff — reccd's `GET /recommendations` — is not surfaced anywhere in the UI.
+
+This design adds a **For You** section that fetches ranked picks from reccd and lets the user
+launch a torrent search for any of them, closing the loop: search → stream → rate feeds reccd,
+so future recommendations personalize over time.
+
+## Context: the reccd API we consume
+
+`GET /recommendations?type=movie|tv&genre=<str>&limit=<n>&explore=true`, `Authorization: Bearer <token>`.
+
+Response: JSON array of `{ imdbId: string, title: string, year: number, score: number, reasons: string[] }`.
+
+Notes that shape this design:
+- reccd returns **no magnet/torrent** — only IMDb id + title + year. Selecting a recommendation
+  must therefore start a torlink **search** for that title.
+- Results are diversity re-ranked and may include a **wildcard pick** (a title with `reasons`
+  exactly `["wildcard pick"]`), so the array is not strictly score-descending.
+- `genre` is a free string on reccd's side (no fixed vocabulary torlink can enumerate).
+- `explore=true` ranks purely on a title's own recency/quality with personalization off — good
+  for browsing outside your usual taste, especially combined with a genre.
+- A missing/unknown token returns `401 { "error": "unauthorized" }`.
+- The user's `/profile` is empty until posted events resolve against reccd's catalog; until then
+  recommendations fall back to recency/quality priors. This is expected, not an error.
+
+## Non-goals (deferred beyond v1)
+
+- Group "movie night" blending across users (`with=` param).
+- `/similar/:imdbId` "because you liked X" drilldowns.
+- An in-app reccd setup wizard — v1 configures via `config.json` / env vars.
+- Cross-session caching of recommendations.
+
+## Architecture
+
+Three units, each independently understandable and testable:
+
+### 1. reccd client — `fetchRecommendations` (`src/recc/client.ts`)
+
+Add alongside the existing `postEvent`:
+
+```
+interface Recommendation { imdbId: string; title: string; year: number; score: number; reasons: string[]; }
+
+interface RecommendationQuery { type?: "movie" | "tv"; genre?: string; explore?: boolean; limit?: number; }
+
+type FetchRecommendationsResult =
+  | { ok: true; items: Recommendation[] }
+  | { ok: false; error: string };
+
+async function fetchRecommendations(
+  config: ReccClientConfig,
+  query: RecommendationQuery,
+  opts?: { fetchImpl?: FetchImpl; timeoutMs?: number },
+): Promise<FetchRecommendationsResult>;
+```
+
+Behaviour — deliberately **different from `postEvent`**:
+- `postEvent` is fire-and-forget (an analytics write that must never affect torlink).
+  `fetchRecommendations` is a **blocking read the user is waiting on**, so failures are
+  surfaced, not swallowed.
+- Builds the query string from provided fields only (omit `type`/`genre` when unset;
+  `explore=true` only when true; `limit` always sent, default 20).
+- `Bearer ${config.reccToken ?? ""}` auth header (same convention as `postEvent`).
+- Timeout ~10s via `AbortSignal.timeout`.
+- Returns a discriminated result:
+  - `401` → `{ ok: false, error: "reccd rejected the token — check reccToken" }`
+  - other non-2xx → `{ ok: false, error: "recommendations unavailable (HTTP <status>)" }`
+  - network error / timeout → `{ ok: false, error: "couldn't reach reccd" }`
+  - success → `{ ok: true, items }` (parsed/shape-guarded; malformed body → `ok:false`).
+
+### 2. `useRecommendations` hook (`src/ui/hooks/useRecommendations.ts`)
+
+Owns fetch state and filters so the view component stays presentational:
+
+- State: `items`, `loading`, `error`, and filters `{ type: "all" | "movie" | "tv"; genre?: string; explore: boolean }`.
+- Exposes `refresh()`, `setType()`, `setGenre()`, `toggleExplore()`. Any filter change triggers a refetch.
+- Maps `type: "all"` to *omitting* the reccd `type` param.
+- Reads reccd config (resolved `reccUrl`/`reccToken`) passed in from `App.tsx`.
+- Does not fetch when `reccUrl` is unset (drives the "set up" hint in the view).
+
+### 3. `ForYou` view (`src/ui/components/ForYou.tsx`)
+
+Presentational list bound to the hook.
+
+- **Rows:** `title · year · reason-tag`. The reason tag is the first `reasons` entry
+  (or `wildcard pick` when that is the sole reason). Score is not shown (internal ranking detail).
+- **Controls (footer hints):**
+  - `t` — cycle type: all → movie → tv → all
+  - `g` — set genre: opens a free-text prompt (empty submission clears the genre)
+  - `e` — toggle explore mode
+  - `r` — refresh
+  - `↑↓` / `j k` — move selection
+  - `↵` — search this title (see bridge below)
+  - `esc` — back to sidebar
+- **States:**
+  - loading → spinner "Finding recommendations…"
+  - error → the hook's error string + "press r to retry"
+  - empty list → "No picks yet — stream something and they'll start showing up here."
+  - `reccUrl` unset → "Set up recommendations: add reccUrl/reccToken to config.json
+    (or TORLINK_RECC_URL / TORLINK_RECC_TOKEN)."
+
+**Genre input** uses a free-text prompt (reusing torlink's existing prompt/TextField pattern)
+rather than a curated cycle-list, because reccd's genre vocabulary is open-ended and a fixed
+list would be guesswork.
+
+### 4. Selection → search bridge
+
+On `↵` over a recommendation, `ForYou` calls two things already available in `App.tsx`:
+1. `setSection(category)` where category derives from the current type filter
+   (`movie → "movies"`, `tv → "tv"`, `all → "all"`), so the Results view's category is sensible.
+2. `submitQuery(title)` — the existing callback that sets the query, records search history,
+   and runs the concurrent search.
+
+Query is **title-only** for v1. Torrent release names are matched better without an appended
+year (year often hurts recall); if recall proves poor we can add `"{title} {year}"` for movies
+later. After the jump, the normal Results flow applies (stream / download / favourite), and the
+existing `postEvent` wiring records the resulting activity back to reccd — closing the loop.
+
+## Wiring changes (`src/ui/store.ts`, `Sidebar.tsx`, `App.tsx`, `keymap.ts`)
+
+- `Section` type: add `"forYou"`. `isCategory()` already excludes non-category sections by
+  explicit checks; add `"forYou"` to that exclusion list.
+- `Sidebar.tsx`: add `{ key: "forYou", label: "For You" }` at the **top of the `LIBRARY` group**.
+- `App.tsx`: render a `display`-toggled content block
+  `display={section === "forYou" ? "flex" : "none"}` wrapping `<ForYou … />`, passing reccd
+  config, `submitQuery`, and `setSection`.
+- `keymap.ts`: add a "For You" `HELP_GROUPS` entry and any footer hint labels.
+
+## Config
+
+- Read `reccUrl` / `reccToken` from `config.json` (fields already exist).
+- Add **env overrides** `TORLINK_RECC_URL` / `TORLINK_RECC_TOKEN`, resolved the same way
+  torlink already resolves `realDebridToken`, media player, and DNS from env (a
+  `resolveReccConfig(config, env)` helper mirroring the existing `resolve*` functions).
+- No new persisted config keys.
+
+## Error handling summary
+
+| Situation | Behaviour |
+|---|---|
+| `reccUrl` unset | View shows setup hint; no fetch. |
+| 401 from reccd | Error row: "reccd rejected the token — check reccToken", `r` retries. |
+| Network/timeout | Error row: "couldn't reach reccd", `r` retries. |
+| Empty array | Friendly empty state, not an error. |
+| Malformed body | Treated as `ok:false` with a generic "unexpected response from reccd". |
+
+## Testing
+
+- **`src/recc/client.test.ts`** (extend): `fetchRecommendations` — success parse; 401 mapping;
+  timeout/network mapping; malformed-body mapping; query-string building across
+  type/genre/explore/limit combinations (including `type:"all"` omitting the param).
+- **`src/ui/hooks/useRecommendations.test.ts`** (new): filter changes trigger refetch;
+  `type:"all"` omits param; error state surfaces from the client.
+- **`src/ui/components/ForYou.test.tsx`** (new): renders list / loading / error / empty /
+  unconfigured states; `t`/`e` change filters; `g` opens the genre prompt; `↵` calls
+  `submitQuery(title)` + `setSection(expectedCategory)`. Mirrors the existing
+  `RatePrompt.test.tsx` component-test style.
+
+## Rollout / verification
+
+1. Set `reccUrl` (`http://192.168.0.98:4100`) and `reccToken` in the local `config.json`.
+2. Launch torlink, open **For You**, confirm live picks render, filters work, and selecting a
+   pick runs a search and lands in Results.
+3. Stream a title, confirm the existing event posting reaches reccd (personalization loop).

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -338,10 +338,14 @@ save(
           rdToken="rd_live_xxx"
           rdStatus={RD_STATUS}
           rutrackerUser="you"
+          reccConfigured
+          reccStatus={{ state: "connected", host: "reccd.local:4100" }}
           onManageRd={() => {}}
           onSignOutRd={() => {}}
           onManageRutracker={() => {}}
           onSignOutRutracker={() => {}}
+          onManageRecc={() => {}}
+          onSignOutRecc={() => {}}
         />
       </Box>
     </Box>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -130,6 +130,7 @@ function makeStore(
     startDebridDownload: noop,
     streamResult: noop,
     debridConfigured: false,
+    reccConfigured: false,
     streamActive: false,
     rdStatus: null,
     copyLink: noop,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -5,6 +5,7 @@ import {
   resolveRealDebridToken,
   resolveMediaPlayer,
   resolveDnsServers,
+  resolveReccConfig,
 } from "./config";
 
 describe("config realDebridToken", () => {
@@ -180,5 +181,38 @@ describe("config favourites", () => {
   it("defaults to [] when favourites is missing", async () => {
     await saveConfig({ downloadDir: "/tmp/dl", trackers: [] });
     expect((await loadConfig()).favourites).toEqual([]);
+  });
+});
+
+describe("resolveReccConfig", () => {
+  const base = { downloadDir: "/tmp/dl", trackers: [] as string[] };
+
+  it("uses config values when no env override is set", () => {
+    delete process.env.TORLINK_RECC_URL;
+    delete process.env.TORLINK_RECC_TOKEN;
+    expect(resolveReccConfig({ ...base, reccUrl: "http://host:4100", reccToken: "tok" })).toEqual({
+      reccUrl: "http://host:4100",
+      reccToken: "tok",
+    });
+  });
+
+  it("prefers env vars over config values", () => {
+    process.env.TORLINK_RECC_URL = "http://env:4100";
+    process.env.TORLINK_RECC_TOKEN = "envtok";
+    try {
+      expect(resolveReccConfig({ ...base, reccUrl: "http://host:4100", reccToken: "tok" })).toEqual({
+        reccUrl: "http://env:4100",
+        reccToken: "envtok",
+      });
+    } finally {
+      delete process.env.TORLINK_RECC_URL;
+      delete process.env.TORLINK_RECC_TOKEN;
+    }
+  });
+
+  it("returns undefined fields when neither env nor config is set", () => {
+    delete process.env.TORLINK_RECC_URL;
+    delete process.env.TORLINK_RECC_TOKEN;
+    expect(resolveReccConfig({ ...base })).toEqual({ reccUrl: undefined, reccToken: undefined });
   });
 });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -15,6 +15,20 @@ describe("config realDebridToken", () => {
   });
 });
 
+describe("config recc fields", () => {
+  it("round-trips reccUrl and reccToken through save and load", async () => {
+    await saveConfig({
+      downloadDir: "/tmp/dl",
+      reccUrl: "http://localhost:4100",
+      reccToken: "recc-abc123",
+      trackers: [],
+    });
+    const cfg = await loadConfig();
+    expect(cfg.reccUrl).toBe("http://localhost:4100");
+    expect(cfg.reccToken).toBe("recc-abc123");
+  });
+});
+
 describe("config UI preferences", () => {
   it("round-trips the persisted sort and category", async () => {
     await saveConfig({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,6 +3,7 @@ import { configFile, defaultDownloadDir } from "./paths";
 import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 import { parseDnsServers } from "../util/dns";
 import type { SourceId } from "../sources/types";
+import type { ReccClientConfig } from "../recc/client";
 
 // A pinned VIDEO torrent/series to return to, remembering which episodes have
 // been streamed. Never stores stream URLs — only the magnet + metadata, so it
@@ -109,6 +110,18 @@ export function resolveDnsServers(config: Config): string[] {
   const env = process.env[DNS_ENV];
   const raw = env !== undefined ? env : (config.dnsServers ?? []).join(",");
   return parseDnsServers(raw);
+}
+
+const RECC_URL_ENV = "TORLINK_RECC_URL";
+const RECC_TOKEN_ENV = "TORLINK_RECC_TOKEN";
+
+// The effective reccd connection (env wins over config, matching the other
+// resolve* helpers). An undefined reccUrl means "recommendations not
+// configured" — the For You view then shows a setup hint instead of fetching.
+export function resolveReccConfig(config: Config): ReccClientConfig {
+  const url = process.env[RECC_URL_ENV]?.trim() || config.reccUrl?.trim() || undefined;
+  const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
+  return { reccUrl: url, reccToken: token };
 }
 
 export async function loadConfig(): Promise<Config> {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -23,6 +23,10 @@ export interface Config {
   // encryption); a REALDEBRID_API_TOKEN env var overrides it at read time, so
   // those who prefer it can keep the token off disk entirely.
   realDebridToken?: string;
+  // Base URL of the reccd recommendation service, e.g. http://localhost:4100
+  reccUrl?: string;
+  // Bearer token for authenticating with reccd
+  reccToken?: string;
   // Preferred media-player command for streaming (e.g. "mpv", "iina", "vlc",
   // or an absolute path). Empty/unset falls back to auto-detection. A
   // TORLINK_PLAYER env var overrides it.

--- a/src/recc/client.test.ts
+++ b/src/recc/client.test.ts
@@ -41,4 +41,27 @@ describe("postEvent", () => {
       postEvent({ reccUrl: "http://localhost:4100", reccToken: "t" }, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl })
     ).resolves.toBeUndefined();
   });
+
+  it("sends a request body of exactly { events: [event] }", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(202, { accepted: 1 }));
+    const event = { type: "watched" as const, rawName: "The.Matrix.1999.1080p", ts: 1000, source: "torlink" };
+    await postEvent({ reccUrl: "http://localhost:4100", reccToken: "dev-token" }, event, { fetchImpl });
+    const [, init] = fetchImpl.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(init.body)).toEqual({ events: [event] });
+  });
+
+  it("still fires with an empty bearer token when reccToken is omitted", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(202, { accepted: 1 }));
+    await postEvent(
+      { reccUrl: "http://localhost:4100" },
+      { type: "watched", rawName: "x", ts: 1, source: "torlink" },
+      { fetchImpl }
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://localhost:4100/events",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer " }),
+      })
+    );
+  });
 });

--- a/src/recc/client.test.ts
+++ b/src/recc/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { postEvent } from "./client.js";
+
+function jsonRes(status: number, body: unknown = {}) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("postEvent", () => {
+  it("posts to {reccUrl}/events with a bearer token and the event payload", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(202, { accepted: 1 }));
+    await postEvent(
+      { reccUrl: "http://localhost:4100", reccToken: "dev-token" },
+      { type: "watched", rawName: "The.Matrix.1999.1080p", ts: 1000, source: "torlink" },
+      { fetchImpl }
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://localhost:4100/events",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ authorization: "Bearer dev-token" }),
+      })
+    );
+  });
+
+  it("does nothing when reccUrl is not configured", async () => {
+    const fetchImpl = vi.fn();
+    await postEvent({}, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("swallows network errors without throwing", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(
+      postEvent({ reccUrl: "http://localhost:4100", reccToken: "t" }, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl })
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows non-2xx responses without throwing", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500));
+    await expect(
+      postEvent({ reccUrl: "http://localhost:4100", reccToken: "t" }, { type: "watched", rawName: "x", ts: 1, source: "torlink" }, { fetchImpl })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/recc/client.test.ts
+++ b/src/recc/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { postEvent } from "./client.js";
+import { postEvent, fetchRecommendations } from "./client.js";
+import type { FetchImpl } from "../util/net";
 
 function jsonRes(status: number, body: unknown = {}) {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
@@ -63,5 +64,81 @@ describe("postEvent", () => {
         headers: expect.objectContaining({ authorization: "Bearer " }),
       })
     );
+  });
+});
+
+function fakeFetch(
+  handler: (url: string) => { status: number; body?: unknown; throwErr?: boolean },
+): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    const r = handler(String(url));
+    if (r.throwErr) throw new Error("network down");
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+    } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+const CONFIG = { reccUrl: "http://host:4100", reccToken: "tok" };
+const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
+
+describe("fetchRecommendations", () => {
+  it("returns ok with parsed items on 200", async () => {
+    const { impl } = fakeFetch(() => ({ status: 200, body: [REC] }));
+    const res = await fetchRecommendations(CONFIG, { limit: 5 }, { fetchImpl: impl });
+    expect(res).toEqual({ ok: true, items: [REC] });
+  });
+
+  it("builds the query string from provided filters", async () => {
+    const { impl, urls } = fakeFetch(() => ({ status: 200, body: [] }));
+    await fetchRecommendations(CONFIG, { type: "movie", genre: "Western", explore: true, limit: 5 }, { fetchImpl: impl });
+    expect(urls[0]).toContain("/recommendations?");
+    expect(urls[0]).toContain("type=movie");
+    expect(urls[0]).toContain("genre=Western");
+    expect(urls[0]).toContain("explore=true");
+    expect(urls[0]).toContain("limit=5");
+  });
+
+  it("omits type/genre/explore when unset and defaults limit to 20", async () => {
+    const { impl, urls } = fakeFetch(() => ({ status: 200, body: [] }));
+    await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(urls[0]).not.toContain("type=");
+    expect(urls[0]).not.toContain("genre=");
+    expect(urls[0]).not.toContain("explore=");
+    expect(urls[0]).toContain("limit=20");
+  });
+
+  it("maps 401 to a token error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 401, body: { error: "unauthorized" } }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "reccd rejected the token — check reccToken" });
+  });
+
+  it("maps other non-2xx to an unavailable error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 500 }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "recommendations unavailable (HTTP 500)" });
+  });
+
+  it("maps a network throw to an unreachable error", async () => {
+    const { impl } = fakeFetch(() => ({ status: 0, throwErr: true }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "couldn't reach reccd" });
+  });
+
+  it("rejects a malformed body", async () => {
+    const { impl } = fakeFetch(() => ({ status: 200, body: [{ imdbId: 1 }] }));
+    const res = await fetchRecommendations(CONFIG, {}, { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "unexpected response from reccd" });
+  });
+
+  it("returns a not-configured error when reccUrl is missing", async () => {
+    const res = await fetchRecommendations({ reccToken: "t" }, {});
+    expect(res).toEqual({ ok: false, error: "recommendations not configured" });
   });
 });

--- a/src/recc/client.ts
+++ b/src/recc/client.ts
@@ -1,4 +1,5 @@
 import type { FetchImpl } from "../util/net";
+import { log } from "../util/logger";
 
 export type ReccEventType =
   | "started"
@@ -29,6 +30,12 @@ export interface PostEventOptions {
 // Fire-and-forget: posts a single event to the self-hosted reccd service.
 // reccd being unreachable, slow, or erroring must never affect torlink — any
 // failure (network error, non-2xx response) is swallowed silently.
+//
+// Deliberately uses plain injected fetch with a single attempt instead of
+// fetchResilient (used for blocking calls like Real-Debrid): retrying a
+// dropped analytics event during a reccd outage would pile up concurrent
+// requests precisely when the target is struggling, the opposite of what's
+// wanted here.
 export async function postEvent(
   config: ReccClientConfig,
   event: ReccEvent,
@@ -41,13 +48,22 @@ export async function postEvent(
       method: "POST",
       headers: {
         "content-type": "application/json",
+        // reccd's server always requires a token, so an empty string here
+        // (rather than omitting the header) is deliberate: it produces a
+        // clearly-wrong-looking auth attempt rather than silently masking a
+        // forgotten reccToken config value.
         authorization: `Bearer ${config.reccToken ?? ""}`,
       },
       body: JSON.stringify({ events: [event] }),
       signal: AbortSignal.timeout(opts.timeoutMs ?? 3000),
     });
-    if (!res.ok) return;
-  } catch {
-    // Network error, timeout, etc. — never surface to the caller.
+    if (!res.ok) {
+      log.debug(`recc postEvent: non-ok response from ${config.reccUrl}/events (status ${res.status})`);
+      return;
+    }
+  } catch (err) {
+    log.debug(
+      `recc postEvent: failed to reach ${config.reccUrl}/events: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }

--- a/src/recc/client.ts
+++ b/src/recc/client.ts
@@ -1,0 +1,53 @@
+import type { FetchImpl } from "../util/net";
+
+export type ReccEventType =
+  | "started"
+  | "watched"
+  | "favourited"
+  | "unfavourited"
+  | "liked"
+  | "disliked"
+  | "abandoned";
+
+export interface ReccEvent {
+  type: ReccEventType;
+  rawName: string;
+  ts: number;
+  source: string;
+}
+
+export interface ReccClientConfig {
+  reccUrl?: string;
+  reccToken?: string;
+}
+
+export interface PostEventOptions {
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+}
+
+// Fire-and-forget: posts a single event to the self-hosted reccd service.
+// reccd being unreachable, slow, or erroring must never affect torlink — any
+// failure (network error, non-2xx response) is swallowed silently.
+export async function postEvent(
+  config: ReccClientConfig,
+  event: ReccEvent,
+  opts: PostEventOptions = {},
+): Promise<void> {
+  if (!config.reccUrl) return;
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/events`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${config.reccToken ?? ""}`,
+      },
+      body: JSON.stringify({ events: [event] }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 3000),
+    });
+    if (!res.ok) return;
+  } catch {
+    // Network error, timeout, etc. — never surface to the caller.
+  }
+}

--- a/src/recc/client.ts
+++ b/src/recc/client.ts
@@ -67,3 +67,72 @@ export async function postEvent(
     );
   }
 }
+
+export interface Recommendation {
+  imdbId: string;
+  title: string;
+  year: number;
+  score: number;
+  reasons: string[];
+}
+
+export interface RecommendationQuery {
+  type?: "movie" | "tv";
+  genre?: string;
+  explore?: boolean;
+  limit?: number;
+}
+
+export type FetchRecommendationsResult =
+  | { ok: true; items: Recommendation[] }
+  | { ok: false; error: string };
+
+function isRecommendation(v: unknown): v is Recommendation {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.imdbId === "string" &&
+    typeof r.title === "string" &&
+    typeof r.year === "number" &&
+    typeof r.score === "number" &&
+    Array.isArray(r.reasons) &&
+    r.reasons.every((x) => typeof x === "string")
+  );
+}
+
+// A blocking read, unlike the fire-and-forget postEvent: the user is waiting on
+// these results, so failures are surfaced as a discriminated result rather than
+// swallowed. reccd returns no magnet — the caller starts a torrent search from
+// the returned title.
+export async function fetchRecommendations(
+  config: ReccClientConfig,
+  query: RecommendationQuery,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchRecommendationsResult> {
+  if (!config.reccUrl) return { ok: false, error: "recommendations not configured" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  const params = new URLSearchParams();
+  if (query.type) params.set("type", query.type);
+  if (query.genre && query.genre.trim()) params.set("genre", query.genre.trim());
+  if (query.explore) params.set("explore", "true");
+  params.set("limit", String(query.limit ?? 20));
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/recommendations?${params.toString()}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 10000),
+    });
+    if (res.status === 401) return { ok: false, error: "reccd rejected the token — check reccToken" };
+    if (!res.ok) return { ok: false, error: `recommendations unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!Array.isArray(body) || !body.every(isRecommendation)) {
+      return { ok: false, error: "unexpected response from reccd" };
+    }
+    return { ok: true, items: body };
+  } catch (err) {
+    log.debug(
+      `recc fetchRecommendations: failed to reach ${config.reccUrl}/recommendations: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, error: "couldn't reach reccd" };
+  }
+}

--- a/src/recc/status.test.ts
+++ b/src/recc/status.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { checkReccConnection, formatReccStatus } from "./status";
+import type { FetchImpl } from "../util/net";
+
+function fakeFetch(handler: (url: string) => { status: number; throwErr?: boolean }): FetchImpl {
+  return (async (url: string) => {
+    const r = handler(String(url));
+    if (r.throwErr) throw new Error("network down");
+    return { ok: r.status >= 200 && r.status < 300, status: r.status, json: async () => ({}) } as unknown as Response;
+  }) as unknown as FetchImpl;
+}
+
+const CFG = { reccUrl: "http://192.168.0.98:4100", reccToken: "tok" };
+
+describe("checkReccConnection", () => {
+  it("returns unconfigured when reccUrl is missing", async () => {
+    expect(await checkReccConnection({ reccToken: "t" })).toEqual({ state: "unconfigured" });
+  });
+
+  it("returns connected on 200", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 200 })) });
+    expect(res).toEqual({ state: "connected", host: "192.168.0.98:4100" });
+  });
+
+  it("returns badToken on 401", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 401 })) });
+    expect(res).toEqual({ state: "badToken", host: "192.168.0.98:4100" });
+  });
+
+  it("returns unreachable on other non-2xx", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 500 })) });
+    expect(res).toEqual({ state: "unreachable", host: "192.168.0.98:4100" });
+  });
+
+  it("returns unreachable on a network error", async () => {
+    const res = await checkReccConnection(CFG, { fetchImpl: fakeFetch(() => ({ status: 0, throwErr: true })) });
+    expect(res).toEqual({ state: "unreachable", host: "192.168.0.98:4100" });
+  });
+
+  it("hits the /profile endpoint with a bearer header", async () => {
+    let seen = "";
+    const impl = (async (url: string, init: { headers?: Record<string, string> }) => {
+      seen = String(url);
+      expect(init.headers?.authorization).toBe("Bearer tok");
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }) as unknown as FetchImpl;
+    await checkReccConnection(CFG, { fetchImpl: impl });
+    expect(seen).toBe("http://192.168.0.98:4100/profile");
+  });
+});
+
+describe("formatReccStatus", () => {
+  it("formats each state", () => {
+    expect(formatReccStatus(null)).toBe("Not configured");
+    expect(formatReccStatus({ state: "unconfigured" })).toBe("Not configured");
+    expect(formatReccStatus({ state: "connected", host: "h:4100" })).toBe("Connected · h:4100");
+    expect(formatReccStatus({ state: "badToken", host: "h:4100" })).toBe("Token rejected");
+    expect(formatReccStatus({ state: "unreachable", host: "h:4100" })).toBe("Unreachable · h:4100");
+  });
+});

--- a/src/recc/status.ts
+++ b/src/recc/status.ts
@@ -1,0 +1,55 @@
+import type { FetchImpl } from "../util/net";
+import type { ReccClientConfig } from "./client";
+
+export type ReccConnection = "unconfigured" | "connected" | "badToken" | "unreachable";
+
+export interface ReccStatus {
+  state: ReccConnection;
+  host?: string;
+}
+
+function hostOf(reccUrl: string): string {
+  try {
+    return new URL(reccUrl).host || reccUrl;
+  } catch {
+    return reccUrl;
+  }
+}
+
+// Pings reccd's authenticated GET /profile to classify the connection for the
+// Accounts pane. Never throws — network/timeout/other errors map to
+// "unreachable". /profile is a cheap authenticated GET that cleanly separates
+// 200 (connected) from 401 (bad token).
+export async function checkReccConnection(
+  config: ReccClientConfig,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<ReccStatus> {
+  if (!config.reccUrl) return { state: "unconfigured" };
+  const host = hostOf(config.reccUrl);
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/profile`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 6000),
+    });
+    if (res.status === 401) return { state: "badToken", host };
+    if (!res.ok) return { state: "unreachable", host };
+    return { state: "connected", host };
+  } catch {
+    return { state: "unreachable", host };
+  }
+}
+
+// One-line status for the Accounts row / setup prompt.
+export function formatReccStatus(status: ReccStatus | null): string {
+  if (!status || status.state === "unconfigured") return "Not configured";
+  switch (status.state) {
+    case "connected":
+      return `Connected · ${status.host}`;
+    case "badToken":
+      return "Token rejected";
+    case "unreachable":
+      return `Unreachable · ${status.host}`;
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -460,25 +460,26 @@ export function App({
   }, []);
 
   const toggleFavourite = useCallback((item: FavouriteItem) => {
+    if (!config) return;
+    const wasFavourited = isFavouritedIn(config.favourites ?? [], item.id);
     setConfigState((prev) => {
       if (!prev) return prev;
-      const wasFavourited = isFavouritedIn(prev.favourites ?? [], item.id);
       const favourites = toggleFavouriteList(prev.favourites ?? [], item);
       const next = { ...prev, favourites };
       void saveConfig(next);
-      void postEvent(
-        { reccUrl: prev.reccUrl, reccToken: prev.reccToken },
-        {
-          type: wasFavourited ? "unfavourited" : "favourited",
-          rawName: item.name,
-          ts: Date.now(),
-          source: "torlink",
-        },
-      );
       return next;
     });
+    void postEvent(
+      { reccUrl: config.reccUrl, reccToken: config.reccToken },
+      {
+        type: wasFavourited ? "unfavourited" : "favourited",
+        rawName: item.name,
+        ts: Date.now(),
+        source: "torlink",
+      },
+    );
     setNotice("Favourites updated.");
-  }, []);
+  }, [config]);
 
   const removeFavourite = useCallback((id: string) => {
     setConfigState((prev) => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -79,6 +79,8 @@ import { StreamFilePrompt } from "./components/StreamFilePrompt";
 import { SourcesPrompt } from "./components/SourcesPrompt";
 import { DnsPrompt } from "./components/DnsPrompt";
 import { RutrackerPrompt, type LoginStatus } from "./components/RutrackerPrompt";
+import { ReccdPrompt } from "./components/ReccdPrompt";
+import { checkReccConnection, type ReccStatus } from "../recc/status";
 import { Accounts } from "./components/Accounts";
 import { Watchlist } from "./components/Watchlist";
 import { Favourites } from "./components/Favourites";
@@ -161,6 +163,8 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingToken, setEditingToken] = useState(false);
+  const [editingRecc, setEditingRecc] = useState(false);
+  const [reccStatus, setReccStatus] = useState<ReccStatus | null>(null);
   const [editingPlayer, setEditingPlayer] = useState(false);
   const [editingSources, setEditingSources] = useState(false);
   const [editingDns, setEditingDns] = useState(false);
@@ -650,6 +654,49 @@ export function App({
     setRdStatus(null);
     setNotice("Real-Debrid token cleared.");
   }, [config, setConfig, closeTokenPrompt]);
+
+  const refreshReccStatus = useCallback((cfg: Config | null) => {
+    const rc = cfg ? resolveReccConfig(cfg) : {};
+    if (!rc.reccUrl) {
+      setReccStatus(null);
+      return;
+    }
+    void checkReccConnection(rc).then(setReccStatus);
+  }, []);
+
+  useEffect(() => {
+    refreshReccStatus(config);
+  }, [config?.reccUrl, config?.reccToken, refreshReccStatus]);
+
+  const closeReccPrompt = useCallback(() => setEditingRecc(false), []);
+
+  const openReccPrompt = useCallback(() => {
+    setView("browser");
+    setShowHelp(false);
+    setEditingRecc(true);
+    refreshReccStatus(config);
+  }, [config, refreshReccStatus]);
+
+  const saveReccConfig = useCallback(
+    (rawUrl: string, rawToken: string) => {
+      closeReccPrompt();
+      const url = rawUrl.trim().replace(/\/+$/, "");
+      const token = rawToken.trim();
+      persistConfig({ reccUrl: url || undefined, reccToken: token || undefined });
+      setNotice(url ? `${ICON.done} reccd set to ${url}` : "reccd connection cleared.");
+    },
+    [closeReccPrompt, persistConfig],
+  );
+
+  const clearReccConfig = useCallback(() => {
+    closeReccPrompt();
+    if (process.env["TORLINK_RECC_URL"]?.trim() || process.env["TORLINK_RECC_TOKEN"]?.trim()) {
+      setNotice("reccd is set via TORLINK_RECC_* env vars — unset them to clear it.");
+      return;
+    }
+    persistConfig({ reccUrl: undefined, reccToken: undefined });
+    setNotice("reccd connection cleared.");
+  }, [closeReccPrompt, persistConfig]);
 
   const startDownload = useCallback(
     (input: DownloadInput) => {
@@ -1351,7 +1398,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt || ratePrompt
+        showHelp || editingFolder || editingToken || editingRecc || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt || ratePrompt
           ? "help"
           : region,
       setRegion,
@@ -1402,6 +1449,7 @@ export function App({
     showHelp,
     editingFolder,
     editingToken,
+    editingRecc,
     editingPlayer,
     editingSources,
     editingDns,
@@ -1450,6 +1498,7 @@ export function App({
       }
       if (editingFolder) return; // the folder prompt owns input (its own esc + enter)
       if (editingToken) return; // the token prompt owns input
+      if (editingRecc) return; // the reccd prompt owns input
       if (editingPlayer) return; // the media-player prompt owns input
       if (editingSources) return; // the sources panel owns input
       if (editingDns) return; // the DNS prompt owns input
@@ -1625,6 +1674,19 @@ export function App({
               onSubmit={setRealDebridToken}
               onClear={clearRealDebridToken}
               onCancel={closeTokenPrompt}
+            />
+          </Box>
+        ) : null}
+
+        {editingRecc ? (
+          <Box marginTop={1}>
+            <ReccdPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              url={store.config.reccUrl ?? ""}
+              token={store.config.reccToken ?? ""}
+              status={reccStatus}
+              onSubmit={saveReccConfig}
+              onCancel={closeReccPrompt}
             />
           </Box>
         ) : null}
@@ -1931,7 +1993,7 @@ export function App({
           height={bodyH}
           marginTop={compact ? 0 : 1}
           display={
-            showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+            showHelp || editingFolder || editingToken || editingRecc || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
               ? "none"
               : "flex"
           }
@@ -1970,6 +2032,13 @@ export function App({
                 onSignOutRd={clearRealDebridToken}
                 onManageRutracker={openRutrackerPrompt}
                 onSignOutRutracker={signOutRutracker}
+                reccConfigured={store.reccConfigured}
+                reccStatus={reccStatus}
+                reccEnvOverride={Boolean(
+                  process.env["TORLINK_RECC_URL"]?.trim() || process.env["TORLINK_RECC_TOKEN"]?.trim(),
+                )}
+                onManageRecc={openReccPrompt}
+                onSignOutRecc={clearReccConfig}
               />
             </Box>
             <Box display={section === "watchlist" ? "flex" : "none"} flexDirection="column">
@@ -1994,7 +2063,7 @@ export function App({
         {showFooter ? (
           <Box
             display={
-              showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || streamFiles || preparing || torrentPrompt || keepPrompt
+              showHelp || editingFolder || editingToken || editingRecc || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || streamFiles || preparing || torrentPrompt || keepPrompt
                 ? "none"
                 : "flex"
             }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1984,6 +1984,7 @@ export function App({
                 active={store.region === "content" && section === "forYou"}
                 setSection={store.setSection}
                 submitQuery={store.submitQuery}
+                setCaptureMode={store.setCaptureMode}
               />
             </Box>
           </Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1367,6 +1367,7 @@ export function App({
       startDebridDownload,
       streamResult,
       debridConfigured: resolveRealDebridToken(config) !== "",
+      reccConfigured: Boolean(resolveReccConfig(config).reccUrl),
       streamActive: activeStream !== null,
       rdStatus,
       copyLink,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,6 +7,7 @@ import {
   resolveRealDebridToken,
   resolveMediaPlayer,
   resolveDnsServers,
+  resolveReccConfig,
   type Config,
   type FavouriteItem,
 } from "../config/config";
@@ -81,6 +82,7 @@ import { RutrackerPrompt, type LoginStatus } from "./components/RutrackerPrompt"
 import { Accounts } from "./components/Accounts";
 import { Watchlist } from "./components/Watchlist";
 import { Favourites } from "./components/Favourites";
+import { ForYou } from "./components/ForYou";
 import { TrackersPrompt } from "./components/TrackersPrompt";
 import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
 import { LimitsPrompt, type TransferLimits } from "./components/LimitsPrompt";
@@ -473,7 +475,7 @@ export function App({
       return next;
     });
     void postEvent(
-      { reccUrl: config.reccUrl, reccToken: config.reccToken },
+      resolveReccConfig(config),
       {
         type: wasFavourited ? "unfavourited" : "favourited",
         rawName: item.name,
@@ -691,7 +693,7 @@ export function App({
         );
         onPlayed?.();
         void postEvent(
-          { reccUrl: config.reccUrl, reccToken: config.reccToken },
+          resolveReccConfig(config),
           { type: "watched", rawName: name ?? url, ts: Date.now(), source: "torlink" },
         );
         return;
@@ -781,7 +783,7 @@ export function App({
           }
           setActiveStream({ session, name: input.name, input });
           void postEvent(
-            { reccUrl: config.reccUrl, reccToken: config.reccToken },
+            resolveReccConfig(config),
             { type: "started", rawName: input.name, ts: Date.now(), source: "torlink" },
           );
           if (candidates.length > 1) {
@@ -922,7 +924,7 @@ export function App({
             return;
           }
           void postEvent(
-            { reccUrl: config.reccUrl, reccToken: config.reccToken },
+            resolveReccConfig(config),
             { type: "started", rawName: input.name, ts: Date.now(), source: "torlink" },
           );
           if (candidates.length > 1) {
@@ -1853,7 +1855,7 @@ export function App({
               onLike={() => {
                 if (config) {
                   void postEvent(
-                    { reccUrl: config.reccUrl, reccToken: config.reccToken },
+                    resolveReccConfig(config),
                     { type: "liked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
                   );
                 }
@@ -1862,7 +1864,7 @@ export function App({
               onDislike={() => {
                 if (config) {
                   void postEvent(
-                    { reccUrl: config.reccUrl, reccToken: config.reccToken },
+                    resolveReccConfig(config),
                     { type: "disliked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
                   );
                 }
@@ -1974,6 +1976,14 @@ export function App({
             </Box>
             <Box display={section === "library" ? "flex" : "none"} flexDirection="column">
               <Favourites />
+            </Box>
+            <Box display={section === "forYou" ? "flex" : "none"} flexDirection="column">
+              <ForYou
+                reccConfig={resolveReccConfig(store.config)}
+                active={store.region === "content" && section === "forYou"}
+                setSection={store.setSection}
+                submitQuery={store.submitQuery}
+              />
             </Box>
           </Box>
         </Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1980,6 +1980,7 @@ export function App({
             <Box display={section === "forYou" ? "flex" : "none"} flexDirection="column">
               <ForYou
                 reccConfig={resolveReccConfig(store.config)}
+                visible={section === "forYou"}
                 active={store.region === "content" && section === "forYou"}
                 setSection={store.setSection}
                 submitQuery={store.submitQuery}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -916,6 +916,10 @@ export function App({
             setNotice("Real-Debrid returned nothing to stream.");
             return;
           }
+          void postEvent(
+            { reccUrl: config.reccUrl, reccToken: config.reccToken },
+            { type: "started", rawName: input.name, ts: Date.now(), source: "torlink" },
+          );
           if (candidates.length > 1) {
             setPreparing(null);
             setStreamedFiles(new Set());

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -85,6 +85,7 @@ import { TrackersPrompt } from "./components/TrackersPrompt";
 import { DownloadFilePrompt } from "./components/DownloadFilePrompt";
 import { LimitsPrompt, type TransferLimits } from "./components/LimitsPrompt";
 import { VpnPrompt } from "./components/VpnPrompt";
+import { RatePrompt } from "./components/RatePrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -221,6 +222,8 @@ export function App({
   const [keepPrompt, setKeepPrompt] = useState<
     { session: TorrentStreamSession; input: DownloadInput } | null
   >(null);
+  // Ask for an explicit like/dislike signal once a stream ends.
+  const [ratePrompt, setRatePrompt] = useState<{ name: string } | null>(null);
   const vpnUnsafe = useRef(false);
   const prepareAbort = useRef<AbortController | null>(null);
   const [recovered, setRecovered] = useState(false);
@@ -831,6 +834,7 @@ export function App({
     const active = activeStream;
     if (!active) return;
     setActiveStream(null);
+    setRatePrompt({ name: active.name });
     if (active.session.isComplete()) {
       // Fully downloaded: offer to keep it as a real download + seed instead
       // of discarding the temp files.
@@ -1345,7 +1349,7 @@ export function App({
       disabledSources: (config.disabledSources ?? []) as SourceId[],
       toggleSource,
       region:
-        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt
+        showHelp || editingFolder || editingToken || editingPlayer || editingSources || editingDns || editingRutracker || editingTrackers || editingLimits || editingVpn || pendingP2P || pendingDownload || fileSelection || streamFiles || preparing || torrentPrompt || keepPrompt || ratePrompt
           ? "help"
           : region,
       setRegion,
@@ -1410,6 +1414,7 @@ export function App({
     preparing,
     torrentPrompt,
     keepPrompt,
+    ratePrompt,
     activeStream,
     captureMode,
     downloadFocus,
@@ -1454,6 +1459,7 @@ export function App({
       if (fileSelection) return; // the download file picker owns input
       if (torrentPrompt) return; // the torrent privacy warning owns input
       if (keepPrompt) return; // the keep-download prompt owns input
+      if (ratePrompt) return; // the like/dislike prompt owns input
       if (streamFiles) return; // the file picker owns input
       if (preparing) {
         if (key.escape) cancelPreparing();
@@ -1835,6 +1841,34 @@ export function App({
                 void session.stop(); // discard temp
                 setNotice("Stream stopped.");
               }}
+            />
+          </Box>
+        ) : null}
+
+        {ratePrompt ? (
+          <Box marginTop={1}>
+            <RatePrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              name={ratePrompt.name}
+              onLike={() => {
+                if (config) {
+                  void postEvent(
+                    { reccUrl: config.reccUrl, reccToken: config.reccToken },
+                    { type: "liked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                  );
+                }
+                setRatePrompt(null);
+              }}
+              onDislike={() => {
+                if (config) {
+                  void postEvent(
+                    { reccUrl: config.reccUrl, reccToken: config.reccToken },
+                    { type: "disliked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                  );
+                }
+                setRatePrompt(null);
+              }}
+              onDismiss={() => setRatePrompt(null)}
             />
           </Box>
         ) : null}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,6 +17,7 @@ import { rdStatusFromUser, type RdStatus } from "../integrations/rdStatus";
 import { attemptAutoPlay, detectAndPlay, launchPlayer, streamCandidates } from "../util/player";
 import type { ResolvedFile } from "../integrations/realdebrid";
 import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
+import { postEvent } from "../recc/client";
 import { classifyStreamRoute } from "./streamRoute";
 import { keepMovePlan, moveKeptFiles } from "./streamKeep";
 import { DownloadQueue } from "../download/queue";
@@ -461,9 +462,19 @@ export function App({
   const toggleFavourite = useCallback((item: FavouriteItem) => {
     setConfigState((prev) => {
       if (!prev) return prev;
+      const wasFavourited = isFavouritedIn(prev.favourites ?? [], item.id);
       const favourites = toggleFavouriteList(prev.favourites ?? [], item);
       const next = { ...prev, favourites };
       void saveConfig(next);
+      void postEvent(
+        { reccUrl: prev.reccUrl, reccToken: prev.reccToken },
+        {
+          type: wasFavourited ? "unfavourited" : "favourited",
+          rawName: item.name,
+          ts: Date.now(),
+          source: "torlink",
+        },
+      );
       return next;
     });
     setNotice("Favourites updated.");
@@ -675,6 +686,10 @@ export function App({
           `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}`,
         );
         onPlayed?.();
+        void postEvent(
+          { reccUrl: config.reccUrl, reccToken: config.reccToken },
+          { type: "watched", rawName: name ?? url, ts: Date.now(), source: "torlink" },
+        );
         return;
       }
       // Couldn't play automatically: stash context, copy the link, and open the
@@ -761,6 +776,10 @@ export function App({
             return;
           }
           setActiveStream({ session, name: input.name, input });
+          void postEvent(
+            { reccUrl: config.reccUrl, reccToken: config.reccToken },
+            { type: "started", rawName: input.name, ts: Date.now(), source: "torlink" },
+          );
           if (candidates.length > 1) {
             setStreamedFiles(new Set());
             setStreamSource(input);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1494,7 +1494,7 @@ export function App({
         openDnsPrompt();
         return;
       }
-      if (input === "t") {
+      if (input === "t" && !(region === "content" && section === "forYou")) {
         setShowHelp(false);
         setEditingTrackers(true);
         return;

--- a/src/ui/components/Accounts.test.tsx
+++ b/src/ui/components/Accounts.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render } from "ink-testing-library";
 import { StoreContext, type Store } from "../store";
 import { Accounts } from "./Accounts";
+import type { ReccStatus } from "../../recc/status";
 
 function storeStub(): Store {
   return { region: "content", section: "accounts" } as unknown as Store;
@@ -12,10 +13,15 @@ const baseProps = {
   rdToken: "",
   rdStatus: null,
   rutrackerUser: undefined as string | undefined,
+  reccConfigured: false,
+  reccStatus: null as ReccStatus | null,
+  reccEnvOverride: false,
   onManageRd: noop,
   onSignOutRd: noop,
   onManageRutracker: noop,
   onSignOutRutracker: noop,
+  onManageRecc: noop,
+  onSignOutRecc: noop,
 };
 
 function renderAccounts(overrides: Partial<typeof baseProps> = {}) {
@@ -27,18 +33,45 @@ function renderAccounts(overrides: Partial<typeof baseProps> = {}) {
 }
 
 describe("Accounts", () => {
-  it("lists Real-Debrid and RuTracker", () => {
+  it("lists Real-Debrid, RuTracker and reccd", () => {
     const frame = renderAccounts().lastFrame() ?? "";
     expect(frame).toContain("Real-Debrid");
     expect(frame).toContain("RuTracker");
+    expect(frame).toContain("reccd");
   });
 
-  it("shows signed-out state when no credentials", () => {
-    expect(renderAccounts().lastFrame() ?? "").toContain("Not signed in");
+  it("shows Not configured for reccd when unconfigured", () => {
+    expect(renderAccounts().lastFrame() ?? "").toContain("Not configured");
   });
 
   it("shows the RuTracker username when signed in", () => {
     const frame = renderAccounts({ rutrackerUser: "alice" }).lastFrame() ?? "";
     expect(frame).toContain("alice");
+  });
+
+  it("shows connected status when reccd is configured and reachable", () => {
+    const frame = renderAccounts({
+      reccConfigured: true,
+      reccStatus: { state: "connected", host: "192.168.0.98:4100" },
+    }).lastFrame() ?? "";
+    expect(frame).toContain("Connected");
+  });
+
+  it("notes an env override when reccEnvOverride is set", () => {
+    const frame = renderAccounts({
+      reccConfigured: true,
+      reccStatus: { state: "connected", host: "h:4100" },
+      reccEnvOverride: true,
+    }).lastFrame() ?? "";
+    expect(frame).toContain("env override");
+  });
+
+  it("shows a warn marker and Unreachable when reccd is configured but unreachable", () => {
+    const frame = renderAccounts({
+      reccConfigured: true,
+      reccStatus: { state: "unreachable", host: "h:4100" },
+    }).lastFrame() ?? "";
+    expect(frame).toContain("Unreachable");
+    expect(frame).toContain("⚠");
   });
 });

--- a/src/ui/components/Accounts.tsx
+++ b/src/ui/components/Accounts.tsx
@@ -6,11 +6,15 @@ import { wrapStep } from "../move";
 import { COLOR, GUTTER, ICON } from "../theme";
 import { truncate } from "../../util/format";
 import { formatAccountStatus, type RdStatus } from "../../integrations/rdStatus";
+import { formatReccStatus, type ReccStatus } from "../../recc/status";
 
 interface AccountsProps {
   rdToken: string;
   rdStatus: RdStatus | null;
   rutrackerUser?: string;
+  reccConfigured: boolean;
+  reccStatus: ReccStatus | null;
+  reccEnvOverride?: boolean;
   // True while a torrent stream is active; "x" is reserved for stopping it
   // globally, so sign-out must not also fire on the same keystroke.
   streamActive?: boolean;
@@ -18,6 +22,8 @@ interface AccountsProps {
   onSignOutRd: () => void;
   onManageRutracker: () => void;
   onSignOutRutracker: () => void;
+  onManageRecc: () => void;
+  onSignOutRecc: () => void;
 }
 
 interface Row {
@@ -26,7 +32,14 @@ interface Row {
   label: string;
   homepage: string;
   signedIn: boolean;
+  // Drives the status icon/colour when signedIn: green tick when true, a warn
+  // marker otherwise (e.g. reccd configured but unreachable / bad token).
+  ok: boolean;
   status: string;
+  emptyStatus: string;
+  verbSignedIn: string;
+  verbSignOut: string;
+  verbSignedOut: string;
   onManage: () => void;
   onSignOut: () => void;
 }
@@ -35,11 +48,16 @@ export function Accounts({
   rdToken,
   rdStatus,
   rutrackerUser,
+  reccConfigured,
+  reccStatus,
+  reccEnvOverride = false,
   streamActive = false,
   onManageRd,
   onSignOutRd,
   onManageRutracker,
   onSignOutRutracker,
+  onManageRecc,
+  onSignOutRecc,
 }: AccountsProps) {
   const { region, section, contentWidth, listRows } = useStore();
   const focused = region === "content" && section === "accounts";
@@ -52,7 +70,12 @@ export function Accounts({
       label: "Real-Debrid",
       homepage: "real-debrid.com",
       signedIn: rdToken !== "",
+      ok: rdToken !== "",
       status: formatAccountStatus(rdStatus, new Date()),
+      emptyStatus: "Not connected",
+      verbSignedIn: "switch",
+      verbSignOut: "sign out",
+      verbSignedOut: "sign in",
       onManage: onManageRd,
       onSignOut: onSignOutRd,
     },
@@ -62,9 +85,29 @@ export function Accounts({
       label: "RuTracker",
       homepage: "rutracker.org",
       signedIn: !!rutrackerUser,
+      ok: !!rutrackerUser,
       status: rutrackerUser ? `Signed in as ${truncate(rutrackerUser, 24)}` : "Not signed in",
+      emptyStatus: "Not signed in",
+      verbSignedIn: "switch",
+      verbSignOut: "sign out",
+      verbSignedOut: "sign in",
       onManage: onManageRutracker,
       onSignOut: onSignOutRutracker,
+    },
+    {
+      tag: "RCD",
+      color: COLOR.accent,
+      label: "reccd",
+      homepage: "self-hosted · private service",
+      signedIn: reccConfigured,
+      ok: reccStatus?.state === "connected",
+      status: `${formatReccStatus(reccStatus)}${reccEnvOverride ? " · env override active" : ""}`,
+      emptyStatus: "Not configured",
+      verbSignedIn: "edit",
+      verbSignOut: "clear",
+      verbSignedOut: "set up",
+      onManage: onManageRecc,
+      onSignOut: onSignOutRecc,
     },
   ];
 
@@ -105,26 +148,26 @@ export function Accounts({
                 </Text>
                 {r.signedIn ? (
                   <Text>
-                    <Text color={COLOR.good}>{`${ICON.done} `}</Text>
+                    <Text color={r.ok ? COLOR.good : COLOR.warn}>{`${r.ok ? ICON.done : ICON.warn} `}</Text>
                     <Text dimColor>{r.status}</Text>
                   </Text>
                 ) : (
-                  <Text dimColor>{`${ICON.dot} ${r.label === "Real-Debrid" ? "Not connected" : "Not signed in"}`}</Text>
+                  <Text dimColor>{`${ICON.dot} ${r.emptyStatus}`}</Text>
                 )}
               </Box>
               <Box flexShrink={0} marginLeft={1}>
                 {r.signedIn ? (
                   <Text>
                     <Text color={COLOR.alt}>↵</Text>
-                    <Text dimColor> switch</Text>
+                    <Text dimColor>{` ${r.verbSignedIn}`}</Text>
                     <Text dimColor>{`  ${ICON.dot}  `}</Text>
                     <Text color={COLOR.alt}>x</Text>
-                    <Text dimColor> sign out</Text>
+                    <Text dimColor>{` ${r.verbSignOut}`}</Text>
                   </Text>
                 ) : (
                   <Text>
                     <Text color={COLOR.alt}>↵</Text>
-                    <Text dimColor> sign in</Text>
+                    <Text dimColor>{` ${r.verbSignedOut}`}</Text>
                   </Text>
                 )}
               </Box>

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -17,6 +17,7 @@ import { deliveryMethod } from "../downloadState";
 import type { QueueItem } from "../../download/types";
 import type { HistoryItem } from "../../download/history";
 import type { SourceId } from "../../sources/types";
+import { postEvent } from "../../recc/client";
 
 const ROWS_PER_ACTIVE = 2;
 const MARK = 2;
@@ -91,6 +92,7 @@ function SourceBadge({
 
 export function Downloads() {
   const {
+    config,
     queue,
     region,
     section,
@@ -144,8 +146,13 @@ export function Downloads() {
       } else if (inActive) {
         const it = active[clamped];
         if (!it) return;
-        if (input === "c") queue.cancel(it.id);
-        else if (input === "p") queue.togglePause(it.id);
+        if (input === "c") {
+          void postEvent(
+            { reccUrl: config.reccUrl, reccToken: config.reccToken },
+            { type: "abandoned", rawName: it.name, ts: Date.now(), source: "torlink" },
+          );
+          queue.cancel(it.id);
+        } else if (input === "p") queue.togglePause(it.id);
         else if (input === "y") {
           if (it.directUrl) copyLink(it.directUrl, it.name);
           else if (it.via === "realdebrid") {

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -147,6 +147,7 @@ export function Downloads() {
         const it = active[clamped];
         if (!it) return;
         if (input === "c") {
+          // "abandoned" also covers dismissing an already-failed item — reccd doesn't distinguish
           void postEvent(
             { reccUrl: config.reccUrl, reccToken: config.reccToken },
             { type: "abandoned", rawName: it.name, ts: Date.now(), source: "torlink" },

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -4,6 +4,7 @@ import { ForYou } from "./ForYou";
 import type { FetchImpl } from "../../util/net";
 
 const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+const ESC = String.fromCharCode(27);
 
 const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
 const CONFIG = { reccUrl: "http://host:4100", reccToken: "tok" };
@@ -80,5 +81,47 @@ describe("ForYou", () => {
     );
     await flush();
     expect(lastFrame()).toContain("unavailable");
+  });
+
+  it("suppresses global shortcuts by setting captureMode to 'text' when the genre prompt opens", async () => {
+    const { impl } = fetchStub();
+    const setCaptureMode = vi.fn();
+    const { stdin } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        setCaptureMode={setCaptureMode}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("g");
+    await flush();
+    expect(setCaptureMode).toHaveBeenCalledWith("text");
+  });
+
+  it("restores captureMode to 'none' when the genre prompt is cancelled", async () => {
+    const { impl } = fetchStub();
+    const setCaptureMode = vi.fn();
+    const { stdin } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        setCaptureMode={setCaptureMode}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("g");
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(setCaptureMode).toHaveBeenCalledWith("none");
   });
 });

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ForYou } from "./ForYou";
+import type { FetchImpl } from "../../util/net";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+
+const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
+const CONFIG = { reccUrl: "http://host:4100", reccToken: "tok" };
+
+function fetchStub(): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    return { ok: true, status: 200, json: async () => [REC] } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+describe("ForYou", () => {
+  it("fetches and renders picks once active", async () => {
+    const { impl } = fetchStub();
+    const { lastFrame } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("Chernobyl");
+    expect(lastFrame()).toContain("2019");
+  });
+
+  it("shows a setup hint when reccUrl is unset", async () => {
+    const { impl } = fetchStub();
+    const { lastFrame } = render(
+      <ForYou reccConfig={{}} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("set up");
+  });
+
+  it("cycles the type filter with 't' and refetches", async () => {
+    const { impl, urls } = fetchStub();
+    const { stdin } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    stdin.write("t");
+    await flush();
+    expect(urls.some((u) => u.includes("type=movie"))).toBe(true);
+  });
+
+  it("searches the selected title on enter", async () => {
+    const { impl } = fetchStub();
+    const setSection = vi.fn();
+    const submitQuery = vi.fn();
+    const { stdin } = render(
+      <ForYou reccConfig={CONFIG} active setSection={setSection} submitQuery={submitQuery} fetchImpl={impl} />,
+    );
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(submitQuery).toHaveBeenCalledWith("Chernobyl");
+    expect(setSection).toHaveBeenCalledWith("all");
+  });
+
+  it("fetches exactly once on first activation", async () => {
+    let calls = 0;
+    const impl = (async () => {
+      calls++;
+      return { ok: true, status: 200, json: async () => [REC] } as unknown as Response;
+    }) as unknown as FetchImpl;
+    render(<ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />);
+    await flush();
+    expect(calls).toBe(1);
+  });
+
+  it("shows an error when the fetch fails", async () => {
+    const impl = (async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response) as unknown as FetchImpl;
+    const { lastFrame } = render(
+      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("unavailable");
+  });
+});

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -35,7 +35,7 @@ describe("ForYou", () => {
       <ForYou reccConfig={{}} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
     );
     await flush();
-    expect(lastFrame()).toContain("set up");
+    expect(lastFrame()).toContain("Accounts");
   });
 
   it("cycles the type filter with 't' and refetches", async () => {

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -21,7 +21,7 @@ describe("ForYou", () => {
   it("fetches and renders picks once active", async () => {
     const { impl } = fetchStub();
     const { lastFrame } = render(
-      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+      <ForYou reccConfig={CONFIG} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
     );
     await flush();
     expect(lastFrame()).toContain("Chernobyl");
@@ -31,7 +31,7 @@ describe("ForYou", () => {
   it("shows a setup hint when reccUrl is unset", async () => {
     const { impl } = fetchStub();
     const { lastFrame } = render(
-      <ForYou reccConfig={{}} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+      <ForYou reccConfig={{}} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
     );
     await flush();
     expect(lastFrame()).toContain("set up");
@@ -40,7 +40,7 @@ describe("ForYou", () => {
   it("cycles the type filter with 't' and refetches", async () => {
     const { impl, urls } = fetchStub();
     const { stdin } = render(
-      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+      <ForYou reccConfig={CONFIG} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
     );
     await flush();
     stdin.write("t");
@@ -53,7 +53,7 @@ describe("ForYou", () => {
     const setSection = vi.fn();
     const submitQuery = vi.fn();
     const { stdin } = render(
-      <ForYou reccConfig={CONFIG} active setSection={setSection} submitQuery={submitQuery} fetchImpl={impl} />,
+      <ForYou reccConfig={CONFIG} visible active setSection={setSection} submitQuery={submitQuery} fetchImpl={impl} />,
     );
     await flush();
     stdin.write("\r");
@@ -68,7 +68,7 @@ describe("ForYou", () => {
       calls++;
       return { ok: true, status: 200, json: async () => [REC] } as unknown as Response;
     }) as unknown as FetchImpl;
-    render(<ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />);
+    render(<ForYou reccConfig={CONFIG} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />);
     await flush();
     expect(calls).toBe(1);
   });
@@ -76,7 +76,7 @@ describe("ForYou", () => {
   it("shows an error when the fetch fails", async () => {
     const impl = (async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response) as unknown as FetchImpl;
     const { lastFrame } = render(
-      <ForYou reccConfig={CONFIG} active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
+      <ForYou reccConfig={CONFIG} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />,
     );
     await flush();
     expect(lastFrame()).toContain("unavailable");

--- a/src/ui/components/ForYou.tsx
+++ b/src/ui/components/ForYou.tsx
@@ -11,6 +11,7 @@ import { cleanText, truncate } from "../../util/format";
 
 interface ForYouProps {
   reccConfig: ReccClientConfig;
+  visible: boolean;
   active: boolean;
   setSection: (s: Section) => void;
   submitQuery: (q: string) => void;
@@ -21,8 +22,8 @@ interface ForYouProps {
 const NEXT_TYPE: Record<ReccType, ReccType> = { all: "movie", movie: "tv", tv: "all" };
 const TYPE_SECTION: Record<ReccType, Section> = { all: "all", movie: "movies", tv: "tv" };
 
-export function ForYou({ reccConfig, active, setSection, submitQuery, fetchImpl, width = 60 }: ForYouProps) {
-  const recs = useRecommendations(reccConfig, active, fetchImpl);
+export function ForYou({ reccConfig, visible, active, setSection, submitQuery, fetchImpl, width = 60 }: ForYouProps) {
+  const recs = useRecommendations(reccConfig, visible, fetchImpl);
   const [selected, setSelected] = useState(0);
   const [editingGenre, setEditingGenre] = useState(false);
 

--- a/src/ui/components/ForYou.tsx
+++ b/src/ui/components/ForYou.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { FetchImpl } from "../../util/net";
 import type { ReccClientConfig } from "../../recc/client";
-import type { Section } from "../store";
+import type { CaptureMode, Section } from "../store";
 import { useRecommendations, type ReccType } from "../hooks/useRecommendations";
 import { GenrePrompt } from "./GenrePrompt";
 import { Panel } from "./Panel";
@@ -15,6 +15,7 @@ interface ForYouProps {
   active: boolean;
   setSection: (s: Section) => void;
   submitQuery: (q: string) => void;
+  setCaptureMode?: (m: CaptureMode) => void;
   fetchImpl?: FetchImpl;
   width?: number;
 }
@@ -22,7 +23,16 @@ interface ForYouProps {
 const NEXT_TYPE: Record<ReccType, ReccType> = { all: "movie", movie: "tv", tv: "all" };
 const TYPE_SECTION: Record<ReccType, Section> = { all: "all", movie: "movies", tv: "tv" };
 
-export function ForYou({ reccConfig, visible, active, setSection, submitQuery, fetchImpl, width = 60 }: ForYouProps) {
+export function ForYou({
+  reccConfig,
+  visible,
+  active,
+  setSection,
+  submitQuery,
+  setCaptureMode,
+  fetchImpl,
+  width = 60,
+}: ForYouProps) {
   const recs = useRecommendations(reccConfig, visible, fetchImpl);
   const [selected, setSelected] = useState(0);
   const [editingGenre, setEditingGenre] = useState(false);
@@ -36,7 +46,10 @@ export function ForYou({ reccConfig, visible, active, setSection, submitQuery, f
       else if (key.downArrow || input === "j") setSelected((i) => (count ? (i + 1) % count : 0));
       else if (input === "t") { setSelected(0); recs.setType(NEXT_TYPE[recs.type]); }
       else if (input === "e") { setSelected(0); recs.toggleExplore(); }
-      else if (input === "g") setEditingGenre(true);
+      else if (input === "g") {
+        setEditingGenre(true);
+        setCaptureMode?.("text");
+      }
       else if (input === "r") recs.refresh();
       else if (key.return) {
         const item = recs.items[selected];
@@ -56,10 +69,14 @@ export function ForYou({ reccConfig, visible, active, setSection, submitQuery, f
         value={recs.genre}
         onSubmit={(g) => {
           setEditingGenre(false);
+          setCaptureMode?.("none");
           setSelected(0);
           recs.setGenre(g.trim());
         }}
-        onCancel={() => setEditingGenre(false)}
+        onCancel={() => {
+          setEditingGenre(false);
+          setCaptureMode?.("none");
+        }}
       />
     );
   }

--- a/src/ui/components/ForYou.tsx
+++ b/src/ui/components/ForYou.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import type { FetchImpl } from "../../util/net";
+import type { ReccClientConfig } from "../../recc/client";
+import type { Section } from "../store";
+import { useRecommendations, type ReccType } from "../hooks/useRecommendations";
+import { GenrePrompt } from "./GenrePrompt";
+import { Panel } from "./Panel";
+import { COLOR, GUTTER, ICON } from "../theme";
+import { cleanText, truncate } from "../../util/format";
+
+interface ForYouProps {
+  reccConfig: ReccClientConfig;
+  active: boolean;
+  setSection: (s: Section) => void;
+  submitQuery: (q: string) => void;
+  fetchImpl?: FetchImpl;
+  width?: number;
+}
+
+const NEXT_TYPE: Record<ReccType, ReccType> = { all: "movie", movie: "tv", tv: "all" };
+const TYPE_SECTION: Record<ReccType, Section> = { all: "all", movie: "movies", tv: "tv" };
+
+export function ForYou({ reccConfig, active, setSection, submitQuery, fetchImpl, width = 60 }: ForYouProps) {
+  const recs = useRecommendations(reccConfig, active, fetchImpl);
+  const [selected, setSelected] = useState(0);
+  const [editingGenre, setEditingGenre] = useState(false);
+
+  const configured = Boolean(reccConfig.reccUrl);
+  const count = recs.items.length;
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow || input === "k") setSelected((i) => (count ? (i - 1 + count) % count : 0));
+      else if (key.downArrow || input === "j") setSelected((i) => (count ? (i + 1) % count : 0));
+      else if (input === "t") { setSelected(0); recs.setType(NEXT_TYPE[recs.type]); }
+      else if (input === "e") { setSelected(0); recs.toggleExplore(); }
+      else if (input === "g") setEditingGenre(true);
+      else if (input === "r") recs.refresh();
+      else if (key.return) {
+        const item = recs.items[selected];
+        if (item) {
+          setSection(TYPE_SECTION[recs.type]);
+          submitQuery(item.title);
+        }
+      }
+    },
+    { isActive: active && configured && !editingGenre },
+  );
+
+  if (editingGenre) {
+    return (
+      <GenrePrompt
+        width={width}
+        value={recs.genre}
+        onSubmit={(g) => {
+          setEditingGenre(false);
+          setSelected(0);
+          recs.setGenre(g.trim());
+        }}
+        onCancel={() => setEditingGenre(false)}
+      />
+    );
+  }
+
+  if (!configured) {
+    return (
+      <Box flexDirection="column">
+        <Text color={COLOR.text}>Recommendations aren't set up yet.</Text>
+        <Text dimColor>To set up, add reccUrl and reccToken to config.json,</Text>
+        <Text dimColor>or set TORLINK_RECC_URL / TORLINK_RECC_TOKEN.</Text>
+      </Box>
+    );
+  }
+
+  const filterLine = `type: ${recs.type}${recs.genre ? ` · genre: ${recs.genre}` : ""}${recs.explore ? " · explore" : ""}`;
+
+  return (
+    <Panel title="For You" width={width} focused={active}>
+      <Box marginBottom={1}>
+        <Text dimColor>{filterLine}</Text>
+      </Box>
+      {recs.loading ? (
+        <Text dimColor>Finding recommendations…</Text>
+      ) : recs.error ? (
+        <Box flexDirection="column">
+          <Text color={COLOR.text}>{recs.error}</Text>
+          <Text dimColor>press r to retry</Text>
+        </Box>
+      ) : count === 0 ? (
+        <Text dimColor>No picks yet — stream something and they'll show up here.</Text>
+      ) : (
+        recs.items.map((item, i) => {
+          const tag = item.reasons[0] ?? "";
+          const isSel = i === selected;
+          return (
+            <Box key={item.imdbId}>
+              <Box width={GUTTER} flexShrink={0}>
+                <Text color={COLOR.accent}>{isSel ? ICON.pointer : ""}</Text>
+              </Box>
+              <Box flexGrow={1} minWidth={0}>
+                <Text color={isSel ? COLOR.accent : COLOR.text} wrap="truncate-end">
+                  {truncate(cleanText(item.title), 40)}
+                </Text>
+              </Box>
+              <Text dimColor>{`  ${item.year}  `}</Text>
+              <Text dimColor>{tag}</Text>
+            </Box>
+          );
+        })
+      )}
+    </Panel>
+  );
+}

--- a/src/ui/components/ForYou.tsx
+++ b/src/ui/components/ForYou.tsx
@@ -85,7 +85,7 @@ export function ForYou({
     return (
       <Box flexDirection="column">
         <Text color={COLOR.text}>Recommendations aren't set up yet.</Text>
-        <Text dimColor>To set up, add reccUrl and reccToken to config.json,</Text>
+        <Text dimColor>Set up reccd in the Accounts pane (↵ on reccd),</Text>
         <Text dimColor>or set TORLINK_RECC_URL / TORLINK_RECC_TOKEN.</Text>
       </Box>
     );

--- a/src/ui/components/GenrePrompt.test.tsx
+++ b/src/ui/components/GenrePrompt.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { GenrePrompt } from "./GenrePrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+
+describe("GenrePrompt", () => {
+  it("submits the typed genre on enter", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const { stdin } = render(<GenrePrompt width={40} value="" onSubmit={onSubmit} onCancel={onCancel} />);
+    await flush();
+    stdin.write("Western");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("Western");
+  });
+
+  it("cancels on escape", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const { stdin } = render(<GenrePrompt width={40} value="" onSubmit={onSubmit} onCancel={onCancel} />);
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/GenrePrompt.tsx
+++ b/src/ui/components/GenrePrompt.tsx
@@ -1,0 +1,36 @@
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { COLOR, ICON } from "../theme";
+
+interface GenrePromptProps {
+  width: number;
+  value: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+// Free-text genre filter for the For You view. reccd treats genre as an open
+// string, so this is a plain text field; an empty submission clears the filter.
+export function GenrePrompt({ width, value, onSubmit, onCancel }: GenrePromptProps) {
+  useInput((_input, key) => {
+    if (key.escape) onCancel();
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="filter by genre" width={width} focused height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField defaultValue={value} placeholder="e.g. Western — empty clears" onSubmit={onSubmit} />
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <PromptHints submitLabel="filter" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/RatePrompt.test.tsx
+++ b/src/ui/components/RatePrompt.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { RatePrompt } from "./RatePrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+
+describe("RatePrompt", () => {
+  it("calls onLike when 'l' is pressed", async () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(
+      <RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />,
+    );
+    await flush();
+    stdin.write("l");
+    await flush();
+    expect(onLike).toHaveBeenCalled();
+  });
+
+  it("calls onDislike when 'd' is pressed", async () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(
+      <RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />,
+    );
+    await flush();
+    stdin.write("d");
+    await flush();
+    expect(onDislike).toHaveBeenCalled();
+  });
+
+  it("calls onDismiss on escape", async () => {
+    const onLike = vi.fn();
+    const onDislike = vi.fn();
+    const onDismiss = vi.fn();
+    const { stdin } = render(
+      <RatePrompt name="The Matrix" onLike={onLike} onDislike={onDislike} onDismiss={onDismiss} />,
+    );
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/RatePrompt.tsx
+++ b/src/ui/components/RatePrompt.tsx
@@ -1,0 +1,56 @@
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+import { cleanText, truncate } from "../../util/format";
+
+interface RatePromptProps {
+  width?: number;
+  name: string;
+  onLike: () => void;
+  onDislike: () => void;
+  onDismiss: () => void;
+}
+
+// Shown after a stream ends: a quick like/dislike signal beyond passive
+// watching. Styled like the other inline prompts; owns keyboard input while
+// mounted.
+export function RatePrompt({ width = 40, name, onLike, onDislike, onDismiss }: RatePromptProps) {
+  useInput((input, key) => {
+    if (key.escape) {
+      onDismiss();
+      return;
+    }
+    if (input === "l") {
+      onLike();
+      return;
+    }
+    if (input === "d") {
+      onDislike();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="How was it?" width={width} focused height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <Text color={COLOR.text} wrap="wrap">
+              {truncate(cleanText(name), 40)}
+            </Text>
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <Text color={COLOR.alt}>l</Text>
+        <Text dimColor> like</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>d</Text>
+        <Text dimColor> dislike</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>esc</Text>
+        <Text dimColor> skip</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/ReccdPrompt.test.tsx
+++ b/src/ui/components/ReccdPrompt.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { ReccdPrompt } from "./ReccdPrompt";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+const ESC = String.fromCharCode(27);
+
+describe("ReccdPrompt", () => {
+  it("renders URL and Token fields and the status line", () => {
+    const { lastFrame } = render(
+      <ReccdPrompt width={60} url="" token="" status={{ state: "unconfigured" }} onSubmit={() => {}} onCancel={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("URL");
+    expect(frame).toContain("Token");
+    expect(frame).toContain("Not configured");
+  });
+
+  it("cancels on escape", async () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <ReccdPrompt width={60} url="" token="" status={null} onSubmit={() => {}} onCancel={onCancel} />,
+    );
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("submits the entered url and token", async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <ReccdPrompt width={60} url="" token="" status={null} onSubmit={onSubmit} onCancel={() => {}} />,
+    );
+    await flush();
+    stdin.write("http://h:4100"); // typed into the focused URL field
+    await flush();
+    stdin.write("\r"); // enter on URL advances to the Token field
+    await flush();
+    stdin.write("tok"); // typed into the Token field
+    await flush();
+    stdin.write("\r"); // enter on Token submits
+    await flush();
+    expect(onSubmit).toHaveBeenCalledWith("http://h:4100", "tok");
+  });
+});

--- a/src/ui/components/ReccdPrompt.tsx
+++ b/src/ui/components/ReccdPrompt.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+import { formatReccStatus, type ReccStatus } from "../../recc/status";
+
+type FieldKey = "url" | "token";
+
+interface ReccdPromptProps {
+  width: number;
+  url: string;
+  token: string;
+  status: ReccStatus | null;
+  onSubmit: (url: string, token: string) => void;
+  onCancel: () => void;
+}
+
+function Field({
+  label,
+  active,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box>
+      <Box width={8} flexShrink={0}>
+        <Text color={active ? COLOR.accent : undefined} dimColor={!active}>
+          {label}
+        </Text>
+      </Box>
+      <Text color={active ? COLOR.accent : COLOR.alt}>{`${ICON.pointer} `}</Text>
+      <Box flexGrow={1} minWidth={0}>
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+// A private, self-hosted service — reccd is a single URL + bearer token the user
+// stands up themselves. Two fields, modeled on RutrackerPrompt.
+export function ReccdPrompt({ width, url, token, status, onSubmit, onCancel }: ReccdPromptProps) {
+  const [field, setField] = useState<FieldKey>("url");
+  const [urlVal, setUrlVal] = useState(url);
+  const [tokenVal, setTokenVal] = useState(token);
+
+  const submit = (): void => onSubmit(urlVal.trim(), tokenVal);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (key.upArrow) setField("url");
+    else if (key.downArrow) setField("token");
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="reccd — private, self-hosted recommendations" width={width} focused height={4}>
+        <Field label="URL" active={field === "url"}>
+          <TextField
+            isDisabled={field !== "url"}
+            defaultValue={url}
+            placeholder="http://localhost:4100"
+            onChange={setUrlVal}
+            onSubmit={() => setField("token")}
+            onExitDown={() => setField("token")}
+          />
+        </Field>
+        <Field label="Token" active={field === "token"}>
+          <TextField
+            isDisabled={field !== "token"}
+            mask
+            defaultValue={token}
+            placeholder="bearer token from reccd `user:add`"
+            onChange={setTokenVal}
+            onSubmit={submit}
+          />
+        </Field>
+        <Box marginTop={1}>
+          <Text dimColor>{`status: ${formatReccStatus(status)}`}</Text>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <Text color={COLOR.alt}>↵</Text>
+        <Text dimColor> next / save</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>↑↓</Text>
+        <Text dimColor> field</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>esc</Text>
+        <Text dimColor> cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/Results.ratePrompt.test.tsx
+++ b/src/ui/components/Results.ratePrompt.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { StoreContext, type Store } from "../store";
+import { Results } from "./Results";
+import type { DownloadQueue } from "../../download/queue";
+import type { TorrentResult } from "../../sources/types";
+
+// Results renders results from useConcurrentSearch, which performs real
+// network fetches. Stub it with a single fixed result so the `d` keybinding
+// has something to act on, without needing a network harness.
+const sampleResult: TorrentResult = {
+  infoHash: "abc123",
+  name: "Sample Movie",
+  sizeBytes: 0,
+  seeders: 1,
+  leechers: 0,
+  source: "yts",
+  magnet: "magnet:?xt=urn:btih:abc123",
+};
+
+vi.mock("../hooks/useConcurrentSearch", () => ({
+  useConcurrentSearch: () => ({
+    results: [sampleResult],
+    perSource: {},
+    loading: false,
+    done: 1,
+    total: 1,
+  }),
+}));
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+
+function baseStore(overrides: Partial<Store> = {}): Store {
+  const queue = {
+    getItems: () => [],
+    getHistory: () => [],
+    on: () => {},
+    off: () => {},
+  } as unknown as DownloadQueue;
+
+  return {
+    query: "",
+    submitQuery: () => {},
+    searchHistory: [],
+    disabledSources: [],
+    section: "all",
+    region: "content",
+    setRegion: () => {},
+    setCaptureMode: () => {},
+    requestP2PDownload: vi.fn(),
+    requestDownloadTo: () => {},
+    startDebridDownload: () => {},
+    streamResult: () => {},
+    debridConfigured: false,
+    copyMagnet: () => {},
+    contentWidth: 80,
+    listRows: 20,
+    queue,
+    sort: "none",
+    setSort: () => {},
+    toggleSavedSearch: () => {},
+    toggleFavourite: () => {},
+    isFavourited: () => false,
+    ...overrides,
+  } as unknown as Store;
+}
+
+describe("Results — rate-prompt input isolation", () => {
+  it("pressing 'd' downloads the selected result when focused (sanity check)", async () => {
+    const store = baseStore({ region: "content" });
+    const { stdin } = render(
+      <StoreContext.Provider value={store}>
+        <Results />
+      </StoreContext.Provider>,
+    );
+    await flush();
+    stdin.write("d");
+    await flush();
+    expect(store.requestP2PDownload).toHaveBeenCalled();
+  });
+
+  it("pressing 'd' does NOT trigger a download while a prompt (e.g. the rate prompt) is open", async () => {
+    // App.tsx derives store.region as "help" whenever any modal/prompt
+    // (including ratePrompt) is open, which deactivates Results' useInput
+    // subscriptions via `isActive`. This guards that invariant.
+    const store = baseStore({ region: "help" });
+    const { stdin } = render(
+      <StoreContext.Provider value={store}>
+        <Results />
+      </StoreContext.Provider>,
+    );
+    await flush();
+    stdin.write("d");
+    await flush();
+    expect(store.requestP2PDownload).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/Sidebar.test.tsx
+++ b/src/ui/components/Sidebar.test.tsx
@@ -30,4 +30,22 @@ describe("Sidebar", () => {
     );
     expect(lastFrame() ?? "").toContain("Accounts");
   });
+
+  it("hides the For You entry when reccd is not configured", () => {
+    const { lastFrame } = render(
+      <StoreContext.Provider value={baseStore()}>
+        <Sidebar />
+      </StoreContext.Provider>,
+    );
+    expect(lastFrame() ?? "").not.toContain("For You");
+  });
+
+  it("shows the For You entry when reccd is configured", () => {
+    const { lastFrame } = render(
+      <StoreContext.Provider value={{ ...baseStore(), reccConfigured: true } as unknown as Store}>
+        <Sidebar />
+      </StoreContext.Provider>,
+    );
+    expect(lastFrame() ?? "").toContain("For You");
+  });
 });

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -13,6 +13,7 @@ const FILTERS: NavItem[] = CATEGORIES.map((c) => ({
   label: c.label,
 }));
 const LIBRARY: NavItem[] = [
+  { key: "forYou", label: "For You" },
   { key: "watchlist", label: "Watchlist" },
   { key: "library", label: "Library" },
   { key: "downloads", label: "Downloads" },

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -33,17 +33,21 @@ export const RAIL_WIDTH =
   GUTTER + Math.max(...NAV.map((n) => n.label.length + (BADGED(n.key) ? BADGE_W : 0)));
 
 export function Sidebar() {
-  const { section, setSection, region, setRegion, queue } = useStore();
+  const { section, setSection, region, setRegion, queue, reccConfigured } = useStore();
   const focused = region === "sidebar";
-  const idx = Math.max(0, NAV.findIndex((n) => n.key === section));
+  // Hide the For You entry entirely until reccd is configured.
+  const library = reccConfigured ? LIBRARY : LIBRARY.filter((n) => n.key !== "forYou");
+  const groups: NavItem[][] = [FILTERS, library];
+  const nav = groups.flat();
+  const idx = Math.max(0, nav.findIndex((n) => n.key === section));
   useQueueItems(queue);
   const active = queue.activeCount;
   const seeding = queue.seedingCount;
 
   useInput(
     (input, key) => {
-      if (key.upArrow || input === "k") setSection(NAV[wrapStep(idx, -1, NAV.length)]!.key);
-      else if (key.downArrow || input === "j") setSection(NAV[wrapStep(idx, 1, NAV.length)]!.key);
+      if (key.upArrow || input === "k") setSection(nav[wrapStep(idx, -1, nav.length)]!.key);
+      else if (key.downArrow || input === "j") setSection(nav[wrapStep(idx, 1, nav.length)]!.key);
       else if (key.return) setRegion("content");
     },
     { isActive: focused },
@@ -51,7 +55,7 @@ export function Sidebar() {
 
   return (
     <Box flexDirection="column" width={RAIL_WIDTH} marginRight={1}>
-      {GROUPS.map((items, gi) => (
+      {groups.map((items, gi) => (
         <Box key={gi} flexDirection="column" marginTop={gi > 0 ? 1 : 0}>
           {items.map((item) => {
             const selected = item.key === section;

--- a/src/ui/hooks/useRecommendations.ts
+++ b/src/ui/hooks/useRecommendations.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FetchImpl } from "../../util/net";
+import {
+  fetchRecommendations,
+  type ReccClientConfig,
+  type Recommendation,
+  type RecommendationQuery,
+} from "../../recc/client";
+
+export type ReccType = "all" | "movie" | "tv";
+
+export interface RecommendationsState {
+  items: Recommendation[];
+  loading: boolean;
+  error: string | null;
+  type: ReccType;
+  genre: string;
+  explore: boolean;
+  refresh: () => void;
+  setType: (t: ReccType) => void;
+  setGenre: (g: string) => void;
+  toggleExplore: () => void;
+}
+
+// Owns the For You view's fetch state and filters. Fetches lazily — only once
+// the section is first visited (`enabled`), then again on refresh or any filter
+// change. A request counter guards against an older in-flight response landing
+// after a newer one.
+export function useRecommendations(
+  config: ReccClientConfig,
+  enabled: boolean,
+  fetchImpl?: FetchImpl,
+): RecommendationsState {
+  const [items, setItems] = useState<Recommendation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [type, setTypeState] = useState<ReccType>("all");
+  const [genre, setGenreState] = useState("");
+  const [explore, setExplore] = useState(false);
+  const loadedRef = useRef(false);
+  const filtersRef = useRef({ type, genre, explore });
+  const reqRef = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!config.reccUrl) {
+      setItems([]);
+      setError(null);
+      return;
+    }
+    const req = ++reqRef.current;
+    setLoading(true);
+    setError(null);
+    const query: RecommendationQuery = {
+      type: type === "all" ? undefined : type,
+      genre: genre.trim() || undefined,
+      explore,
+      limit: 20,
+    };
+    const result = await fetchRecommendations(config, query, { fetchImpl });
+    if (req !== reqRef.current) return; // superseded by a newer request
+    if (result.ok) {
+      setItems(result.items);
+      setError(null);
+    } else {
+      setItems([]);
+      setError(result.error);
+    }
+    setLoading(false);
+  }, [config, type, genre, explore, fetchImpl]);
+
+  // Lazy first load: fire once, the first time the section is visited.
+  useEffect(() => {
+    if (enabled && !loadedRef.current && config.reccUrl) {
+      loadedRef.current = true;
+      filtersRef.current = { type, genre, explore };
+      void load();
+    }
+  }, [enabled, config.reccUrl, load, type, genre, explore]);
+
+  // Refetch when a filter actually changes after the first load. Compared
+  // against the last-loaded filters (not merely "has loaded"), so this never
+  // double-fires alongside the lazy first load on the initial commit. config /
+  // fetchImpl are intentionally excluded: their identity churns every render
+  // and should not trigger a refetch on their own (use `r` / refresh for that).
+  useEffect(() => {
+    if (!loadedRef.current) return;
+    const prev = filtersRef.current;
+    if (prev.type === type && prev.genre === genre && prev.explore === explore) return;
+    filtersRef.current = { type, genre, explore };
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, genre, explore]);
+
+  const refresh = useCallback(() => void load(), [load]);
+  const setType = useCallback((t: ReccType) => setTypeState(t), []);
+  const setGenre = useCallback((g: string) => setGenreState(g), []);
+  const toggleExplore = useCallback(() => setExplore((v) => !v), []);
+
+  return { items, loading, error, type, genre, explore, refresh, setType, setGenre, toggleExplore };
+}

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -56,6 +56,17 @@ export const HELP_GROUPS: HelpGroup[] = [
     ],
   },
   {
+    title: "For You",
+    hints: [
+      { keys: "↑ ↓", label: "Move between picks" },
+      { keys: "↵", label: "Search this title" },
+      { keys: "t", label: "Cycle movie / TV / all" },
+      { keys: "g", label: "Filter by genre" },
+      { keys: "e", label: "Toggle explore mode" },
+      { keys: "r", label: "Refresh recommendations" },
+    ],
+  },
+  {
     title: "Downloads",
     hints: [
       { keys: "p", label: "Pause/resume" },
@@ -124,6 +135,18 @@ export function footerHints(
   }
   if (section === "library") {
     return [NAVIGATE, { keys: "↵", label: "Resume" }, { keys: "x", label: "Remove" }, SWITCH, ALWAYS];
+  }
+  if (section === "forYou") {
+    return [
+      NAVIGATE,
+      { keys: "↵", label: "Search title" },
+      { keys: "t", label: "Type" },
+      { keys: "g", label: "Genre" },
+      { keys: "e", label: "Explore" },
+      { keys: "r", label: "Refresh" },
+      SWITCH,
+      ALWAYS,
+    ];
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -138,6 +138,8 @@ export interface Store {
   }) => void;
   // True when an RD token is available (config or env var).
   debridConfigured: boolean;
+  // True when a recc (recommendation engine) URL is configured.
+  reccConfigured: boolean;
   // True while a torrent-stream session is live. While true, "x" is reserved
   // globally for stopping the stream, so components with their own "x"
   // handler (clear history, sign out) must ignore it.

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -11,7 +11,14 @@ export type View = "splash" | "browser";
 
 export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music" | "books";
 
-export type Section = Category | "watchlist" | "library" | "downloads" | "seeding" | "accounts";
+export type Section =
+  | Category
+  | "watchlist"
+  | "library"
+  | "downloads"
+  | "seeding"
+  | "accounts"
+  | "forYou";
 
 // The "category" sections (all/games/movies/tv/anime) — i.e. the results view,
 // as opposed to the downloads/seeding/accounts views.
@@ -21,7 +28,8 @@ export function isCategory(section: Section): boolean {
     section !== "library" &&
     section !== "downloads" &&
     section !== "seeding" &&
-    section !== "accounts"
+    section !== "accounts" &&
+    section !== "forYou"
   );
 }
 

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -157,6 +157,7 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
     isFavourited: () => false,
     section: "all",
     setSection: noop,
+    reccConfigured: false,
     sort: "none",
     setSort: noop,
     disabledSources: [],


### PR DESCRIPTION
## Summary
- Integrates torlink with the self-hosted **reccd** recommendation service.
- Posts activity events (started / watched / favourited / liked / disliked / abandoned) to reccd, including a post-stream like/dislike prompt.
- Adds a **For You** section: fetches `GET /recommendations`, browse ranked picks, filter by **type / genre / explore**, and press ↵ to launch a torrent search for a pick (reccd returns no magnets). The nav item is **hidden until reccd is configured**.
- Config via `config.json` `reccUrl` / `reccToken`, with `TORLINK_RECC_URL` / `TORLINK_RECC_TOKEN` env overrides (mirrors the existing `resolve*` helpers).

## Notes
- This branch was cut at #24, so it is **behind `main`** — `main` needs merging in before it can land.
- New code is unit-tested: `fetchRecommendations` (blocking client + error mapping), `resolveReccConfig`, `GenrePrompt`, the `useRecommendations` hook + `ForYou` view, and sidebar visibility gating. The pre-existing flaky `src/download/queue.test.ts` RD test is unrelated (passes in isolation).

## Test plan
- [ ] `npx vitest run` green; `npx tsc --noEmit` clean
- [ ] Configure reccd, open **For You**, confirm picks render and `t` / `g` / `e` / `r` / ↵ all work
- [ ] Confirm the "For You" item is hidden when reccd isn't configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)