### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torlnk-rd",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "torlnk-rd",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torlnk-rd",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Search, stream and download torrents — in your terminal or your browser. Zero setup, optional Real-Debrid.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Minor bump for the browser interface (#48): search, posters, streaming and the For You feed.

Version-only change — `package.json` plus the synced lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)