### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk-rd",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk-rd",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk-rd",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release bump for **v1.7.0**. `package.json` + `package-lock.json` only.

## What's in 1.7.0 (since v1.6.1)

- **New — "For You" recommendations** (#38): integrates with a self-hosted **reccd** service. Posts activity events (started/watched/favourited/liked/disliked/abandoned) incl. a post-stream rating prompt, and adds a **For You** view to browse ranked picks (filter by type/genre/explore, ↵ to search a pick). Hidden until reccd is configured.
- **Fix — Windows player launch trap** (#39): a configured-but-missing player (e.g. `vlc.exe` not on PATH) no longer dead-ends at "No player found". A failed launch now offers **Auto-detect / Edit / Cancel**, and auto-detect self-heals `config.mediaPlayer`. The watched ✓ now only marks on a successful launch.
- **Upstream sync — v1.5.0** (#40, #41): boot resilience when saved state fails to restore (#111), `uint8-util` pinned to 2.2.6, cross-platform CI matrix (Linux/macOS/Windows), boot-guard cleanup.

Tag `v1.7.0` will be pushed after this merges to trigger the build/publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)