### PR TITLE
Web UI: browse top lists from a blank search, matching the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ TORLINK_DNS=cloudflare npm start
 
 ## In your browser (optional)
 
-Add `--web` and torlink also serves a browser interface — search every source, posters and plots, play something, the queue, and your For You feed — over the same queue as the process hosting it. Handy for a seedbox you check from your phone, or just for using torlink without a terminal open.
+Add `--web` and torlink also serves a browser interface — search every source (or submit an empty box to browse the curated library, same as the TUI), posters and plots, play something, the queue, and your For You feed — over the same queue as the process hosting it. Handy for a seedbox you check from your phone, or just for using torlink without a terminal open.
 
 ```sh
 torlnk --web          # the TUI hosts it; quitting the TUI stops it

--- a/docs/superpowers/plans/2026-07-28-web-browse-mode.md
+++ b/docs/superpowers/plans/2026-07-28-web-browse-mode.md
@@ -1,0 +1,587 @@
+# Web Browse Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the web UI browse curated top lists by submitting a blank search box, exactly as the TUI does.
+
+**Architecture:** The core already supports this — browse mode *is* `query === ""` flowing through `runSearch`, and each source maps an empty query to its own top/latest endpoint. The web layer fences it off in two places, so this is: stop rejecting blank `q` on the server, add an explicit `mode` field to the browser's view state (the empty string is currently overloaded to mean "nothing has run yet"), and change the DOM guard plus the labels.
+
+**Tech Stack:** TypeScript, node:http, plain-DOM browser bundle (no framework), vitest. No jsdom in this repo — browser logic lives in pure modules (`searchModel.ts`) and only DOM binding lives in `app.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-web-browse-mode-design.md`
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/web/routes.ts:447-457` | Modify | `parseSearchParams` — blank `q` becomes valid (browse); absent `q` stays a 400 |
+| `src/web/routes.test.ts:749-783` | Modify | Invert the blank-query rejection cases |
+| `src/web/server.test.ts` (`describe("/api/search")`, from `:592`) | Modify | Socket-level proof a blank-`q` stream opens 200 and reaches `done` |
+| `src/web/static/searchModel.ts:85-113, 152-175` | Modify | Add `mode` to `SearchView`; `searchStatus` switches on it |
+| `src/web/static/searchModel.test.ts:48-50, 189-230, 248-258` | Modify | Test helper gains `mode`; new browse status branches; blank `searchUrl` |
+| `src/web/static/app.ts:576, 606, 657-662` | Modify | Drop the empty guard, set `mode`, re-run on tab switch while browsing |
+| `src/web/static/index.html:52-53` | Modify | Label and placeholder that say blank = browse |
+| `README.md:184` | Modify | Mention browse in the web section |
+
+No new files. No changes to `src/core`, `src/sources`, `src/ui`, or `src/web/wire.ts`.
+
+---
+
+## Task 1: Server accepts a blank query as browse
+
+**Files:**
+- Modify: `src/web/routes.ts:447-457`
+- Test: `src/web/routes.test.ts:770-772`
+
+- [ ] **Step 1: Rewrite the failing test**
+
+In `src/web/routes.test.ts`, find this case inside `describe("parseSearchParams")` (around line 770):
+
+```ts
+  it.each(["", "q=", "q=%20%20"])("rejects a missing or blank query (%s)", (qs) => {
+    expect(parseSearchParams(new URLSearchParams(qs))).toEqual({ ok: false, error: "missing query" });
+  });
+```
+
+Replace it with these three cases:
+
+```ts
+  // A blank q is not a mistake, it is browse mode: the same empty query the TUI
+  // sends when you press Enter on an empty box, which every source maps to its
+  // own top/latest endpoint. See runSearch — it has no empty-query check.
+  it.each(["q=", "q=%20%20"])("accepts a blank query as browse (%s)", (qs) => {
+    expect(parseSearchParams(new URLSearchParams(qs))).toEqual({
+      ok: true,
+      params: { query: "", group: null },
+    });
+  });
+
+  it("browses one group when a blank query names a tab", () => {
+    expect(parseSearchParams(new URLSearchParams("q=&group=Movies"))).toEqual({
+      ok: true,
+      params: { query: "", group: "Movies" },
+    });
+  });
+
+  // q must still be *present*. A bare GET /api/search with no params is far
+  // more likely to be a stray request than an intent to fan out to 23 sources.
+  it("rejects a request with no q at all", () => {
+    expect(parseSearchParams(new URLSearchParams(""))).toEqual({ ok: false, error: "missing query" });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/web/routes.test.ts -t parseSearchParams`
+
+Expected: FAIL — the two new accepting cases get `{ ok: false, error: "missing query" }`. The "no q at all" case already passes.
+
+- [ ] **Step 3: Make blank valid in `parseSearchParams`**
+
+In `src/web/routes.ts`, change the first two lines of the function body (line 447-449):
+
+```ts
+export function parseSearchParams(
+  query: URLSearchParams,
+): { ok: true; params: SearchParams } | { ok: false; error: string } {
+  const q = (query.get("q") ?? "").trim();
+  if (!q) return { ok: false, error: "missing query" };
+```
+
+to:
+
+```ts
+export function parseSearchParams(
+  query: URLSearchParams,
+): { ok: true; params: SearchParams } | { ok: false; error: string } {
+  const raw = query.get("q");
+  if (raw === null) return { ok: false, error: "missing query" };
+  const q = raw.trim();
+```
+
+Leave the rest of the function (the `group` handling) exactly as it is.
+
+- [ ] **Step 4: Update the doc comment above the function**
+
+The existing comment explains why a blank query is rejected, which is now wrong. Replace this paragraph in the block comment above `parseSearchParams`:
+
+```
+ * Separate from the streaming itself because SSE gives up its status code the
+ * moment the headers go out: once we have written `200 text/event-stream`,
+ * "you forgot the query" can only be an error *frame*, which a client has to
+ * parse to discover it asked wrong. So the decidable part is a pure function
+ * the socket layer runs first and answers 400 from.
+```
+
+with:
+
+```
+ * Separate from the streaming itself because SSE gives up its status code the
+ * moment the headers go out: once we have written `200 text/event-stream`,
+ * "you asked wrong" can only be an error *frame*, which a client has to parse
+ * to discover it. So the decidable part is a pure function the socket layer
+ * runs first and answers 400 from.
+ *
+ * A blank `q` is *valid*: it is browse mode, the empty query the TUI sends when
+ * you press Enter on an empty box, which each source maps to its own top/latest
+ * endpoint. But `q` must be *present* — a bare `GET /api/search` is far more
+ * likely to be a stray request than an intent to fan out to every source, so
+ * absent and blank are deliberately different answers.
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/web/routes.test.ts -t parseSearchParams`
+
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/routes.ts src/web/routes.test.ts
+git commit -m "feat(web): accept a blank search query as browse mode"
+```
+
+---
+
+## Task 2: Prove a blank query streams over a real socket
+
+`parseSearchParams` passing is not proof the stream works — the 400 was answered in `server.ts` before the SSE headers, so this asserts the whole path end to end.
+
+**Files:**
+- Test: `src/web/server.test.ts` (inside `describe("/api/search")`, which starts at `:592`)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/web/server.test.ts`, inside `describe("/api/search")`, add this after the existing `it("narrows to a group", ...)` test. It reuses the `searchServer()` helper already defined in that describe block (which stubs `searchImpl` so no network is touched):
+
+```ts
+  // Browse mode: no query at all. The server must not 400 this, and the stream
+  // must complete exactly like a real search.
+  it("streams a blank query as browse", async () => {
+    const base = await searchServer();
+    const res = await fetch(`${base}/api/search?q=`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    const text = await res.text();
+    expect(text.match(/event: results/g)).toHaveLength(3);
+    expect(text).toContain("event: done");
+    expect(text).toContain("yts result");
+  });
+
+  it("rejects a search with no q at all", async () => {
+    const base = await searchServer();
+    const res = await fetch(`${base}/api/search`);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing query" });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npx vitest run src/web/server.test.ts -t "/api/search"`
+
+Expected: PASS both — Task 1 already made the server accept this. If the blank-query test fails with a 400, the Task 1 change did not land.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web/server.test.ts
+git commit -m "test(web): cover the blank-query search stream at the socket level"
+```
+
+---
+
+## Task 3: Add an explicit `mode` to the browser's view state
+
+`SearchView.query` currently means two things at once — the query text, and "has anything been submitted yet". `searchStatus` returns the idle line whenever `!view.query`, so a blank browse query would render identically to a fresh page. This task adds the field and the browse status lines together, because the field is useless without a reader.
+
+**Files:**
+- Modify: `src/web/static/searchModel.ts:85-113` (`SearchView`, `emptyView`) and `:152-175` (`searchStatus`)
+- Test: `src/web/static/searchModel.test.ts:48-50` (helper), `:189-230` (status), `:248-258` (url)
+
+- [ ] **Step 1: Update the test helper so existing tests still describe a search**
+
+In `src/web/static/searchModel.test.ts`, the helper at line 48 is:
+
+```ts
+function view(over: Partial<SearchView> = {}): SearchView {
+  return { ...emptyView(), query: "sintel", ...over };
+}
+```
+
+Change it to set the mode alongside the query, and add a browse-flavoured sibling:
+
+```ts
+function view(over: Partial<SearchView> = {}): SearchView {
+  return { ...emptyView(), query: "sintel", mode: "search", ...over };
+}
+
+/** A view mid-browse: the blank query the TUI sends on an empty submit. */
+function browsing(over: Partial<SearchView> = {}): SearchView {
+  return { ...emptyView(), query: "", mode: "browse", ...over };
+}
+```
+
+- [ ] **Step 2: Write the failing browse status tests**
+
+In the same file, add these to `describe("searchStatus")` (which starts at line 189), after the existing tests:
+
+```ts
+  it("counts sources while browsing, without calling it a search", () => {
+    const v = browsing({ running: true, snapshot: snapshot([], { done: 12, total: 23 }) });
+    expect(searchStatus(v, 0).text).toBe("Loading 12/23 sources");
+    expect(searchStatus(v, 5).text).toBe("loading… 12/23 sources");
+  });
+
+  it("says nothing is new rather than quoting an empty query", () => {
+    const v = browsing({ snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(searchStatus(v, 0).text).toBe("Nothing new right now.");
+    expect(searchStatus(v, 0).tone).toBe("dim");
+  });
+
+  it("labels browse results as the newest across all sources", () => {
+    const v = browsing({ snapshot: snapshot([result()], { total: 3, done: 3 }) });
+    expect(searchStatus(v, 4).text).toBe("4 results · newest across all sources");
+  });
+
+  // The mode-independent branches must keep winning over the browse lines:
+  // "every source is down" and "your filters did this" are still the truth.
+  it("keeps the outage and filter branches while browsing", () => {
+    const down = {
+      perSource: {
+        a: { loading: false, error: "timed out", code: "timed out", count: 0 },
+        b: { loading: false, error: "HTTP 503", code: "HTTP 503", count: 0 },
+      },
+      total: 2,
+      done: 2,
+    };
+    const failed = searchStatus(browsing({ snapshot: snapshot([], down) }), 0);
+    expect(failed.text).toBe("Couldn't reach any source. They may be down.");
+    expect(failed.tone).toBe("error");
+
+    const filtered = browsing({ snapshot: snapshot([result()], { total: 2, done: 2 }), textFilter: "zzz" });
+    expect(searchStatus(filtered, 0).text).toBe("Nothing matches those filters.");
+  });
+
+  it("still shows the idle line before anything is submitted", () => {
+    expect(searchStatus(emptyView(), 0).text).toBe("Search across every enabled source.");
+  });
+```
+
+- [ ] **Step 3: Write the failing blank-URL test**
+
+Still in `searchModel.test.ts`, add to `describe("searchUrl")` (line 248):
+
+```ts
+  it("sends q= for a browse, so the server can tell blank from absent", () => {
+    expect(searchUrl("", "All", "")).toBe("/api/search?q=&group=All");
+  });
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `npx vitest run src/web/static/searchModel.test.ts`
+
+Expected: FAIL — typecheck errors on `mode` not existing in `SearchView`, and the browse status assertions get `"Search across every enabled source."`. The `searchUrl` test should already pass (`URLSearchParams` keeps an empty value's key).
+
+- [ ] **Step 5: Add the `mode` field**
+
+In `src/web/static/searchModel.ts`, change `SearchView` (line 85-97) to:
+
+```ts
+export interface SearchView {
+  /** The submitted query. Empty in `browse` mode and before the first submit. */
+  query: string;
+  /**
+   * Which of three states the pane is in. This is NOT derivable from `query`:
+   * browse mode submits the empty string, so `!query` alone cannot tell "the
+   * user asked for the top lists" from "nothing has been submitted yet", and
+   * conflating them makes a browse render as a fresh page.
+   */
+  mode: "idle" | "search" | "browse";
+  /** `ALL_TAB` or one of the server's group names. */
+  group: string;
+  /** The latest frame, or null before one arrives. */
+  snapshot: PublicSearchSnapshot | null;
+  /** True between submitting and the `done` frame (or an error). */
+  running: boolean;
+  sort: Sort;
+  hideDead: boolean;
+  textFilter: string;
+}
+```
+
+and add `mode` to `emptyView()` (line 99-113):
+
+```ts
+export function emptyView(): SearchView {
+  return {
+    query: "",
+    mode: "idle",
+    group: ALL_TAB,
+    snapshot: null,
+    running: false,
+    // "none", NOT a seeders sort. `core/search.ts` has already ordered every
+    // snapshot by seeders then recency and the TUI leaves that alone, so a
+    // browser that applied its own default would put a different hit at the top
+    // of the same query. See sortResults: "none" returns the list as given.
+    sort: "none",
+    hideDead: false,
+    textFilter: "",
+  };
+}
+```
+
+- [ ] **Step 6: Teach `searchStatus` the browse lines**
+
+Replace the body of `searchStatus` in `src/web/static/searchModel.ts` (line 152-175) with:
+
+```ts
+export function searchStatus(view: SearchView, shown: number): SearchStatus {
+  if (view.mode === "idle") return { text: "Search across every enabled source.", tone: "dim" };
+  const browse = view.mode === "browse";
+  const progress = progressLabel(view.snapshot);
+  if (view.running) {
+    // "Loading" not "Searching" while browsing: nothing was searched for. Same
+    // word the TUI's spinner uses for the same state. Both casings are spelled
+    // out rather than derived — `noUncheckedIndexedAccess` makes `verb[0]`
+    // possibly-undefined, and a two-word table is clearer than appeasing it.
+    const head =
+      shown > 0
+        ? `${browse ? "loading" : "searching"}… ${progress}`
+        : `${browse ? "Loading" : "Searching"} ${progress}`;
+    return { text: head, tone: "dim" };
+  }
+  const down = erroredSources(view.snapshot);
+  const total = view.snapshot?.total ?? 0;
+  if (shown === 0) {
+    // Every source failing and every source finding nothing look identical in a
+    // results list, so they must not read the same. This is the whole reason
+    // `perSource.error` is on the wire. Both of these outrank the mode: they are
+    // true whether or not the user typed anything.
+    if (total > 0 && down.length >= total) {
+      return { text: "Couldn't reach any source. They may be down.", tone: "error" };
+    }
+    if (view.hideDead || view.textFilter.trim()) {
+      return { text: "Nothing matches those filters.", tone: "dim" };
+    }
+    if (browse) return { text: "Nothing new right now.", tone: "dim" };
+    return { text: `No results for “${view.query}”.`, tone: "dim" };
+  }
+  const note = down.length > 0 ? ` · ${down.length} source${down.length === 1 ? "" : "s"} down` : "";
+  // The TUI drops the count while browsing because its panel title already says
+  // "latest". The web has no such title, so keep the count and append the
+  // phrase rather than replacing one true thing with another.
+  const tail = browse ? " · newest across all sources" : "";
+  return { text: `${shown} result${shown === 1 ? "" : "s"}${note}${tail}`, tone: "dim" };
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `npx vitest run src/web/static/searchModel.test.ts`
+
+Expected: PASS. Every pre-existing test in this file must still pass — the `search`-mode strings are unchanged.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: errors only in `src/web/static/app.ts`, where `emptyView()`-derived views are spread without a `mode` — Task 4 fixes those. If `app.ts` reports nothing, `mode` was made optional by mistake; it must be required.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/web/static/searchModel.ts src/web/static/searchModel.test.ts
+git commit -m "feat(web): add an explicit browse mode to the search view state"
+```
+
+---
+
+## Task 4: Wire it up in the DOM
+
+`app.ts` has no test coverage by design (no DOM environment in this repo), so this task is typecheck-and-hand-verify. Keep the edits to binding only — no decisions.
+
+**Files:**
+- Modify: `src/web/static/app.ts:576` (tab switch), `:606` (`startSearch`), `:657-662` (submit)
+- Modify: `src/web/static/index.html:52-53`
+
+- [ ] **Step 1: Set the mode in `startSearch`**
+
+In `src/web/static/app.ts`, the function at line 606 begins:
+
+```ts
+function startSearch(query: string): void {
+  stopSearch();
+  searchView = { ...searchView, query, snapshot: null, running: true };
+```
+
+Change those first lines to derive the mode from the query:
+
+```ts
+function startSearch(query: string): void {
+  stopSearch();
+  // An empty query is browse mode, not a mistake — the server accepts it and
+  // every source answers with its own top/latest list. See parseSearchParams.
+  const mode = query ? "search" : "browse";
+  searchView = { ...searchView, query, mode, snapshot: null, running: true };
+```
+
+Leave the rest of the function unchanged; `searchUrl(query, ...)` already emits `q=` for an empty query.
+
+- [ ] **Step 2: Drop the empty-query guard in the submit handler**
+
+At line 657-662 the handler is:
+
+```ts
+searchForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const query = queryInput.value.trim();
+  if (!query) return;
+  startSearch(query);
+});
+```
+
+Change it to:
+
+```ts
+searchForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  // No guard on an empty value: submitting a blank box is how you browse the
+  // top lists, the same as pressing Enter on an empty box in the TUI.
+  startSearch(queryInput.value.trim());
+});
+```
+
+- [ ] **Step 3: Make a tab switch re-run a browse**
+
+At line 576, inside the tab click handler in `renderTabs`, the re-run is guarded on the query being non-empty, which would silently do nothing while browsing:
+
+```ts
+        if (searchView.query) startSearch(searchView.query);
+        else renderResults();
+```
+
+Change it to switch on the mode instead:
+
+```ts
+        // `mode`, not `query`: a browse has an empty query but absolutely needs
+        // re-running, because the server only fetched the old tab's sources.
+        if (searchView.mode === "idle") renderResults();
+        else startSearch(searchView.query);
+```
+
+- [ ] **Step 4: Say so in the markup**
+
+In `src/web/static/index.html`, lines 51-53 are:
+
+```html
+          <label for="query">Search every source</label>
+          <input id="query" type="search" placeholder="the matrix 1999" autocomplete="off" />
+          <button type="submit">Search</button>
+```
+
+Change the placeholder so browse is discoverable (the label and button stay — the button still submits a blank box):
+
+```html
+          <label for="query">Search every source</label>
+          <input
+            id="query"
+            type="search"
+            placeholder="the matrix 1999 — or leave blank to browse"
+            autocomplete="off"
+          />
+          <button type="submit">Search</button>
+```
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `npm run typecheck && npm run lint`
+
+Expected: both clean. The `mode` errors from Task 3 Step 8 are now resolved.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `npm test`
+
+Expected: PASS. Nothing outside `src/web` was touched, so any failure here is a real regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/static/app.ts src/web/static/index.html
+git commit -m "feat(web): browse the top lists by submitting a blank search"
+```
+
+---
+
+## Task 5: Verify it in a real browser
+
+The browser bundle is served from `dist/web`, **not** `src` — see `README.md:269-271`. Skipping the build here shows stale assets and reads exactly like a cache bug.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build`
+
+Expected: exit 0, and `dist/web/app.js` newer than your edit to `src/web/static/app.ts`.
+
+- [ ] **Step 2: Start the server headless**
+
+Run: `npx tsx src/index.tsx serve --web --web-port 9162`
+
+Expected: it stays running and reports the UI on `http://127.0.0.1:9162`. Leave it up for the next steps (run it in the background so you keep a shell).
+
+- [ ] **Step 3: Drive it in Chrome DevTools**
+
+Navigate to `http://127.0.0.1:9162`, then:
+- Confirm the search input's placeholder reads `the matrix 1999 — or leave blank to browse`.
+- Submit the empty box. Confirm the status line goes `Loading n/23 sources` → `n results · newest across all sources`, and that real rows appear.
+- Check the network panel: the request is `GET /api/search?q=&group=All` with status **200** and content-type `text/event-stream`, and it carries `event: results` frames and one `event: done`.
+- Check the console for errors — there should be none.
+- Click the **movies** tab. Confirm the request re-fires as `q=&group=Movies` and the rows change.
+- Type a real query and submit. Confirm the status line reverts to `n results` with no `newest across all sources` tail.
+
+- [ ] **Step 4: Confirm the guard that remains**
+
+Run: `curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9162/api/search`
+
+Expected: `400`. A bare request with no `q` must not start a 23-source fan-out.
+
+- [ ] **Step 5: Stop the server**
+
+Kill the process from Step 2.
+
+- [ ] **Step 6: Document it**
+
+In `README.md`, line 184 currently reads:
+
+```
+Add `--web` and torlink also serves a browser interface — search every source, posters and plots, play something, the queue, and your For You feed — over the same queue as the process hosting it. Handy for a seedbox you check from your phone, or just for using torlink without a terminal open.
+```
+
+Change it to mention browse, matching how line 52 describes it for the TUI:
+
+```
+Add `--web` and torlink also serves a browser interface — search every source (or submit an empty box to browse the curated library, same as the TUI), posters and plots, play something, the queue, and your For You feed — over the same queue as the process hosting it. Handy for a seedbox you check from your phone, or just for using torlink without a terminal open.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: note that the web UI can browse from a blank search"
+```
+
+---
+
+## Done when
+
+- `npm test`, `npm run typecheck` and `npm run lint` are all clean.
+- `GET /api/search?q=` streams results; `GET /api/search` is a 400.
+- A blank submit in the browser shows top lists with the `newest across all sources` status, and switching tabs re-fetches.
+- A real query behaves exactly as it did before.

--- a/docs/superpowers/plans/2026-07-28-web-browse-mode.md
+++ b/docs/superpowers/plans/2026-07-28-web-browse-mode.md
@@ -158,8 +158,8 @@ git commit -m "feat(web): accept a blank search query as browse mode"
 In `src/web/server.test.ts`, inside `describe("/api/search")`, add this after the existing `it("narrows to a group", ...)` test. It reuses the `searchServer()` helper already defined in that describe block (which stubs `searchImpl` so no network is touched):
 
 ```ts
-  // Browse mode: no query at all. The server must not 400 this, and the stream
-  // must complete exactly like a real search.
+  // Browse mode: q present but blank. The server must not 400 this, and the
+  // stream must complete exactly like a real search.
   it("streams a blank query as browse", async () => {
     const base = await searchServer();
     const res = await fetch(`${base}/api/search?q=`);
@@ -171,13 +171,21 @@ In `src/web/server.test.ts`, inside `describe("/api/search")`, add this after th
     expect(text).toContain("yts result");
   });
 
-  it("rejects a search with no q at all", async () => {
+  // The tab-switch path in Task 4 depends on this: a browse still has to be
+  // narrowed by group, and only a socket test proves the fan-out really is.
+  it("narrows a browse to a group", async () => {
     const base = await searchServer();
-    const res = await fetch(`${base}/api/search`);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "missing query" });
+    const text = await (await fetch(`${base}/api/search?q=&group=TV`)).text();
+    expect(text).toContain("eztv result");
+    expect(text).not.toContain("yts result");
   });
 ```
+
+Do **not** add a standalone `no q at all` test here: the pre-existing table
+`it.each([["/api/search", "missing query"], …])` further down this describe block
+already asserts exactly that, and duplicating it is bookkeeping that will drift.
+That table also has a row `["/api/search?q=", "missing query"]` which asserts the
+behaviour Task 1 just inverted — **remove that one row** and leave the other two.
 
 - [ ] **Step 2: Run the tests**
 

--- a/docs/superpowers/specs/2026-07-28-web-browse-mode-design.md
+++ b/docs/superpowers/specs/2026-07-28-web-browse-mode-design.md
@@ -118,8 +118,10 @@ test.
 - `index.html:52-53`: label → `Search every source`, placeholder →
   `the matrix 1999 — or leave blank to browse`.
 
-Tab switching (`app.ts:568-578`) re-runs the current query, so it carries browse
-mode across tabs with no extra work.
+- `app.ts:576`: the tab-switch re-run is guarded on `if (searchView.query)`,
+  which would silently do nothing while browsing. It must switch on `mode`
+  instead — a browse has an empty query but still needs re-running, because the
+  server only fetched the previous tab's sources.
 
 Explicitly unchanged: the results list and row rendering, the preview pane,
 `POST /api/add`, and the play/stream flows — all are query-agnostic. Unlike the

--- a/docs/superpowers/specs/2026-07-28-web-browse-mode-design.md
+++ b/docs/superpowers/specs/2026-07-28-web-browse-mode-design.md
@@ -1,0 +1,151 @@
+# Web browse mode (blank search) — design
+
+**Date:** 2026-07-28
+**Status:** approved, ready to plan
+
+## Problem
+
+The TUI lets you press Enter on an empty search box to browse curated top lists.
+The web UI cannot. The capability is not missing from the core — it is fenced off
+at two points in the web layer:
+
+- `src/web/routes.ts:448-451` — `parseSearchParams` answers `400 {"error":"missing query"}`
+  for a blank `q`.
+- `src/web/static/app.ts:657-662` — the submit handler silently returns on a
+  blank input, so the request is never made.
+
+## How browse mode already works
+
+Browse is not a mode in the core. It is `query === ""` flowing through the same
+pipeline: `runSearch("")` → `cachedSearch(source, "")` → `source.search("")`.
+`runSearch` (`src/core/search.ts:114`) contains no empty-query check. Each source
+decides what an empty query means for itself:
+
+- TPB/apibay: the precompiled per-category Top-100 JSON (`data_top100_207.json`, …)
+- 1337x: `/popular-<slug>` pages
+- YTS: `list_movies.json?sort_by=date_added`
+- EZTV: browse-only — it returns `[]` for a *non-empty* query
+- SubsPlease: `?f=latest`; Nyaa: the newest RSS listing; FitGirl: `/feed/`
+- RuTracker: `tracker.php?nm=` (empty `nm`)
+- Torrents-CSV and BitTorrented deliberately opt out (`return []`) — no browse endpoint
+
+Merging, dedupe by infohash, and the default seeders-desc-then-recency order are
+identical to a real search. Category tabs, sort, text filter and alive-only all
+apply unchanged. There is no pagination in browse mode.
+
+The TUI's own affordances (`src/ui/components/Results.tsx`) derive everything from
+`const browsing = query.trim() === ""`: panel title `latest`, status
+`newest across all sources`, spinner `Loading n/m sources`, empty state
+`Nothing new right now.`
+
+## Decisions
+
+1. **Entry point: submitting a blank search box**, matching the TUI exactly. No
+   new pane, no separate button. A visible hint makes it discoverable.
+2. **No auto-load on page open.** The TUI lands in browse mode because its
+   initial query state is `""`; the web will not. A fresh tab or refresh would
+   otherwise cost a full 23-source fan-out per load, and web refreshes are cheap
+   and frequent in a way TUI launches are not. Browse fires only on explicit
+   blank submit.
+3. **`q` must be present, but may be empty.** `?q=` is browse; a bare
+   `GET /api/search` with no `q` at all stays a 400, so a stray unparameterised
+   request cannot trigger a 23-source fan-out.
+4. **Browse state is explicit, not inferred from the empty string.** See below.
+
+## Changes
+
+### Server: `src/web/routes.ts`
+
+`parseSearchParams` (`:447-457`) stops treating blank as invalid:
+
+```ts
+const raw = query.get("q");
+if (raw === null) return { ok: false, error: "missing query" };
+const q = raw.trim();   // "" is legal: browse the top lists
+```
+
+Group handling is untouched, so `?q=&group=Movies` browses the movie top lists —
+the same set the TUI's Movies tab shows while browsing. An unknown group is still
+rejected. `searchSources` and `startSearchStream` need no change: they pass the
+query straight through to `runSearch`.
+
+The doc comment on `parseSearchParams` must be updated — it currently explains
+why a blank query is rejected.
+
+### Browser state: `src/web/static/searchModel.ts`
+
+`SearchView` overloads `query` as both the query text and the "has anything run
+yet" flag: `searchStatus` returns the idle line whenever `!view.query`
+(`:152`). A blank browse query would therefore be indistinguishable from a fresh
+page. Add an explicit field:
+
+```ts
+mode: "idle" | "search" | "browse"
+```
+
+`searchStatus` switches on `mode` instead of on `!view.query`. The resulting
+lines, mirroring the TUI:
+
+| state | line | tone |
+|---|---|---|
+| idle | `Search across every enabled source.` (unchanged) | dim |
+| browse, running | `Loading 12/23 sources`, or `loading… 12/23 sources` once rows are showing | dim |
+| browse, settled, 0 shown | `Nothing new right now.` | dim |
+| browse, settled, n shown | `n results · newest across all sources` | dim |
+| search, running | `Searching 12/23 sources`, or `searching… 12/23 sources` once rows are showing (unchanged) | dim |
+| search, settled, 0 shown | `No results for “x”.` (unchanged) | dim |
+| search, settled, n shown | `n results` (unchanged) | dim |
+
+One deliberate divergence from the TUI: the TUI's browse status line is *only*
+`newest across all sources`, dropping the count, because its panel title already
+flips to `latest`. The web has no such title, so the count stays and the phrase
+is appended to it.
+
+The `Couldn't reach any source. They may be down.` and
+`Nothing matches those filters.` branches are mode-independent and stay shared,
+keeping their precedence over the per-mode empty lines. The
+`· n sources down` suffix likewise applies in both modes.
+
+`searchUrl` already emits `q=` for an empty query, because
+`new URLSearchParams({ q: "" })` keeps the key. No change needed, but it gets a
+test.
+
+### DOM: `src/web/static/app.ts`, `src/web/static/index.html`
+
+- `app.ts:657-662`: drop `if (!query) return`; pass the trimmed value to
+  `startSearch` and set `mode` to `browse` when it is empty, `search` otherwise.
+- `app.ts:606` `startSearch`: set `mode` on the view alongside `query`.
+- `index.html:52-53`: label → `Search every source`, placeholder →
+  `the matrix 1999 — or leave blank to browse`.
+
+Tab switching (`app.ts:568-578`) re-runs the current query, so it carries browse
+mode across tabs with no extra work.
+
+Explicitly unchanged: the results list and row rendering, the preview pane,
+`POST /api/add`, and the play/stream flows — all are query-agnostic. Unlike the
+TUI there is no watchlist key to disable on the web, so that asymmetry needs no
+handling.
+
+## Testing
+
+- `src/web/routes.test.ts:749-783` — the existing
+  `it.each(["", "q=", "q=%20%20"])` → `"missing query"` case inverts: `q=` and
+  `q=%20%20` become valid browse params (`query: ""`), and only the
+  no-`q`-at-all case stays a 400. Add a blank-`q`-with-`group` case.
+- `src/web/server.test.ts` (`describe("/api/search")`, `:592`) — a blank-`q`
+  stream opens `200 text/event-stream` and reaches `done`.
+- `src/web/static/searchModel.test.ts` — the browse status branches, that filter
+  and all-sources-down branches still win over them, and that
+  `searchUrl("", …)` emits `q=`.
+- `app.ts` is untested by design (no DOM environment); its changes are the two
+  guard/label edits, verified by hand.
+- Manual: `npm run build`, run with `--web`, drive it in Chrome DevTools and
+  confirm real top-list results arrive over the SSE stream. Note
+  `README.md:269-271` — assets are served from `dist/web`, so `npm run dev`
+  alone shows stale browser bundles.
+
+## Out of scope
+
+- Pagination or "load more" for browse results.
+- A dedicated `latest` pane or tab.
+- Any change to which endpoint a source uses for an empty query.

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -768,8 +768,27 @@ describe("parseSearchParams", () => {
     });
   });
 
-  it.each(["", "q=", "q=%20%20"])("rejects a missing or blank query (%s)", (qs) => {
-    expect(parseSearchParams(new URLSearchParams(qs))).toEqual({ ok: false, error: "missing query" });
+  // A blank q is not a mistake, it is browse mode: the same empty query the TUI
+  // sends when you press Enter on an empty box, which every source maps to its
+  // own top/latest endpoint. See runSearch — it has no empty-query check.
+  it.each(["q=", "q=%20%20"])("accepts a blank query as browse (%s)", (qs) => {
+    expect(parseSearchParams(new URLSearchParams(qs))).toEqual({
+      ok: true,
+      params: { query: "", group: null },
+    });
+  });
+
+  it("browses one group when a blank query names a tab", () => {
+    expect(parseSearchParams(new URLSearchParams("q=&group=Movies"))).toEqual({
+      ok: true,
+      params: { query: "", group: "Movies" },
+    });
+  });
+
+  // q must still be *present*. A bare GET /api/search with no params is far
+  // more likely to be a stray request than an intent to fan out to 23 sources.
+  it("rejects a request with no q at all", () => {
+    expect(parseSearchParams(new URLSearchParams(""))).toEqual({ ok: false, error: "missing query" });
   });
 
   // A typo'd tab that quietly searches everything is worse than one that says

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -768,9 +768,7 @@ describe("parseSearchParams", () => {
     });
   });
 
-  // A blank q is not a mistake, it is browse mode: the same empty query the TUI
-  // sends when you press Enter on an empty box, which every source maps to its
-  // own top/latest endpoint. See runSearch — it has no empty-query check.
+  // Blank is browse mode, not a mistake. See parseSearchParams.
   it.each(["q=", "q=%20%20"])("accepts a blank query as browse (%s)", (qs) => {
     expect(parseSearchParams(new URLSearchParams(qs))).toEqual({
       ok: true,
@@ -785,8 +783,7 @@ describe("parseSearchParams", () => {
     });
   });
 
-  // q must still be *present*. A bare GET /api/search with no params is far
-  // more likely to be a stray request than an intent to fan out to 23 sources.
+  // Absent and blank are deliberately different. See parseSearchParams.
   it("rejects a request with no q at all", () => {
     expect(parseSearchParams(new URLSearchParams(""))).toEqual({ ok: false, error: "missing query" });
   });

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -434,9 +434,15 @@ export interface SearchParams {
  *
  * Separate from the streaming itself because SSE gives up its status code the
  * moment the headers go out: once we have written `200 text/event-stream`,
- * "you forgot the query" can only be an error *frame*, which a client has to
- * parse to discover it asked wrong. So the decidable part is a pure function
- * the socket layer runs first and answers 400 from.
+ * "you asked wrong" can only be an error *frame*, which a client has to parse
+ * to discover it. So the decidable part is a pure function the socket layer
+ * runs first and answers 400 from.
+ *
+ * A blank `q` is *valid*: it is browse mode, the empty query the TUI sends when
+ * you press Enter on an empty box, which each source maps to its own top/latest
+ * endpoint. But `q` must be *present* — a bare `GET /api/search` is far more
+ * likely to be a stray request than an intent to fan out to every source, so
+ * absent and blank are deliberately different answers.
  *
  * An unknown group is rejected rather than silently searched as "All": a typo'd
  * tab that quietly returns everything is worse than one that says no. A group
@@ -447,8 +453,9 @@ export interface SearchParams {
 export function parseSearchParams(
   query: URLSearchParams,
 ): { ok: true; params: SearchParams } | { ok: false; error: string } {
-  const q = (query.get("q") ?? "").trim();
-  if (!q) return { ok: false, error: "missing query" };
+  const raw = query.get("q");
+  if (raw === null) return { ok: false, error: "missing query" };
+  const q = raw.trim();
   const rawGroup = (query.get("group") ?? "").trim();
   if (!rawGroup || rawGroup === "All") return { ok: true, params: { query: q, group: null } };
   const group = SOURCE_GROUPS.find((g) => g === rawGroup);

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -650,6 +650,26 @@ describe("/api/search", () => {
     expect(text).not.toContain("yts result");
   });
 
+  // Browse mode: no query at all. The server must not 400 this, and the stream
+  // must complete exactly like a real search.
+  it("streams a blank query as browse", async () => {
+    const base = await searchServer();
+    const res = await fetch(`${base}/api/search?q=`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    const text = await res.text();
+    expect(text.match(/event: results/g)).toHaveLength(3);
+    expect(text).toContain("event: done");
+    expect(text).toContain("yts result");
+  });
+
+  it("rejects a search with no q at all", async () => {
+    const base = await searchServer();
+    const res = await fetch(`${base}/api/search`);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing query" });
+  });
+
   // A search spends the user's bandwidth on up to 23 requests to public
   // trackers, so an anonymous caller with a loop is a traffic amplifier.
   it("401s without credentials when a token is set", async () => {
@@ -680,7 +700,6 @@ describe("/api/search", () => {
   // socket, "you asked wrong" can only be a frame the client has to parse.
   it.each([
     ["/api/search", "missing query"],
-    ["/api/search?q=", "missing query"],
     ["/api/search?q=x&group=Films", "unknown group"],
   ])("400s %s as a real status, not an error frame", async (path, error) => {
     const base = await searchServer();

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -650,8 +650,8 @@ describe("/api/search", () => {
     expect(text).not.toContain("yts result");
   });
 
-  // Browse mode: no query at all. The server must not 400 this, and the stream
-  // must complete exactly like a real search.
+  // Browse mode: q present but blank. The server must not 400 this, and the
+  // stream must complete exactly like a real search.
   it("streams a blank query as browse", async () => {
     const base = await searchServer();
     const res = await fetch(`${base}/api/search?q=`);
@@ -663,11 +663,11 @@ describe("/api/search", () => {
     expect(text).toContain("yts result");
   });
 
-  it("rejects a search with no q at all", async () => {
+  it("narrows a browse to a group", async () => {
     const base = await searchServer();
-    const res = await fetch(`${base}/api/search`);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "missing query" });
+    const text = await (await fetch(`${base}/api/search?q=&group=TV`)).text();
+    expect(text).toContain("eztv result");
+    expect(text).not.toContain("yts result");
   });
 
   // A search spends the user's bandwidth on up to 23 requests to public

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -616,6 +616,10 @@ function startSearch(raw: string): void {
   // most sources answer with their own top/latest list; a couple opt out.
   const mode = modeForQuery(query);
   searchView = { ...searchView, query, mode, snapshot: null, running: true };
+  // The box and the state must not disagree: without this, submitting "   "
+  // leaves #query showing whitespace while searchView.query (and the URL sent
+  // to the server) is already trimmed.
+  queryInput.value = query;
   selectedHash = null;
   preview.select(null, searchView.group);
   renderResults();
@@ -1084,12 +1088,20 @@ async function actOnPick(action: ReccAction, item: PublicRecommendation): Promis
 
 /** Hand a pick to the search pane — the feed's way out into the rest of the app. */
 function searchForPick(item: PublicRecommendation): void {
+  // A blank title from reccd must not fall through to browse mode: an empty
+  // submit is a deliberate user gesture, and silently answering a pick with
+  // the top-100 list would look like a working search for the wrong thing.
+  const title = item.title.trim();
+  if (!title) {
+    showNotice("That pick has no title to search for.");
+    return;
+  }
   const group = searchGroupForType(recc.state().filters.type, sources);
   searchView = { ...searchView, group };
   renderTabs();
-  queryInput.value = item.title;
+  queryInput.value = title;
   showView("search");
-  startSearch(item.title);
+  startSearch(title);
 }
 
 // Same createElement/textContent rule as every other list on this page, and for

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -31,6 +31,7 @@ import {
   ALL_TAB,
   categoryTabs,
   emptyView,
+  modeForQuery,
   parseSort,
   previewApplies,
   reportsHealthLookup,
@@ -574,8 +575,7 @@ function renderTabs(): void {
         // already here: the server searches only that group's sources, so the
         // other tabs' hits were never fetched. Matches the TUI, where each tab
         // is its own slice of one fan-out.
-        // `mode`, not `query`: a browse has an empty query but absolutely needs
-        // re-running, because the server only fetched the old tab's sources.
+        // mode, not query: a browse's query is empty but still needs re-running.
         if (searchView.mode === "idle") renderResults();
         else startSearch(searchView.query);
       });
@@ -606,11 +606,15 @@ function stopSearch(): void {
   searchStream = null;
 }
 
-function startSearch(query: string): void {
+function startSearch(raw: string): void {
   stopSearch();
+  // Trimmed here, once, so every caller — including searchForPick, which hands
+  // over an untrusted title from reccd — gets the same normalisation the server
+  // applies before it decides search vs. browse (parseSearchParams).
+  const query = raw.trim();
   // An empty query is browse mode, not a mistake — the server accepts it and
-  // every source answers with its own top/latest list. See parseSearchParams.
-  const mode = query ? "search" : "browse";
+  // most sources answer with their own top/latest list; a couple opt out.
+  const mode = modeForQuery(query);
   searchView = { ...searchView, query, mode, snapshot: null, running: true };
   selectedHash = null;
   preview.select(null, searchView.group);
@@ -664,7 +668,7 @@ searchForm.addEventListener("submit", (event) => {
   event.preventDefault();
   // No guard on an empty value: submitting a blank box is how you browse the
   // top lists, the same as pressing Enter on an empty box in the TUI.
-  startSearch(queryInput.value.trim());
+  startSearch(queryInput.value);
 });
 
 sortSelect.addEventListener("change", () => {

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -39,6 +39,7 @@ import {
   searchStatus,
   searchUrl,
   sourceLabel,
+  statusLineHidden,
   visibleResults,
   type AddVia,
   type PublicSearchResult,
@@ -747,7 +748,7 @@ function renderResults(): void {
   const status = searchStatus(searchView, shown.length);
   searchStatusLine.textContent = status.text;
   searchStatusLine.classList.toggle("error", status.tone === "error");
-  searchStatusLine.hidden = shown.length > 0 && !searchView.running;
+  searchStatusLine.hidden = statusLineHidden(searchView, shown.length);
   searchProgress.textContent = searchView.snapshot
     ? `${searchView.snapshot.done}/${searchView.snapshot.total} sources`
     : "";

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -573,8 +573,10 @@ function renderTabs(): void {
         // already here: the server searches only that group's sources, so the
         // other tabs' hits were never fetched. Matches the TUI, where each tab
         // is its own slice of one fan-out.
-        if (searchView.query) startSearch(searchView.query);
-        else renderResults();
+        // `mode`, not `query`: a browse has an empty query but absolutely needs
+        // re-running, because the server only fetched the old tab's sources.
+        if (searchView.mode === "idle") renderResults();
+        else startSearch(searchView.query);
       });
       return button;
     }),
@@ -605,7 +607,10 @@ function stopSearch(): void {
 
 function startSearch(query: string): void {
   stopSearch();
-  searchView = { ...searchView, query, snapshot: null, running: true };
+  // An empty query is browse mode, not a mistake — the server accepts it and
+  // every source answers with its own top/latest list. See parseSearchParams.
+  const mode = query ? "search" : "browse";
+  searchView = { ...searchView, query, mode, snapshot: null, running: true };
   selectedHash = null;
   preview.select(null, searchView.group);
   renderResults();
@@ -656,9 +661,9 @@ function startSearch(query: string): void {
 
 searchForm.addEventListener("submit", (event) => {
   event.preventDefault();
-  const query = queryInput.value.trim();
-  if (!query) return;
-  startSearch(query);
+  // No guard on an empty value: submitting a blank box is how you browse the
+  // top lists, the same as pressing Enter on an empty box in the TUI.
+  startSearch(queryInput.value.trim());
 });
 
 sortSelect.addEventListener("change", () => {

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -50,12 +50,7 @@
       <section id="pane-search">
         <form id="search" class="card">
           <label for="query">Search every source</label>
-          <input
-            id="query"
-            type="search"
-            placeholder="the matrix 1999 — or leave blank to browse"
-            autocomplete="off"
-          />
+          <input id="query" type="search" placeholder="the matrix 1999 — or leave blank to browse" autocomplete="off" />
           <button type="submit">Search</button>
         </form>
 

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -90,7 +90,7 @@
           <span id="search-progress" class="progress"></span>
         </div>
 
-        <p id="search-status" class="empty">Search across every enabled source.</p>
+        <p id="search-status" class="empty">Search across every enabled source — or submit a blank box to browse.</p>
 
         <div class="split">
           <ul id="results" class="rows"></ul>

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -50,7 +50,12 @@
       <section id="pane-search">
         <form id="search" class="card">
           <label for="query">Search every source</label>
-          <input id="query" type="search" placeholder="the matrix 1999" autocomplete="off" />
+          <input
+            id="query"
+            type="search"
+            placeholder="the matrix 1999 — or leave blank to browse"
+            autocomplete="off"
+          />
           <button type="submit">Search</button>
         </form>
 

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -286,6 +286,21 @@ describe("searchStatus", () => {
       "Search across every enabled source — or submit a blank box to browse.",
     );
   });
+
+  it("does not blame an active filter for an upstream that returned nothing while browsing", () => {
+    const v = browsing({ hideDead: true, snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(searchStatus(v, 0).text).toBe("Nothing new right now.");
+  });
+
+  it("does not blame an active filter for an upstream that returned nothing while searching", () => {
+    const v = view({ hideDead: true, snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(searchStatus(v, 0).text).toBe("No results for “sintel”.");
+  });
+
+  it("uses the singular for exactly one browse result", () => {
+    const v = browsing({ snapshot: snapshot([result()], { total: 3, done: 3 }) });
+    expect(searchStatus(v, 1).text).toBe("1 result · newest across all sources");
+  });
 });
 
 describe("statusLineHidden", () => {

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -6,6 +6,7 @@ import {
   categoryTabs,
   emptyView,
   erroredSources,
+  modeForQuery,
   previewApplies,
   progressLabel,
   reportsHealthLookup,
@@ -281,7 +282,9 @@ describe("searchStatus", () => {
   });
 
   it("still shows the idle line before anything is submitted", () => {
-    expect(searchStatus(emptyView(), 0).text).toBe("Search across every enabled source.");
+    expect(searchStatus(emptyView(), 0).text).toBe(
+      "Search across every enabled source — or submit a blank box to browse.",
+    );
   });
 });
 
@@ -313,6 +316,21 @@ describe("statusLineHidden", () => {
 
   it("keeps the line up before anything has been submitted", () => {
     expect(statusLineHidden(emptyView(), 0)).toBe(false);
+  });
+});
+
+describe("modeForQuery", () => {
+  it("is search for real text", () => {
+    expect(modeForQuery("sintel")).toBe("search");
+  });
+
+  it("is browse for an empty string", () => {
+    expect(modeForQuery("")).toBe("browse");
+  });
+
+  it("is browse for whitespace-only text, matching the server's trim", () => {
+    expect(modeForQuery("   ")).toBe("browse");
+    expect(modeForQuery("\t\n")).toBe("browse");
   });
 });
 

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -249,6 +249,17 @@ describe("searchStatus", () => {
     expect(searchStatus(v, 4).text).toBe("4 results · newest across all sources");
   });
 
+  it("composes the outage note and the browse tail, in that order", () => {
+    const v = browsing({
+      snapshot: snapshot([result()], {
+        total: 3,
+        done: 3,
+        perSource: { a: { loading: false, error: "timed out", code: "timed out", count: 0 } },
+      }),
+    });
+    expect(searchStatus(v, 4).text).toBe("4 results · 1 source down · newest across all sources");
+  });
+
   // The mode-independent branches must keep winning over the browse lines:
   // "every source is down" and "your filters did this" are still the truth.
   it("keeps the outage and filter branches while browsing", () => {

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -46,7 +46,12 @@ function snapshot(results: PublicSearchResult[], over: Partial<PublicSearchSnaps
 }
 
 function view(over: Partial<SearchView> = {}): SearchView {
-  return { ...emptyView(), query: "sintel", ...over };
+  return { ...emptyView(), query: "sintel", mode: "search", ...over };
+}
+
+/** A view mid-browse: the blank query the TUI sends on an empty submit. */
+function browsing(over: Partial<SearchView> = {}): SearchView {
+  return { ...emptyView(), query: "", mode: "browse", ...over };
 }
 
 const ALWAYS_HEALTHY = (): boolean => true;
@@ -226,6 +231,46 @@ describe("searchStatus", () => {
     });
     expect(searchStatus(v, 4).text).toBe("4 results · 1 source down");
   });
+
+  it("counts sources while browsing, without calling it a search", () => {
+    const v = browsing({ running: true, snapshot: snapshot([], { done: 12, total: 23 }) });
+    expect(searchStatus(v, 0).text).toBe("Loading 12/23 sources");
+    expect(searchStatus(v, 5).text).toBe("loading… 12/23 sources");
+  });
+
+  it("says nothing is new rather than quoting an empty query", () => {
+    const v = browsing({ snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(searchStatus(v, 0).text).toBe("Nothing new right now.");
+    expect(searchStatus(v, 0).tone).toBe("dim");
+  });
+
+  it("labels browse results as the newest across all sources", () => {
+    const v = browsing({ snapshot: snapshot([result()], { total: 3, done: 3 }) });
+    expect(searchStatus(v, 4).text).toBe("4 results · newest across all sources");
+  });
+
+  // The mode-independent branches must keep winning over the browse lines:
+  // "every source is down" and "your filters did this" are still the truth.
+  it("keeps the outage and filter branches while browsing", () => {
+    const down = {
+      perSource: {
+        a: { loading: false, error: "timed out", code: "timed out", count: 0 },
+        b: { loading: false, error: "HTTP 503", code: "HTTP 503", count: 0 },
+      },
+      total: 2,
+      done: 2,
+    };
+    const failed = searchStatus(browsing({ snapshot: snapshot([], down) }), 0);
+    expect(failed.text).toBe("Couldn't reach any source. They may be down.");
+    expect(failed.tone).toBe("error");
+
+    const filtered = browsing({ snapshot: snapshot([result()], { total: 2, done: 2 }), textFilter: "zzz" });
+    expect(searchStatus(filtered, 0).text).toBe("Nothing matches those filters.");
+  });
+
+  it("still shows the idle line before anything is submitted", () => {
+    expect(searchStatus(emptyView(), 0).text).toBe("Search across every enabled source.");
+  });
 });
 
 describe("progressLabel / erroredSources", () => {
@@ -254,6 +299,10 @@ describe("searchUrl", () => {
 
   it("omits ?k= entirely on a tokenless server", () => {
     expect(searchUrl("x", "All", "")).toBe("/api/search?q=x&group=All");
+  });
+
+  it("sends q= for a browse, so the server can tell blank from absent", () => {
+    expect(searchUrl("", "All", "")).toBe("/api/search?q=&group=All");
   });
 });
 

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -14,6 +14,7 @@ import {
   searchStatus,
   searchUrl,
   sourceLabel,
+  statusLineHidden,
   visibleResults,
   type PublicSearchResult,
   type PublicSearchSnapshot,
@@ -281,6 +282,37 @@ describe("searchStatus", () => {
 
   it("still shows the idle line before anything is submitted", () => {
     expect(searchStatus(emptyView(), 0).text).toBe("Search across every enabled source.");
+  });
+});
+
+describe("statusLineHidden", () => {
+  it("hides the line for a settled search with rows — the count is redundant with the rows themselves", () => {
+    const v = view({ snapshot: snapshot([result()], { total: 1, done: 1 }) });
+    expect(statusLineHidden(v, 1)).toBe(true);
+  });
+
+  it("keeps the line up while a search is still running, even with rows already in", () => {
+    const v = view({ running: true, snapshot: snapshot([result()], { total: 3, done: 1 }) });
+    expect(statusLineHidden(v, 1)).toBe(false);
+  });
+
+  it("keeps the line up for a settled search with no rows — it's the only message the user gets", () => {
+    const v = view({ snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(statusLineHidden(v, 0)).toBe(false);
+  });
+
+  it("keeps the line up for a settled browse with rows — it names what the rows are", () => {
+    const v = browsing({ snapshot: snapshot([result()], { total: 3, done: 3 }) });
+    expect(statusLineHidden(v, 1)).toBe(false);
+  });
+
+  it("keeps the line up for a settled browse with no rows", () => {
+    const v = browsing({ snapshot: snapshot([], { total: 2, done: 2 }) });
+    expect(statusLineHidden(v, 0)).toBe(false);
+  });
+
+  it("keeps the line up before anything has been submitted", () => {
+    expect(statusLineHidden(emptyView(), 0)).toBe(false);
   });
 });
 

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -83,8 +83,15 @@ export function sourceLabel(sources: SourcesResponse | null, id: string): string
 
 /** Everything the results list is rendered from. */
 export interface SearchView {
-  /** The submitted query. Empty before the first search. */
+  /** The submitted query. Empty in `browse` mode and before the first submit. */
   query: string;
+  /**
+   * Which of three states the pane is in. This is NOT derivable from `query`:
+   * browse mode submits the empty string, so `!query` alone cannot tell "the
+   * user asked for the top lists" from "nothing has been submitted yet", and
+   * conflating them makes a browse render as a fresh page.
+   */
+  mode: "idle" | "search" | "browse";
   /** `ALL_TAB` or one of the server's group names. */
   group: string;
   /** The latest frame, or null before one arrives. */
@@ -99,6 +106,7 @@ export interface SearchView {
 export function emptyView(): SearchView {
   return {
     query: "",
+    mode: "idle",
     group: ALL_TAB,
     snapshot: null,
     running: false,
@@ -150,10 +158,18 @@ export interface SearchStatus {
 }
 
 export function searchStatus(view: SearchView, shown: number): SearchStatus {
-  if (!view.query) return { text: "Search across every enabled source.", tone: "dim" };
+  if (view.mode === "idle") return { text: "Search across every enabled source.", tone: "dim" };
+  const browse = view.mode === "browse";
   const progress = progressLabel(view.snapshot);
   if (view.running) {
-    const head = shown > 0 ? `searching… ${progress}` : `Searching ${progress}`;
+    // "Loading" not "Searching" while browsing: nothing was searched for. Same
+    // word the TUI's spinner uses for the same state. Both casings are spelled
+    // out rather than derived — `noUncheckedIndexedAccess` makes `verb[0]`
+    // possibly-undefined, and a two-word table is clearer than appeasing it.
+    const head =
+      shown > 0
+        ? `${browse ? "loading" : "searching"}… ${progress}`
+        : `${browse ? "Loading" : "Searching"} ${progress}`;
     return { text: head, tone: "dim" };
   }
   const down = erroredSources(view.snapshot);
@@ -161,17 +177,23 @@ export function searchStatus(view: SearchView, shown: number): SearchStatus {
   if (shown === 0) {
     // Every source failing and every source finding nothing look identical in a
     // results list, so they must not read the same. This is the whole reason
-    // `perSource.error` is on the wire.
+    // `perSource.error` is on the wire. Both of these outrank the mode: they are
+    // true whether or not the user typed anything.
     if (total > 0 && down.length >= total) {
       return { text: "Couldn't reach any source. They may be down.", tone: "error" };
     }
     if (view.hideDead || view.textFilter.trim()) {
       return { text: "Nothing matches those filters.", tone: "dim" };
     }
+    if (browse) return { text: "Nothing new right now.", tone: "dim" };
     return { text: `No results for “${view.query}”.`, tone: "dim" };
   }
   const note = down.length > 0 ? ` · ${down.length} source${down.length === 1 ? "" : "s"} down` : "";
-  return { text: `${shown} result${shown === 1 ? "" : "s"}${note}`, tone: "dim" };
+  // The TUI drops the count while browsing because its panel title already says
+  // "latest". The web has no such title, so keep the count and append the
+  // phrase rather than replacing one true thing with another.
+  const tail = browse ? " · newest across all sources" : "";
+  return { text: `${shown} result${shown === 1 ? "" : "s"}${note}${tail}`, tone: "dim" };
 }
 
 /** The `GET /api/search` URL for a query. `token` empty means a tokenless server. */

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -197,6 +197,24 @@ export function searchStatus(view: SearchView, shown: number): SearchStatus {
   return { text: `${shown} result${shown === 1 ? "" : "s"}${note}${tail}`, tone: "dim" };
 }
 
+/**
+ * Whether the status line should be hidden once results are on screen.
+ *
+ * A settled search's status line is just a result count, and that count is
+ * redundant with the rows the user is already looking at — hide it. Browse
+ * mode's line is not a count, or not only one: `searchStatus`'s "· newest
+ * across all sources" tail is the only thing on the page saying these rows
+ * are a curated top list rather than a match for something typed, so it must
+ * stay up exactly when there are rows to explain. Anything still `running` or
+ * with nothing to show keeps the line for the same reason `searchStatus` still
+ * has something to say then — the progress text and the empty-state messages
+ * ("Nothing new right now.", "Couldn't reach any source.", …) are the only
+ * content on the page in those cases.
+ */
+export function statusLineHidden(view: SearchView, shown: number): boolean {
+  return shown > 0 && !view.running && view.mode !== "browse";
+}
+
 /** The `GET /api/search` URL for a query. `token` empty means a tokenless server. */
 export function searchUrl(query: string, group: string, token: string): string {
   const params = new URLSearchParams({ q: query, group });

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -180,14 +180,18 @@ export function searchStatus(view: SearchView, shown: number): SearchStatus {
   const down = erroredSources(view.snapshot);
   const total = view.snapshot?.total ?? 0;
   if (shown === 0) {
-    // Every source failing and every source finding nothing look identical in a
-    // results list, so they must not read the same. This is the whole reason
-    // `perSource.error` is on the wire. Both of these outrank the mode: they are
-    // true whether or not the user typed anything.
+    // The outage branch outranks the mode: "every source is down" is true
+    // whether or not the user typed anything. The filter branch below is NOT
+    // mode-independent in the same way — see its own comment.
     if (total > 0 && down.length >= total) {
       return { text: "Couldn't reach any source. They may be down.", tone: "error" };
     }
-    if (view.hideDead || view.textFilter.trim()) {
+    // A filter can only be to blame if something arrived and was then removed.
+    // Without this check an empty upstream reads as the user's fault — and the
+    // TUI doesn't make that mistake (Results.tsx:538 gates the same message on
+    // having rows to filter).
+    const fetched = view.snapshot?.results.length ?? 0;
+    if (fetched > 0 && (view.hideDead || view.textFilter.trim())) {
       return { text: "Nothing matches those filters.", tone: "dim" };
     }
     if (browse) return { text: "Nothing new right now.", tone: "dim" };

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -83,7 +83,7 @@ export function sourceLabel(sources: SourcesResponse | null, id: string): string
 
 /** Everything the results list is rendered from. */
 export interface SearchView {
-  /** The submitted query. Empty in `browse` mode and before the first submit. */
+  /** The submitted query. Only meaningful in `"search"` mode. */
   query: string;
   /**
    * Which of three states the pane is in. This is NOT derivable from `query`:
@@ -162,10 +162,11 @@ export function searchStatus(view: SearchView, shown: number): SearchStatus {
   const browse = view.mode === "browse";
   const progress = progressLabel(view.snapshot);
   if (view.running) {
-    // "Loading" not "Searching" while browsing: nothing was searched for. Same
-    // word the TUI's spinner uses for the same state. Both casings are spelled
-    // out rather than derived — `noUncheckedIndexedAccess` makes `verb[0]`
-    // possibly-undefined, and a two-word table is clearer than appeasing it.
+    // "Loading" not "Searching" while browsing: nothing was searched for. Both
+    // casings are spelled out rather than capitalized at runtime — the literal
+    // strings are what you grep for when a status line looks wrong.
+    // The TUI's lowercase line (Results.tsx:510) says "searching…" even while
+    // browsing; that reads wrong and is not worth copying.
     const head =
       shown > 0
         ? `${browse ? "loading" : "searching"}… ${progress}`

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -158,7 +158,11 @@ export interface SearchStatus {
 }
 
 export function searchStatus(view: SearchView, shown: number): SearchStatus {
-  if (view.mode === "idle") return { text: "Search across every enabled source.", tone: "dim" };
+  if (view.mode === "idle")
+    return {
+      text: "Search across every enabled source — or submit a blank box to browse.",
+      tone: "dim",
+    };
   const browse = view.mode === "browse";
   const progress = progressLabel(view.snapshot);
   if (view.running) {
@@ -213,6 +217,20 @@ export function searchStatus(view: SearchView, shown: number): SearchStatus {
  */
 export function statusLineHidden(view: SearchView, shown: number): boolean {
   return shown > 0 && !view.running && view.mode !== "browse";
+}
+
+/**
+ * Which mode a submitted query puts the view into.
+ *
+ * Trims before deciding because the server does: `parseSearchParams` trims
+ * `raw` before checking for blank. A caller that used truthiness on the
+ * untrimmed string would label a whitespace-only submit `"search"` while the
+ * server treats it as a browse — the exact query/mode split this field exists
+ * to prevent, one layer up. Never returns `"idle"`; that is `emptyView()`'s
+ * business only.
+ */
+export function modeForQuery(query: string): SearchView["mode"] {
+  return query.trim() ? "search" : "browse";
 }
 
 /** The `GET /api/search` URL for a query. `token` empty means a tokenless server. */


### PR DESCRIPTION
## Summary

The TUI lets you press Enter on an empty search box to browse curated top lists. The web UI couldn't — not because the capability was missing, but because the web layer fenced it off.

Browse mode isn't new machinery: it's `query === ""` flowing through the existing `runSearch` pipeline, where each source already maps an empty query to its own top/latest endpoint (apibay Top-100, 1337x `/popular-*`, YTS `date_added`, EZTV browse). Two guards blocked it — a silent client-side `if (!query) return` and a hard 400 in `parseSearchParams`.

- **Server:** a blank `q` is now valid and means browse. A *bare* `GET /api/search` with no `q` at all still 400s, so a stray unparameterised request can't trigger a 23-source fan-out.
- **View state:** `SearchView` gained a required `mode: "idle" | "search" | "browse"`. `query` was overloaded to mean both the query text and "has anything run yet", which made a blank browse render identically to a fresh page.
- **Status lines** mirroring the TUI: `Loading n/m sources`, `Nothing new right now.`, and `n results · newest across all sources`. New pure helpers `modeForQuery` and `statusLineHidden` keep the decisions unit-testable — `app.ts` has no DOM test environment by design.
- **Discoverability:** the input placeholder and the idle status line both mention it. No auto-load on page open — a fresh tab would otherwise cost a full fan-out on every refresh.

Design and plan are committed under `docs/superpowers/`.

## Bugs found and fixed during review

- **Client/server disagreement:** the client used truthiness where the server trims, so `"   "` was labelled a *search* while the server browsed it — rendering `searching…` over top-list rows and `No results for “   ”` on empty.
- **Tab switching while browsing silently no-opped**, because the re-run was guarded on a non-empty query. The server only fetches the active tab's sources, so the rows were stale.
- **`newest across all sources` was invisible** in exactly the settled state where you'd read it: the status line is hidden once rows show. Unlike a result count, that label is the only thing saying *what* the rows are.
- **A blank reccd title** made the For You feed's search button silently fire a browse instead of failing.
- **The filter branch blamed your filters for an empty upstream** — with alive-only checked, a browse returning zero rows read "Nothing matches those filters." The TUI gates the same message on actually having rows to filter (`Results.tsx:538`).

## Test Plan

- [x] `npm test` — 108 files / 1406 tests passing
- [x] `npm run typecheck` clean; `eslint .` 0 errors (one pre-existing warning in untouched `src/ui/App.tsx:852`)
- [x] Blank submit → `GET /api/search?q=&group=All` → 200 → `807 results · 1 source down · newest across all sources` with real rows
- [x] Movies tab re-fires `q=&group=Movies` → 213 real top-list rows
- [x] Whitespace-only submit normalises to `q=` and the box is rewritten to match
- [x] A real query hides the status line and shows no browse tail
- [x] `GET /api/search` (no `q`) → 400; clean browser console
- [x] Socket-level tests cover the blank stream and blank-plus-group narrowing

## Known gap, deliberately left

There's no in-flight de-dupe on submit. On a token-protected server, a repeat Enter on the unlock form can land in the auto-focused empty box and fire a fan-out. Guarding it would also block legitimate re-submits to refresh a browse, so it's left as a follow-up decision rather than fixed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)