### PR TITLE
Fix Windows VLC launch trap: offer auto-detect/edit when a configured player fails

### DIFF
--- a/docs/superpowers/plans/2026-07-22-player-launch-fallback-and-watched-gating.md
+++ b/docs/superpowers/plans/2026-07-22-player-launch-fallback-and-watched-gating.md
@@ -1,0 +1,558 @@
+# Player launch fallback & watched-tick gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a configured media player fails to launch, offer the user auto-detect / edit / cancel (auto-detect self-heals the saved config), and only mark an episode watched when a player actually starts.
+
+**Architecture:** Extract the automatic launch decision (try configured → else auto-detect) into pure, injectable, unit-tested helpers in `src/util/player.ts`. Keep the Ink wiring in `src/ui/App.tsx` thin: `playStream` calls the helper, routes failures to the right prompt, and fires an `onPlayed` callback only on a real launch. Reuse the existing `ConfirmPrompt` for the 3-way choice (no new component).
+
+**Tech Stack:** TypeScript, React + Ink (TUI), Vitest. Commands: `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`.
+
+---
+
+## File structure
+
+- **Modify** `src/util/player.ts` — add `PlayDeps`, `AutoPlayOutcome`, `detectAndPlay`, `attemptAutoPlay`. Pure logic, no UI.
+- **Modify** `src/util/player.test.ts` — add tests for the two new helpers.
+- **Modify** `src/ui/App.tsx` — rewrite `playStream`, `playFromPicker`, `setMediaPlayer`, `closePlayerPrompt`; add `pendingStream` + `playerPromptMode` state and `autoDetectPlayer` / `editPlayerCommand` handlers; render `ConfirmPrompt` vs `StreamPlayerPrompt` by mode.
+
+No new files. `ConfirmPrompt` (`src/ui/components/ConfirmPrompt.tsx`) is already imported by `App.tsx` (line 67) and already supports confirm / alt-key / cancel.
+
+---
+
+## Task 1: Pure launch-decision helpers in `player.ts`
+
+**Files:**
+- Modify: `src/util/player.ts` (append after `launchPlayer`, end of file)
+- Test: `src/util/player.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the top import in `src/util/player.test.ts`:
+
+```ts
+import { pickStreamFile, detectPlayer, streamCandidates, attemptAutoPlay, detectAndPlay } from "./player";
+```
+
+Append these `describe` blocks to `src/util/player.test.ts`:
+
+```ts
+describe("detectAndPlay", () => {
+  it("returns the detected player when it launches", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => "mpv",
+      launch: async () => true,
+    });
+    expect(player).toBe("mpv");
+  });
+
+  it("returns null when detection finds nothing", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => null,
+      launch: async () => true,
+    });
+    expect(player).toBeNull();
+  });
+
+  it("returns null when the detected player fails to launch", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => "mpv",
+      launch: async () => false,
+    });
+    expect(player).toBeNull();
+  });
+});
+
+describe("attemptAutoPlay", () => {
+  it("launches the configured player and reports played", async () => {
+    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+      launch: async (cmd) => cmd === "vlc.exe",
+    });
+    expect(out).toEqual({ played: true, player: "vlc.exe", configuredFailed: false });
+  });
+
+  it("flags a configured player that fails to launch and does NOT auto-detect", async () => {
+    let detected = false;
+    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+      launch: async () => false,
+      detect: async () => {
+        detected = true;
+        return "mpv";
+      },
+    });
+    expect(out).toEqual({ played: false, configuredFailed: true });
+    expect(detected).toBe(false);
+  });
+
+  it("auto-detects and launches when nothing is configured", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => "mpv",
+      launch: async () => true,
+    });
+    expect(out).toEqual({ played: true, player: "mpv", configuredFailed: false });
+  });
+
+  it("reports not-played (configuredFailed false) when detection finds nothing", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => null,
+      launch: async () => true,
+    });
+    expect(out).toEqual({ played: false, configuredFailed: false });
+  });
+
+  it("reports not-played when the detected player fails to launch", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => "mpv",
+      launch: async () => false,
+    });
+    expect(out).toEqual({ played: false, configuredFailed: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/util/player.test.ts`
+Expected: FAIL — `attemptAutoPlay is not a function` / `detectAndPlay is not a function` (imports unresolved).
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to the end of `src/util/player.ts` (after `launchPlayer`):
+
+```ts
+export interface PlayDeps {
+  detect?: () => Promise<string | null>;
+  launch?: (command: string, url: string) => Promise<boolean>;
+}
+
+// Outcome of the automatic (no-prompt) part of starting playback.
+export interface AutoPlayOutcome {
+  // A player launched successfully.
+  played: boolean;
+  // The command/path that launched (present only when played).
+  player?: string;
+  // A non-empty configured command was tried and failed to launch — the caller
+  // should offer the auto-detect/edit choice rather than the plain prompt.
+  configuredFailed: boolean;
+}
+
+// Auto-detect a player and launch it on the URL. Returns the launched
+// command/path (so the caller can persist it) or null when nothing was detected
+// or the detected player failed to launch. Deps injectable for testing.
+export async function detectAndPlay(url: string, deps: PlayDeps = {}): Promise<string | null> {
+  const detect = deps.detect ?? detectPlayer;
+  const launch = deps.launch ?? launchPlayer;
+  const detected = await detect();
+  if (detected && (await launch(detected, url))) return detected;
+  return null;
+}
+
+// The automatic part of playing a stream: try the configured player first, and
+// only auto-detect when nothing is configured. Never prompts or touches config —
+// it reports what happened so the UI can decide whether/what to prompt. A
+// configured command that fails is reported as configuredFailed (NOT silently
+// auto-detected) so the UI can offer the auto-detect/edit choice.
+export async function attemptAutoPlay(
+  configured: string,
+  url: string,
+  deps: PlayDeps = {},
+): Promise<AutoPlayOutcome> {
+  const launch = deps.launch ?? launchPlayer;
+  if (configured) {
+    if (await launch(configured, url)) {
+      return { played: true, player: configured, configuredFailed: false };
+    }
+    return { played: false, configuredFailed: true };
+  }
+  const player = await detectAndPlay(url, deps);
+  return player
+    ? { played: true, player, configuredFailed: false }
+    : { played: false, configuredFailed: false };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/util/player.test.ts`
+Expected: PASS (all `attemptAutoPlay` and `detectAndPlay` cases green).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/util/player.ts src/util/player.test.ts
+git commit -m "feat(player): add attemptAutoPlay/detectAndPlay launch-decision helpers"
+```
+
+---
+
+## Task 2: Wire the fallback prompt and watched-gating into `App.tsx`
+
+All edits land together (the new handlers are referenced by the render block, so the file only compiles once every edit is applied). Apply steps 1–8, then verify with steps 9–12.
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+
+- [ ] **Step 1: Update the player import**
+
+Replace (line ~17):
+
+```ts
+import { detectPlayer, launchPlayer, streamCandidates } from "../util/player";
+```
+
+with:
+
+```ts
+import { attemptAutoPlay, detectAndPlay, launchPlayer, streamCandidates } from "../util/player";
+```
+
+(`detectPlayer` is no longer referenced directly in `App.tsx` — the helpers call it internally.)
+
+- [ ] **Step 2: Replace the `pendingStreamUrl` state with richer pending context + prompt mode**
+
+Replace (line ~165):
+
+```ts
+  const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
+```
+
+with:
+
+```ts
+  // Context for a stream awaiting a player-command decision: the URL, an
+  // optional display name, an onPlayed callback fired ONLY when a player really
+  // launches (e.g. to mark an episode watched), and the configured command that
+  // failed (set only for the auto-detect/edit choice prompt).
+  const [pendingStream, setPendingStream] = useState<{
+    url: string;
+    name?: string;
+    onPlayed?: () => void;
+    configured?: string;
+  } | null>(null);
+  // Which media-player prompt is showing: the auto-detect/edit choice (after a
+  // configured player failed) or the plain command entry.
+  const [playerPromptMode, setPlayerPromptMode] = useState<"choice" | "edit">("edit");
+```
+
+- [ ] **Step 3: Rewrite `playStream`**
+
+Replace the whole `playStream` callback (lines ~615–634):
+
+```ts
+  const playStream = useCallback(
+    async (url: string, name?: string) => {
+      if (!config) return;
+      let player = resolveMediaPlayer(config);
+      if (!player) player = (await detectPlayer()) ?? "";
+      if (player && (await launchPlayer(player, url))) {
+        const copied = await writeClipboard(url);
+        setNotice(
+          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${player}${copied ? " · link copied" : ""}`,
+        );
+        return;
+      }
+      // No player available (or it failed to launch): stash the URL, put it on
+      // the clipboard, and ask the user for a command to use.
+      setPendingStreamUrl(url);
+      await writeClipboard(url);
+      setEditingPlayer(true);
+    },
+    [config],
+  );
+```
+
+with:
+
+```ts
+  const playStream = useCallback(
+    async (url: string, name?: string, onPlayed?: () => void) => {
+      if (!config) return;
+      const configured = resolveMediaPlayer(config);
+      const outcome = await attemptAutoPlay(configured, url);
+      if (outcome.played) {
+        const copied = await writeClipboard(url);
+        setNotice(
+          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}`,
+        );
+        onPlayed?.();
+        return;
+      }
+      // Couldn't play automatically: stash context, copy the link, and open the
+      // right prompt — a configured player that failed to launch gets the
+      // auto-detect/edit choice; otherwise the plain command entry.
+      setPendingStream({
+        url,
+        name,
+        onPlayed,
+        configured: outcome.configuredFailed ? configured : undefined,
+      });
+      await writeClipboard(url);
+      setPlayerPromptMode(outcome.configuredFailed ? "choice" : "edit");
+      setEditingPlayer(true);
+    },
+    [config],
+  );
+```
+
+- [ ] **Step 4: Gate the picker's watched-marking behind `onPlayed`**
+
+Replace the whole `playFromPicker` callback (lines ~649–658):
+
+```ts
+  const playFromPicker = useCallback(
+    (file: ResolvedFile) => {
+      void playStream(file.url, file.filename);
+      setStreamedFiles((prev) => new Set(prev).add(file.filename));
+      if (streamSource && isFavouritedIn(config?.favourites ?? [], streamSource.id)) {
+        markWatchedInFavourite(streamSource.id, file.filename);
+      }
+    },
+    [playStream, streamSource, config, markWatchedInFavourite],
+  );
+```
+
+with:
+
+```ts
+  const playFromPicker = useCallback(
+    (file: ResolvedFile) => {
+      // Mark streamed/watched ONLY once a player actually launches (the
+      // onPlayed callback), so a failed stream never gets a ✓.
+      void playStream(file.url, file.filename, () => {
+        setStreamedFiles((prev) => new Set(prev).add(file.filename));
+        if (streamSource && isFavouritedIn(config?.favourites ?? [], streamSource.id)) {
+          markWatchedInFavourite(streamSource.id, file.filename);
+        }
+      });
+    },
+    [playStream, streamSource, config, markWatchedInFavourite],
+  );
+```
+
+- [ ] **Step 5: Update `closePlayerPrompt`**
+
+Replace (lines ~884–888):
+
+```ts
+  const closePlayerPrompt = useCallback(() => {
+    setEditingPlayer(false);
+    setPendingStreamUrl(null);
+    setNotice("Stream link is on your clipboard.");
+  }, []);
+```
+
+with:
+
+```ts
+  const closePlayerPrompt = useCallback(() => {
+    setEditingPlayer(false);
+    setPendingStream(null);
+    setNotice("Stream link is on your clipboard.");
+  }, []);
+```
+
+- [ ] **Step 6: Rewrite `setMediaPlayer` to fire `onPlayed` on a successful launch**
+
+Replace the whole `setMediaPlayer` callback (lines ~890–912):
+
+```ts
+  const setMediaPlayer = useCallback(
+    (raw: string) => {
+      setEditingPlayer(false);
+      if (!config) return;
+      const cmd = raw.trim();
+      const url = pendingStreamUrl;
+      setPendingStreamUrl(null);
+      if (!cmd) {
+        setNotice("Stream link is on your clipboard.");
+        return;
+      }
+      setConfig({ ...config, mediaPlayer: cmd });
+      void (async () => {
+        if (!url) {
+          setNotice(`Media player set: ${cmd}`);
+          return;
+        }
+        const ok = await launchPlayer(cmd, url);
+        setNotice(ok ? `${ICON.done} Streaming in ${cmd}` : `Couldn't launch ${cmd}. Link is on your clipboard.`);
+      })();
+    },
+    [config, setConfig, pendingStreamUrl],
+  );
+```
+
+with:
+
+```ts
+  const setMediaPlayer = useCallback(
+    (raw: string) => {
+      setEditingPlayer(false);
+      if (!config) return;
+      const cmd = raw.trim();
+      const ctx = pendingStream;
+      setPendingStream(null);
+      if (!cmd) {
+        setNotice("Stream link is on your clipboard.");
+        return;
+      }
+      setConfig({ ...config, mediaPlayer: cmd });
+      void (async () => {
+        if (!ctx?.url) {
+          setNotice(`Media player set: ${cmd}`);
+          return;
+        }
+        const ok = await launchPlayer(cmd, ctx.url);
+        if (ok) {
+          setNotice(`${ICON.done} Streaming in ${cmd}`);
+          ctx.onPlayed?.();
+        } else {
+          setNotice(`Couldn't launch ${cmd}. Link is on your clipboard.`);
+        }
+      })();
+    },
+    [config, setConfig, pendingStream],
+  );
+```
+
+- [ ] **Step 7: Add the auto-detect and edit-choice handlers**
+
+Immediately after the `setMediaPlayer` callback (before `openDnsPrompt` at line ~914), insert:
+
+```ts
+  // Auto-detect a working player, launch it, and persist it so a bad saved
+  // command self-heals. Falls back to the command-entry prompt when detection
+  // finds nothing or the detected player won't launch.
+  const autoDetectPlayer = useCallback(() => {
+    const ctx = pendingStream;
+    if (!config || !ctx) {
+      setEditingPlayer(false);
+      setPendingStream(null);
+      return;
+    }
+    void (async () => {
+      const player = await detectAndPlay(ctx.url);
+      if (player) {
+        setConfig({ ...config, mediaPlayer: player });
+        setNotice(`${ICON.done} Streaming in ${player}`);
+        ctx.onPlayed?.();
+        setEditingPlayer(false);
+        setPendingStream(null);
+      } else {
+        setNotice("No player detected — enter a command.");
+        setPlayerPromptMode("edit");
+      }
+    })();
+  }, [config, pendingStream, setConfig]);
+
+  // Switch the choice prompt to the plain command-entry prompt.
+  const editPlayerCommand = useCallback(() => {
+    setPlayerPromptMode("edit");
+  }, []);
+```
+
+- [ ] **Step 8: Render the choice prompt vs the edit prompt by mode**
+
+Replace the player-prompt render block (lines ~1500–1509):
+
+```tsx
+        {editingPlayer ? (
+          <Box marginTop={1}>
+            <StreamPlayerPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              value={resolveMediaPlayer(store.config)}
+              onSubmit={setMediaPlayer}
+              onCancel={closePlayerPrompt}
+            />
+          </Box>
+        ) : null}
+```
+
+with:
+
+```tsx
+        {editingPlayer ? (
+          <Box marginTop={1}>
+            {playerPromptMode === "choice" && pendingStream?.configured ? (
+              <ConfirmPrompt
+                width={Math.max(24, Math.min(cols - 4, 62))}
+                title="media player"
+                message={`Couldn't launch "${pendingStream.configured}". Auto-detect a player?`}
+                altKey="e"
+                altLabel="edit command"
+                onConfirm={autoDetectPlayer}
+                onAlt={editPlayerCommand}
+                onCancel={closePlayerPrompt}
+              />
+            ) : (
+              <StreamPlayerPrompt
+                width={Math.max(24, Math.min(cols - 4, 62))}
+                value={resolveMediaPlayer(store.config)}
+                onSubmit={setMediaPlayer}
+                onCancel={closePlayerPrompt}
+              />
+            )}
+          </Box>
+        ) : null}
+```
+
+- [ ] **Step 9: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors (in particular, no "declared but never read" for `pendingStream`, `playerPromptMode`, `autoDetectPlayer`, `editPlayerCommand`, or a removed `detectPlayer` import).
+
+- [ ] **Step 10: Lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 11: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS (existing suites plus Task 1's new tests; no regressions).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/ui/App.tsx
+git commit -m "feat(stream): offer auto-detect/edit when a configured player fails; mark watched only on successful launch"
+```
+
+---
+
+## Task 3: Manual verification of the end-to-end flow
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build`
+Expected: build succeeds (no type/bundle errors).
+
+- [ ] **Step 2: Reproduce the trap, then confirm the fix**
+
+Temporarily point config at a bad player and launch the dev app:
+
+Run (bash): `TORLINK_PLAYER=definitely-not-a-real-player npm run dev`
+
+Then start a stream (`v`) on any resolved item and confirm:
+- The **choice prompt** appears: `Couldn't launch "definitely-not-a-real-player". Auto-detect a player?` with `e edit command` and `esc cancel` hints.
+- Pressing `y`/`enter` (**Auto-detect**) launches a detected player if one exists, or shows "No player detected — enter a command." and switches to the text-entry prompt.
+- Pressing `e` switches to the text-entry prompt.
+- Pressing `esc` closes with "Stream link is on your clipboard."
+- In a favourited series, the episode's ✓ appears **only** after a player actually launches — cancelling leaves no ✓.
+
+(Using `TORLINK_PLAYER` avoids editing the real `config.json`; it overrides `mediaPlayer` per `resolveMediaPlayer`.)
+
+- [ ] **Step 3: No commit needed** — verification only. If a defect is found, return to Task 2, fix, and re-run steps 9–12 there.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** configured-failure → choice prompt (Task 2 steps 3, 7, 8); auto-detect overwrites config (Task 2 step 7 `setConfig`); `onPlayed` gating (Task 2 steps 3, 4, 6); pending-state widening (step 2); pure tested helper (Task 1); `ConfirmPrompt` reuse instead of a new component (Task 2 step 8). Out-of-scope items (no `launchPlayer` internal change, no OS-error text) are respected.
+- **Type consistency:** `AutoPlayOutcome` (`played`, `player?`, `configuredFailed`) is produced by `attemptAutoPlay` (Task 1) and consumed in `playStream` (Task 2 step 3). `pendingStream` shape (`url`, `name?`, `onPlayed?`, `configured?`) is set in steps 3/7 and read in steps 6/7/8. `detectAndPlay(url, deps)` signature matches its call in step 7. `PlayDeps` (`detect?`, `launch?`) matches all test injections.

