### PR TITLE
chore: sync upstream baairon/torlink (v1.5.0) into fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# A new push to the same branch supersedes the run in flight.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform failing should never hide the result on the others.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [22, 24]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      # Install scripts stay enabled on purpose: the postinstall WebRTC
+      # fallback is itself a shipped code path, and a package-manager change
+      # to how install scripts run is what broke installs in v1.4.1.
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm test
+
+      # Builds what `npm publish` would build, so a broken publish path is
+      # caught here rather than at release time.
+      - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "torlnk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk",
-      "version": "1.5.0",
+      "version": "1.5.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",
         "ink": "^7.0.5",
         "parse-torrent": "^11.0.21",
         "react": "^19.2.7",
+        "uint8-util": "2.2.6",
         "webtorrent": "^2.4.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {
@@ -62,7 +62,11 @@
     "ink": "^7.0.5",
     "parse-torrent": "^11.0.21",
     "react": "^19.2.7",
+    "uint8-util": "2.2.6",
     "webtorrent": "^2.4.1"
+  },
+  "overrides": {
+    "uint8-util": "2.2.6"
   },
   "devDependencies": {
     "@types/node": "^25.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -27,5 +27,9 @@ export const seedsFile = path.join(dataDir, "seeds.json");
 // verify the on-disk file locally instead of re-fetching it from the swarm.
 export const torrentsDir = path.join(dataDir, "torrents");
 
+// Armed just before boot hands saved state to the torrent engine, disarmed
+// once the boot settles; see download/bootguard.ts.
+export const bootMarkerFile = path.join(dataDir, "boot.marker");
+
 // Where a --daemon headless run writes its log and pidfile.
 export const logsDir = path.join(dataDir, "logs");

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -11,12 +11,21 @@ import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
 import { loadHistory } from "../download/history";
 import { reconcileQueue } from "../download/reconcile";
+import {
+  BOOT_SETTLE_MS,
+  armBootMarker,
+  disarmBootMarker,
+  wasBootInterrupted,
+} from "../download/bootguard";
 import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 
 export interface Runtime {
   queue: DownloadQueue;
   downloadDir: string;
+  // True when the previous run died mid-restore and this boot came up in safe
+  // mode: everything paused, no engines started (see download/bootguard.ts).
+  recovered?: boolean;
 }
 
 // Build a queue and restore persisted state, matching the TUI's boot order
@@ -26,11 +35,19 @@ export async function startRuntime(overrideDir?: string): Promise<Runtime> {
   const cfg = await loadConfig();
   const queue = new DownloadQueue();
   queue.setTrackers(cfg.trackers);
-  queue.restore(reconcileQueue(await loadQueue()));
+  // Crash-boot breaker, mirroring the TUI: a marker left by the previous run
+  // means it died mid-restore, so restore paused with the engine cold.
+  const safe = wasBootInterrupted();
+  armBootMarker();
+  queue.restore(reconcileQueue(await loadQueue()), { safe });
   queue.restoreHistory(await loadHistory());
-  queue.restoreSeeds(await loadSeeds());
+  queue.restoreSeeds(await loadSeeds(), { safe });
+  setTimeout(disarmBootMarker, BOOT_SETTLE_MS).unref();
+  if (safe) {
+    console.error("[torlnk] recovered from a crashed start: restored downloads are paused");
+  }
   const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
-  return { queue, downloadDir };
+  return { queue, downloadDir, recovered: safe };
 }
 
 export type AddOutcome = "added" | "duplicate" | "invalid";

--- a/src/deps-pin.test.ts
+++ b/src/deps-pin.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { arr2hex } from "uint8-util";
+
+// Jul-2026 incident: uint8-util 2.3.x (released Jul-20) changed arr2hex to
+// read data.buffer, which throws on the hex STRING webtorrent 2.8.5 passes it
+// from Torrent._onTorrentId. That surfaces as an unhandled promise rejection
+// inside webtorrent's fire-and-forget async startup, unreachable by any
+// caller's try/catch, and it killed every fresh install on every magnet add
+// and every boot with saved downloads (the repo lockfile kept dev and CI on
+// the tolerant 2.2.6, which is why nothing here ever saw it). The exact pin,
+// as a direct dependency AND an override, keeps fresh installs deduped onto
+// the known-good version. Lift it deliberately, with this test, only once the
+// upstream call site or arr2hex handles strings again.
+const KNOWN_GOOD = "2.2.6";
+
+function readJson(rel: string): Record<string, any> {
+  return JSON.parse(readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8"));
+}
+
+describe("uint8-util quarantine pin", () => {
+  it("package.json pins the exact version as a dependency and an override", () => {
+    const pkg = readJson("../package.json");
+    expect(pkg.dependencies["uint8-util"]).toBe(KNOWN_GOOD);
+    expect(pkg.overrides["uint8-util"]).toBe(KNOWN_GOOD);
+  });
+
+  it("the lockfile resolved the pinned version", () => {
+    const lock = readJson("../package-lock.json");
+    expect(lock.packages["node_modules/uint8-util"].version).toBe(KNOWN_GOOD);
+  });
+
+  it("the resolved arr2hex tolerates webtorrent's string infoHash call", () => {
+    const asAny = arr2hex as unknown as (data: unknown) => string;
+    expect(() => asAny("fd568f2ceba6b2603e761e4b13e5308c8b0f8ae4")).not.toThrow();
+  });
+});

--- a/src/download/bootguard.test.ts
+++ b/src/download/bootguard.test.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from "node:fs";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The marker lives at a fixed path derived from TORLINK_STATE_DIR at module
+// init, and other suites (persistSync tests) legitimately disarm it. Each test
+// here gets a private state dir + fresh module instances so parallel test
+// files can never race on the shared marker.
+async function isolated() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-bootguard-"));
+  vi.stubEnv("TORLINK_STATE_DIR", dir);
+  vi.resetModules();
+  const paths = await import("../config/paths");
+  const bootguard = await import("./bootguard");
+  return { dir, paths, bootguard };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("boot crash breaker", () => {
+  it("arms, detects, and disarms the marker", async () => {
+    const { dir, paths, bootguard } = await isolated();
+    try {
+      expect(bootguard.wasBootInterrupted()).toBe(false);
+      bootguard.armBootMarker();
+      expect(existsSync(paths.bootMarkerFile)).toBe(true);
+      expect(bootguard.wasBootInterrupted()).toBe(true);
+      bootguard.disarmBootMarker();
+      expect(bootguard.wasBootInterrupted()).toBe(false);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("arming twice and disarming a missing marker never throw", async () => {
+    const { dir, bootguard } = await isolated();
+    try {
+      bootguard.armBootMarker();
+      expect(() => bootguard.armBootMarker()).not.toThrow();
+      bootguard.disarmBootMarker();
+      expect(() => bootguard.disarmBootMarker()).not.toThrow();
+      expect(bootguard.wasBootInterrupted()).toBe(false);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the data dir on arm when nothing has persisted yet", async () => {
+    const { dir, bootguard } = await isolated();
+    try {
+      // A first-ever boot has no data dir at all; arming must create it
+      // rather than fail quietly and blind the breaker.
+      bootguard.armBootMarker();
+      expect(bootguard.wasBootInterrupted()).toBe(true);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/download/bootguard.ts
+++ b/src/download/bootguard.ts
@@ -1,0 +1,42 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { bootMarkerFile } from "../config/paths";
+
+// Crash-boot breaker for the restore path. A marker file is armed just before
+// persisted state is handed to the torrent engine and disarmed once the boot
+// has stayed alive long enough to be called healthy (or the app flushes state
+// on a clean exit, see DownloadQueue.persistSync). Finding a marker at the
+// next boot therefore means the previous one died while restoring: something
+// in the saved state detonates the engine, and a dependency drifting under
+// webtorrent can turn a perfectly valid magnet into an uncatchable async
+// throw (the Jul-2026 uint8-util incident, see deps-pin.test.ts). That boot
+// restores everything as paused and starts no engines, so the UI always comes
+// up and the user resumes items on their own terms.
+
+// How long after restore the process must survive before the marker is
+// disarmed. Long enough for the engine's async startup (parse, discovery,
+// store init) to have blown up if it was going to.
+export const BOOT_SETTLE_MS = 4000;
+
+export function wasBootInterrupted(): boolean {
+  try {
+    return existsSync(bootMarkerFile);
+  } catch {
+    return false;
+  }
+}
+
+export function armBootMarker(): void {
+  try {
+    mkdirSync(path.dirname(bootMarkerFile), { recursive: true });
+    writeFileSync(bootMarkerFile, JSON.stringify({ at: Date.now(), pid: process.pid }));
+  } catch {
+    // Failing to write the marker never blocks a boot.
+  }
+}
+
+export function disarmBootMarker(): void {
+  try {
+    rmSync(bootMarkerFile, { force: true });
+  } catch {}
+}

--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -84,4 +84,28 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     expect(constructorCalls).toHaveLength(1);
     expect(constructorCalls[0]).not.toHaveProperty("natPmp", false);
   });
+
+  it("stats(id) ignores getter errors and returns safe defaults", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    const fakeTorrent = new EventEmitter();
+    Object.defineProperty(fakeTorrent, "progress", {
+      get() {
+        throw new Error("Metadata not ready");
+      },
+    });
+    Object.defineProperty(fakeTorrent, "length", {
+      get() {
+        throw new Error("Metadata not ready");
+      },
+    });
+    // Inject fakeTorrent directly into private torrents map
+    (engine as unknown as { torrents: Map<string, unknown> }).torrents.set("bad-id", fakeTorrent);
+
+    const result = engine.stats("bad-id");
+    expect(result).not.toBeNull();
+    expect(result?.progress).toBe(0);
+    expect(result?.total).toBe(0);
+    engine.destroy();
+  });
 });

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -134,8 +134,11 @@ export class TorrentEngine {
       peers = t.numPeers || 0;
       timeRemaining = t.timeRemaining;
       name = t.name || "";
-    } catch (err) {
-      // Ignore webtorrent getter errors that occur before metadata is fully parsed or on error
+    } catch {
+      // Every stat is read inside this try on purpose: webtorrent getters can
+      // throw before metadata parses and on a torrent in an error state, and
+      // stats() runs from the poll interval, where an escaping throw is an
+      // uncaught exception. Partial numbers beat a dead poller.
     }
 
     return {

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -28,7 +28,7 @@ export interface AddHandlers {
   onError?: (message: string) => void;
 }
 
-function message(e: unknown): string {
+export function message(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
@@ -116,26 +116,38 @@ export class TorrentEngine {
 
     let progress = 0;
     let downloaded = 0;
+    let total = 0;
+    let speed = 0;
+    let uploadSpeed = 0;
+    let uploaded = 0;
+    let peers = 0;
     let timeRemaining = Infinity;
+    let name = "";
 
     try {
-      progress = t.progress;
-      downloaded = t.downloaded;
+      progress = t.progress || 0;
+      downloaded = t.downloaded || 0;
+      total = t.length || 0;
+      speed = t.downloadSpeed || 0;
+      uploadSpeed = t.uploadSpeed || 0;
+      uploaded = t.uploaded || 0;
+      peers = t.numPeers || 0;
       timeRemaining = t.timeRemaining;
+      name = t.name || "";
     } catch (err) {
-      // Ignore webtorrent getter errors that occur before metadata is fully parsed
+      // Ignore webtorrent getter errors that occur before metadata is fully parsed or on error
     }
 
     return {
       progress,
       downloaded,
-      total: t.length || 0,
-      speed: t.downloadSpeed || 0,
-      uploadSpeed: t.uploadSpeed || 0,
-      uploaded: t.uploaded || 0,
-      peers: t.numPeers || 0,
+      total,
+      speed,
+      uploadSpeed,
+      uploaded,
+      peers,
       timeRemaining,
-      name: t.name || '',
+      name,
     };
   }
 

--- a/src/download/queue.safemode.test.ts
+++ b/src/download/queue.safemode.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { DownloadQueue } from "./queue";
+import { armBootMarker, wasBootInterrupted } from "./bootguard";
+import type { HistoryItem } from "./history";
+import type { QueueItem } from "./types";
+
+function item(over: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: "q1",
+    name: "Some Download",
+    magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
+    dir: "/downloads",
+    status: "downloading",
+    progress: 0,
+    totalBytes: 100,
+    downloadedBytes: 0,
+    speed: 0,
+    peers: 0,
+    addedAt: 1,
+    ...over,
+  };
+}
+
+function h(over: Partial<HistoryItem> = {}): HistoryItem {
+  return {
+    id: "h1",
+    name: "Some Download",
+    magnet: "magnet:?xt=urn:btih:2222222222222222222222222222222222222222",
+    dir: "/downloads",
+    sizeBytes: 100,
+    completedAt: 1,
+    ...over,
+  };
+}
+
+// Inject a spy engine whose add() also throws: safe mode must not merely
+// survive engine failures, it must never reach the engine at all.
+function coldEngine(q: DownloadQueue): { adds: () => number } {
+  let n = 0;
+  const eng = (q as unknown as { engine: { add: () => void } }).engine;
+  eng.add = () => {
+    n++;
+    throw new Error("engine must stay cold in safe mode");
+  };
+  return { adds: () => n };
+}
+
+describe("DownloadQueue safe-mode restore (crash-boot breaker)", () => {
+  it("restores active and queued items as paused without touching the engine", () => {
+    const q = new DownloadQueue();
+    const engine = coldEngine(q);
+    q.restore(
+      [
+        item({ id: "a", status: "downloading" }),
+        item({ id: "b", status: "queued" }),
+        item({ id: "c", status: "failed", error: "boom" }),
+        item({ id: "d", status: "paused" }),
+      ],
+      { safe: true },
+    );
+
+    expect(engine.adds()).toBe(0);
+    const by = new Map(q.getItems().map((it) => [it.id, it.status]));
+    expect(by.get("a")).toBe("paused");
+    expect(by.get("b")).toBe("paused");
+    expect(by.get("c")).toBe("failed");
+    expect(by.get("d")).toBe("paused");
+    q.suspend();
+  });
+
+  it("restores persisted seeders as paused seeds without touching the engine", () => {
+    const q = new DownloadQueue();
+    const engine = coldEngine(q);
+    q.restoreHistory([h({ id: "s1" }), h({ id: "s2" })]);
+    q.restoreSeeds(
+      [
+        { id: "s1", status: "seeding" },
+        { id: "s2", status: "paused" },
+      ],
+      { safe: true },
+    );
+
+    expect(engine.adds()).toBe(0);
+    expect(q.getSeed("s1")?.status).toBe("paused");
+    expect(q.getSeed("s2")?.status).toBe("paused");
+    expect(q.seedingCount).toBe(0);
+    q.suspend();
+  });
+
+  it("default restore still starts engines (safe mode is opt-in)", () => {
+    const q = new DownloadQueue();
+    let adds = 0;
+    const eng = (q as unknown as { engine: { add: () => void } }).engine;
+    eng.add = () => {
+      adds++;
+    };
+    q.restore([item({ id: "a", status: "downloading" })]);
+    expect(adds).toBe(1);
+    q.suspend();
+  });
+
+  it("persistSync disarms the boot marker (a clean flush proves a healthy run)", () => {
+    const q = new DownloadQueue();
+    armBootMarker();
+    expect(wasBootInterrupted()).toBe(true);
+    q.persistSync();
+    expect(wasBootInterrupted()).toBe(false);
+  });
+});

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -84,3 +84,54 @@ describe("strayDownload (missing-file safety-net)", () => {
     expect(strayDownload({ total: 0, progress: 0, speed: 0 })).toBe(false);
   });
 });
+
+describe("DownloadQueue error resilience on boot", () => {
+  it("restore() marks item failed if engine.add throws synchronously", () => {
+    const q = new DownloadQueue();
+    // Spy on internal engine to force synchronous throw when add is called
+    const fakeEngine = (q as unknown as { engine: { add: () => void } }).engine;
+    fakeEngine.add = () => {
+      throw new Error("Disk error during add");
+    };
+
+    expect(() =>
+      q.restore([
+        {
+          id: "err1",
+          name: "Broken Download",
+          source: undefined,
+          magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
+          dir: "/downloads",
+          status: "downloading",
+          progress: 0,
+          totalBytes: 100,
+          downloadedBytes: 0,
+          speed: 0,
+          peers: 0,
+          addedAt: Date.now(),
+        },
+      ])
+    ).not.toThrow();
+
+    const errItem = q.getItems().find((i) => i.id === "err1");
+    expect(errItem?.status).toBe("failed");
+    expect(errItem?.error).toContain("Disk error during add");
+    q.suspend();
+  });
+
+  it("restoreSeeds() marks seed paused if engine.add throws synchronously", () => {
+    const q = new DownloadQueue();
+    q.restoreHistory([h({ id: "h-broken" })]);
+    const fakeEngine = (q as unknown as { engine: { add: () => void } }).engine;
+    fakeEngine.add = () => {
+      throw new Error("Chunk store init failed");
+    };
+
+    expect(() =>
+      q.restoreSeeds([{ id: "h-broken", status: "seeding" }])
+    ).not.toThrow();
+
+    expect(q.getSeed("h-broken")?.status).toBe("paused");
+    q.suspend();
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { TorrentEngine, type AddHandlers } from "./engine";
+import { TorrentEngine, message, type AddHandlers } from "./engine";
 import {
   saveQueue,
   saveQueueSync,
@@ -145,7 +145,14 @@ export class DownloadQueue extends EventEmitter {
   }
 
   private startEngine(item: QueueItem): void {
-    this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    try {
+      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    } catch (e) {
+      item.status = "failed";
+      item.error = message(e);
+      item.speed = 0;
+      item.peers = 0;
+    }
   }
 
   /**
@@ -502,7 +509,14 @@ export class DownloadQueue extends EventEmitter {
     // Seed from the stored .torrent metadata when we have it (verifies the local
     // file immediately, no swarm needed); fall back to the magnet otherwise.
     const source = torrentMetaExists(h.id) ? torrentMetaPath(h.id) : h.magnet;
-    this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
+    try {
+      this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
+    } catch (e) {
+      this.seeds.set(h.id, { ...base, status: "paused" });
+      this.changed();
+      void this.persistSeeds();
+      return;
+    }
     this.ensurePoll();
     this.changed();
     void this.persistSeeds();
@@ -531,12 +545,16 @@ export class DownloadQueue extends EventEmitter {
 
   restoreSeeds(records: SeedRecord[]): void {
     for (const r of records) {
-      const h = this.history.find((x) => x.id === r.id);
-      if (!h) continue;
-      // Respect the persisted choice: resume seeders, but leave a paused seed
-      // paused (and visibly so) instead of auto-starting it.
-      if (r.status === "seeding") this.startSeeding(h);
-      else this.restorePaused(h);
+      try {
+        const h = this.history.find((x) => x.id === r.id);
+        if (!h) continue;
+        // Respect the persisted choice: resume seeders, but leave a paused seed
+        // paused (and visibly so) instead of auto-starting it.
+        if (r.status === "seeding") this.startSeeding(h);
+        else this.restorePaused(h);
+      } catch (e) {
+        // If restoring a specific seed fails, ignore and proceed to the next record
+      }
     }
   }
 
@@ -577,20 +595,26 @@ export class DownloadQueue extends EventEmitter {
   restore(items: QueueItem[]): void {
     let active = 0;
     for (const raw of items) {
-      this.items.set(raw.id, raw);
-      if (raw.status !== "downloading") continue;
-      if (this.maxDownloads === 0 || active < this.maxDownloads) {
-        this.startEngine(raw);
-        active++;
-      } else {
-        // Over the cap on boot → hold as queued (promoted as slots free).
-        raw.status = "queued";
+      try {
+        this.items.set(raw.id, raw);
+        if (raw.status !== "downloading") continue;
+        if (this.maxDownloads === 0 || active < this.maxDownloads) {
+          this.startEngine(raw);
+          active++;
+        } else {
+          // Over the cap on boot → hold as queued (promoted as slots free).
+          raw.status = "queued";
+        }
+      } catch (e) {
+        // Ignore corrupted items during restore
       }
     }
     if (active > 0) this.ensurePoll();
     this.changed();
     // Fill any remaining slots from persisted "queued" items.
-    this.promote();
+    try {
+      this.promote();
+    } catch {}
   }
 
   restoreHistory(items: HistoryItem[]): void {

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -14,6 +14,7 @@ import {
 } from "./persist";
 import { saveHistory, saveHistorySync, type HistoryItem } from "./history";
 import { deleteSeedData } from "./delete-data";
+import { disarmBootMarker } from "./bootguard";
 import type { QueueItem, SeedItem } from "./types";
 import type { SourceId } from "../sources/types";
 
@@ -52,6 +53,13 @@ export interface AddInput {
   magnet: string;
   source?: SourceId;
   sizeBytes?: number;
+}
+
+export interface RestoreOptions {
+  // Safe mode: the previous boot died while restoring (see bootguard.ts), so
+  // bring every item back paused and start no engines. The list stays intact
+  // and visible; the user resumes each item on their own terms.
+  safe?: boolean;
 }
 
 export class DownloadQueue extends EventEmitter {
@@ -543,19 +551,21 @@ export class DownloadQueue extends EventEmitter {
     else this.startSeeding(h);
   }
 
-  restoreSeeds(records: SeedRecord[]): void {
+  restoreSeeds(records: SeedRecord[], opts: RestoreOptions = {}): void {
     for (const r of records) {
       try {
         const h = this.history.find((x) => x.id === r.id);
         if (!h) continue;
         // Respect the persisted choice: resume seeders, but leave a paused seed
-        // paused (and visibly so) instead of auto-starting it.
-        if (r.status === "seeding") this.startSeeding(h);
+        // paused (and visibly so) instead of auto-starting it. In safe mode
+        // even seeders come back paused, since re-seeding also feeds the engine.
+        if (r.status === "seeding" && !opts.safe) this.startSeeding(h);
         else this.restorePaused(h);
       } catch (e) {
         // If restoring a specific seed fails, ignore and proceed to the next record
       }
     }
+    if (opts.safe) void this.persistSeeds();
   }
 
   // Rebuild a paused seed from history without touching the engine, so it shows
@@ -592,7 +602,18 @@ export class DownloadQueue extends EventEmitter {
     return saveSeeds(this.seedRecords()).catch(() => {});
   }
 
-  restore(items: QueueItem[]): void {
+  restore(items: QueueItem[], opts: RestoreOptions = {}): void {
+    if (opts.safe) {
+      // Engines stay cold: pause everything that would have started and keep
+      // the rest as saved, then persist so the paused state is the new truth.
+      for (const raw of items) {
+        if (raw.status === "downloading" || raw.status === "queued") raw.status = "paused";
+        this.items.set(raw.id, raw);
+      }
+      this.changed();
+      void this.persist();
+      return;
+    }
     let active = 0;
     for (const raw of items) {
       try {
@@ -688,6 +709,9 @@ export class DownloadQueue extends EventEmitter {
     saveQueueSync(this.getItems());
     saveHistorySync(this.history);
     saveSeedsSync(this.seedRecords());
+    // A clean flush doubles as proof this run did not die mid-restore, so the
+    // crash-boot breaker stands down (see bootguard.ts).
+    disarmBootMarker();
   }
 
   suspend(): void {

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -156,6 +156,10 @@ export class DownloadQueue extends EventEmitter {
     try {
       this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
     } catch (e) {
+      // engine.add routes webtorrent's own synchronous failures through
+      // onError, so the only throw that reaches here is the client failing to
+      // construct at all (a broken native module, a hostile environment). Fail
+      // this one item instead of the caller, which is usually a whole restore.
       item.status = "failed";
       item.error = message(e);
       item.speed = 0;
@@ -519,7 +523,9 @@ export class DownloadQueue extends EventEmitter {
     const source = torrentMetaExists(h.id) ? torrentMetaPath(h.id) : h.magnet;
     try {
       this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
-    } catch (e) {
+    } catch {
+      // Same narrow case as startEngine: only a client that won't construct
+      // lands here. Leave the seed paused so it stays visible and resumable.
       this.seeds.set(h.id, { ...base, status: "paused" });
       this.changed();
       void this.persistSeeds();
@@ -553,17 +559,13 @@ export class DownloadQueue extends EventEmitter {
 
   restoreSeeds(records: SeedRecord[], opts: RestoreOptions = {}): void {
     for (const r of records) {
-      try {
-        const h = this.history.find((x) => x.id === r.id);
-        if (!h) continue;
-        // Respect the persisted choice: resume seeders, but leave a paused seed
-        // paused (and visibly so) instead of auto-starting it. In safe mode
-        // even seeders come back paused, since re-seeding also feeds the engine.
-        if (r.status === "seeding" && !opts.safe) this.startSeeding(h);
-        else this.restorePaused(h);
-      } catch (e) {
-        // If restoring a specific seed fails, ignore and proceed to the next record
-      }
+      const h = this.history.find((x) => x.id === r.id);
+      if (!h) continue;
+      // Respect the persisted choice: resume seeders, but leave a paused seed
+      // paused (and visibly so) instead of auto-starting it. In safe mode even
+      // seeders come back paused, since re-seeding also feeds the engine.
+      if (r.status === "seeding" && !opts.safe) this.startSeeding(h);
+      else this.restorePaused(h);
     }
     if (opts.safe) void this.persistSeeds();
   }
@@ -616,26 +618,20 @@ export class DownloadQueue extends EventEmitter {
     }
     let active = 0;
     for (const raw of items) {
-      try {
-        this.items.set(raw.id, raw);
-        if (raw.status !== "downloading") continue;
-        if (this.maxDownloads === 0 || active < this.maxDownloads) {
-          this.startEngine(raw);
-          active++;
-        } else {
-          // Over the cap on boot → hold as queued (promoted as slots free).
-          raw.status = "queued";
-        }
-      } catch (e) {
-        // Ignore corrupted items during restore
+      this.items.set(raw.id, raw);
+      if (raw.status !== "downloading") continue;
+      if (this.maxDownloads === 0 || active < this.maxDownloads) {
+        this.startEngine(raw);
+        active++;
+      } else {
+        // Over the cap on boot → hold as queued (promoted as slots free).
+        raw.status = "queued";
       }
     }
     if (active > 0) this.ensurePoll();
     this.changed();
     // Fill any remaining slots from persisted "queued" items.
-    try {
-      this.promote();
-    } catch {}
+    this.promote();
   }
 
   restoreHistory(items: HistoryItem[]): void {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { render } from "ink";
 import { parseCliArgs, HELP_TEXT } from "./cli/args";
 import { daemonize } from "./daemon/daemonize";
 import { runAttach } from "./daemon/attach";
+import { containUnhandledRejections, logCrash } from "./util/crashlog";
 import { VERSION } from "./version";
 import { App } from "./ui/App";
 
@@ -22,6 +23,14 @@ if (cmd.kind === "invalid") {
   console.error(HELP_TEXT);
   process.exit(1);
 }
+
+// An unhandled promise rejection must never take the whole app down: webtorrent
+// can produce one from inside its own async internals where no caller's
+// try/catch or error event can reach (see util/crashlog.ts). Contained and
+// logged for every mode; headless runs also echo one line to their log.
+containUnhandledRejections({
+  echo: cmd.kind === "update" || cmd.kind === "watch" || cmd.kind === "serve" || cmd.kind === "files",
+});
 
 // Run/reattach the TUI inside a persistent tmux session (execs tmux, then exits).
 if (cmd.kind === "attach") {
@@ -122,6 +131,7 @@ process.on("SIGTERM", () => forceExit(0));
 process.on("exit", restoreTerminal);
 
 process.on("uncaughtException", (err) => {
+  logCrash("uncaughtException", err);
   restoreTerminal();
   console.error(err);
   process.exit(1);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
-import { loadConfig, saveConfig, defaultConfig, type Config } from "../config/config";
+import { loadConfig, saveConfig, type Config } from "../config/config";
 import { normalizeDownloadDir } from "../config/folder";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
@@ -13,6 +13,7 @@ import {
   disarmBootMarker,
   wasBootInterrupted,
 } from "../download/bootguard";
+import { logCrash } from "../util/crashlog";
 import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { readClipboard, writeClipboard } from "../util/clipboard";
@@ -115,12 +116,7 @@ export function App({
     booting.current = true;
     let alive = true;
     void (async () => {
-      let cfg: Config;
-      try {
-        cfg = await loadConfig();
-      } catch {
-        cfg = { ...defaultConfig, trackers: [] };
-      }
+      const cfg = await loadConfig();
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
       // Crash-boot breaker: a marker left behind by the previous boot means it
@@ -128,15 +124,18 @@ export function App({
       // engine cold (safe mode) instead of walking into the same explosion.
       const safeBoot = wasBootInterrupted();
       armBootMarker();
+      // One fail-safe around the whole restore, holding a single invariant: the
+      // app always reaches a usable screen. Nothing below throws today (every
+      // loader falls back to empty state and the engine calls are guarded), but
+      // a future one that did would otherwise strand the boot on the loading
+      // spinner, which is the worst failure this app has.
       try {
         q.restore(reconcileQueue(await loadQueue()), { safe: safeBoot });
-      } catch {}
-      try {
         q.restoreHistory(await loadHistory());
-      } catch {}
-      try {
         q.restoreSeeds(await loadSeeds(), { safe: safeBoot });
-      } catch {}
+      } catch (e) {
+        logCrash("boot-restore", e);
+      }
       setTimeout(disarmBootMarker, BOOT_SETTLE_MS).unref();
       if (!alive) {
         q.suspend();
@@ -148,23 +147,21 @@ export function App({
         setRecovered(true);
         setNotice("Recovered from a crashed start · downloads paused");
       }
-      try {
-        const launch = initialMagnet
-          ? parseInput(initialMagnet)
-          : initialTorrent
-            ? await magnetFromTorrentFile(initialTorrent)
-            : null;
-        if (launch) {
-          await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
-          q.add(
-            { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
-            cfg.downloadDir,
-          );
-          setView("browser");
-          setSection("downloads");
-          setRegion("content");
-        }
-      } catch {}
+      const launch = initialMagnet
+        ? parseInput(initialMagnet)
+        : initialTorrent
+          ? await magnetFromTorrentFile(initialTorrent)
+          : null;
+      if (launch) {
+        await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
+        q.add(
+          { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
+          cfg.downloadDir,
+        );
+        setView("browser");
+        setSection("downloads");
+        setRegion("content");
+      }
     })();
     return () => {
       alive = false;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,6 +7,12 @@ import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
 import { loadHistory } from "../download/history";
 import { reconcileQueue } from "../download/reconcile";
+import {
+  BOOT_SETTLE_MS,
+  armBootMarker,
+  disarmBootMarker,
+  wasBootInterrupted,
+} from "../download/bootguard";
 import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { readClipboard, writeClipboard } from "../util/clipboard";
@@ -101,6 +107,7 @@ export function App({
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
+  const [recovered, setRecovered] = useState(false);
   const booting = useRef(false);
 
   useEffect(() => {
@@ -116,21 +123,31 @@ export function App({
       }
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
+      // Crash-boot breaker: a marker left behind by the previous boot means it
+      // died mid-restore, so this one restores everything paused with the
+      // engine cold (safe mode) instead of walking into the same explosion.
+      const safeBoot = wasBootInterrupted();
+      armBootMarker();
       try {
-        q.restore(reconcileQueue(await loadQueue()));
+        q.restore(reconcileQueue(await loadQueue()), { safe: safeBoot });
       } catch {}
       try {
         q.restoreHistory(await loadHistory());
       } catch {}
       try {
-        q.restoreSeeds(await loadSeeds());
+        q.restoreSeeds(await loadSeeds(), { safe: safeBoot });
       } catch {}
+      setTimeout(disarmBootMarker, BOOT_SETTLE_MS).unref();
       if (!alive) {
         q.suspend();
         return;
       }
       setConfigState(cfg);
       setQueue(q);
+      if (safeBoot) {
+        setRecovered(true);
+        setNotice("Recovered from a crashed start · downloads paused");
+      }
       try {
         const launch = initialMagnet
           ? parseInput(initialMagnet)
@@ -545,7 +562,7 @@ export function App({
     return (
       <StoreContext.Provider value={store}>
         <TabTitle />
-        <Splash updateVersion={updateVersion} />
+        <Splash updateVersion={updateVersion} recovered={recovered} />
       </StoreContext.Provider>
     );
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
-import { loadConfig, saveConfig, type Config } from "../config/config";
+import { loadConfig, saveConfig, defaultConfig, type Config } from "../config/config";
 import { normalizeDownloadDir } from "../config/folder";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
@@ -108,33 +108,46 @@ export function App({
     booting.current = true;
     let alive = true;
     void (async () => {
-      const cfg = await loadConfig();
+      let cfg: Config;
+      try {
+        cfg = await loadConfig();
+      } catch {
+        cfg = { ...defaultConfig, trackers: [] };
+      }
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
-      q.restore(reconcileQueue(await loadQueue()));
-      q.restoreHistory(await loadHistory());
-      q.restoreSeeds(await loadSeeds());
+      try {
+        q.restore(reconcileQueue(await loadQueue()));
+      } catch {}
+      try {
+        q.restoreHistory(await loadHistory());
+      } catch {}
+      try {
+        q.restoreSeeds(await loadSeeds());
+      } catch {}
       if (!alive) {
         q.suspend();
         return;
       }
       setConfigState(cfg);
       setQueue(q);
-      const launch = initialMagnet
-        ? parseInput(initialMagnet)
-        : initialTorrent
-          ? await magnetFromTorrentFile(initialTorrent)
-          : null;
-      if (launch) {
-        await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
-        q.add(
-          { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
-          cfg.downloadDir,
-        );
-        setView("browser");
-        setSection("downloads");
-        setRegion("content");
-      }
+      try {
+        const launch = initialMagnet
+          ? parseInput(initialMagnet)
+          : initialTorrent
+            ? await magnetFromTorrentFile(initialTorrent)
+            : null;
+        if (launch) {
+          await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
+          q.add(
+            { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
+            cfg.downloadDir,
+          );
+          setView("browser");
+          setSection("downloads");
+          setRegion("content");
+        }
+      } catch {}
     })();
     return () => {
       alive = false;

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -11,7 +11,10 @@ const CATEGORIES = sourcesByGroup()
   .map((g) => g.group.toLowerCase())
   .join(`  ${ICON.dot}  `);
 
-export function Splash({ updateVersion }: { updateVersion?: string | null } = {}) {
+export function Splash({
+  updateVersion,
+  recovered,
+}: { updateVersion?: string | null; recovered?: boolean } = {}) {
   const { submitQuery, quitAll, cols, rows } = useStore();
   const { isRawModeSupported } = useStdin();
 
@@ -33,6 +36,9 @@ export function Splash({ updateVersion }: { updateVersion?: string | null } = {}
       alignItems="center"
     >
       <UpdateBanner latest={updateVersion ?? null} />
+      {recovered ? (
+        <Text dimColor>{`↻ recovered from a crashed start · downloads paused`}</Text>
+      ) : null}
       {showLogo ? (
         <Logo />
       ) : (

--- a/src/update/bundle.test.ts
+++ b/src/update/bundle.test.ts
@@ -138,12 +138,17 @@ describe("applyBundleUpdate", () => {
     const { deps, log } = applyDeps();
     const ok = await applyBundleUpdate(release, "/opt/torlnk-runtime", deps);
     expect(ok).toBe(true);
+    // Paths are built with path.join, so the separator is platform-specific
+    // (backslash on Windows). Build the expectations the same way rather than
+    // hard-coding forward slashes.
+    const archive = path.join("/tmp/torlnk-upd", "torlnk-linux-x64.tar.gz");
+    const stage = path.join("/tmp/torlnk-upd", "stage");
     expect(log).toEqual([
       "download https://d/asset.tar.gz",
-      "write /tmp/torlnk-upd/torlnk-linux-x64.tar.gz",
+      `write ${archive}`,
       "readText https://d/SHA256SUMS",
       "verify",
-      "extract /tmp/torlnk-upd/torlnk-linux-x64.tar.gz -> /tmp/torlnk-upd/stage",
+      `extract ${archive} -> ${stage}`,
       "swap",
     ]);
   });

--- a/src/util/crashlog.test.ts
+++ b/src/util/crashlog.test.ts
@@ -1,0 +1,71 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Same isolation story as bootguard.test.ts: the log path is derived from
+// TORLINK_STATE_DIR at module init, so each test gets a private dir and fresh
+// module instances.
+async function isolated() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-crashlog-"));
+  vi.stubEnv("TORLINK_STATE_DIR", dir);
+  vi.resetModules();
+  const crashlog = await import("./crashlog");
+  return { dir, crashlog };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("crash log", () => {
+  it("appends a timestamped entry and reports success", async () => {
+    const { dir, crashlog } = await isolated();
+    try {
+      expect(crashlog.logCrash("unhandledRejection", new Error("Chunk store init failed"))).toBe(true);
+      const text = await fs.readFile(crashlog.crashLogFile, "utf8");
+      expect(text).toContain("[unhandledRejection]");
+      expect(text).toContain("Chunk store init failed");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stringifies non-Error reasons instead of failing", async () => {
+    const { dir, crashlog } = await isolated();
+    try {
+      expect(crashlog.logCrash("unhandledRejection", "plain string reason")).toBe(true);
+      const text = await fs.readFile(crashlog.crashLogFile, "utf8");
+      expect(text).toContain("plain string reason");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("containUnhandledRejections", () => {
+  it("registers a listener whose handler logs and never throws", async () => {
+    const { dir, crashlog } = await isolated();
+    const before = process.listeners("unhandledRejection");
+    try {
+      crashlog.containUnhandledRejections();
+      const added = process
+        .listeners("unhandledRejection")
+        .filter((l) => !before.includes(l));
+      expect(added).toHaveLength(1);
+
+      // Drive the handler directly: a real unhandled rejection would race the
+      // test harness's own bookkeeping.
+      const handler = added[0]! as (reason: unknown, promise: Promise<unknown>) => void;
+      expect(() => handler(new Error("Invalid torrent identifier"), Promise.resolve())).not.toThrow();
+      const text = await fs.readFile(crashlog.crashLogFile, "utf8");
+      expect(text).toContain("Invalid torrent identifier");
+    } finally {
+      for (const l of process.listeners("unhandledRejection")) {
+        if (!before.includes(l)) process.removeListener("unhandledRejection", l);
+      }
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/util/crashlog.ts
+++ b/src/util/crashlog.ts
@@ -1,0 +1,37 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { logsDir } from "../config/paths";
+
+export const crashLogFile = path.join(logsDir, "crash.log");
+
+// Append one timestamped entry. Returns false when even logging failed: a
+// crash logger must never become a crash source itself.
+export function logCrash(kind: string, err: unknown): boolean {
+  try {
+    mkdirSync(logsDir, { recursive: true });
+    const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    appendFileSync(crashLogFile, `${new Date().toISOString()} [${kind}] ${detail}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Node kills the process on any unhandled promise rejection, and webtorrent
+// can produce one from inside its own async internals with no error event and
+// nothing a caller's try/catch can reach (its fire-and-forget _onTorrentId is
+// where the Jul-2026 uint8-util drift detonated on every boot). Registering a
+// listener flips that default from process death to a contained event: the
+// torrent whose startup blew up stays visibly stalled, everything else lives.
+// Every occurrence lands in crash.log; `echo` additionally mirrors one line
+// to stderr for headless runs (the TUI never echoes, a stray write would tear
+// the alt screen).
+export function containUnhandledRejections(opts: { echo?: boolean } = {}): void {
+  process.on("unhandledRejection", (reason) => {
+    logCrash("unhandledRejection", reason);
+    if (opts.echo) {
+      const msg = reason instanceof Error ? reason.message : String(reason);
+      console.error(`[torlnk] recovered from a background error: ${msg}`);
+    }
+  });
+}


### PR DESCRIPTION
Catches the fork up with upstream `baairon/torlink` — merges the 5 new upstream commits (up to **v1.5.0**) that we were behind on. Fork is now 0 behind upstream.

## What upstream brought in
- **Boot resiliency**: crash-boot breaker + safe mode, self-heal after engine crashes, guarded `stats()` reads (new `bootguard.ts` / `crashlog.ts` + tests).
- **CI**: cross-platform matrix (Linux/macOS/Windows, node 22/24) running typecheck, tests, and build. Kept the fork's `lint` step.
- **Deps**: pin `uint8-util@2.2.6` as a direct dependency.

## Conflict resolution
Resolved keeping all fork features (Real-Debrid pipeline, VPN kill switch, stream picker/favourites) alongside upstream's changes:
- `queue.ts` — kept our VPN check + `selectedFileIndices` in `startEngine`, wrapped `engine.add` in upstream's construction-failure try/catch; kept upstream's `RestoreOptions`/safe-mode restore.
- `App.tsx` — kept our RD state + `setTransferPolicy`, layered in upstream's safe-boot restore and `recovered` state.
- `engine.ts` / `Splash.tsx` — combined both sides.
- Kept the fork's package name/version (`torlnk-rd` 1.6.1) over upstream's rename/bump.

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ 545 passed
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)