### PR TITLE
feat: add opt-in adult "Porn" category (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Games are the only category that intentionally distributes executable software, 
   <img src="preview/sources.svg" alt="torlink's source picker: toggle any source on or off, grouped by category" style="max-width: 832px; width: 100%; height: auto;">
 </p>
 
+### Adult content (optional, off by default)
+
+torlink ships with an optional **Porn** category that is **off by default** — its tab, sources, and results stay completely hidden until you turn it on. Press **`Shift+X`** to toggle it; when enabled you get a **Porn** tab (backed by The Pirate Bay and 1337x) and adult results also appear under **All**.
+
+Prefer to control it without touching the app? Set `TORLINK_ADULT=1` before launching to force it on, or `TORLINK_ADULT=0` to force it off (the env var takes precedence over the in-app setting). It can also be persisted by setting `"adultContent": true` in your config file.
+
 ### Blocked by your network?
 
 Some networks (ISPs, work Wi-Fi, some routers) quietly block torrent sites at the DNS level, so every source looks offline. If that's happening, point torlink's own lookups at a public resolver over DNS-over-HTTPS — it doesn't touch the rest of your system.

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -131,6 +131,7 @@ function makeStore(
     streamResult: noop,
     debridConfigured: false,
     reccConfigured: false,
+    adultEnabled: false,
     streamActive: false,
     rdStatus: null,
     copyLink: noop,
@@ -368,6 +369,7 @@ save(
       <SourcesPrompt
         width={PROMPT_WIDTH}
         disabled={["torrents-csv", "x1337-music"] as SourceId[]}
+        adultEnabled={false}
         onToggle={() => {}}
         onCancel={() => {}}
       />

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -6,6 +6,7 @@ import {
   resolveMediaPlayer,
   resolveDnsServers,
   resolveReccConfig,
+  resolveAdultContent,
 } from "./config";
 
 describe("config realDebridToken", () => {
@@ -125,6 +126,39 @@ describe("config torrentStreamAck", () => {
     });
     const cfg = await loadConfig();
     expect(cfg.torrentStreamAck).toBe(true);
+  });
+});
+
+describe("resolveAdultContent", () => {
+  const KEY = "TORLINK_ADULT";
+  afterEach(() => {
+    delete process.env[KEY];
+  });
+
+  it("defaults to OFF and honours the persisted flag", () => {
+    delete process.env[KEY];
+    expect(resolveAdultContent({ downloadDir: "/d", trackers: [] })).toBe(false);
+    expect(resolveAdultContent({ downloadDir: "/d", trackers: [], adultContent: false })).toBe(false);
+    expect(resolveAdultContent({ downloadDir: "/d", trackers: [], adultContent: true })).toBe(true);
+  });
+
+  it("lets the env var override the config in both directions", () => {
+    // Env forces ON even when config is off/unset.
+    for (const truthy of ["1", "true", "YES", "on"]) {
+      process.env[KEY] = truthy;
+      expect(resolveAdultContent({ downloadDir: "/d", trackers: [] })).toBe(true);
+    }
+    // Env forces OFF even when config is on.
+    for (const falsy of ["0", "false", "no", ""]) {
+      process.env[KEY] = falsy;
+      expect(resolveAdultContent({ downloadDir: "/d", trackers: [], adultContent: true })).toBe(false);
+    }
+  });
+
+  it("round-trips adultContent across a save/load cycle", async () => {
+    await saveConfig({ downloadDir: "/tmp/dl", trackers: [], adultContent: true });
+    const cfg = await loadConfig();
+    expect(cfg.adultContent).toBe(true);
   });
 });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -35,6 +35,9 @@ export interface Config {
   // Set once the user has acknowledged that streaming via torrent exposes their
   // IP to the swarm (the no-Real-Debrid path). Absent/false = not yet warned.
   torrentStreamAck?: boolean;
+  // Opt-in adult ("Porn") category. Absent/false = OFF: the Porn tab and its
+  // sources are hidden and never searched. A TORLINK_ADULT env var overrides it.
+  adultContent?: boolean;
   // Remembered UI preferences, so torlink reopens the way you left it. Both are
   // stored as opaque strings validated by the UI layer (parseSort/parseCategory)
   // so a hand-edited or stale value degrades gracefully to the default.
@@ -110,6 +113,18 @@ export function resolveDnsServers(config: Config): string[] {
   const env = process.env[DNS_ENV];
   const raw = env !== undefined ? env : (config.dnsServers ?? []).join(",");
   return parseDnsServers(raw);
+}
+
+const ADULT_ENV = "TORLINK_ADULT";
+
+// Whether the adult ("Porn") category is enabled. The env var wins over the
+// persisted config (matching the other resolve* helpers) so it can be turned on
+// or off per-session without touching config.json. Anything other than a
+// truthy token (1/true/yes/on) in the env var forces it off.
+export function resolveAdultContent(config: Config): boolean {
+  const env = process.env[ADULT_ENV];
+  if (env !== undefined) return /^(1|true|yes|on)$/i.test(env.trim());
+  return config.adultContent === true;
 }
 
 const RECC_URL_ENV = "TORLINK_RECC_URL";

--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { tpbMovies, tpbTv, tpbMusic } from "./piratebay";
+import { tpbMovies, tpbTv, tpbMusic, tpbPorn } from "./piratebay";
 
 describe("Pirate Bay sources", () => {
   it("should have tpbMovies", () => {
@@ -18,5 +18,12 @@ describe("Pirate Bay sources", () => {
     expect(tpbMusic).toBeDefined();
     expect(tpbMusic.id).toBe("tpb-music");
     expect(tpbMusic.groups).toContain("Music");
+  });
+
+  it("should have tpbPorn flagged as an adult Porn source", () => {
+    expect(tpbPorn).toBeDefined();
+    expect(tpbPorn.id).toBe("tpb-porn");
+    expect(tpbPorn.groups).toContain("Porn");
+    expect(tpbPorn.adult).toBe(true);
   });
 });

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -10,11 +10,15 @@ const TV_CATS = new Set([205, 208]);
 export const TPB_BOOK_CATEGORIES: ReadonlySet<number> = new Set([102, 601, 602]);
 // Audio Books (102) belong to Books, not Music.
 const MUSIC_CATS = new Set([100, 101, 103, 104, 199]);
+// Porn (video only): Movies (501), Movies DVDR (502), HD-Movies (505), Movie
+// clips (506). Skips Pictures (503) and Games (504), which aren't streamable.
+const PORN_CATS = new Set([501, 502, 505, 506]);
 
 const TOP_MOVIES = `${API}/precompiled/data_top100_207.json`;
 const TOP_TV = `${API}/precompiled/data_top100_208.json`;
 const TOP_BOOKS = `${API}/precompiled/data_top100_601.json`;
 const TOP_MUSIC = `${API}/precompiled/data_top100_100.json`;
+const TOP_PORN = `${API}/precompiled/data_top100_500.json`;
 
 interface ApibayItem {
   id?: string;
@@ -115,4 +119,14 @@ export const tpbMusic: Source = {
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, MUSIC_CATS, TOP_MUSIC, "tpb-music", opts),
+};
+
+export const tpbPorn: Source = {
+  id: "tpb-porn",
+  label: "TPB",
+  groups: ["Porn"],
+  adult: true,
+  homepage: "https://thepiratebay.org",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, PORN_CATS, TOP_PORN, "tpb-porn", opts),
 };

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -1,24 +1,46 @@
 import { describe, it, expect } from "vitest";
-import { SOURCES, enabledSources, toggleDisabledSource } from "./registry";
+import { SOURCES, enabledSources, sourcesByGroup, toggleDisabledSource } from "./registry";
+
+// Adult sources are hidden unless the adult flag is passed, so the default
+// enabled set is the non-adult subset.
+const NON_ADULT = SOURCES.filter((s) => !s.adult);
 
 describe("enabledSources", () => {
-  it("returns every source when nothing is disabled", () => {
-    expect(enabledSources([])).toEqual([...SOURCES]);
+  it("returns every non-adult source when nothing is disabled", () => {
+    expect(enabledSources([])).toEqual(NON_ADULT);
+  });
+
+  it("includes adult sources when adult content is enabled", () => {
+    expect(enabledSources([], true)).toEqual([...SOURCES]);
+    // At least one adult source exists and is otherwise hidden.
+    expect(SOURCES.some((s) => s.adult)).toBe(true);
+    expect(enabledSources([]).some((s) => s.adult)).toBe(false);
   });
 
   it("filters out disabled sources, preserving order", () => {
     const enabled = enabledSources(["yts", "nyaa"]);
     expect(enabled.some((s) => s.id === "yts")).toBe(false);
     expect(enabled.some((s) => s.id === "nyaa")).toBe(false);
-    expect(enabled).toHaveLength(SOURCES.length - 2);
+    expect(enabled).toHaveLength(NON_ADULT.length - 2);
     // order matches the registry
     expect(enabled.map((s) => s.id)).toEqual(
-      SOURCES.filter((s) => s.id !== "yts" && s.id !== "nyaa").map((s) => s.id),
+      NON_ADULT.filter((s) => s.id !== "yts" && s.id !== "nyaa").map((s) => s.id),
     );
   });
 
-  it("ignores unknown ids in the disabled list", () => {
-    expect(enabledSources(["not-a-source" as never])).toEqual([...SOURCES]);
+  it("still hides adult sources even when they are not in the disabled list", () => {
+    expect(enabledSources(["not-a-source" as never])).toEqual(NON_ADULT);
+  });
+});
+
+describe("sourcesByGroup adult gating", () => {
+  it("omits the Porn group unless adult content is enabled", () => {
+    expect(sourcesByGroup().some((g) => g.group === "Porn")).toBe(false);
+    const withAdult = sourcesByGroup(true);
+    const porn = withAdult.find((g) => g.group === "Porn");
+    expect(porn?.sources.map((s) => s.id)).toEqual(["tpb-porn", "x1337-porn"]);
+    // Porn is ordered last.
+    expect(withAdult.at(-1)?.group).toBe("Porn");
   });
 });
 

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -4,8 +4,8 @@ import { fitgirl } from "./fitgirl";
 import { nyaa, nyaaLiterature } from "./nyaa";
 import { subsplease } from "./subsplease";
 import { torrentsCsv } from "./torrentscsv";
-import { tpbBooks, tpbMovies, tpbMusic, tpbTv } from "./piratebay";
-import { x1337Movies, x1337Music, x1337Tv } from "./x1337";
+import { tpbBooks, tpbMovies, tpbMusic, tpbPorn, tpbTv } from "./piratebay";
+import { x1337Movies, x1337Music, x1337Porn, x1337Tv } from "./x1337";
 import { yts } from "./yts";
 import {
   rutrackerGames,
@@ -39,6 +39,8 @@ export const SOURCES: readonly Source[] = [
   rutrackerMusic,
   rutrackerBooks,
   bittorrented,
+  tpbPorn,
+  x1337Porn,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -48,10 +50,16 @@ export function getSource(id: SourceId): Source {
 }
 
 // The sources actually searched, given the user's disabled list. Order is
-// preserved so results and status lines stay stable.
-export function enabledSources(disabled: readonly SourceId[]): Source[] {
-  if (disabled.length === 0) return [...SOURCES];
-  return SOURCES.filter((s) => !disabled.includes(s.id));
+// preserved so results and status lines stay stable. Adult sources are omitted
+// unless the adult ("Porn") category is enabled — this single choke-point keeps
+// them out of both the "All" aggregate and per-source searching when disabled.
+export function enabledSources(
+  disabled: readonly SourceId[],
+  adultEnabled = false,
+): Source[] {
+  return SOURCES.filter(
+    (s) => (adultEnabled || !s.adult) && !disabled.includes(s.id),
+  );
 }
 
 // Flip a source's disabled state, returning a new list (never mutates input).
@@ -62,11 +70,16 @@ export function toggleDisabledSource(
   return disabled.includes(id) ? disabled.filter((d) => d !== id) : [...disabled, id];
 }
 
+// "Porn" is kept last and only surfaced when adult content is enabled.
 const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime", "Music", "Books"];
+const ADULT_GROUP_ORDER: readonly SourceGroup[] = [...GROUP_ORDER, "Porn"];
 
-export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
-  return GROUP_ORDER.map((group) => ({
-    group,
-    sources: SOURCES.filter((s) => s.groups?.includes(group)),
-  })).filter((g) => g.sources.length > 0);
+export function sourcesByGroup(adultEnabled = false): { group: SourceGroup; sources: Source[] }[] {
+  const order = adultEnabled ? ADULT_GROUP_ORDER : GROUP_ORDER;
+  return order
+    .map((group) => ({
+      group,
+      sources: SOURCES.filter((s) => (adultEnabled || !s.adult) && s.groups?.includes(group)),
+    }))
+    .filter((g) => g.sources.length > 0);
 }

--- a/src/sources/rutracker/index.ts
+++ b/src/sources/rutracker/index.ts
@@ -30,7 +30,8 @@ interface Row {
   added?: number;
 }
 
-type RutrackerGroup = SourceGroup;
+// RuTracker never feeds the adult category, so drop "Porn" from its group set.
+type RutrackerGroup = Exclude<SourceGroup, "Porn">;
 
 const SECTION_GROUP: Record<string, RutrackerGroup> = {
   "Сериалы": "TV",

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -13,6 +13,8 @@ export type SourceId =
   | "x1337-movies"
   | "x1337-tv"
   | "x1337-music"
+  | "tpb-porn"
+  | "x1337-porn"
   | "rt-games"
   | "rt-movies"
   | "rt-tv"
@@ -21,7 +23,7 @@ export type SourceId =
   | "rt-books"
   | "bittorrented";
 
-export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music" | "Books";
+export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music" | "Books" | "Porn";
 
 export interface TorrentResult {
   infoHash: string;
@@ -47,6 +49,9 @@ export interface Source {
   // The category tabs a source feeds. Most sources belong to one; a general
   // index can feed several. A source with none shows under the All tab only.
   groups?: readonly SourceGroup[];
+  // Adult source: hidden and never searched unless the user has enabled the
+  // adult ("Porn") category (config.adultContent / TORLINK_ADULT).
+  adult?: boolean;
   homepage: string;
   // True when the source returns real swarm counts. False when its feed has
   // none, so seeders: 0 means unknown, not dead (the alive-only filter must

--- a/src/sources/x1337.test.ts
+++ b/src/sources/x1337.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseUploadDate } from "./x1337";
+import { parseUploadDate, x1337Porn } from "./x1337";
 
 const detail = (span: string) =>
   `<ul class="list"><li><strong>Date uploaded</strong><span>${span}</span> </li></ul>`;
@@ -19,5 +19,13 @@ describe("parseUploadDate", () => {
   it("returns undefined when the field is missing or unparseable", () => {
     expect(parseUploadDate("<div>no date here</div>")).toBeUndefined();
     expect(parseUploadDate(detail("sometime"))).toBeUndefined();
+  });
+});
+
+describe("x1337Porn", () => {
+  it("is an adult source in the Porn group", () => {
+    expect(x1337Porn.id).toBe("x1337-porn");
+    expect(x1337Porn.groups).toContain("Porn");
+    expect(x1337Porn.adult).toBe(true);
   });
 });

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -79,17 +79,31 @@ async function detailInfo(
   }
 }
 
+// 1337x category names used in /category-search/<q>/<Cat>/ and the slug used in
+// the /popular-<slug> browse pages. "XXX" is 1337x's adult category.
+const CAT_SLUG: Record<"Movies" | "TV" | "Music" | "Porn", string> = {
+  Movies: "movies",
+  TV: "tv",
+  Music: "music",
+  Porn: "xxx",
+};
+const CAT_SEGMENT: Record<"Movies" | "TV" | "Music" | "Porn", string> = {
+  Movies: "Movies",
+  TV: "TV",
+  Music: "Music",
+  Porn: "XXX",
+};
+
 async function search(
   query: string,
-  cat: "Movies" | "TV" | "Music",
+  cat: "Movies" | "TV" | "Music" | "Porn",
   source: SourceId,
   opts: SearchOptions = {},
 ): Promise<TorrentResult[]> {
   const q = query.trim();
-  const catSlug =
-    cat === "Movies" ? "movies" : cat === "TV" ? "tv" : "music";
+  const catSlug = CAT_SLUG[cat];
   const path = q
-    ? `/category-search/${encodeURIComponent(q).replace(/%20/g, "+")}/${cat}/1/`
+    ? `/category-search/${encodeURIComponent(q).replace(/%20/g, "+")}/${CAT_SEGMENT[cat]}/1/`
     : `/popular-${catSlug}`;
 
   let base = "";
@@ -168,4 +182,14 @@ export const x1337Music: Source = {
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "Music", "x1337-music", opts),
+};
+
+export const x1337Porn: Source = {
+  id: "x1337-porn",
+  label: "1337x",
+  groups: ["Porn"],
+  adult: true,
+  homepage: "https://1337x.to",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "Porn", "x1337-porn", opts),
 };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,6 +8,7 @@ import {
   resolveMediaPlayer,
   resolveDnsServers,
   resolveReccConfig,
+  resolveAdultContent,
   type Config,
   type FavouriteItem,
 } from "../config/config";
@@ -320,7 +321,9 @@ export function App({
         setSection("downloads");
         setRegion("content");
       } else {
-        setSection(parseCategory(cfg.category));
+        // Don't restore into the hidden Porn tab when adult content is off.
+        const restored = parseCategory(cfg.category);
+        setSection(restored === "porn" && !resolveAdultContent(cfg) ? "all" : restored);
       }
     })();
     return () => {
@@ -1533,6 +1536,7 @@ export function App({
       streamResult,
       debridConfigured: resolveRealDebridToken(config) !== "",
       reccConfigured: Boolean(resolveReccConfig(config).reccUrl),
+      adultEnabled: resolveAdultContent(config),
       streamActive: activeStream !== null,
       rdStatus,
       copyLink,
@@ -1681,6 +1685,20 @@ export function App({
       if (input === "V") {
         setShowHelp(false);
         setEditingVpn(true);
+        return;
+      }
+      if (input === "X") {
+        setShowHelp(false);
+        // The env var wins over config (resolveAdultContent), so flipping the
+        // stored preference can't override it — say so rather than silently
+        // no-op'ing.
+        if (process.env.TORLINK_ADULT !== undefined) {
+          setNotice("Adult content is controlled by the TORLINK_ADULT env var.");
+          return;
+        }
+        const enabled = config?.adultContent !== true;
+        persistConfig({ adultContent: enabled });
+        setNotice(enabled ? "Adult content enabled." : "Adult content disabled.");
         return;
       }
       if (input === "m") {
@@ -1875,6 +1893,7 @@ export function App({
             <SourcesPrompt
               width={Math.max(24, Math.min(cols - 4, 62))}
               disabled={(store.config.disabledSources ?? []) as SourceId[]}
+              adultEnabled={store.adultEnabled}
               onToggle={toggleSource}
               onCancel={() => setEditingSources(false)}
             />

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -208,10 +208,14 @@ export function Results() {
     toggleSavedSearch,
     toggleFavourite,
     isFavourited,
+    adultEnabled,
   } = useStore();
 
-  const search = useConcurrentSearch(query, disabledSources);
-  const enabled = useMemo(() => enabledSources(disabledSources), [disabledSources]);
+  const search = useConcurrentSearch(query, disabledSources, adultEnabled);
+  const enabled = useMemo(
+    () => enabledSources(disabledSources, adultEnabled),
+    [disabledSources, adultEnabled],
+  );
 
   const queueItems = useQueueItems(queue);
   const queueHistory = useQueueHistory(queue);

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -33,11 +33,13 @@ export const RAIL_WIDTH =
   GUTTER + Math.max(...NAV.map((n) => n.label.length + (BADGED(n.key) ? BADGE_W : 0)));
 
 export function Sidebar() {
-  const { section, setSection, region, setRegion, queue, reccConfigured } = useStore();
+  const { section, setSection, region, setRegion, queue, reccConfigured, adultEnabled } = useStore();
   const focused = region === "sidebar";
+  // Hide the Porn tab entirely until adult content is enabled.
+  const filters = adultEnabled ? FILTERS : FILTERS.filter((n) => n.key !== "porn");
   // Hide the For You entry entirely until reccd is configured.
   const library = reccConfigured ? LIBRARY : LIBRARY.filter((n) => n.key !== "forYou");
-  const groups: NavItem[][] = [FILTERS, library];
+  const groups: NavItem[][] = [filters, library];
   const nav = groups.flat();
   const idx = Math.max(0, nav.findIndex((n) => n.key === section));
   useQueueItems(queue);

--- a/src/ui/components/SourcesPrompt.test.tsx
+++ b/src/ui/components/SourcesPrompt.test.tsx
@@ -6,29 +6,46 @@ import { SOURCES } from "../../sources/registry";
 const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
 const ESC = String.fromCharCode(27);
 
+// Adult sources are gated behind the adultEnabled flag, so the default panel
+// shows one fewer count than the full registry.
+const NON_ADULT = SOURCES.filter((s) => !s.adult).length;
+const ADULT = SOURCES.length - NON_ADULT;
+
 describe("SourcesPrompt", () => {
-  it("renders every source with an on/off count", () => {
+  it("renders every non-adult source with an on/off count", () => {
     const { lastFrame } = render(
-      <SourcesPrompt width={60} disabled={[]} onToggle={() => {}} onCancel={() => {}} />,
+      <SourcesPrompt width={60} disabled={[]} adultEnabled={false} onToggle={() => {}} onCancel={() => {}} />,
     );
     const frame = lastFrame() ?? "";
-    expect(frame).toContain(`${SOURCES.length}/${SOURCES.length}`);
+    expect(frame).toContain(`${NON_ADULT}/${NON_ADULT}`);
     // A couple of the source labels show up.
     expect(frame).toContain("YTS");
     expect(frame).toContain("Nyaa");
+    // The Porn group is hidden while adult content is disabled.
+    expect(frame).not.toContain("Porn");
+  });
+
+  it("includes adult sources and the Porn group when adult content is enabled", () => {
+    expect(ADULT).toBeGreaterThan(0);
+    const { lastFrame } = render(
+      <SourcesPrompt width={60} disabled={[]} adultEnabled onToggle={() => {}} onCancel={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain(`${SOURCES.length}/${SOURCES.length}`);
+    expect(frame).toContain("Porn");
   });
 
   it("reflects a disabled source in the count", () => {
     const { lastFrame } = render(
-      <SourcesPrompt width={60} disabled={["yts"]} onToggle={() => {}} onCancel={() => {}} />,
+      <SourcesPrompt width={60} disabled={["yts"]} adultEnabled={false} onToggle={() => {}} onCancel={() => {}} />,
     );
-    expect(lastFrame() ?? "").toContain(`${SOURCES.length - 1}/${SOURCES.length}`);
+    expect(lastFrame() ?? "").toContain(`${NON_ADULT - 1}/${NON_ADULT}`);
   });
 
   it("toggles the highlighted source when space is pressed", async () => {
     const onToggle = vi.fn();
     const { stdin } = render(
-      <SourcesPrompt width={60} disabled={[]} onToggle={onToggle} onCancel={() => {}} />,
+      <SourcesPrompt width={60} disabled={[]} adultEnabled={false} onToggle={onToggle} onCancel={() => {}} />,
     );
     await flush();
     stdin.write(" ");
@@ -41,7 +58,7 @@ describe("SourcesPrompt", () => {
   it("cancels on escape", async () => {
     const onCancel = vi.fn();
     const { stdin } = render(
-      <SourcesPrompt width={60} disabled={[]} onToggle={() => {}} onCancel={onCancel} />,
+      <SourcesPrompt width={60} disabled={[]} adultEnabled={false} onToggle={() => {}} onCancel={onCancel} />,
     );
     await flush();
     stdin.write(ESC);

--- a/src/ui/components/SourcesPrompt.tsx
+++ b/src/ui/components/SourcesPrompt.tsx
@@ -10,12 +10,13 @@ import type { SourceId } from "../../sources/types";
 interface SourcesPromptProps {
   width: number;
   disabled: SourceId[];
+  adultEnabled: boolean;
   onToggle: (id: SourceId) => void;
   onCancel: () => void;
 }
 
-export function SourcesPrompt({ width, disabled, onToggle, onCancel }: SourcesPromptProps) {
-  const groups = sourcesByGroup();
+export function SourcesPrompt({ width, disabled, adultEnabled, onToggle, onCancel }: SourcesPromptProps) {
+  const groups = sourcesByGroup(adultEnabled);
   const flat = groups.flatMap((g) => g.sources);
   const [cursor, setCursor] = useState(0);
   const clamped = Math.min(cursor, Math.max(0, flat.length - 1));

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -86,11 +86,12 @@ const RESULT_FLUSH_MS = 150;
 export function useConcurrentSearch(
   query: string,
   disabled: readonly SourceId[] = [],
+  adultEnabled = false,
 ): ConcurrentSearchState {
   // A stable key so the search only re-runs when the *set* of enabled sources
   // changes, not on every render that hands in a fresh array.
-  const disabledKey = disabled.join(",");
-  const sources = useMemo(() => enabledSources(disabled), [disabledKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const disabledKey = `${disabled.join(",")}|${adultEnabled ? "1" : "0"}`;
+  const sources = useMemo(() => enabledSources(disabled, adultEnabled), [disabledKey]); // eslint-disable-line react-hooks/exhaustive-deps
   const [state, setState] = useState<ConcurrentSearchState>(() => idleState(sources));
 
   useEffect(() => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -24,6 +24,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "t", label: "Extra trackers" },
       { keys: "L", label: "Transfer and seeding limits" },
       { keys: "V", label: "VPN kill switch" },
+      { keys: "shift+x", label: "Toggle adult content (Porn category)" },
       { keys: "q", label: "Quit" },
     ],
   },

--- a/src/ui/store.test.ts
+++ b/src/ui/store.test.ts
@@ -10,6 +10,7 @@ describe("parseCategory", () => {
     expect(parseCategory("anime")).toBe("anime");
     expect(parseCategory("music")).toBe("music");
     expect(parseCategory("books")).toBe("books");
+    expect(parseCategory("porn")).toBe("porn");
   });
 
   it("falls back to 'all' for missing, unknown, or non-category values", () => {

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -9,7 +9,7 @@ import type { Sort } from "./sort";
 
 export type View = "splash" | "browser";
 
-export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music" | "books";
+export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music" | "books" | "porn";
 
 export type Section =
   | Category
@@ -41,6 +41,8 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
   { key: "anime", label: "Anime", group: "Anime" },
   { key: "music", label: "Music", group: "Music" },
   { key: "books", label: "Books", group: "Books" },
+  // Adult category; only rendered when adult content is enabled (see Sidebar).
+  { key: "porn", label: "Porn", group: "Porn" },
 ];
 
 // Parse a persisted category preference, falling back to "all" for anything
@@ -140,6 +142,9 @@ export interface Store {
   debridConfigured: boolean;
   // True when a recc (recommendation engine) URL is configured.
   reccConfigured: boolean;
+  // True when the adult ("Porn") category is enabled (config or TORLINK_ADULT).
+  // Gates the Porn tab, its sources, and the Porn group in the sources panel.
+  adultEnabled: boolean;
   // True while a torrent-stream session is live. While true, "x" is reserved
   // globally for stopping the stream, so components with their own "x"
   // handler (clear history, sign out) must ignore it.

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -158,6 +158,7 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
     section: "all",
     setSection: noop,
     reccConfigured: false,
+    adultEnabled: false,
     sort: "none",
     setSort: noop,
     disabledSources: [],

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -46,6 +46,8 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
   "x1337-music": { tag: "1337", color: "#f6a55c" },
+  "tpb-porn": { tag: "TPB", color: "#5fd0c5" },
+  "x1337-porn": { tag: "1337", color: "#f6a55c" },
   "rt-games": { tag: "RUT", color: "#8fce5a" },
   "rt-movies": { tag: "RUT", color: "#8fce5a" },
   "rt-tv": { tag: "RUT", color: "#8fce5a" },

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -7,16 +7,18 @@ import { useStore } from "../store";
 import { sourcesByGroup } from "../../sources/registry";
 import { COLOR, ICON } from "../theme";
 
-const CATEGORIES = sourcesByGroup()
-  .map((g) => g.group.toLowerCase())
-  .join(`  ${ICON.dot}  `);
+const categoryLine = (adultEnabled: boolean): string =>
+  sourcesByGroup(adultEnabled)
+    .map((g) => g.group.toLowerCase())
+    .join(`  ${ICON.dot}  `);
 
 export function Splash({
   updateVersion,
   recovered,
 }: { updateVersion?: string | null; recovered?: boolean } = {}) {
-  const { submitQuery, searchHistory, quitAll, cols, rows, debridConfigured, rdStatus, setView, setRegion } = useStore();
+  const { submitQuery, searchHistory, quitAll, cols, rows, debridConfigured, rdStatus, setView, setRegion, adultEnabled } = useStore();
   const { isRawModeSupported } = useStdin();
+  const categories = categoryLine(adultEnabled);
 
   useInput(
     (input, key) => {
@@ -59,7 +61,7 @@ export function Splash({
         <Text color={COLOR.text}>A curated, terminal-native torrent downloader.</Text>
       </Box>
       <Box>
-        <Text dimColor>{CATEGORIES}</Text>
+        <Text dimColor>{categories}</Text>
       </Box>
       <Box marginTop={1}>
         {debridConfigured ? (


### PR DESCRIPTION
## What

Adds a **Porn** content category to torlink, backed by **The Pirate Bay** (apibay 500-range) and **1337x**. It is **off by default** and fully configurable — nothing about it (tab, sources, results) is visible until explicitly enabled.

## How it works

A single choke-point gates everything: adult sources are registered like any other source but tagged `adult: true`, and an effective `adultEnabled` boolean filters them out of `enabledSources()` / `sourcesByGroup()` and the sidebar unless enabled.

- **Off by default:** `config.adultContent` is omitted from `defaultConfig` (falsy = OFF), following the `torrentStreamAck` convention.
- **Configurable:** `resolveAdultContent()` with a `TORLINK_ADULT` env override (env wins over config, mirroring the other `resolve*` helpers).
- **In-app toggle:** `Shift+X` flips it with a notice; if `TORLINK_ADULT` is controlling it, the notice says so instead of silently no-op'ing.
- **Scope when on:** adult results appear in the **Porn tab and under All**, exactly like other sources.
- **Boot safety:** won't restore into the hidden Porn tab when adult content is off.
- reccd "For You" is untouched (movie/TV only; adult already filtered server-side).

## Tests

- `resolveAdultContent` — default OFF, config flag, `TORLINK_ADULT` override both directions, save/load round-trip
- registry gating — adult sources / Porn group excluded unless enabled, ordered last
- new `tpbPorn` / `x1337Porn` source definitions
- updated existing category/source assertions for the adult subset

## Verification

- ✅ `npm run typecheck`
- ✅ `npm test` — 640/640
- ✅ `npm run build`

README documents the opt-in under **What it searches → Adult content**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)