--- a/docs/superpowers/specs/2026-07-22-player-launch-fallback-and-watched-gating-design.md
+++ b/docs/superpowers/specs/2026-07-22-player-launch-fallback-and-watched-gating-design.md
@@ -1,0 +1,151 @@
+# Player launch fallback & watched-tick gating
+
+**Date:** 2026-07-22
+**Status:** Approved (design)
+**Builds on:** the existing streaming + media-player launch feature
+(`src/util/player.ts`, `playStream`/`playFromPicker` in `src/ui/App.tsx`).
+
+## Motivation
+
+A user on Windows hit a permanent "No player found" trap while streaming.
+Root cause (confirmed by reproduction on the affected machine):
+
+- Their `config.mediaPlayer` was the bare string `"vlc.exe"` — saved earlier
+  when a "No player found" prompt asked them to type a command.
+- `playStream` (`App.tsx:618`) prefers `resolveMediaPlayer(config)` and only
+  auto-detects when it is empty. So the bare value is used and **auto-detection
+  is skipped entirely**.
+- `launchPlayer("vlc.exe", url)` → `spawn("vlc.exe")` with no shell → `ENOENT`
+  (VLC is not on `PATH`; `where vlc` returns exit 1). Windows has no launch
+  fallback, so it fails.
+- The working install-path fallback (`winPlayerPath`, which resolves
+  `C:\Program Files\VideoLAN\VLC\vlc.exe` and launches fine) is never reached.
+
+The trap is self-perpetuating: the fix the prompt offered (type a command) is
+exactly what broke it, and every subsequent run repeats the failure.
+
+A second, independent defect surfaced during investigation: `playFromPicker`
+(`App.tsx:649`) marks an episode **watched (the tick)** eagerly, right after
+`void playStream(...)`, without checking whether a player actually launched. So
+a failed stream still gets ticked.
+
+## Scope
+
+**In scope**
+
+- Restructure `playStream` so a **configured player that fails to launch** no
+  longer dead-ends: it opens a choice prompt (**Auto-detect / Edit / Cancel**)
+  instead of the plain command-entry prompt.
+- **Auto-detect** path: run `detectPlayer()`, and on a player that launches,
+  **overwrite `config.mediaPlayer`** with the detected (absolute) path so the
+  trap self-heals permanently.
+- Gate all "mark played" side effects (session `streamedFiles` + persisted
+  `markWatchedInFavourite`) behind an **`onPlayed` callback** that fires only
+  when a player actually launches — synchronously or via a deferred prompt
+  choice.
+- A new `PlayerFallbackPrompt` choice component, modelled on the existing
+  choice prompts.
+- Widen the pending-stream state to carry `{ url, name?, onPlayed?, configured? }`
+  and a prompt-mode flag.
+- Extract the launch-decision sequence into a pure, injectable, unit-tested
+  helper in `src/util/player.ts`; add tests (TDD).
+
+**Out of scope (YAGNI)**
+
+- Changing `launchPlayer`'s internals to resolve bare command names against
+  install paths — the Auto-detect path already resolves to the absolute install
+  path, making this redundant.
+- Detailed OS-error surfacing (e.g. printing `ENOENT`). The choice prompt names
+  the player that failed (`Couldn't launch "vlc.exe".`), which is enough.
+- Any change to the Real-Debrid / torrent stream *resolution* paths — this is
+  purely about player selection and launch.
+- New keybindings.
+
+## Design
+
+### 1. Success signalling: `onPlayed` callback
+
+`playStream(url, name?, onPlayed?)` invokes `onPlayed()` the instant any player
+launches successfully — from the direct configured/detected launch **or** from
+a later prompt choice. Chosen over a `Promise<boolean>` return because the
+deferred prompt paths make a stored callback simpler than a stored promise
+resolver in React state (fewer stale-closure hazards).
+
+- `playFromPicker` passes a callback that marks streamed + watched.
+- `finishStream` passes nothing (it never marked watched).
+
+### 2. `playStream` control flow (`App.tsx`)
+
+```
+configured = resolveMediaPlayer(config)
+if configured:
+    if await launchPlayer(configured, url):
+        success(configured); onPlayed(); return
+    → open CHOICE prompt, carrying { url, name, onPlayed, configured }
+else:
+    detected = await detectPlayer()
+    if detected && await launchPlayer(detected, url):
+        success(detected); onPlayed(); return
+    → open EDIT prompt (existing StreamPlayerPrompt), carrying { url, name, onPlayed }
+```
+
+Before falling into either prompt, the URL is copied to the clipboard (as today).
+
+### 3. `PlayerFallbackPrompt` (new choice component)
+
+Shown only when a **configured** player fails. Modelled on an existing choice
+prompt (e.g. the keep/torrent prompt) for consistency.
+
+> `Couldn't launch "vlc.exe".`  → **Auto-detect** · **Edit command** · **Cancel (link copied)**
+
+- **Auto-detect** → `detectPlayer()`.
+  - Found and launches → overwrite `config.mediaPlayer` with the detected
+    absolute path, success notice, `onPlayed()`, close.
+  - Nothing found / launch fails → fall through to the Edit prompt.
+- **Edit command** → existing `StreamPlayerPrompt` (type command/path). A
+  successful launch saves the value and fires `onPlayed()`.
+- **Cancel** → link already on clipboard; close; no `onPlayed`.
+
+### 4. Pending state
+
+Replace `pendingStreamUrl: string | null` with
+`pendingStream: { url: string; name?: string; onPlayed?: () => void; configured?: string } | null`.
+Add a prompt-mode flag so `editingPlayer` can render the choice prompt vs the
+edit prompt. `setMediaPlayer` reads `onPlayed` from this state and fires it only
+on a successful launch.
+
+### 5. Picker marking gated (`playFromPicker`)
+
+Drop the eager `setStreamedFiles(...)` / `markWatchedInFavourite(...)`. Pass them
+as the `onPlayed` callback to `playStream` instead, so the tick appears only when
+a player really starts.
+
+### Data flow (tick)
+
+`playFromPicker` → `playStream(url, name, onPlayed)` → [launch succeeds anywhere]
+→ `onPlayed()` → `setStreamedFiles(add)` + (if favourited) `markWatchedInFavourite`.
+The watched list rendered at `App.tsx:1557` (union of persisted `watchedFor` and
+session `streamedFiles`) therefore reflects only real playbacks.
+
+### Error handling
+
+- Configured launch failure → choice prompt (never a silent dead-end).
+- Auto-detect finding nothing / failing to launch → routed to the Edit prompt.
+- Cancel / empty command → link on clipboard, no tick, existing notice.
+
+### Testing (TDD)
+
+Extract the launch-decision sequence into a pure helper in `player.ts` with
+injectable `detect` and `launch`, returning an outcome such as
+`{ played: true, player } | { played: false, configuredFailed: boolean }`. Unit
+tests (in `player.test.ts`) cover:
+
+- Configured player launches → `played:true`, `onPlayed` fired, no prompt.
+- Configured player fails → `configuredFailed:true` (routes to choice prompt),
+  `onPlayed` NOT fired.
+- No configured player, detection launches → `played:true`.
+- No configured player, detection fails → `played:false` (routes to edit
+  prompt), `onPlayed` NOT fired.
+
+The thin Ink wiring (which prompt renders, config overwrite) stays minimal on
+top of the tested helper.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -467,6 +467,19 @@ export function App({
     });
   }, []);
 
