### PR TITLE
feat: For You feedback — rate (watched/like/dislike) + add to watchlist

### DIFF
--- a/docs/superpowers/plans/2026-07-22-foryou-feedback.md
+++ b/docs/superpowers/plans/2026-07-22-foryou-feedback.md
@@ -1,0 +1,608 @@
+# For You Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On the For You page, let the user rate the highlighted pick (watched / like / dislike — posting the matching reccd event and dismissing it) and add it to the watchlist (`w`), closing the recommendation feedback loop.
+
+**Architecture:** Reuse the existing `RatePrompt` modal (extended with an optional "watched" action) owned by `App`; `ForYou` asks App to open it for the selected pick and hands over a "dismiss this pick" closure that runs only on a real rating. Watchlist add reuses the existing `toggleSavedSearch` store action. Refresh already exists (`r`) and is untouched.
+
+**Tech Stack:** TypeScript (ESM), React + Ink, Vitest + ink-testing-library.
+
+**Reference:** Spec at `docs/superpowers/specs/2026-07-22-foryou-feedback-design.md`.
+
+**Test-run notes (important):**
+- Run vitest scoped and excluding stale nested worktrees: `npx vitest run --exclude '**/.claude/**' <path>`.
+- `npx eslint` is broken repo-wide (missing `@eslint/js`) — do NOT run it; rely on `npx tsc --noEmit` + vitest.
+
+---
+
+## File Structure
+
+Modified:
+- `src/ui/components/RatePrompt.tsx` (+ `RatePrompt.test.tsx`) — optional watched action + title.
+- `src/ui/hooks/useRecommendations.ts` — `dismiss(imdbId)`.
+- `src/ui/components/ForYou.tsx` (+ `ForYou.test.tsx`) — `f` (rate) and `w` (watchlist) keys + new props.
+- `src/ui/App.tsx` — extend `ratePrompt` state, add `openRatePick`, wire ForYou props, extend RatePrompt render.
+- `src/ui/keymap.ts` — For You `?` group + footer hints.
+
+No new files.
+
+---
+
+## Task 1: Extend RatePrompt with an optional "watched" action
+
+**Files:**
+- Modify: `src/ui/components/RatePrompt.tsx`
+- Test: `src/ui/components/RatePrompt.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append these cases inside the `describe("RatePrompt", ...)` block in `src/ui/components/RatePrompt.test.tsx` (the file already defines `flush`, `ESC`, and imports):
+
+```tsx
+  it("shows the watched affordance and calls onWatched when 'w' is pressed (when onWatched given)", async () => {
+    const onWatched = vi.fn();
+    const { stdin, lastFrame } = render(
+      <RatePrompt name="The Matrix" onLike={vi.fn()} onDislike={vi.fn()} onWatched={onWatched} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("watched");
+    stdin.write("w");
+    await flush();
+    expect(onWatched).toHaveBeenCalled();
+  });
+
+  it("does not render the watched affordance when onWatched is omitted", async () => {
+    const { lastFrame } = render(
+      <RatePrompt name="The Matrix" onLike={vi.fn()} onDislike={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).not.toContain("watched");
+  });
+
+  it("uses a custom title when provided", async () => {
+    const { lastFrame } = render(
+      <RatePrompt name="The Matrix" title="Rate this pick" onLike={vi.fn()} onDislike={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("Rate this pick");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run --exclude '**/.claude/**' src/ui/components/RatePrompt.test.tsx`
+Expected: FAIL — `onWatched`/`title` props don't exist; "watched" not rendered.
+
+- [ ] **Step 3: Implement**
+
+Replace the entire contents of `src/ui/components/RatePrompt.tsx` with:
+
+```tsx
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+import { cleanText, truncate } from "../../util/format";
+
+interface RatePromptProps {
+  width?: number;
+  name: string;
+  // Heading; defaults to the post-stream phrasing. For You passes "Rate this pick".
+  title?: string;
+  onLike: () => void;
+  onDislike: () => void;
+  // Optional: when provided, a "watched" action (key `w`) is shown. Post-stream
+  // callers omit it, so that prompt stays like/dislike only.
+  onWatched?: () => void;
+  onDismiss: () => void;
+}
+
+// Shown after a stream ends, or from For You: a quick feedback signal. Styled
+// like the other inline prompts; owns keyboard input while mounted.
+export function RatePrompt({ width = 40, name, title = "How was it?", onLike, onDislike, onWatched, onDismiss }: RatePromptProps) {
+  useInput((input, key) => {
+    if (key.escape) {
+      onDismiss();
+      return;
+    }
+    if (onWatched && input === "w") {
+      onWatched();
+      return;
+    }
+    if (input === "l") {
+      onLike();
+      return;
+    }
+    if (input === "d") {
+      onDislike();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title={title} width={width} focused height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <Text color={COLOR.text} wrap="wrap">
+              {truncate(cleanText(name), 40)}
+            </Text>
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        {onWatched ? (
+          <Text>
+            <Text color={COLOR.alt}>w</Text>
+            <Text dimColor> watched</Text>
+            <Text dimColor>{`     ${ICON.dot}     `}</Text>
+          </Text>
+        ) : null}
+        <Text color={COLOR.alt}>l</Text>
+        <Text dimColor> like</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>d</Text>
+        <Text dimColor> dislike</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>esc</Text>
+        <Text dimColor> skip</Text>
+      </Box>
+    </Box>
+  );
+}
+```
+
+Note: the nested `<Text>` wrapper for the watched affordance mirrors how Ink composes inline coloured spans elsewhere in this file (adjacent `<Text>` children inside a row `<Box>`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run --exclude '**/.claude/**' src/ui/components/RatePrompt.test.tsx`
+Expected: PASS (the 3 original cases + 3 new).
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: `TypeScript: No errors found`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/components/RatePrompt.tsx src/ui/components/RatePrompt.test.tsx
+git commit -m "feat: RatePrompt optional watched action + custom title"
+```
+
+---
+
+## Task 2: Add `dismiss(imdbId)` to useRecommendations
+
+**Files:**
+- Modify: `src/ui/hooks/useRecommendations.ts`
+
+(The hook has no direct test; its `dismiss` is exercised through ForYou in Task 3. This task is a small, type-checked addition.)
+
+- [ ] **Step 1: Add `dismiss` to the state interface**
+
+In `src/ui/hooks/useRecommendations.ts`, add to the `RecommendationsState` interface (after `refresh: () => void;`):
+
+```ts
+  dismiss: (imdbId: string) => void;
+```
+
+- [ ] **Step 2: Implement `dismiss` and return it**
+
+After the `refresh` definition (`const refresh = useCallback(() => void load(), [load]);`), add:
+
+```ts
+  // Optimistically remove a pick from the list (e.g. once it's been rated).
+  // Events are fire-and-forget, so we don't wait on reccd before dropping it.
+  const dismiss = useCallback((imdbId: string) => {
+    setItems((prev) => prev.filter((it) => it.imdbId !== imdbId));
+  }, []);
+```
+
+Then add `dismiss` to the returned object:
+
+```ts
+  return { items, loading, error, type, genre, explore, refresh, dismiss, setType, setGenre, toggleExplore };
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. (ForYou doesn't consume `dismiss` yet; that's Task 3.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/hooks/useRecommendations.ts
+git commit -m "feat: add dismiss(imdbId) to useRecommendations"
+```
+
+---
+
+## Task 3: ForYou — `f` (rate) and `w` (watchlist) keys
+
+**Files:**
+- Modify: `src/ui/components/ForYou.tsx`
+- Test: `src/ui/components/ForYou.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append these cases inside the `describe("ForYou", ...)` block in `src/ui/components/ForYou.test.tsx` (the file already defines `flush`, `ESC`, `REC`, `CONFIG`, `fetchStub`):
+
+```tsx
+  it("opens the rate prompt for the selected pick on 'f' and dismisses it when rated", async () => {
+    const { impl } = fetchStub();
+    const onRatePick = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        onRatePick={onRatePick}
+        toggleSavedSearch={vi.fn()}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("f");
+    await flush();
+    expect(onRatePick).toHaveBeenCalledWith("Chernobyl", expect.any(Function));
+    // Invoking the provided callback dismisses the pick from the list.
+    const onRated = onRatePick.mock.calls[0]![1] as () => void;
+    onRated();
+    await flush();
+    expect(lastFrame()).not.toContain("Chernobyl");
+  });
+
+  it("adds the selected pick to the watchlist on 'w' without dismissing it", async () => {
+    const { impl } = fetchStub();
+    const toggleSavedSearch = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        onRatePick={vi.fn()}
+        toggleSavedSearch={toggleSavedSearch}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("w");
+    await flush();
+    expect(toggleSavedSearch).toHaveBeenCalledWith("Chernobyl");
+    expect(lastFrame()).toContain("Chernobyl"); // stays in the list
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run --exclude '**/.claude/**' src/ui/components/ForYou.test.tsx`
+Expected: FAIL — `f`/`w` do nothing; `onRatePick`/`toggleSavedSearch` props not accepted/used.
+
+- [ ] **Step 3: Add the two props (optional, mirroring `setCaptureMode`)**
+
+In `src/ui/components/ForYou.tsx`, add to the `ForYouProps` interface (after `submitQuery: (q: string) => void;`):
+
+```ts
+  onRatePick?: (name: string, onRated: () => void) => void;
+  toggleSavedSearch?: (query: string) => void;
+```
+
+Add them to the destructured params (after `submitQuery,`):
+
+```ts
+  onRatePick,
+  toggleSavedSearch,
+```
+
+- [ ] **Step 4: Import `useEffect` and clamp selection after dismissal**
+
+Change the React import at the top from:
+
+```ts
+import { useState } from "react";
+```
+
+to:
+
+```ts
+import { useEffect, useState } from "react";
+```
+
+Add this effect right after the `const [editingGenre, setEditingGenre] = useState(false);` line (so a dismissal that shrinks the list can't leave `selected` past the end):
+
+```ts
+  // Keep the highlight in range when the list shrinks (e.g. after a pick is
+  // rated and dismissed).
+  useEffect(() => {
+    if (selected >= count && count > 0) setSelected(count - 1);
+  }, [count, selected]);
+```
+
+- [ ] **Step 5: Add the `w` and `f` key branches**
+
+In the `useInput` handler, insert these two branches between the `else if (input === "r") recs.refresh();` line and the `else if (key.return) {` line:
+
+```ts
+      else if (input === "w") {
+        const item = recs.items[selected];
+        if (item) toggleSavedSearch?.(item.title);
+      }
+      else if (input === "f") {
+        const item = recs.items[selected];
+        if (item) onRatePick?.(item.title, () => recs.dismiss(item.imdbId));
+      }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run --exclude '**/.claude/**' src/ui/components/ForYou.test.tsx`
+Expected: PASS (all existing cases + the 2 new).
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/components/ForYou.tsx src/ui/components/ForYou.test.tsx
+git commit -m "feat: For You rate (f) and add-to-watchlist (w) keys"
+```
+
+---
+
+## Task 4: Wire into App.tsx
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+
+- [ ] **Step 1: Extend the `ratePrompt` state shape**
+
+Find (line ~250):
+
+```ts
+  const [ratePrompt, setRatePrompt] = useState<{ name: string } | null>(null);
+```
+
+Replace with:
+
+```ts
+  const [ratePrompt, setRatePrompt] = useState<{
+    name: string;
+    showWatched?: boolean;
+    title?: string;
+    onRated?: () => void;
+  } | null>(null);
+```
+
+The existing post-stream call `setRatePrompt({ name: active.name });` (line ~1004) stays valid and unchanged (the new fields are optional).
+
+- [ ] **Step 2: Add the `openRatePick` handler**
+
+Find the end of the `toggleSavedSearch` useCallback (lines ~475-487; it ends with `}, []);` right after `setNotice("Watchlist updated.");`). Immediately after it, add:
+
+```ts
+  // Opens the shared RatePrompt for a For You pick (adds the "watched" action and
+  // a fitting title). `onRated` fires only on a real rating (not on skip), so the
+  // caller can dismiss the pick from its list.
+  const openRatePick = useCallback((name: string, onRated: () => void) => {
+    setRatePrompt({ name, showWatched: true, title: "Rate this pick", onRated });
+  }, []);
+```
+
+- [ ] **Step 3: Extend the RatePrompt render**
+
+Find the RatePrompt render block (lines ~2068-2092) and replace it with:
+
+```tsx
+        {ratePrompt ? (
+          <Box marginTop={1}>
+            <RatePrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              name={ratePrompt.name}
+              title={ratePrompt.title}
+              onWatched={
+                ratePrompt.showWatched
+                  ? () => {
+                      if (config) {
+                        void postEvent(
+                          resolveReccConfig(config),
+                          { type: "watched", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                        );
+                      }
+                      ratePrompt.onRated?.();
+                      setRatePrompt(null);
+                    }
+                  : undefined
+              }
+              onLike={() => {
+                if (config) {
+                  void postEvent(
+                    resolveReccConfig(config),
+                    { type: "liked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                  );
+                }
+                ratePrompt.onRated?.();
+                setRatePrompt(null);
+              }}
+              onDislike={() => {
+                if (config) {
+                  void postEvent(
+                    resolveReccConfig(config),
+                    { type: "disliked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                  );
+                }
+                ratePrompt.onRated?.();
+                setRatePrompt(null);
+              }}
+              onDismiss={() => setRatePrompt(null)}
+            />
+          </Box>
+        ) : null}
+```
+
+(Change vs current: adds `title`, adds `onWatched` conditional, and adds `ratePrompt.onRated?.();` before `setRatePrompt(null)` in onLike/onDislike. `onDismiss` deliberately does NOT call `onRated`, so skip keeps the pick. Post-stream usage passes no `onRated`/`showWatched`, so `onRated?.()` is a no-op and no watched action shows.)
+
+- [ ] **Step 4: Pass the new props to `<ForYou>`**
+
+Find the `<ForYou>` render (lines ~2207-2214):
+
+```tsx
+              <ForYou
+                reccConfig={resolveReccConfig(store.config)}
+                visible={section === "forYou"}
+                active={store.region === "content" && section === "forYou"}
+                setSection={store.setSection}
+                submitQuery={store.submitQuery}
+                setCaptureMode={store.setCaptureMode}
+              />
+```
+
+Add two props (leave `active` unchanged — see note):
+
+```tsx
+              <ForYou
+                reccConfig={resolveReccConfig(store.config)}
+                visible={section === "forYou"}
+                active={store.region === "content" && section === "forYou"}
+                setSection={store.setSection}
+                submitQuery={store.submitQuery}
+                setCaptureMode={store.setCaptureMode}
+                onRatePick={openRatePick}
+                toggleSavedSearch={store.toggleSavedSearch}
+              />
+```
+
+Note: no `&& !ratePrompt` is needed on `active`. The store's `region` field already resolves to `"help"` whenever `ratePrompt` is set (it's in the `region` ternary at `App.tsx:1519` and in the store `useMemo` deps at `App.tsx:1586`), so `store.region === "content"` is already false while the prompt is open, making ForYou's `useInput` inert automatically.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Full test suite**
+
+Run: `npx vitest run --exclude '**/.claude/**'`
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 7: Manual smoke (optional but recommended)**
+
+Run the app (`npm run dev`), open For You (with reccd configured and some picks): press `f` → the "Rate this pick" prompt shows `w watched · l like · d dislike · esc skip`; choosing one dismisses the pick and (with reccd reachable) posts the event; `esc` keeps it. Press `w` on a pick → "Watchlist updated." notice, pick stays, and it appears in the Watchlist sidebar section.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/App.tsx
+git commit -m "feat: wire For You rate/watchlist actions into App"
+```
+
+---
+
+## Task 5: Keymap hints
+
+**Files:**
+- Modify: `src/ui/keymap.ts`
+
+- [ ] **Step 1: Update the For You `?` help group**
+
+Find (lines ~59-69):
+
+```ts
+  {
+    title: "For You",
+    hints: [
+      { keys: "↑ ↓", label: "Move between picks" },
+      { keys: "↵", label: "Search this title" },
+      { keys: "t", label: "Cycle movie / TV / all" },
+      { keys: "g", label: "Filter by genre" },
+      { keys: "e", label: "Toggle explore mode" },
+      { keys: "r", label: "Refresh recommendations" },
+    ],
+  },
+```
+
+Replace the `hints` array to add the two new keys (place after the `e` line, before `r`):
+
+```ts
+  {
+    title: "For You",
+    hints: [
+      { keys: "↑ ↓", label: "Move between picks" },
+      { keys: "↵", label: "Search this title" },
+      { keys: "t", label: "Cycle movie / TV / all" },
+      { keys: "g", label: "Filter by genre" },
+      { keys: "e", label: "Toggle explore mode" },
+      { keys: "f", label: "Rate — watched / like / dislike" },
+      { keys: "w", label: "Add to watchlist" },
+      { keys: "r", label: "Refresh recommendations" },
+    ],
+  },
+```
+
+- [ ] **Step 2: Update the For You footer hints**
+
+Find (lines ~141-152):
+
+```ts
+  if (section === "forYou") {
+    return [
+      NAVIGATE,
+      { keys: "↵", label: "Search title" },
+      { keys: "t", label: "Type" },
+      { keys: "g", label: "Genre" },
+      { keys: "e", label: "Explore" },
+      { keys: "r", label: "Refresh" },
+      SWITCH,
+      ALWAYS,
+    ];
+  }
+```
+
+Replace with (add `f` and `w`):
+
+```ts
+  if (section === "forYou") {
+    return [
+      NAVIGATE,
+      { keys: "↵", label: "Search title" },
+      { keys: "f", label: "Rate" },
+      { keys: "w", label: "Watch" },
+      { keys: "t", label: "Type" },
+      { keys: "g", label: "Genre" },
+      { keys: "e", label: "Explore" },
+      { keys: "r", label: "Refresh" },
+      SWITCH,
+      ALWAYS,
+    ];
+  }
+```
+
+- [ ] **Step 3: Type-check + full suite**
+
+Run: `npx tsc --noEmit && npx vitest run --exclude '**/.claude/**'`
+Expected: no type errors; all tests pass. (No dedicated keymap test; footer width is terse enough — the `?` sheet carries the full list.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/keymap.ts
+git commit -m "docs: For You keymap hints for rate (f) and watchlist (w)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** rate prompt with watched/like/dislike (Tasks 1, 4) ✓; posts correct reccd events (Task 4) ✓; dismiss on rate, not on skip (Tasks 2, 3, 4 — `onRated` only wired to like/dislike/watched, not `onDismiss`) ✓; `w` add-to-watchlist without dismissal (Task 3) ✓; refresh untouched ✓; keymap help + footer (Task 5) ✓; tests for RatePrompt watched, ForYou `f`/`w` (Tasks 1, 3) ✓.
+- **Deviation from spec (intentional, simpler):** the spec's step to gate ForYou's `active` prop with `&& !ratePrompt` is omitted — verified unnecessary because `store.region` already becomes `"help"` when `ratePrompt` is set (it's in the region ternary and the memo deps), so ForYou is already inert while the prompt is open. Adding the gate would be redundant.
+- **Type consistency:** `onRatePick(name, onRated)` signature matches between ForYou prop (Task 3), the `openRatePick` handler (Task 4), and the ForYou test (Task 3). `dismiss(imdbId)` matches between the hook (Task 2) and its ForYou call site (Task 3). `ratePrompt` shape (`{ name, showWatched?, title?, onRated? }`) is consistent between the state decl and the render (Task 4).
+- **Props optionality:** `onRatePick`/`toggleSavedSearch` are optional (like `setCaptureMode`), so the existing ForYou tests that don't pass them still compile; ForYou calls them with `?.`.
+- **Line-number caveat:** anchors are quoted exactly; locate by the quoted text if line numbers have shifted.

--- a/docs/superpowers/specs/2026-07-22-foryou-feedback-design.md
+++ b/docs/superpowers/specs/2026-07-22-foryou-feedback-design.md
@@ -9,7 +9,9 @@ Add the ability to give reccd feedback on a "For You" recommendation directly
 from the pick list: mark it **watched**, **liked**, or **disliked**. Choosing an
 action posts the corresponding event to reccd and dismisses the pick from the
 list, closing the loop so acting on suggestions improves future recommendations.
-Refresh already exists (the `r` key re-fetches) and is unchanged.
+Also add **add to watchlist** (`w`, matching the results view) so a pick can be
+saved to watch later. Refresh already exists (the `r` key re-fetches) and is
+unchanged.
 
 ## Background
 
@@ -29,6 +31,14 @@ Refresh already exists (the `r` key re-fetches) and is unchanged.
   global `useInput` guards it with `if (ratePrompt) return` (~1638) so the modal
   owns keyboard input while open.
 - Today no `watched`/`liked`/`disliked` event is ever emitted from For You.
+- The "watchlist" (sidebar section) is the app's saved-searches list:
+  `config.savedSearches` — an array of plain query strings, not magnets. It's
+  managed by the store action `toggleSavedSearch(query: string)` (`App.tsx:475`),
+  which dedups (`src/ui/savedSearches.ts`), caps at 50, persists via `saveConfig`,
+  and shows a "Watchlist updated." notice. It's bound to `w` in the results view
+  (`Results.tsx:347`) and Enter on a watchlist row re-runs the query. So "add a
+  pick to the watchlist" = `toggleSavedSearch(pick.title)`; no magnet needed. `w`
+  is currently unbound on For You.
 
 ## Goals
 
@@ -61,6 +71,13 @@ Refresh already exists (the `r` key re-fetches) and is unchanged.
   3. closes the prompt.
 - `esc`/skip closes the prompt and leaves the pick in place.
 
+New key **`w`** on For You toggles the highlighted pick into the watchlist via
+`toggleSavedSearch(item.title)` (same title string that Enter searches). This is
+a direct action (no modal): it shows the existing "Watchlist updated." notice and
+**does not dismiss** the pick — you're saving it to watch later, so it stays.
+Pressing `w` again toggles it back off (the action is a toggle). No reccd event
+is posted (watchlist is local config, not a recommendation signal).
+
 ### Component changes
 
 **`RatePrompt`** — add an optional `onWatched?: () => void` prop. When provided,
@@ -75,10 +92,13 @@ with that id from `items`. Selection lives in ForYou, so ForYou re-clamps
 `selected` after the list shrinks (e.g. via an effect keyed on `items.length`,
 mirroring how it already resets selection to 0 on type/explore changes).
 
-**`ForYou`** — add a new prop `onRatePick: (name: string, onRated: () => void) => void`.
-The `useInput` handler gains `else if (input === "f")` that, for the selected
-item, calls `onRatePick(item.title, () => recs.dismiss(item.imdbId))` (no-op if
-there is no selected item).
+**`ForYou`** — add two new props: `onRatePick: (name: string, onRated: () => void) => void`
+and `toggleSavedSearch: (query: string) => void` (mirroring the existing
+`submitQuery` prop). The `useInput` handler gains:
+- `else if (input === "f")` — for the selected item, calls
+  `onRatePick(item.title, () => recs.dismiss(item.imdbId))` (no-op if no selection).
+- `else if (input === "w")` — for the selected item, calls
+  `toggleSavedSearch(item.title)` (no-op if no selection). No dismissal.
 
 ForYou's own `useInput` must be inert while the rate prompt is open — otherwise
 keys like `r`/`t`/`e` would act on the list underneath the modal. ForYou's
@@ -99,6 +119,8 @@ to true.
 - The `<ForYou>` `active` prop changes from
   `store.region === "content" && section === "forYou"` to that same expression
   `&& !ratePrompt`, so ForYou's handler is inert while the prompt is open.
+- `<ForYou>` also receives `toggleSavedSearch={store.toggleSavedSearch}` (already
+  on the store).
 - The `<RatePrompt>` render passes `onWatched` only when `showWatched` is true.
   Each of onLike/onDislike/onWatched: post the matching event (as today for
   like/dislike), then call `ratePrompt.onRated?.()`, then `setRatePrompt(null)`.
@@ -121,8 +143,12 @@ ForYou: press `f` on pick P
 
 ## Keymap / Footer
 
-- `keymap.ts` For You `?` group (lines ~59-69): add `{ keys: "f", label: "Rate — watched / like / dislike" }`.
-- `keymap.ts` footer hints for `forYou` (lines ~141-152): add `{ keys: "f", label: "Rate" }`.
+- `keymap.ts` For You `?` group (lines ~59-69): add
+  `{ keys: "f", label: "Rate — watched / like / dislike" }` and
+  `{ keys: "w", label: "Add to watchlist" }`.
+- `keymap.ts` footer hints for `forYou` (lines ~141-152): add
+  `{ keys: "f", label: "Rate" }` and `{ keys: "w", label: "Watch" }`
+  (matching the results-view footer label for `w`).
 
 ## Error Handling
 
@@ -137,6 +163,9 @@ configured (and harmlessly no-ops otherwise).
 
 - `ForYou.test.tsx`: pressing `f` on a pick invokes `onRatePick` with the pick's
   title; the provided `onRated` closure dismisses the pick from the list.
+- `ForYou.test.tsx`: pressing `w` on a pick invokes `toggleSavedSearch` with the
+  pick's title and does NOT dismiss the pick. (The test harness stub
+  `src/ui/testHarness.ts` already provides a `toggleSavedSearch` noop to spy on.)
 - `RatePrompt.test.tsx` (new or extended): with `onWatched` provided, the `w`
   affordance renders and `w` fires `onWatched`; without it, only like/dislike
   render (post-stream behavior preserved).

--- a/docs/superpowers/specs/2026-07-22-foryou-feedback-design.md
+++ b/docs/superpowers/specs/2026-07-22-foryou-feedback-design.md
@@ -1,0 +1,156 @@
+# For You Feedback Design
+
+**Date:** 2026-07-22
+**Status:** Approved
+
+## Summary
+
+Add the ability to give reccd feedback on a "For You" recommendation directly
+from the pick list: mark it **watched**, **liked**, or **disliked**. Choosing an
+action posts the corresponding event to reccd and dismisses the pick from the
+list, closing the loop so acting on suggestions improves future recommendations.
+Refresh already exists (the `r` key re-fetches) and is unchanged.
+
+## Background
+
+- The For You page (`src/ui/components/ForYou.tsx`) renders `Recommendation`
+  items (`{ imdbId, title, year, score, reasons }`) from `useRecommendations`
+  (`src/ui/hooks/useRecommendations.ts`). It owns its own `useInput` handler
+  (gated `active && configured && !editingGenre`) with keys j/k/↑↓ (move), `t`
+  (type), `e` (explore), `g` (genre), `r` (refresh), Enter (search the title).
+- reccd already accepts the event types we need via `postEvent`
+  (`src/recc/client.ts`): `ReccEventType` includes `watched`, `liked`,
+  `disliked` (plus `started`, `favourited`, `unfavourited`, `abandoned`). An
+  event is `{ type, rawName, ts, source }`; all torlink call sites use
+  `source: "torlink"` and `ts: Date.now()`.
+- `RatePrompt` (`src/ui/components/RatePrompt.tsx`) is a small inline modal shown
+  after a stream ends: `l` like / `d` dislike / `esc` skip. It's owned by App
+  via `ratePrompt` state (`src/ui/App.tsx:250`), rendered at ~2068, and the App
+  global `useInput` guards it with `if (ratePrompt) return` (~1638) so the modal
+  owns keyboard input while open.
+- Today no `watched`/`liked`/`disliked` event is ever emitted from For You.
+
+## Goals
+
+- From a highlighted For You pick, open a prompt to mark it watched / liked /
+  disliked, posting the matching reccd event.
+- Dismiss the acted-on pick from the list immediately (fire-and-forget events),
+  advancing selection to the next pick.
+- Reuse the existing `RatePrompt` component and the existing App-owned modal
+  input-guarding, so we don't reinvent focus handling.
+
+## Non-Goals (YAGNI)
+
+- Changing refresh (already works via `r`).
+- Auto-refetching when the list empties (deferred; user opted for manual `r`).
+- Undo of a rating, or any local persistence of dismissed picks.
+- Any new reccd endpoint or event type (all already exist).
+
+## Design
+
+### Interaction
+
+- New key **`f`** on For You (mnemonic: feedback) opens the RatePrompt for the
+  currently-highlighted pick.
+- The prompt shows **`w` watched · `l` like · `d` dislike · `esc` skip** when
+  opened from For You.
+- Choosing watched/like/dislike:
+  1. posts `{ type: "watched" | "liked" | "disliked", rawName: item.title,
+     ts: Date.now(), source: "torlink" }` to reccd via `postEvent`,
+  2. dismisses that pick from the list (`useRecommendations.dismiss(imdbId)`),
+  3. closes the prompt.
+- `esc`/skip closes the prompt and leaves the pick in place.
+
+### Component changes
+
+**`RatePrompt`** — add an optional `onWatched?: () => void` prop. When provided,
+the prompt renders the `w watched` affordance and handles the `w` key; when
+omitted (the existing post-stream caller), behavior is unchanged (like/dislike
+only). An optional `title?` prop lets the For You invocation use a heading like
+"Rate this pick" instead of the post-stream "How was it?" (default keeps
+"How was it?").
+
+**`useRecommendations`** — add `dismiss(imdbId: string)` that removes the item
+with that id from `items`. Selection lives in ForYou, so ForYou re-clamps
+`selected` after the list shrinks (e.g. via an effect keyed on `items.length`,
+mirroring how it already resets selection to 0 on type/explore changes).
+
+**`ForYou`** — add a new prop `onRatePick: (name: string, onRated: () => void) => void`.
+The `useInput` handler gains `else if (input === "f")` that, for the selected
+item, calls `onRatePick(item.title, () => recs.dismiss(item.imdbId))` (no-op if
+there is no selected item).
+
+ForYou's own `useInput` must be inert while the rate prompt is open — otherwise
+keys like `r`/`t`/`e` would act on the list underneath the modal. ForYou's
+handler is gated by its `active` prop, and App computes that prop, so App will
+pass `active={store.region === "content" && section === "forYou" && !ratePrompt}`.
+When the prompt opens, `active` flips to false, ForYou's handler goes inert, and
+the App-owned RatePrompt (guarded by the existing `if (ratePrompt) return` in the
+global handler) owns input exclusively. When the prompt closes, `active` returns
+to true.
+
+**`App`** — extend `ratePrompt` state to
+`{ name: string; showWatched?: boolean; title?: string; onRated?: () => void } | null`.
+- The post-stream call (`src/ui/App.tsx:1004`) stays `setRatePrompt({ name })`
+  — unchanged behavior.
+- A new handler `openRatePick(name, onRated)` sets
+  `setRatePrompt({ name, showWatched: true, title: "Rate this pick", onRated })`,
+  passed to `<ForYou onRatePick=...>`.
+- The `<ForYou>` `active` prop changes from
+  `store.region === "content" && section === "forYou"` to that same expression
+  `&& !ratePrompt`, so ForYou's handler is inert while the prompt is open.
+- The `<RatePrompt>` render passes `onWatched` only when `showWatched` is true.
+  Each of onLike/onDislike/onWatched: post the matching event (as today for
+  like/dislike), then call `ratePrompt.onRated?.()`, then `setRatePrompt(null)`.
+  `onDismiss` stays `setRatePrompt(null)` (does NOT call `onRated`, so skip keeps
+  the pick).
+
+### Data flow
+
+```
+ForYou: press `f` on pick P
+  → onRatePick(P.title, dismissClosure)                 [prop up to App]
+    → App.setRatePrompt({ name, showWatched, title, onRated: dismissClosure })
+      → RatePrompt renders (owns input; App global handler guarded)
+        → user presses w/l/d
+          → App.postEvent(reccConfig, { type, rawName: name, ... })
+          → onRated()  ⇒ ForYou/useRecommendations.dismiss(P.imdbId)
+          → setRatePrompt(null)
+        → user presses esc ⇒ setRatePrompt(null) only (pick kept)
+```
+
+## Keymap / Footer
+
+- `keymap.ts` For You `?` group (lines ~59-69): add `{ keys: "f", label: "Rate — watched / like / dislike" }`.
+- `keymap.ts` footer hints for `forYou` (lines ~141-152): add `{ keys: "f", label: "Rate" }`.
+
+## Error Handling
+
+`postEvent` is fire-and-forget and swallows all failures (network, non-2xx) — a
+reccd outage must never disrupt the UI. Dismissal happens regardless of whether
+the event reaches reccd (consistent with the rest of the app's event posting).
+If `reccConfig.reccUrl` is unset, `postEvent` no-ops; For You already shows a
+setup hint when reccd is unconfigured, so the rate key is only meaningful when
+configured (and harmlessly no-ops otherwise).
+
+## Testing
+
+- `ForYou.test.tsx`: pressing `f` on a pick invokes `onRatePick` with the pick's
+  title; the provided `onRated` closure dismisses the pick from the list.
+- `RatePrompt.test.tsx` (new or extended): with `onWatched` provided, the `w`
+  affordance renders and `w` fires `onWatched`; without it, only like/dislike
+  render (post-stream behavior preserved).
+- `useRecommendations` (via ForYou or a focused test): `dismiss(imdbId)` removes
+  the item and selection re-clamps without going out of range.
+- App-level wiring is exercised where feasible; if no App test harness exists,
+  rely on the component/hook tests plus the type-checker (matching the existing
+  test coverage boundary).
+
+## Files
+
+Modified:
+- `src/ui/components/ForYou.tsx` (+ `ForYou.test.tsx`)
+- `src/ui/hooks/useRecommendations.ts`
+- `src/ui/components/RatePrompt.tsx` (+ `RatePrompt.test.tsx`)
+- `src/ui/App.tsx`
+- `src/ui/keymap.ts`

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -247,7 +247,12 @@ export function App({
     { session: TorrentStreamSession; input: DownloadInput } | null
   >(null);
   // Ask for an explicit like/dislike signal once a stream ends.
-  const [ratePrompt, setRatePrompt] = useState<{ name: string } | null>(null);
+  const [ratePrompt, setRatePrompt] = useState<{
+    name: string;
+    showWatched?: boolean;
+    title?: string;
+    onRated?: () => void;
+  } | null>(null);
   const vpnUnsafe = useRef(false);
   const prepareAbort = useRef<AbortController | null>(null);
   const [recovered, setRecovered] = useState(false);
@@ -484,6 +489,13 @@ export function App({
       return next;
     });
     setNotice("Watchlist updated.");
+  }, []);
+
+  // Opens the shared RatePrompt for a For You pick (adds the "watched" action and
+  // a fitting title). `onRated` fires only on a real rating (not on skip), so the
+  // caller can dismiss the pick from its list.
+  const openRatePick = useCallback((name: string, onRated: () => void) => {
+    setRatePrompt({ name, showWatched: true, title: "Rate this pick", onRated });
   }, []);
 
   const toggleFavourite = useCallback((item: FavouriteItem) => {
@@ -2070,6 +2082,21 @@ export function App({
             <RatePrompt
               width={Math.max(24, Math.min(cols - 4, 62))}
               name={ratePrompt.name}
+              title={ratePrompt.title}
+              onWatched={
+                ratePrompt.showWatched
+                  ? () => {
+                      if (config) {
+                        void postEvent(
+                          resolveReccConfig(config),
+                          { type: "watched", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
+                        );
+                      }
+                      ratePrompt.onRated?.();
+                      setRatePrompt(null);
+                    }
+                  : undefined
+              }
               onLike={() => {
                 if (config) {
                   void postEvent(
@@ -2077,6 +2104,7 @@ export function App({
                     { type: "liked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
                   );
                 }
+                ratePrompt.onRated?.();
                 setRatePrompt(null);
               }}
               onDislike={() => {
@@ -2086,6 +2114,7 @@ export function App({
                     { type: "disliked", rawName: ratePrompt.name, ts: Date.now(), source: "torlink" },
                   );
                 }
+                ratePrompt.onRated?.();
                 setRatePrompt(null);
               }}
               onDismiss={() => setRatePrompt(null)}
@@ -2211,6 +2240,8 @@ export function App({
                 setSection={store.setSection}
                 submitQuery={store.submitQuery}
                 setCaptureMode={store.setCaptureMode}
+                onRatePick={openRatePick}
+                toggleSavedSearch={store.toggleSavedSearch}
               />
             </Box>
           </Box>

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -124,4 +124,52 @@ describe("ForYou", () => {
     await flush();
     expect(setCaptureMode).toHaveBeenCalledWith("none");
   });
+
+  it("opens the rate prompt for the selected pick on 'f' and dismisses it when rated", async () => {
+    const { impl } = fetchStub();
+    const onRatePick = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        onRatePick={onRatePick}
+        toggleSavedSearch={vi.fn()}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("f");
+    await flush();
+    expect(onRatePick).toHaveBeenCalledWith("Chernobyl", expect.any(Function));
+    // Invoking the provided callback dismisses the pick from the list.
+    const onRated = onRatePick.mock.calls[0]![1] as () => void;
+    onRated();
+    await flush();
+    expect(lastFrame()).not.toContain("Chernobyl");
+  });
+
+  it("adds the selected pick to the watchlist on 'w' without dismissing it", async () => {
+    const { impl } = fetchStub();
+    const toggleSavedSearch = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ForYou
+        reccConfig={CONFIG}
+        visible
+        active
+        setSection={vi.fn()}
+        submitQuery={vi.fn()}
+        onRatePick={vi.fn()}
+        toggleSavedSearch={toggleSavedSearch}
+        fetchImpl={impl}
+      />,
+    );
+    await flush();
+    stdin.write("w");
+    await flush();
+    expect(toggleSavedSearch).toHaveBeenCalledWith("Chernobyl");
+    expect(lastFrame()).toContain("Chernobyl"); // stays in the list
+  });
 });

--- a/src/ui/components/ForYou.tsx
+++ b/src/ui/components/ForYou.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { FetchImpl } from "../../util/net";
 import type { ReccClientConfig } from "../../recc/client";
@@ -15,6 +15,8 @@ interface ForYouProps {
   active: boolean;
   setSection: (s: Section) => void;
   submitQuery: (q: string) => void;
+  onRatePick?: (name: string, onRated: () => void) => void;
+  toggleSavedSearch?: (query: string) => void;
   setCaptureMode?: (m: CaptureMode) => void;
   fetchImpl?: FetchImpl;
   width?: number;
@@ -29,6 +31,8 @@ export function ForYou({
   active,
   setSection,
   submitQuery,
+  onRatePick,
+  toggleSavedSearch,
   setCaptureMode,
   fetchImpl,
   width = 60,
@@ -39,6 +43,12 @@ export function ForYou({
 
   const configured = Boolean(reccConfig.reccUrl);
   const count = recs.items.length;
+
+  // Keep the highlight in range when the list shrinks (e.g. after a pick is
+  // rated and dismissed).
+  useEffect(() => {
+    if (selected >= count && count > 0) setSelected(count - 1);
+  }, [count, selected]);
 
   useInput(
     (input, key) => {
@@ -51,6 +61,14 @@ export function ForYou({
         setCaptureMode?.("text");
       }
       else if (input === "r") recs.refresh();
+      else if (input === "w") {
+        const item = recs.items[selected];
+        if (item) toggleSavedSearch?.(item.title);
+      }
+      else if (input === "f") {
+        const item = recs.items[selected];
+        if (item) onRatePick?.(item.title, () => recs.dismiss(item.imdbId));
+      }
       else if (key.return) {
         const item = recs.items[selected];
         if (item) {

--- a/src/ui/components/RatePrompt.test.tsx
+++ b/src/ui/components/RatePrompt.test.tsx
@@ -44,4 +44,32 @@ describe("RatePrompt", () => {
     await flush();
     expect(onDismiss).toHaveBeenCalled();
   });
+
+  it("shows the watched affordance and calls onWatched when 'w' is pressed (when onWatched given)", async () => {
+    const onWatched = vi.fn();
+    const { stdin, lastFrame } = render(
+      <RatePrompt name="The Matrix" onLike={vi.fn()} onDislike={vi.fn()} onWatched={onWatched} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("watched");
+    stdin.write("w");
+    await flush();
+    expect(onWatched).toHaveBeenCalled();
+  });
+
+  it("does not render the watched affordance when onWatched is omitted", async () => {
+    const { lastFrame } = render(
+      <RatePrompt name="The Matrix" onLike={vi.fn()} onDislike={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).not.toContain("watched");
+  });
+
+  it("uses a custom title when provided", async () => {
+    const { lastFrame } = render(
+      <RatePrompt name="The Matrix" title="Rate this pick" onLike={vi.fn()} onDislike={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    await flush();
+    expect(lastFrame()).toContain("Rate this pick");
+  });
 });

--- a/src/ui/components/RatePrompt.tsx
+++ b/src/ui/components/RatePrompt.tsx
@@ -6,18 +6,26 @@ import { cleanText, truncate } from "../../util/format";
 interface RatePromptProps {
   width?: number;
   name: string;
+  // Heading; defaults to the post-stream phrasing. For You passes "Rate this pick".
+  title?: string;
   onLike: () => void;
   onDislike: () => void;
+  // Optional: when provided, a "watched" action (key `w`) is shown. Post-stream
+  // callers omit it, so that prompt stays like/dislike only.
+  onWatched?: () => void;
   onDismiss: () => void;
 }
 
-// Shown after a stream ends: a quick like/dislike signal beyond passive
-// watching. Styled like the other inline prompts; owns keyboard input while
-// mounted.
-export function RatePrompt({ width = 40, name, onLike, onDislike, onDismiss }: RatePromptProps) {
+// Shown after a stream ends, or from For You: a quick feedback signal. Styled
+// like the other inline prompts; owns keyboard input while mounted.
+export function RatePrompt({ width = 40, name, title = "How was it?", onLike, onDislike, onWatched, onDismiss }: RatePromptProps) {
   useInput((input, key) => {
     if (key.escape) {
       onDismiss();
+      return;
+    }
+    if (onWatched && input === "w") {
+      onWatched();
       return;
     }
     if (input === "l") {
@@ -31,7 +39,7 @@ export function RatePrompt({ width = 40, name, onLike, onDislike, onDismiss }: R
 
   return (
     <Box flexDirection="column" width={width}>
-      <Panel title="How was it?" width={width} focused height={2}>
+      <Panel title={title} width={width} focused height={2}>
         <Box>
           <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
           <Box flexGrow={1} minWidth={0}>
@@ -42,6 +50,13 @@ export function RatePrompt({ width = 40, name, onLike, onDislike, onDismiss }: R
         </Box>
       </Panel>
       <Box marginTop={1}>
+        {onWatched ? (
+          <Text>
+            <Text color={COLOR.alt}>w</Text>
+            <Text dimColor> watched</Text>
+            <Text dimColor>{`     ${ICON.dot}     `}</Text>
+          </Text>
+        ) : null}
         <Text color={COLOR.alt}>l</Text>
         <Text dimColor> like</Text>
         <Text dimColor>{`     ${ICON.dot}     `}</Text>

--- a/src/ui/hooks/useRecommendations.ts
+++ b/src/ui/hooks/useRecommendations.ts
@@ -17,6 +17,7 @@ export interface RecommendationsState {
   genre: string;
   explore: boolean;
   refresh: () => void;
+  dismiss: (imdbId: string) => void;
   setType: (t: ReccType) => void;
   setGenre: (g: string) => void;
   toggleExplore: () => void;
@@ -92,9 +93,15 @@ export function useRecommendations(
   }, [type, genre, explore]);
 
   const refresh = useCallback(() => void load(), [load]);
+
+  // Optimistically remove a pick from the list (e.g. once it's been rated).
+  // Events are fire-and-forget, so we don't wait on reccd before dropping it.
+  const dismiss = useCallback((imdbId: string) => {
+    setItems((prev) => prev.filter((it) => it.imdbId !== imdbId));
+  }, []);
   const setType = useCallback((t: ReccType) => setTypeState(t), []);
   const setGenre = useCallback((g: string) => setGenreState(g), []);
   const toggleExplore = useCallback(() => setExplore((v) => !v), []);
 
-  return { items, loading, error, type, genre, explore, refresh, setType, setGenre, toggleExplore };
+  return { items, loading, error, type, genre, explore, refresh, dismiss, setType, setGenre, toggleExplore };
 }

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -64,6 +64,8 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "t", label: "Cycle movie / TV / all" },
       { keys: "g", label: "Filter by genre" },
       { keys: "e", label: "Toggle explore mode" },
+      { keys: "f", label: "Rate — watched / like / dislike" },
+      { keys: "w", label: "Add to watchlist" },
       { keys: "r", label: "Refresh recommendations" },
     ],
   },
@@ -142,6 +144,8 @@ export function footerHints(
     return [
       NAVIGATE,
       { keys: "↵", label: "Search title" },
+      { keys: "f", label: "Rate" },
+      { keys: "w", label: "Watch" },
       { keys: "t", label: "Type" },
       { keys: "g", label: "Genre" },
       { keys: "e", label: "Explore" },


### PR DESCRIPTION
## Summary

Closes the recommendation feedback loop on the **For You** page. On the highlighted pick:

- **`f`** — opens the (reused) RatePrompt with **Watched · Like · Dislike · skip**. Choosing one posts the matching event to reccd (`watched`/`liked`/`disliked`, `source: "torlink"`) and dismisses the pick from the list; `esc` keeps it.
- **`w`** — toggles the pick into the watchlist (`toggleSavedSearch`, "Watchlist updated." notice), matching the results view. The pick stays; no reccd event.
- **`r`** — refresh (already existed; unchanged).

Acting on suggestions now feeds reccd, so future recommendations improve.

## Implementation

- `RatePrompt` gains optional `onWatched` + `title`; the post-stream prompt is unchanged (no watched action there).
- `useRecommendations` gains `dismiss(imdbId)`; ForYou re-clamps selection when the list shrinks.
- ForYou gets optional `onRatePick` / `toggleSavedSearch` props; App owns the shared RatePrompt and passes a dismiss closure that fires only on a real rating (not on skip).
- No `active && !ratePrompt` gate was needed — the store's `region` already flips to `"help"` when the prompt is open, so ForYou's input is inert automatically.
- Keymap help + footer updated.

Built spec → plan → TDD (subagent-driven); spec & plan under `docs/superpowers/`.

## Test plan

- [x] Focused tests pass: `RatePrompt` (watched action, custom title, post-stream unchanged) and `ForYou` (`f` opens prompt + dismisses on rate; `w` adds to watchlist without dismissing).
- [x] Full vitest suite green.
- [ ] Manual: For You → `f` → rate a pick → it disappears + event reaches reccd; `esc` keeps it; `w` → appears in Watchlist sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)