+  // Mark a file streamed this session and, when its torrent is favourited,
+  // persist watched progress. Called only once a player actually launches, so a
+  // failed/cancelled stream never earns a ✓.
+  const markPlayed = useCallback(
+    (favId: string, filename: string) => {
+      setStreamedFiles((prev) => new Set(prev).add(filename));
+      if (isFavouritedIn(config?.favourites ?? [], favId)) {
+        markWatchedInFavourite(favId, filename);
+      }
+    },
+    [config, markWatchedInFavourite],
+  );
+
   const isFavourited = useCallback(
     (id: string) => isFavouritedIn(config?.favourites ?? [], id),
     [config],
@@ -655,10 +668,10 @@ export function App({
 
   // Hand a resolved file to the player path and clear any picker/preparing UI.
   const finishStream = useCallback(
-    (file: ResolvedFile, name?: string) => {
+    (file: ResolvedFile, name?: string, onPlayed?: () => void) => {
       setStreamFiles(null);
       setPreparing(null);
-      void playStream(file.url, name ?? file.filename);
+      void playStream(file.url, name ?? file.filename, onPlayed);
     },
     [playStream],
   );
@@ -671,13 +684,10 @@ export function App({
       // Mark streamed/watched ONLY once a player actually launches (the
       // onPlayed callback), so a failed stream never gets a ✓.
       void playStream(file.url, file.filename, () => {
-        setStreamedFiles((prev) => new Set(prev).add(file.filename));
-        if (streamSource && isFavouritedIn(config?.favourites ?? [], streamSource.id)) {
-          markWatchedInFavourite(streamSource.id, file.filename);
-        }
+        if (streamSource) markPlayed(streamSource.id, file.filename);
       });
     },
-    [playStream, streamSource, config, markWatchedInFavourite],
+    [playStream, streamSource, markPlayed],
   );
 
   const cancelPreparing = useCallback(() => {
@@ -729,7 +739,9 @@ export function App({
             setStreamSource(input);
             setStreamFiles(candidates);
           } else {
-            void playStream(candidates[0]!.url, input.name);
+            void playStream(candidates[0]!.url, input.name, () =>
+              markPlayed(input.id, candidates[0]!.filename),
+            );
           }
         } catch (e) {
           prepareAbort.current = null;
@@ -739,7 +751,7 @@ export function App({
         }
       })();
     },
-    [config, preparing, streamFiles, activeStream, playStream, ensureVpnSafe],
+    [config, preparing, streamFiles, activeStream, playStream, ensureVpnSafe, markPlayed],
   );
 
   useEffect(() => {
@@ -865,7 +877,9 @@ export function App({
             setStreamFiles(candidates);
             return;
           }
-          finishStream(candidates[0]!, input.name);
+          finishStream(candidates[0]!, input.name, () =>
+            markPlayed(input.id, candidates[0]!.filename),
+          );
         } catch (e) {
           prepareAbort.current = null;
           setPreparing(null);
@@ -886,7 +900,7 @@ export function App({
         }
       })();
     },
-    [config, finishStream, preparing, streamFiles, activeStream, rdStatus, startTorrentStream],
+    [config, finishStream, preparing, streamFiles, activeStream, rdStatus, startTorrentStream, markPlayed],
   );
 
   // Reopen a favourited series: re-resolve its magnet through the same stream

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,7 +14,7 @@ import { setDnsServers } from "../util/dns";
 import { normalizeDownloadDir } from "../config/folder";
 import { validateToken, isPremiumActive, resolveMagnet, isTokenRejection } from "../integrations/realdebrid";
 import { rdStatusFromUser, type RdStatus } from "../integrations/rdStatus";
-import { detectPlayer, launchPlayer, streamCandidates } from "../util/player";
+import { attemptAutoPlay, detectAndPlay, launchPlayer, streamCandidates } from "../util/player";
 import type { ResolvedFile } from "../integrations/realdebrid";
 import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
 import { classifyStreamRoute } from "./streamRoute";
@@ -162,7 +162,19 @@ export function App({
   const [editingVpn, setEditingVpn] = useState(false);
   const [pendingP2P, setPendingP2P] = useState<DownloadInput | null>(null);
   const [fileSelection, setFileSelection] = useState<QueueItem | null>(null);
-  const [pendingStreamUrl, setPendingStreamUrl] = useState<string | null>(null);
+  // Context for a stream awaiting a player-command decision: the URL, an
+  // optional display name, an onPlayed callback fired ONLY when a player really
+  // launches (e.g. to mark an episode watched), and the configured command that
+  // failed (set only for the auto-detect/edit choice prompt).
+  const [pendingStream, setPendingStream] = useState<{
+    url: string;
+    name?: string;
+    onPlayed?: () => void;
+    configured?: string;
+  } | null>(null);
+  // Which media-player prompt is showing: the auto-detect/edit choice (after a
+  // configured player failed) or the plain command entry.
+  const [playerPromptMode, setPlayerPromptMode] = useState<"choice" | "edit">("edit");
   // A result waiting on the "download to" prompt (f); null when the prompt is
   // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
   // into the same alternate folder only costs one typed path per session.
@@ -613,21 +625,29 @@ export function App({
   // Try to play a resolved stream URL: use the configured/detected player, else
   // copy the link to the clipboard and prompt for a player command.
   const playStream = useCallback(
-    async (url: string, name?: string) => {
+    async (url: string, name?: string, onPlayed?: () => void) => {
       if (!config) return;
-      let player = resolveMediaPlayer(config);
-      if (!player) player = (await detectPlayer()) ?? "";
-      if (player && (await launchPlayer(player, url))) {
+      const configured = resolveMediaPlayer(config);
+      const outcome = await attemptAutoPlay(configured, url);
+      if (outcome.played) {
         const copied = await writeClipboard(url);
         setNotice(
-          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${player}${copied ? " · link copied" : ""}`,
+          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}`,
         );
+        onPlayed?.();
         return;
       }
-      // No player available (or it failed to launch): stash the URL, put it on
-      // the clipboard, and ask the user for a command to use.
-      setPendingStreamUrl(url);
+      // Couldn't play automatically: stash context, copy the link, and open the
+      // right prompt — a configured player that failed to launch gets the
+      // auto-detect/edit choice; otherwise the plain command entry.
+      setPendingStream({
+        url,
+        name,
+        onPlayed,
+        configured: outcome.configuredFailed ? configured : undefined,
+      });
       await writeClipboard(url);
+      setPlayerPromptMode(outcome.configuredFailed ? "choice" : "edit");
       setEditingPlayer(true);
     },
     [config],
@@ -648,11 +668,14 @@ export function App({
   // persists watched progress when the current torrent is favourited.
   const playFromPicker = useCallback(
     (file: ResolvedFile) => {
-      void playStream(file.url, file.filename);
-      setStreamedFiles((prev) => new Set(prev).add(file.filename));
-      if (streamSource && isFavouritedIn(config?.favourites ?? [], streamSource.id)) {
-        markWatchedInFavourite(streamSource.id, file.filename);
-      }
+      // Mark streamed/watched ONLY once a player actually launches (the
+      // onPlayed callback), so a failed stream never gets a ✓.
+      void playStream(file.url, file.filename, () => {
+        setStreamedFiles((prev) => new Set(prev).add(file.filename));
+        if (streamSource && isFavouritedIn(config?.favourites ?? [], streamSource.id)) {
+          markWatchedInFavourite(streamSource.id, file.filename);
+        }
+      });
     },
     [playStream, streamSource, config, markWatchedInFavourite],
   );
@@ -883,7 +906,7 @@ export function App({
 
   const closePlayerPrompt = useCallback(() => {
     setEditingPlayer(false);
-    setPendingStreamUrl(null);
+    setPendingStream(null);
     setNotice("Stream link is on your clipboard.");
   }, []);
 
@@ -892,24 +915,59 @@ export function App({
       setEditingPlayer(false);
       if (!config) return;
       const cmd = raw.trim();
-      const url = pendingStreamUrl;
-      setPendingStreamUrl(null);
+      const ctx = pendingStream;
+      setPendingStream(null);
       if (!cmd) {
         setNotice("Stream link is on your clipboard.");
         return;
       }
       setConfig({ ...config, mediaPlayer: cmd });
       void (async () => {
-        if (!url) {
+        if (!ctx?.url) {
           setNotice(`Media player set: ${cmd}`);
           return;
         }
-        const ok = await launchPlayer(cmd, url);
-        setNotice(ok ? `${ICON.done} Streaming in ${cmd}` : `Couldn't launch ${cmd}. Link is on your clipboard.`);
+        const ok = await launchPlayer(cmd, ctx.url);
+        if (ok) {
+          setNotice(`${ICON.done} Streaming in ${cmd}`);
+          ctx.onPlayed?.();
+        } else {
+          setNotice(`Couldn't launch ${cmd}. Link is on your clipboard.`);
+        }
       })();
     },
-    [config, setConfig, pendingStreamUrl],
+    [config, setConfig, pendingStream],
   );
+
+  // Auto-detect a working player, launch it, and persist it so a bad saved
+  // command self-heals. Falls back to the command-entry prompt when detection
+  // finds nothing or the detected player won't launch.
+  const autoDetectPlayer = useCallback(() => {
+    const ctx = pendingStream;
+    if (!config || !ctx) {
+      setEditingPlayer(false);
+      setPendingStream(null);
+      return;
+    }
+    void (async () => {
+      const player = await detectAndPlay(ctx.url);
+      if (player) {
+        setConfig({ ...config, mediaPlayer: player });
+        setNotice(`${ICON.done} Streaming in ${player}`);
+        ctx.onPlayed?.();
+        setEditingPlayer(false);
+        setPendingStream(null);
+      } else {
+        setNotice("No player detected — enter a command.");
+        setPlayerPromptMode("edit");
+      }
+    })();
+  }, [config, pendingStream, setConfig]);
+
+  // Switch the choice prompt to the plain command-entry prompt.
+  const editPlayerCommand = useCallback(() => {
+    setPlayerPromptMode("edit");
+  }, []);
 
   const openDnsPrompt = useCallback(() => {
     setShowHelp(false);
@@ -1499,12 +1557,25 @@ export function App({
 
         {editingPlayer ? (
           <Box marginTop={1}>
-            <StreamPlayerPrompt
-              width={Math.max(24, Math.min(cols - 4, 62))}
-              value={resolveMediaPlayer(store.config)}
-              onSubmit={setMediaPlayer}
-              onCancel={closePlayerPrompt}
-            />
+            {playerPromptMode === "choice" && pendingStream?.configured ? (
+              <ConfirmPrompt
+                width={Math.max(24, Math.min(cols - 4, 62))}
+                title="media player"
+                message={`Couldn't launch "${pendingStream.configured}". Auto-detect a player?`}
+                altKey="e"
+                altLabel="edit command"
+                onConfirm={autoDetectPlayer}
+                onAlt={editPlayerCommand}
+                onCancel={closePlayerPrompt}
+              />
+            ) : (
+              <StreamPlayerPrompt
+                width={Math.max(24, Math.min(cols - 4, 62))}
+                value={resolveMediaPlayer(store.config)}
+                onSubmit={setMediaPlayer}
+                onCancel={closePlayerPrompt}
+              />
+            )}
           </Box>
         ) : null}
 

--- a/src/util/player.test.ts
+++ b/src/util/player.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pickStreamFile, detectPlayer, streamCandidates } from "./player";
+import { pickStreamFile, detectPlayer, streamCandidates, attemptAutoPlay, detectAndPlay } from "./player";
 import type { ResolvedFile } from "../integrations/realdebrid";
 
 function f(filename: string, bytes: number): ResolvedFile {
@@ -135,5 +135,77 @@ describe("streamCandidates", () => {
 
   it("returns an empty array for no files", () => {
     expect(streamCandidates([])).toEqual([]);
+  });
+});
+
+describe("detectAndPlay", () => {
+  it("returns the detected player when it launches", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => "mpv",
+      launch: async () => true,
+    });
+    expect(player).toBe("mpv");
+  });
+
+  it("returns null when detection finds nothing", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => null,
+      launch: async () => true,
+    });
+    expect(player).toBeNull();
+  });
+
+  it("returns null when the detected player fails to launch", async () => {
+    const player = await detectAndPlay("http://x", {
+      detect: async () => "mpv",
+      launch: async () => false,
+    });
+    expect(player).toBeNull();
+  });
+});
+
+describe("attemptAutoPlay", () => {
+  it("launches the configured player and reports played", async () => {
+    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+      launch: async (cmd) => cmd === "vlc.exe",
+    });
+    expect(out).toEqual({ played: true, player: "vlc.exe", configuredFailed: false });
+  });
+
+  it("flags a configured player that fails to launch and does NOT auto-detect", async () => {
+    let detected = false;
+    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+      launch: async () => false,
+      detect: async () => {
+        detected = true;
+        return "mpv";
+      },
+    });
+    expect(out).toEqual({ played: false, configuredFailed: true });
+    expect(detected).toBe(false);
+  });
+
+  it("auto-detects and launches when nothing is configured", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => "mpv",
+      launch: async () => true,
+    });
+    expect(out).toEqual({ played: true, player: "mpv", configuredFailed: false });
+  });
+
+  it("reports not-played (configuredFailed false) when detection finds nothing", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => null,
+      launch: async () => true,
+    });
+    expect(out).toEqual({ played: false, configuredFailed: false });
+  });
+
+  it("reports not-played when the detected player fails to launch", async () => {
+    const out = await attemptAutoPlay("", "http://x", {
+      detect: async () => "mpv",
+      launch: async () => false,
+    });
+    expect(out).toEqual({ played: false, configuredFailed: false });
   });
 });

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -277,3 +277,53 @@ export async function launchPlayer(command: string, url: string): Promise<boolea
   if (process.platform === "darwin") return openWithApp(command, url);
   return false;
 }
+
+export interface PlayDeps {
+  detect?: () => Promise<string | null>;
+  launch?: (command: string, url: string) => Promise<boolean>;
+}
+
+// Outcome of the automatic (no-prompt) part of starting playback.
+export interface AutoPlayOutcome {
+  // A player launched successfully.
+  played: boolean;
+  // The command/path that launched (present only when played).
+  player?: string;
+  // A non-empty configured command was tried and failed to launch — the caller
+  // should offer the auto-detect/edit choice rather than the plain prompt.
+  configuredFailed: boolean;
+}
+
+// Auto-detect a player and launch it on the URL. Returns the launched
+// command/path (so the caller can persist it) or null when nothing was detected
+// or the detected player failed to launch. Deps injectable for testing.
+export async function detectAndPlay(url: string, deps: PlayDeps = {}): Promise<string | null> {
+  const detect = deps.detect ?? detectPlayer;
+  const launch = deps.launch ?? launchPlayer;
+  const detected = await detect();
+  if (detected && (await launch(detected, url))) return detected;
+  return null;
+}
+
+// The automatic part of playing a stream: try the configured player first, and
+// only auto-detect when nothing is configured. Never prompts or touches config —
+// it reports what happened so the UI can decide whether/what to prompt. A
+// configured command that fails is reported as configuredFailed (NOT silently
+// auto-detected) so the UI can offer the auto-detect/edit choice.
+export async function attemptAutoPlay(
+  configured: string,
+  url: string,
+  deps: PlayDeps = {},
+): Promise<AutoPlayOutcome> {
+  const launch = deps.launch ?? launchPlayer;
+  if (configured) {
+    if (await launch(configured, url)) {
+      return { played: true, player: configured, configuredFailed: false };
+    }
+    return { played: false, configuredFailed: true };
+  }
+  const player = await detectAndPlay(url, deps);
+  return player
+    ? { played: true, player, configuredFailed: false }
+    : { played: false, configuredFailed: false };
+}


### PR DESCRIPTION
## Summary

Fixes a permanent "No player found" trap when streaming on Windows.

**Root cause:** a bare `mediaPlayer` value in config (e.g. `"vlc.exe"`, saved from an earlier prompt) made `playStream` skip auto-detection, and `spawn("vlc.exe")` failed with `ENOENT` (VLC isn't on `PATH`). Windows had no launch fallback, and the UI collapsed both "nothing detected" and "launch failed" into the same opaque message — so the working install-path fallback was never reached.

## Changes

- **`attemptAutoPlay` / `detectAndPlay`** — pure, injectable launch-decision helpers in `src/util/player.ts` (unit-tested, incl. "a configured failure must NOT silently auto-detect").
- **Fallback prompt** — when a *configured* player fails to launch, offer **Auto-detect / Edit / Cancel** (reusing the existing `ConfirmPrompt`). Auto-detect resolves + launches a working player and overwrites `config.mediaPlayer` with the resolved path, so the trap self-heals.
- **Watched-tick gating** — episodes are marked streamed/watched (the ✓) only via an `onPlayed` callback that fires when a player actually launches. Routed through a shared `markPlayed` helper across the picker, the Real-Debrid single-file path, and the torrent single-file path.

## Test Plan

- [x] `npm test` — 529/529 pass (8 new cases for the helpers)
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds
- [ ] Windows: with a bad `mediaPlayer` (or `TORLINK_PLAYER=notreal`), stream and confirm the Auto-detect/Edit/Cancel prompt appears, Auto-detect launches VLC and persists the fix, and a cancelled stream leaves no ✓

Design & plan: `docs/superpowers/specs/2026-07-22-player-launch-fallback-and-watched-gating-design.md`, `docs/superpowers/plans/2026-07-22-player-launch-fallback-and-watched-gating.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)