### PR TITLE
CLI: one flag per concept, one port per process

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ torlnk --web          # the TUI hosts it; quitting the TUI stops it
 torlnk serve --web    # headless: the add API plus the browser UI
 ```
 
-Either way it lands on **`http://127.0.0.1:9162`**, and `torlnk --web` prints the address on the splash. Change it with `--web-port`. Under `serve`, the UI port is derived from the API port + 1 (so `serve --port 8080 --web` puts the API on 8080 and the UI on 8081) unless you pass `--web-port` yourself.
+`torlnk --web` lands on **`http://127.0.0.1:9162`** and prints the address on the splash; `torlnk serve --web` lands on serve's own port, **`http://127.0.0.1:9161`**. Change either with `--port`. Under `serve` there's one server, not two: the same port answers the dashboard *and* `/add`, `/downloads` and `/control`, so there's one address to remember and one thing to firewall.
 
 **Turning it off is just leaving `--web` off** — there's no setting to forget about, and nothing listens until you ask for it. If the port is already taken, the TUI says so and carries on without the dashboard (the terminal is the product; a missing web UI shouldn't kill your session), while `serve --web` treats it as a startup failure and exits, because a daemon that came up half-configured is worse than one that didn't come up.
 
@@ -197,22 +197,22 @@ Either way it lands on **`http://127.0.0.1:9162`**, and `torlnk --web` prints th
 Binding anything other than loopback **requires** a token — torlink refuses to start rather than leave your queue open to the network:
 
 ```sh
-torlnk --web --web-host 0.0.0.0 --web-token "$(openssl rand -hex 16)"
+torlnk --web --host 0.0.0.0 --token "$(openssl rand -hex 16)"
+torlnk serve --web --host 0.0.0.0 --token "$(openssl rand -hex 16)"
 ```
 
-Under `serve` the UI binds serve's own `--host` and reuses its `--token`, so one process makes one exposure decision; only the port is separate, since two servers can't share one.
+Both commands read the same three flags — `--host`, `--port`, `--token` — because both are one process making one exposure decision.
 
 #### Setting the token
 
-Three ways, in the order torlink prefers them:
+Two ways, in the order torlink prefers them:
 
 | | |
 |---|---|
-| `--web-token <secret>` | Most specific. TUI only. |
-| `--token <secret>` | Works for both — this is `serve`'s own flag, and the TUI accepts it too so the muscle memory carries over. |
-| `TORLINK_API_TOKEN` | Environment. Keeps the secret out of your shell history and out of `ps`, which is what you want on a shared box. Used by `serve` and by `torlnk --web`. |
+| `--token <secret>` | The flag. Works on `--web`, `serve` and `files` alike. |
+| `TORLINK_API_TOKEN` | Environment. Keeps the secret out of your shell history and out of `ps`, which is what you want on a shared box. Used by `serve` and by `torlnk --web`; `files` reads `TORLINK_FILES_TOKEN`. |
 
-A flag beats the environment variable, and `--web-token` beats `--token`. The environment variable is only consulted when you actually pass `--web`, so a `TORLINK_API_TOKEN` you exported for the daemon doesn't quietly become a password on your interactive session.
+The flag beats the environment variable. The environment variable is only consulted when you actually pass `--web`, so a `TORLINK_API_TOKEN` you exported for the daemon doesn't quietly become a password on your interactive session.
 
 There's no token in the config file on purpose: `config.json` is world-readable in your home directory, and a shared secret doesn't belong there.
 
@@ -276,12 +276,12 @@ torlink also runs without the TUI, for servers and seedboxes:
 
     torlnk watch <dir>    download anything dropped into a folder
     torlnk serve          take magnets over HTTP
-    torlnk files          stream finished downloads over HTTP
+    torlnk files [dir]    stream finished downloads over HTTP
     torlnk attach         keep the TUI alive across ssh sessions
     torlnk import-netflix <csv>   send a Netflix viewing-activity CSV to reccd
     torlnk import-trakt           connect Trakt and import your history into reccd
 
-Add `--daemon` to keep watch, serve, or files running after you log out, or `--web` to `serve` for the [browser dashboard](#in-your-browser-optional) alongside the add API; `torlnk --help` has the full list of modes and flags.
+Add `--daemon` to keep watch, serve, or files running after you log out, or `--web` to `serve` for the [browser dashboard](#in-your-browser-optional) on the same port as the add API; `torlnk --help` has the full list of modes and flags.
 
 ## Contributing
 

--- a/docs/superpowers/plans/2026-07-28-cli-flag-consolidation.md
+++ b/docs/superpowers/plans/2026-07-28-cli-flag-consolidation.md
@@ -1,0 +1,1205 @@
+# CLI Flag Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the CLI to one canonical flag per concept (`--host`, `--port`, `--token`, `--to`), serve the browser UI on the same port as the API, and make unknown flags hard errors instead of silent no-ops.
+
+**Architecture:** One `scanFlags(args, spec)` helper replaces `splitBooleans` / `readFlags` / `RUN_VALUE_FLAGS` in `src/cli/args.ts`; every subcommand declares its own value/boolean flag spec and anything outside that spec is `{ kind: "invalid" }`. Removed spellings (`--web-host`, `--web-port`, `--web-token`, `--dir`) carry a per-flag hint through a new optional `hint` field on the invalid command. In `src/daemon/serve.ts`, `--web` stops starting a second listener: the web server already routes the whole daemon API (`src/web/routes.ts:1105`), so under `--web` it binds `--port` and is the only server.
+
+**Tech Stack:** TypeScript, Node 22, vitest, ink (TUI), node:http.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-cli-flag-consolidation-design.md`
+
+**Commands:** `npm test` (vitest run), `npx vitest run <path>` for one file, `npm run typecheck`, `npm run lint`, `npm run build`.
+
+**One intentional deviation from the spec's "Affected code" list:** the `App` component keeps its `webPort` / `webHost` / `webToken` prop names. They are internal props naming *the web mount* inside a component with many other concerns, so bare `host`/`port`/`token` would read as less clear, not more. Only the CLI surface and the user-facing warning strings change. `src/daemon/files.ts` also needs no change — its `FilesOptions.dir` stays; only where that value comes from changes.
+
+---
+
+### Task 1: Strict flag scanner and the `run` branch
+
+**Files:**
+- Modify: `src/cli/args.ts:5-78` (types, `splitBooleans`, `readFlags`), `src/cli/args.ts:159-200` (`RUN_VALUE_FLAGS`, `parseRun`)
+- Test: `src/cli/args.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the whole `describe("web flags", ...)` block (`src/cli/args.test.ts:195-387`) with:
+
+```ts
+describe("run flags", () => {
+  it("enables the web UI alongside the TUI", () => {
+    expect(parseCliArgs(["--web"])).toMatchObject({ kind: "run", web: true });
+  });
+
+  it("reads host, port and token for the TUI", () => {
+    expect(
+      parseCliArgs(["--web", "--host", "0.0.0.0", "--port", "8080", "--token", "s3cret"]),
+    ).toMatchObject({
+      kind: "run",
+      web: true,
+      host: "0.0.0.0",
+      port: 8080,
+      token: "s3cret",
+    });
+  });
+
+  it("combines a magnet with --web in either order", () => {
+    expect(parseCliArgs(["magnet:?xt=urn:btih:abc", "--web"])).toMatchObject({
+      kind: "run",
+      initialMagnet: "magnet:?xt=urn:btih:abc",
+      web: true,
+    });
+    expect(parseCliArgs(["--web", "magnet:?xt=urn:btih:abc"])).toMatchObject({
+      kind: "run",
+      initialMagnet: "magnet:?xt=urn:btih:abc",
+      web: true,
+    });
+  });
+
+  it("combines a .torrent path and an infohash with the web flags", () => {
+    expect(parseCliArgs(["./Foo.torrent", "--web", "--port", "8080"])).toMatchObject({
+      kind: "run",
+      initialTorrent: "./Foo.torrent",
+      web: true,
+      port: 8080,
+    });
+    const hash = "abcdef0123456789abcdef0123456789abcdef01";
+    expect(parseCliArgs(["--host", "127.0.0.1", "--web", hash])).toMatchObject({
+      kind: "run",
+      initialMagnet: hash,
+      web: true,
+      host: "127.0.0.1",
+    });
+  });
+
+  it("takes the flags without --web, so a mount site can still ignore them", () => {
+    expect(parseCliArgs(["--port", "8080"])).toMatchObject({
+      kind: "run",
+      web: false,
+      port: 8080,
+    });
+  });
+
+  it("ignores a port that is not a positive number", () => {
+    for (const bad of ["0", "-1", "nope"]) {
+      expect(parseCliArgs(["--web", "--port", bad])).toMatchObject({ web: true, port: undefined });
+    }
+  });
+
+  it("does not read a token from the environment (mount sites do that)", () => {
+    const prev = process.env.TORLINK_API_TOKEN;
+    process.env.TORLINK_API_TOKEN = "from-env";
+    try {
+      expect(parseCliArgs(["--web"])).toMatchObject({ kind: "run", web: true, token: undefined });
+      expect(parseCliArgs(["serve", "--web"])).toMatchObject({ kind: "serve", token: undefined });
+    } finally {
+      if (prev === undefined) delete process.env.TORLINK_API_TOKEN;
+      else process.env.TORLINK_API_TOKEN = prev;
+    }
+  });
+
+  // --- strictness: never silently swallow an unknown flag ---
+
+  it("still rejects an unknown flag that has a value after it", () => {
+    expect(parseCliArgs(["--nope", "value"])).toEqual({ kind: "invalid", arg: "--nope" });
+  });
+
+  it("rejects a value flag with no value", () => {
+    expect(parseCliArgs(["--web", "--port"])).toEqual({
+      kind: "invalid",
+      arg: "--port (missing value)",
+    });
+  });
+
+  it("rejects a second positional argument", () => {
+    expect(parseCliArgs(["magnet:?xt=urn:btih:abc", "./Foo.torrent"])).toEqual({
+      kind: "invalid",
+      arg: "./Foo.torrent",
+    });
+  });
+
+  it("rejects a non-hash bareword even with --web", () => {
+    expect(parseCliArgs(["--web", "hello"])).toEqual({ kind: "invalid", arg: "hello" });
+  });
+
+  // --- removed spellings get a hint, not a bare "unknown argument" ---
+
+  it("hints at --host when given the removed --web-host", () => {
+    expect(parseCliArgs(["--web", "--web-host", "0.0.0.0"])).toEqual({
+      kind: "invalid",
+      arg: "--web-host",
+      hint: "--web-host is not a flag; the web ui binds --host",
+    });
+  });
+
+  it("hints at --port when given the removed --web-port", () => {
+    expect(parseCliArgs(["--web", "--web-port", "8080"])).toEqual({
+      kind: "invalid",
+      arg: "--web-port",
+      hint: "--web-port is not a flag; the web ui binds --port",
+    });
+  });
+
+  it("hints at --token when given the removed --web-token", () => {
+    expect(parseCliArgs(["--web", "--web-token", "s3cret"])).toEqual({
+      kind: "invalid",
+      arg: "--web-token",
+      hint: "--web-token is not a flag; use --token",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/cli/args.test.ts`
+Expected: FAIL — `--web-host` still parses into `webHost`, `--port` is not a run flag, no `hint` field exists.
+
+- [ ] **Step 3: Replace the parsing machinery**
+
+In `src/cli/args.ts`, change the `run` and `invalid` members of `CliCommand` (`src/cli/args.ts:8-17` and `:48`) to:
+
+```ts
+  | {
+      kind: "run";
+      initialMagnet?: string;
+      initialTorrent?: string;
+      /** Host the browser dashboard in-process, sharing the TUI's queue. */
+      web?: boolean;
+      /** The interface, port and token the in-process dashboard binds. */
+      host?: string;
+      port?: number;
+      token?: string;
+    }
+```
+
+```ts
+  | { kind: "invalid"; arg: string; hint?: string };
+```
+
+Delete `BOOL_FLAGS`, `splitBooleans` and `readFlags` (`src/cli/args.ts:50-78`) and put this in their place:
+
+```ts
+/**
+ * Spellings that used to exist, mapped to the message that names their
+ * replacement. A removed flag must never read as a typo: the whole point of
+ * dropping `--web-host` was that it used to be *accepted and ignored*, so the
+ * one thing the error has to do is say where the setting went.
+ */
+const REMOVED_FLAGS: Record<string, string> = {
+  "web-host": "--web-host is not a flag; the web ui binds --host",
+  "web-port": "--web-port is not a flag; the web ui binds --port",
+  "web-token": "--web-token is not a flag; use --token",
+  dir: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+};
+
+/** What one subcommand accepts: `--flag value` pairs, and valueless booleans. */
+interface FlagSpec {
+  values: readonly string[];
+  bools: readonly string[];
+}
+
+type Scan =
+  | { ok: true; flags: Record<string, string>; bools: Set<string>; rest: string[] }
+  | { ok: false; error: CliCommand };
+
+/**
+ * The one argument reader every command uses. Strict by construction: a `--`
+ * token outside the command's own spec is an error, never a value quietly
+ * eaten off the next argument. That silent swallow is exactly how
+ * `serve --web-host 0.0.0.0` came to bind loopback and say nothing.
+ */
+function scanFlags(args: string[], spec: FlagSpec): Scan {
+  const flags: Record<string, string> = {};
+  const bools = new Set<string>();
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (!arg.startsWith("--")) {
+      rest.push(arg);
+      continue;
+    }
+    const name = arg.slice(2);
+    if (spec.bools.includes(name)) {
+      bools.add(name);
+      continue;
+    }
+    if (spec.values.includes(name)) {
+      const value = args[++i];
+      if (value === undefined) {
+        return { ok: false, error: { kind: "invalid", arg: `${arg} (missing value)` } };
+      }
+      flags[name] = value;
+      continue;
+    }
+    const hint = REMOVED_FLAGS[name];
+    return { ok: false, error: hint ? { kind: "invalid", arg, hint } : { kind: "invalid", arg } };
+  }
+  return { ok: true, flags, bools, rest };
+}
+
+const RUN_FLAGS: FlagSpec = { values: ["host", "port", "token"], bools: ["web"] };
+const WATCH_FLAGS: FlagSpec = {
+  values: ["to", "seed-time"],
+  bools: ["delete-files", "daemon"],
+};
+const SERVE_FLAGS: FlagSpec = {
+  values: ["port", "host", "token", "to", "seed-time"],
+  bools: ["delete-files", "daemon", "web"],
+};
+const FILES_FLAGS: FlagSpec = { values: ["port", "host", "token"], bools: ["daemon"] };
+```
+
+Delete `RUN_VALUE_FLAGS` and its comment (`src/cli/args.ts:155-159`) and replace `parseRun` with:
+
+```ts
+/**
+ * The bare invocation: an optional magnet / info hash / .torrent path, plus the
+ * web-UI flags, in any order. Order-independence is deliberate — `torlnk
+ * "magnet:?..." --web` and `torlnk --web "magnet:?..."` both read naturally, and
+ * accepting only one of them would mean silently dropping either the flag or the
+ * download in the other.
+ */
+function parseRun(args: string[]): CliCommand {
+  const scan = scanFlags(args, RUN_FLAGS);
+  if (!scan.ok) return scan.error;
+
+  let target: string | undefined;
+  for (const arg of scan.rest) {
+    if (target === undefined && isRunTarget(arg)) target = arg;
+    else return { kind: "invalid", arg };
+  }
+
+  const isTorrent = target !== undefined && /\.torrent$/i.test(target);
+  return {
+    kind: "run",
+    initialMagnet: isTorrent ? undefined : target,
+    initialTorrent: isTorrent ? target : undefined,
+    web: scan.bools.has("web"),
+    host: scan.flags.host,
+    port: parsePort(scan.flags.port),
+    token: scan.flags.token,
+  };
+}
+```
+
+The `watch`, `serve` and `files` branches still call the deleted helpers at this point, so the file will not compile until they are converted. Convert all three now by pasting in the final branch bodies from Task 2 Step 3, Task 3 Step 3 (including the `CliCommand` change that drops `webPort`) and Task 4 Step 3. Their tests arrive in those tasks; this step only keeps the tree building.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/cli/args.test.ts && npm run typecheck`
+Expected: the `run flags` block passes. Tests in the first `describe` that still use `--dir` (`src/cli/args.test.ts:79-87`, `:170-192`) fail — Tasks 2 and 4 rewrite them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/args.ts src/cli/args.test.ts
+git commit -m "refactor(cli): strict per-command flag scanner; --host/--port/--token on the TUI"
+```
+
+---
+
+### Task 2: `watch` — `--to` only
+
+**Files:**
+- Modify: `src/cli/args.ts` (the `watch` branch)
+- Test: `src/cli/args.test.ts:70-87`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the `"parses watch with a --to download dir"` test (`src/cli/args.test.ts:70-87`) with:
+
+```ts
+  it("parses watch with a --to download dir", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--to", "/mnt/media"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("rejects the removed --dir on watch with a hint", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--dir", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "--dir",
+      hint: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+    });
+  });
+  it("rejects a second positional on watch", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "/mnt/media",
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/cli/args.test.ts -t watch`
+Expected: FAIL — `--dir` still parses as a download dir.
+
+- [ ] **Step 3: Rewrite the `watch` branch**
+
+```ts
+  if (a === "watch") {
+    const scan = scanFlags(args.slice(1), WATCH_FLAGS);
+    if (!scan.ok) return scan.error;
+    const dir = scan.rest[0];
+    if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
+    // The folder to watch is the one positional this command takes; a second
+    // one is a `--to` the user forgot to name, not a second watch folder.
+    if (scan.rest.length > 1) return { kind: "invalid", arg: scan.rest[1]! };
+    return {
+      kind: "watch",
+      dir,
+      downloadDir: scan.flags.to,
+      seedTimeMs: seedTimeFrom(scan.flags["seed-time"]),
+      deleteFiles: scan.bools.has("delete-files"),
+      daemon: scan.bools.has("daemon"),
+    };
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/cli/args.test.ts -t watch`
+Expected: PASS (all `watch` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/args.ts src/cli/args.test.ts
+git commit -m "refactor(cli): watch takes --to only, rejects --dir with a hint"
+```
+
+---
+
+### Task 3: `serve` — no `--web-port`, no `--dir`, no stray barewords
+
+**Files:**
+- Modify: `src/cli/args.ts` (the `serve` branch)
+- Test: `src/cli/args.test.ts:116-158`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the first `describe` block, after `"ignores a bad --port"` (`src/cli/args.test.ts:159`):
+
+```ts
+  it("enables the web UI on serve without a second port", () => {
+    expect(parseCliArgs(["serve", "--web", "--port", "9999", "--host", "0.0.0.0"])).toMatchObject({
+      kind: "serve",
+      web: true,
+      port: 9999,
+      host: "0.0.0.0",
+    });
+  });
+  it("rejects the removed --web-port on serve with a hint", () => {
+    expect(parseCliArgs(["serve", "--web", "--web-port", "8080"])).toEqual({
+      kind: "invalid",
+      arg: "--web-port",
+      hint: "--web-port is not a flag; the web ui binds --port",
+    });
+  });
+  it("rejects the removed --web-host on serve with a hint", () => {
+    expect(parseCliArgs(["serve", "--web", "--web-host", "0.0.0.0"])).toEqual({
+      kind: "invalid",
+      arg: "--web-host",
+      hint: "--web-host is not a flag; the web ui binds --host",
+    });
+  });
+  it("rejects a bareword on serve instead of ignoring it", () => {
+    expect(parseCliArgs(["serve", "oops"])).toEqual({ kind: "invalid", arg: "oops" });
+  });
+  it("keeps --web out of serve's other flag values", () => {
+    expect(parseCliArgs(["serve", "--web", "--to", "/mnt/media"])).toMatchObject({
+      kind: "serve",
+      web: true,
+      downloadDir: "/mnt/media",
+    });
+  });
+```
+
+Also add `web: false` to the expected object in `"parses serve flags"` (`src/cli/args.test.ts:144-154`) if it is not already there — it is, at `:153`. No change needed to `"parses serve with defaults"`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/cli/args.test.ts -t serve`
+Expected: FAIL — `--web-port` parses into `webPort`, `serve oops` is silently ignored.
+
+- [ ] **Step 3: Rewrite the `serve` branch**
+
+Change the `serve` member of `CliCommand` (`src/cli/args.ts:26-42`) to drop `webPort` and re-word the `web` comment:
+
+```ts
+  | {
+      kind: "serve";
+      port?: number;
+      host?: string;
+      token?: string;
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+      /**
+       * Serve the browser dashboard instead of the bare JSON API. Same port,
+       * same host, same token: the web server already routes the whole API
+       * (web/routes.ts), so there is nothing for a second listener to add.
+       */
+      web?: boolean;
+    }
+```
+
+And the branch:
+
+```ts
+  if (a === "serve") {
+    const scan = scanFlags(args.slice(1), SERVE_FLAGS);
+    if (!scan.ok) return scan.error;
+    if (scan.rest.length > 0) return { kind: "invalid", arg: scan.rest[0]! };
+    return {
+      kind: "serve",
+      port: parsePort(scan.flags.port),
+      host: scan.flags.host,
+      token: scan.flags.token,
+      downloadDir: scan.flags.to,
+      seedTimeMs: seedTimeFrom(scan.flags["seed-time"]),
+      deleteFiles: scan.bools.has("delete-files"),
+      daemon: scan.bools.has("daemon"),
+      web: scan.bools.has("web"),
+    };
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/cli/args.test.ts -t serve && npm run typecheck`
+Expected: the `serve` tests pass. `typecheck` fails in `src/index.tsx` (`cmd.webPort` no longer exists) — Task 8 fixes it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/args.ts src/cli/args.test.ts
+git commit -m "refactor(cli): serve drops --web-port/--dir and rejects unknown args"
+```
+
+---
+
+### Task 4: `files` — folder as a positional
+
+**Files:**
+- Modify: `src/cli/args.ts` (the `files` branch)
+- Test: `src/cli/args.test.ts:160-192`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the `"parses files flags"` test (`src/cli/args.test.ts:170-192`) with:
+
+```ts
+  it("parses files flags with the folder as a positional", () => {
+    expect(
+      parseCliArgs([
+        "files",
+        "/mnt/media",
+        "--port",
+        "9160",
+        "--host",
+        "0.0.0.0",
+        "--token",
+        "s3cret",
+        "--daemon",
+      ]),
+    ).toEqual({
+      kind: "files",
+      port: 9160,
+      host: "0.0.0.0",
+      token: "s3cret",
+      dir: "/mnt/media",
+      daemon: true,
+    });
+  });
+  it("takes the folder positionally in any position", () => {
+    expect(parseCliArgs(["files", "--port", "9160", "/mnt/media"])).toMatchObject({
+      kind: "files",
+      dir: "/mnt/media",
+      port: 9160,
+    });
+  });
+  it("rejects the removed --dir on files with a hint", () => {
+    expect(parseCliArgs(["files", "--dir", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "--dir",
+      hint: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+    });
+  });
+  it("rejects a second positional on files", () => {
+    expect(parseCliArgs(["files", "/mnt/a", "/mnt/b"])).toEqual({
+      kind: "invalid",
+      arg: "/mnt/b",
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/cli/args.test.ts -t files`
+Expected: FAIL — the positional lands nowhere and `--dir` still parses.
+
+- [ ] **Step 3: Rewrite the `files` branch**
+
+```ts
+  if (a === "files") {
+    const scan = scanFlags(args.slice(1), FILES_FLAGS);
+    if (!scan.ok) return scan.error;
+    // Positional, like `watch <dir>`: across the CLI a bare directory is always
+    // the folder the command operates on, and --to is always where output goes.
+    if (scan.rest.length > 1) return { kind: "invalid", arg: scan.rest[1]! };
+    return {
+      kind: "files",
+      port: parsePort(scan.flags.port),
+      host: scan.flags.host,
+      token: scan.flags.token,
+      dir: scan.rest[0],
+      daemon: scan.bools.has("daemon"),
+    };
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/cli/args.test.ts`
+Expected: PASS for every test except the `HELP_TEXT` block (Task 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/args.ts src/cli/args.test.ts
+git commit -m "refactor(cli): files takes its folder positionally"
+```
+
+---
+
+### Task 5: Surface the hint at the top level
+
+**Files:**
+- Modify: `src/index.tsx:21-25`
+
+- [ ] **Step 1: Write the failing test**
+
+There is no test harness for `src/index.tsx` (it is the entry module and runs on import). Verify by hand in Step 4 instead — do not invent a harness for four lines.
+
+- [ ] **Step 2: Read the current code**
+
+`src/index.tsx:21-25` is:
+
+```ts
+if (cmd.kind === "invalid") {
+  console.error(`error: unknown argument '${cmd.arg}'\n`);
+  console.error(HELP_TEXT);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 3: Print the hint when there is one**
+
+```ts
+if (cmd.kind === "invalid") {
+  // A removed flag gets its replacement named. "unknown argument '--web-host'"
+  // is true but useless — the user is looking for the setting, not the spelling.
+  console.error(`error: ${cmd.hint ?? `unknown argument '${cmd.arg}'`}\n`);
+  console.error(HELP_TEXT);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 4: Verify by hand**
+
+Run: `npx tsx src/index.tsx serve --web --web-host 0.0.0.0; echo "exit=$?"`
+Expected: first line `error: --web-host is not a flag; the web ui binds --host`, then the help text, then `exit=1`.
+
+Run: `npx tsx src/index.tsx --nope; echo "exit=$?"`
+Expected: `error: unknown argument '--nope'`, then help, then `exit=1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.tsx
+git commit -m "feat(cli): name the replacement flag when a removed one is passed"
+```
+
+---
+
+### Task 6: Rewrite `HELP_TEXT`
+
+**Files:**
+- Modify: `src/cli/args.ts` (`HELP_TEXT`, from `usage` through the `files mode` block)
+- Test: `src/cli/args.test.ts:389-396`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the `HELP_TEXT` describe block (`src/cli/args.test.ts:389-396`) with:
+
+```ts
+describe("HELP_TEXT", () => {
+  it("documents the web UI on both hosts", () => {
+    expect(HELP_TEXT).toContain("torlnk --web");
+    expect(HELP_TEXT).toContain("torlnk serve --web");
+  });
+  it("documents only the canonical flags", () => {
+    expect(HELP_TEXT).toContain("--host <addr>");
+    expect(HELP_TEXT).toContain("--port <n>");
+    expect(HELP_TEXT).toContain("--token <secret>");
+    expect(HELP_TEXT).toContain("--to <dir>");
+  });
+  it("does not mention the removed spellings", () => {
+    for (const gone of ["--web-host", "--web-port", "--web-token", "--dir <dir>"]) {
+      expect(HELP_TEXT).not.toContain(gone);
+    }
+  });
+  it("shows the files folder as a positional", () => {
+    expect(HELP_TEXT).toContain("torlnk files [dir]");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/cli/args.test.ts -t HELP_TEXT`
+Expected: FAIL — the help still documents `--web-port` and `--web-host`.
+
+- [ ] **Step 3: Rewrite the help text**
+
+In `src/cli/args.ts`, replace the `usage` line for `files`, and the `serve mode`, `web ui`, and `files mode` blocks, so the whole `HELP_TEXT` reads:
+
+```ts
+export const HELP_TEXT = `torlink, terminal-native torrent search
+
+usage
+  torlnk                      open the search TUI
+  torlnk "magnet:?xt=..."     start a download on launch
+  torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk --web                open the TUI and serve the browser UI on :9162
+  torlnk watch <dir>          headless: download torrents dropped into <dir>
+  torlnk serve                headless: HTTP add API (POST /add) on :9161
+  torlnk serve --web          headless: the add API plus the browser UI on :9161
+  torlnk files [dir]          headless: serve downloads over HTTP on :9160
+  torlnk attach               open/reattach the TUI in a persistent tmux session
+  torlnk update [--force]     update to the latest release and restart any daemon
+                              (--force rebuilds/restarts even if already current)
+  torlnk import-netflix <csv>  send a Netflix "viewing activity" CSV to reccd
+  torlnk import-trakt          connect Trakt and import your history into reccd
+  torlnk --version            print the version
+
+once open: type to search every source at once, enter to run, arrows to move,
+d to download, ? for keys
+tip: quote magnet links (they contain & characters)
+
+flags, one name per thing
+  --host <addr>    the interface this process binds (default 127.0.0.1)
+  --port <n>       the port it binds (serve 9161, files 9160, --web 9162)
+  --token <secret> the shared secret; required to bind anything but loopback
+  --to <dir>       where downloads land (watch, serve)
+A bare directory argument is always the folder a command operates on
+(watch <dir>, files [dir]); --to is always where output goes.
+
+watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
+info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
+where files land. Handled files move to <dir>/.processed (or /.failed).
+
+seed mode (watch/serve): --seed-time <dur> stops seeding a torrent that long
+after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
+--delete-files to also remove the downloaded data when the timer expires.
+
+--daemon (watch/serve/files): background the process (own session, logs to a
+file), so you can log out and it keeps running. Prints the pid and log path.
+
+torlnk attach: run the TUI inside a persistent tmux session. Detach with
+tmux's ctrl-b d, log out, then torlnk attach again to reattach where you
+left off. Downloads and seeds keep running while detached.
+
+serve mode (no TUI): a small HTTP API for handing torlink a magnet.
+  POST /add {"magnet":"..."}   queue a magnet or info hash
+  GET  /downloads              list active downloads and seeds
+  GET  /health                 liveness (no auth)
+flags: --port <n> (default 9161), --host <addr>, --token <secret> (required
+to bind a public --host; or TORLINK_API_TOKEN), --to <dir> (where files land).
+
+web ui (--web): search, posters, streaming, the queue and For You in a
+browser, over the same queue as the process hosting it.
+  torlnk --web             the TUI hosts it; quitting the TUI stops it
+  torlnk serve --web       the daemon hosts it, on serve's own port
+It binds --host and --port like everything else — under serve there is one
+server, not two: the dashboard's port also answers /add, /downloads and
+/control. A non-loopback host is refused without a token.
+
+files mode (no TUI): a read-only, range-aware HTTP server over the downloads
+folder, so finished files stream to a browser or media player.
+  GET /            list the folder (JSON)
+  GET /<path>      stream a file (supports Range for seeking/resuming)
+flags: --port <n> (default 9160), --host <addr>, --token <secret> (required
+to bind a public --host; or TORLINK_FILES_TOKEN). Pass the folder to serve as
+a positional argument; it defaults to your downloads folder.
+
+logs: ${logFile}`;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/cli/args.test.ts`
+Expected: PASS, whole file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/args.ts src/cli/args.test.ts
+git commit -m "docs(cli): rewrite --help for the consolidated flag set"
+```
+
+---
+
+### Task 7: One listener under `serve --web`
+
+**Files:**
+- Modify: `src/daemon/serve.ts:29-42` (`ServeOptions`), `:280-345` (guards and the web mount), `:346-412` (the API server), `:425-440` (shutdown)
+- Test: `src/daemon/shutdown.test.ts:103-205`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/daemon/shutdown.test.ts`, replace the first five tests of `describe("runServe web mount", ...)` — `"serves the api and mounts the web ui on the api port + 1"` (`:139`), `"uses --web-port when one is given"` (`:161`), `"does not mount the web ui without --web"` (`:173`), `"warns when --web-port is set without --web"` (`:189`), and `"refuses to start when the web port equals the api port"` (`:199`) — with:
+
+```ts
+  it("serves the api and the web ui on one port", async () => {
+    const port = await freePortPair();
+    const before = new Set(process.listeners("SIGTERM"));
+    const done = runServe({ port, web: true, downloadDir: dir });
+    expect(await waitUntil(() => isListening(port))).toBe(true);
+
+    // One port answers both surfaces: the daemon API's bare paths and the
+    // dashboard's /api/*. That is the whole point of dropping --web-port.
+    const api = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(api.status).toBe(200);
+    const status = await fetch(`http://127.0.0.1:${port}/api/status`);
+    expect(status.status).toBe(200);
+    expect(await status.json()).toMatchObject({ downloads: [], seeds: [] });
+    const downloads = await fetch(`http://127.0.0.1:${port}/downloads`);
+    expect(downloads.status).toBe(200);
+
+    // Nothing on the port the old build derived for the dashboard.
+    expect(await isListening(port + 1)).toBe(false);
+
+    newSignalHandler(before)();
+    await done;
+  });
+
+  it("serves only the api without --web", async () => {
+    const port = await freePortPair();
+    const before = new Set(process.listeners("SIGTERM"));
+    const done = runServe({ port, downloadDir: dir });
+    expect(await waitUntil(() => isListening(port))).toBe(true);
+    const api = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(api.status).toBe(200);
+    // The dashboard's own routes are not mounted, and no second port is bound.
+    const ui = await fetch(`http://127.0.0.1:${port}/api/status`);
+    expect(ui.status).toBe(404);
+    expect(await isListening(port + 1)).toBe(false);
+    newSignalHandler(before)();
+    await done;
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/daemon/shutdown.test.ts`
+Expected: FAIL — `/api/status` on the API port 404s, and `port + 1` is listening.
+
+- [ ] **Step 3: Collapse the two servers into one**
+
+In `src/daemon/serve.ts`, drop `webPort` from `ServeOptions` and re-word the `web` doc comment:
+
+```ts
+  /**
+   * Serve the browser UI. It binds this same host and port: the web server
+   * already routes the entire daemon API (see web/routes.ts, which delegates
+   * every non-/api/ path to handleApi), so a second listener would only be a
+   * second copy of the same surface on a port nobody asked for.
+   */
+  web?: boolean;
+```
+
+Delete the `--web-port ignored without --web` warning block and the `webPort === port` collision check (`src/daemon/serve.ts:293-312`) entirely — neither flag exists any more.
+
+Replace the web-mount block (`src/daemon/serve.ts:319-343`) with:
+
+```ts
+  // With --web there is one server, not two. It binds the port the user chose,
+  // and answers both the dashboard and the add API — one process, one address,
+  // one exposure decision.
+  let web: WebServerHandle | null = null;
+  if (options.web) {
+    try {
+      web = await startWebServer(runtime, {
+        port,
+        host,
+        ...(token ? { token } : {}),
+        log,
+      });
+    } catch (e) {
+      // A startup failure, not a degraded mode: coming up with the dashboard
+      // silently missing is worse than not coming up at all.
+      await failStartup(
+        `error: could not start the web ui on port ${port}: ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+        null,
+      );
+      return;
+    }
+    log(`listening on http://${host}:${port}  (api + web ui, downloads -> ${runtime.downloadDir})`);
+    log(token ? "auth: token required" : "auth: none (loopback only)");
+  }
+```
+
+Wrap the bare API server so it only exists without `--web`. Change `const server = http.createServer((req, res) => {` (`src/daemon/serve.ts:346`) to:
+
+```ts
+  const server = options.web ? null : http.createServer((req, res) => {
+```
+
+Wrap the listen block (`src/daemon/serve.ts:397-412`) in a guard:
+
+```ts
+  if (server) {
+    const listenErr = await new Promise<Error | null>((resolve) => {
+      const onError = (err: Error): void => resolve(err);
+      server.once("error", onError);
+      server.listen(port, host, () => {
+        server.off("error", onError);
+        log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
+        log(token ? "auth: token required" : "auth: none (loopback only)");
+        resolve(null);
+      });
+    });
+    if (listenErr) {
+      await failStartup(`error: could not start the api on port ${port}: ${listenErr.message}`, web);
+      return;
+    }
+  }
+```
+
+And in the shutdown sequence, guard the API close (`src/daemon/serve.ts:425-440`):
+
+```ts
+        if (server) {
+          await new Promise<void>((done) => {
+            server.close(() => done());
+            // The same fix web/server.ts documents for the web server, and for
+            // the same reason: close() stops accepting and then waits for open
+            // connections to end, and a socket that is connected with no
+            // *complete* request in flight — a browser preconnect, a TCP health
+            // probe, a port scan, half-sent headers — never ends. One bare
+            // `net.connect` used to make Ctrl-C hang here forever, which is also
+            // what made `daemon/restart.ts` give up after 10s and report
+            // stillRunning: true, leaving `torlnk update` with the old daemon
+            // still alive.
+            server.closeAllConnections();
+          });
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/daemon/shutdown.test.ts src/daemon/serve.test.ts`
+Expected: PASS. Every remaining shutdown test that passes `web: true` now exercises the single-listener path unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/daemon/serve.ts src/daemon/shutdown.test.ts
+git commit -m "feat(serve): --web serves the api and the dashboard on one port"
+```
+
+---
+
+### Task 8: Wire the new command shapes at the entry point
+
+**Files:**
+- Modify: `src/index.tsx:58-78` (serve/files options), `:127-145` (App props)
+
+- [ ] **Step 1: Confirm the type errors that stand in for a test**
+
+Run: `npm run typecheck`
+Expected: FAIL — `cmd.webPort`, `cmd.webHost`, `cmd.webToken` no longer exist on the parsed commands.
+
+- [ ] **Step 2: Update the `serve` options**
+
+```ts
+} else if (cmd.kind === "serve") {
+  if (cmd.daemon) daemonize("serve");
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_API_TOKEN,
+    downloadDir: cmd.downloadDir,
+    seedTimeMs: cmd.seedTimeMs,
+    deleteFiles: cmd.deleteFiles,
+    web: cmd.web,
+  };
+  void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
+```
+
+The `files` branch (`src/index.tsx:69-78`) needs no change: `cmd.dir` still holds the folder, it just arrives positionally now.
+
+- [ ] **Step 3: Update the App props**
+
+```tsx
+    web={cmd.web}
+    webPort={cmd.port}
+    webHost={cmd.host}
+    // parseCliArgs is pure and never reads the environment, so the env fallback
+    // the daemon paths apply above has to be applied here too — otherwise
+    // `torlnk --web --host 0.0.0.0` with only TORLINK_API_TOKEN set is refused
+    // for a missing token the user did supply.
+    //
+    // Only on the --web path: merging it unconditionally would turn a
+    // TORLINK_API_TOKEN exported for the daemon into a phantom --token and make
+    // App warn about a flag nobody passed.
+    webToken={cmd.web ? (cmd.token ?? process.env.TORLINK_API_TOKEN) : cmd.token}
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run typecheck && npm run lint`
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.tsx
+git commit -m "refactor(cli): wire the consolidated flags through the entry point"
+```
+
+---
+
+### Task 9: The TUI's orphan-flag warning names the new flags
+
+**Files:**
+- Modify: `src/ui/App.tsx:533-546`
+- Test: `src/ui/App.web.test.tsx:295-311`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the `"does not start anything without --web, and warns about orphaned flags"` test (`src/ui/App.web.test.tsx:295-311`) with:
+
+```ts
+  it("does not start anything without --web, and warns about orphaned flags", async () => {
+    const start = vi.fn(async () => makeHandle());
+    const ui = renderUI(<App webPort={19002} startWebServerImpl={start} />);
+    try {
+      await vi.waitFor(() =>
+        expect(logSpies.warn).toHaveBeenCalledWith("[web] --port ignored without --web"),
+      );
+      expect(start).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(ui.frame()).toContain("Search"));
+      ui.press(TAB);
+      await vi.waitFor(() => expect(ui.frame()).toContain("--port ignored without --web"));
+      expectNothingOnStdout();
+    } finally {
+      ui.unmount();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/ui/App.web.test.tsx -t orphaned`
+Expected: FAIL — the warning still says `--web-port`.
+
+- [ ] **Step 3: Rename the flags in the warning**
+
+In `src/ui/App.tsx`, replace the orphan-flag effect (`src/ui/App.tsx:533-546`):
+
+```tsx
+  // `--port 8080` without `--web` parses fine and does nothing. Say so rather
+  // than silently accepting a flag the user believes turned something on.
+  useEffect(() => {
+    if (web) return;
+    const orphans = [
+      webPort !== undefined ? "--port" : null,
+      webHost ? "--host" : null,
+      webToken ? "--token" : null,
+    ].filter((f): f is string => f !== null);
+    if (orphans.length === 0) return;
+    log.warn(`[web] ${orphans.join(", ")} ignored without --web`);
+    setNotice(`${orphans.join(", ")} ignored without --web`);
+  }, [web, webPort, webHost, webToken]);
+```
+
+The props keep their names: they configure the web mount, and inside this component `port`/`host`/`token` would be ambiguous. Only the user-facing strings change.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/ui/App.web.test.tsx`
+Expected: PASS, whole file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/App.tsx src/ui/App.web.test.tsx
+git commit -m "fix(tui): orphan-flag warning names the canonical flags"
+```
+
+---
+
+### Task 10: README
+
+**Files:**
+- Modify: `README.md:184-215` (the browser section), `README.md:284` (the headless summary)
+
+- [ ] **Step 1: Replace the "In your browser" opening**
+
+`README.md:191` currently reads:
+
+> Either way it lands on **`http://127.0.0.1:9162`**, and `torlnk --web` prints the address on the splash. Change it with `--web-port`. Under `serve`, the UI port is derived from the API port + 1 (so `serve --port 8080 --web` puts the API on 8080 and the UI on 8081) unless you pass `--web-port` yourself.
+
+Replace it with:
+
+```markdown
+`torlnk --web` lands on **`http://127.0.0.1:9162`** and prints the address on the splash; `torlnk serve --web` lands on serve's own port, **`http://127.0.0.1:9161`**. Change either with `--port`. Under `serve` there's one server, not two: the same port answers the dashboard *and* `/add`, `/downloads` and `/control`, so there's one address to remember and one thing to firewall.
+```
+
+- [ ] **Step 2: Replace the "Reaching it from another device" block**
+
+`README.md:198-215` (from the code fence through the paragraph ending "doesn't quietly become a password on your interactive session.") becomes:
+
+````markdown
+```sh
+torlnk --web --host 0.0.0.0 --token "$(openssl rand -hex 16)"
+torlnk serve --web --host 0.0.0.0 --token "$(openssl rand -hex 16)"
+```
+
+Both commands read the same three flags — `--host`, `--port`, `--token` — because both are one process making one exposure decision.
+
+#### Setting the token
+
+Two ways, in the order torlink prefers them:
+
+| | |
+|---|---|
+| `--token <secret>` | The flag. Works on `--web`, `serve` and `files` alike. |
+| `TORLINK_API_TOKEN` | Environment. Keeps the secret out of your shell history and out of `ps`, which is what you want on a shared box. Used by `serve` and by `torlnk --web`; `files` reads `TORLINK_FILES_TOKEN`. |
+
+The flag beats the environment variable. The environment variable is only consulted when you actually pass `--web`, so a `TORLINK_API_TOKEN` you exported for the daemon doesn't quietly become a password on your interactive session.
+````
+
+- [ ] **Step 3: Update the headless summary**
+
+`README.md:279` lists `torlnk files          stream finished downloads over HTTP`. Change that line to:
+
+```
+    torlnk files [dir]    stream finished downloads over HTTP
+```
+
+And `README.md:284` currently ends "...or `--web` to `serve` for the [browser dashboard](#in-your-browser-optional) alongside the add API". Change that clause to:
+
+```markdown
+or `--web` to `serve` for the [browser dashboard](#in-your-browser-optional) on the same port as the add API
+```
+
+- [ ] **Step 4: Verify no stale flag names remain**
+
+Run: `grep -n -- "--web-port\|--web-host\|--web-token\|--dir" README.md src/ docs/superpowers/plans/ --include="*.ts" --include="*.tsx" --include="*.md" -r`
+Expected: matches only in `docs/superpowers/specs/2026-07-28-cli-flag-consolidation-design.md`, this plan, and the `REMOVED_FLAGS` table plus its tests. No matches in `README.md` outside the removal context, none in `HELP_TEXT`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: README follows the consolidated flag set"
+```
+
+---
+
+### Task 11: Full verification
+
+**Files:** none — this task only runs things.
+
+- [ ] **Step 1: The whole suite**
+
+Run: `npm test`
+Expected: all files pass. If `src/web/server.test.ts:126` (`"binds a public host when a token is set"`) still has a comment mentioning `--web-host`, reword it to `--host` — it is a comment, not a behaviour.
+
+- [ ] **Step 2: Types and lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: both clean, no output.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: `ESM ⚡️ Build success` twice, then `postbuild: wrote dist/cli.cjs ...`.
+
+- [ ] **Step 4: The original bug, end to end**
+
+Run: `node dist/index.js serve --web --host 0.0.0.0 --token a`
+Expected, within a second or two:
+
+```
+[torlnk serve] ... web ui on http://0.0.0.0:9161 (token required)
+[torlnk serve] ... listening on http://0.0.0.0:9161  (api + web ui, downloads -> ...)
+[torlnk serve] ... auth: token required
+```
+
+No `9162` anywhere. In another shell:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9161/health          # 200
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer a' \
+  http://127.0.0.1:9161/api/status                                             # 200
+```
+
+Then Ctrl-C and confirm the process exits rather than hanging.
+
+- [ ] **Step 5: The removed flags**
+
+```bash
+node dist/index.js serve --web --web-host 0.0.0.0; echo "exit=$?"   # hint + exit=1
+node dist/index.js serve --web --web-port 8080;    echo "exit=$?"   # hint + exit=1
+node dist/index.js watch /tmp --dir /tmp/out;      echo "exit=$?"   # hint + exit=1
+node dist/index.js files --dir /tmp;               echo "exit=$?"   # hint + exit=1
+```
+
+Expected: each prints `error: --<flag> is not a flag; ...` followed by the help, and exits 1.
+
+- [ ] **Step 6: `files` positional**
+
+Run: `node dist/index.js files /tmp` then `curl -s http://127.0.0.1:9160/ | head -c 200`
+Expected: a JSON listing of `/tmp`. Ctrl-C to stop.
+
+- [ ] **Step 7: Commit anything the verification turned up**
+
+```bash
+git add -A
+git commit -m "chore: verification fixes for the flag consolidation"
+```
+
+(Skip if the tree is clean.)
+
+---
+
+## Coverage against the spec
+
+| Spec requirement | Task |
+|---|---|
+| `--host` / `--port` / `--token` / `--to` canonical | 1, 2, 3, 4 |
+| `--web-host`, `--web-port`, `--web-token`, `--dir` removed | 1, 2, 3, 4 |
+| Per-flag hints on removed spellings | 1, 5 |
+| Unknown flags are hard errors on watch/serve/files | 1, 2, 3, 4 |
+| `files` folder positional | 4 |
+| One port per process under `serve --web` | 7 |
+| Defaults 9161 / 9160 / 9162 unchanged | 6 (documented), 7 (serve), unchanged elsewhere |
+| URL paths unchanged | not touched by any task, asserted in 7 |
+| Env var names unchanged | not touched by any task |
+| `--help` matches reality | 6 |
+| `README.md` matches reality | 10 |
+| Success criteria | 11 |

--- a/docs/superpowers/specs/2026-07-28-cli-flag-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-28-cli-flag-consolidation-design.md
@@ -1,0 +1,140 @@
+# CLI flag consolidation
+
+**Date:** 2026-07-28
+**Status:** approved, ready to plan
+
+## Problem
+
+The CLI has grown four names for concepts that only need one, and one name that
+means two different things. The overlap is not cosmetic: it produced a real
+failure where `torlnk serve --web --web-host 0.0.0.0 --token a` bound loopback
+and said nothing, because `serve` never reads `--web-host` and `readFlags`
+silently eats any unrecognised `--flag value` pair.
+
+Current surface:
+
+| Command | Flags |
+|---|---|
+| bare TUI (`run`) | `--web`, `--web-port`, `--web-host`, `--web-token`, `--token` |
+| `watch <dir>` | `--to` / `--dir`, `--seed-time`, `--delete-files`, `--daemon` |
+| `serve` | `--port`, `--host`, `--token`, `--to` / `--dir`, `--seed-time`, `--delete-files`, `--daemon`, `--web`, `--web-port` |
+| `files` | `--port`, `--host`, `--token`, `--dir`, `--daemon` |
+
+The specific collisions:
+
+1. `--host` vs `--web-host` — two names for one concept. `--web-host` works on
+   the TUI only and is silently ignored under `serve`.
+2. `--token` vs `--web-token` — pure alias with a precedence rule
+   (`--web-token` beats `--token`) that needs a README table to explain.
+3. `--to` vs `--dir` — synonyms on `watch`/`serve` (a *destination*), but on
+   `files` `--dir` is the *source* folder. One word, two opposite meanings.
+4. `--port` vs `--web-port` — defensible today (two listeners cannot share a
+   port), but it establishes `--web-*` as a general prefix, which is what makes
+   1 and 2 read as plausible.
+5. Unknown flags are silently swallowed on `watch`/`serve`/`files`. The bare TUI
+   correctly rejects them. This is the root cause of failure 1 being silent.
+
+## Decision
+
+A hard break to one canonical name per concept. No deprecation aliases: removed
+spellings become startup errors with a targeted hint. Flags are the cheap thing
+to break — a wrong flag fails loudly at start, once, and you fix your systemd
+unit.
+
+### Target flag surface
+
+| Flag | Meaning | Valid on |
+|---|---|---|
+| `--host <addr>` | the interface this process binds | run, serve, files |
+| `--port <n>` | the port it binds — API, UI, or both | run, serve, files |
+| `--token <secret>` | auth for whatever this process exposes | run, serve, files |
+| `--to <dir>` | where downloads land | watch, serve |
+| `--web` | also mount the browser UI on this process's port | run, serve |
+| `--seed-time <dur>`, `--delete-files`, `--daemon` | unchanged | as today |
+
+Removed: `--web-host`, `--web-port`, `--web-token`, `--dir`.
+
+Defaults stay per-command so a TUI and a daemon on one box do not collide:
+`serve` 9161, `files` 9160, TUI `--web` 9162.
+
+### One port per process
+
+`serve --web` stops starting a second listener. The web server already routes
+the entire daemon API — `src/web/routes.ts:1105` delegates every non-`/api/`
+path to `handleApi`, explicitly so the two cannot drift — so under `--web` the
+web server binds `--port` and is the only server. Without `--web`, `serve` runs
+its bare API server exactly as today.
+
+The two path namespaces are already disjoint, so no path remapping is needed:
+
+- daemon API: `/health`, `/status`, `/downloads`, `/add`, `/control`
+- web UI: `/api/*`, `/stream/*`, `/play/*`, static assets at `/`
+
+### Source vs destination
+
+`--dir` is deleted. A bare directory argument always means "the folder this
+command operates on"; `--to` always means "where output goes".
+
+```
+torlnk watch ~/inbox --to ~/movies     # source positional, destination flagged
+torlnk serve --to ~/movies             # destination flagged
+torlnk files ~/movies                  # source positional
+```
+
+`files` therefore takes its folder positionally and optionally, defaulting to
+the configured downloads folder as `--dir` does today.
+
+### Unknown flags are errors
+
+`watch`, `serve` and `files` reject any flag they do not define, matching the
+bare TUI. Removed flags get a specific hint rather than a generic message:
+
+```
+error: --web-host is not a flag; the web ui binds --host
+error: --web-port is not a flag; the web ui binds --port
+error: --web-token is not a flag; use --token
+error: --dir is not a flag; use --to (or pass the folder positionally to `files`)
+```
+
+## Explicitly not changing
+
+- **URL paths.** A moved URL fails silently inside someone's script; a wrong
+  flag fails loudly at startup. `/add` and `/api/add` coexisting is mild
+  redundancy, not a real cost.
+- **`TORLINK_API_TOKEN` / `TORLINK_FILES_TOKEN`.** Two env names for two
+  separately-exposed daemons is a deliberate split, not an accidental alias.
+
+## Accepted costs
+
+- `serve --web` moves the UI from `:9162` to `:9161`. Bookmarks and reverse
+  proxy config break once, visibly.
+- Losing `--web-port` means the JSON API can no longer be firewalled separately
+  from the UI. `src/daemon/serve.ts:319` calls that separation intentional; we
+  are judging it over-engineered for a single-user daemon and dropping it
+  knowingly.
+
+## Affected code
+
+- `src/cli/args.ts` — `CliCommand` shapes, `parseRun`, the `serve`/`watch`/
+  `files` branches, `readFlags` strictness, `HELP_TEXT`.
+- `src/index.tsx` — `serve`/`files` option construction, the `App` props for the
+  TUI web mount, the `TORLINK_API_TOKEN` fallback comment.
+- `src/ui/App.tsx` — `webHost`/`webPort`/`webToken` props become `host`/`port`/
+  `token`; the orphan-flag warning list.
+- `src/daemon/serve.ts` — single-listener path under `--web`; startup log.
+- `src/daemon/files.ts` — folder from the positional argument.
+- `README.md` — the flag tables, the token-precedence table (deletable), the
+  `--web-host` example.
+- Tests: `src/cli/args.test.ts`, `src/ui/App.web.test.tsx`, `src/web/server.test.ts`,
+  `src/daemon/serve.test.ts`.
+
+## Success criteria
+
+- `torlnk serve --web --host 0.0.0.0 --token a` serves the API and the UI on
+  `0.0.0.0:9161`, and logs one listening line.
+- `torlnk serve --web --web-host 0.0.0.0` exits non-zero with the hint above.
+- `torlnk files ~/movies` serves that folder; `torlnk files` serves the
+  downloads folder.
+- No non-loopback bind is possible without a token, on any command.
+- `--help` and `README.md` describe exactly the flags that exist, and the token
+  precedence table is gone because precedence no longer exists.

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -192,76 +192,29 @@ describe("parseCliArgs", () => {
   });
 });
 
-describe("web flags", () => {
-  it("enables the web UI on serve", () => {
-    expect(parseCliArgs(["serve", "--web"])).toMatchObject({ kind: "serve", web: true });
-  });
-
-  it("defaults serve web to off", () => {
-    expect(parseCliArgs(["serve"])).toMatchObject({ kind: "serve", web: false });
-  });
-
-  it("reads a web port and token on serve", () => {
-    expect(
-      parseCliArgs(["serve", "--web", "--web-port", "8080", "--token", "s3cret"]),
-    ).toMatchObject({
-      kind: "serve",
-      web: true,
-      webPort: 8080,
-      token: "s3cret",
-    });
-  });
-
+describe("run flags", () => {
   it("enables the web UI alongside the TUI", () => {
     expect(parseCliArgs(["--web"])).toMatchObject({ kind: "run", web: true });
   });
 
-  it("reads a web port and token for the TUI", () => {
+  it("reads host, port and token for the TUI", () => {
     expect(
-      parseCliArgs([
-        "--web",
-        "--web-port",
-        "8080",
-        "--web-host",
-        "0.0.0.0",
-        "--token",
-        "s3cret",
-      ]),
+      parseCliArgs(["--web", "--host", "0.0.0.0", "--port", "8080", "--token", "s3cret"]),
     ).toMatchObject({
       kind: "run",
       web: true,
-      webPort: 8080,
-      webHost: "0.0.0.0",
-      webToken: "s3cret",
+      host: "0.0.0.0",
+      port: 8080,
+      token: "s3cret",
     });
   });
 
-  it("still treats a bare magnet as a run", () => {
-    expect(parseCliArgs(["magnet:?xt=urn:btih:abc"])).toMatchObject({
-      kind: "run",
-      initialMagnet: "magnet:?xt=urn:btih:abc",
-    });
-  });
-
-  it("rejects an invalid web port rather than binding a random one", () => {
-    expect(parseCliArgs(["serve", "--web", "--web-port", "nope"])).toMatchObject({
-      kind: "serve",
-      web: true,
-      webPort: undefined,
-    });
-  });
-
-  // --- flag ordering: a magnet and --web must combine, in either order ---
-
-  it("combines a magnet with --web when the magnet comes first", () => {
+  it("combines a magnet with --web in either order", () => {
     expect(parseCliArgs(["magnet:?xt=urn:btih:abc", "--web"])).toMatchObject({
       kind: "run",
       initialMagnet: "magnet:?xt=urn:btih:abc",
       web: true,
     });
-  });
-
-  it("combines a magnet with --web when --web comes first", () => {
     expect(parseCliArgs(["--web", "magnet:?xt=urn:btih:abc"])).toMatchObject({
       kind: "run",
       initialMagnet: "magnet:?xt=urn:btih:abc",
@@ -269,28 +222,46 @@ describe("web flags", () => {
     });
   });
 
-  it("combines a .torrent path and an infohash with web flags", () => {
-    expect(parseCliArgs(["./Foo.torrent", "--web", "--web-port", "8080"])).toMatchObject({
+  it("combines a .torrent path and an infohash with the web flags", () => {
+    expect(parseCliArgs(["./Foo.torrent", "--web", "--port", "8080"])).toMatchObject({
       kind: "run",
       initialTorrent: "./Foo.torrent",
       web: true,
-      webPort: 8080,
+      port: 8080,
     });
     const hash = "abcdef0123456789abcdef0123456789abcdef01";
-    expect(parseCliArgs(["--web-host", "127.0.0.1", "--web", hash])).toMatchObject({
+    expect(parseCliArgs(["--host", "127.0.0.1", "--web", hash])).toMatchObject({
       kind: "run",
       initialMagnet: hash,
       web: true,
-      webHost: "127.0.0.1",
+      host: "127.0.0.1",
     });
   });
 
-  it("takes web flags without --web, so a mount site can still ignore them", () => {
-    expect(parseCliArgs(["--web-port", "8080"])).toMatchObject({
+  it("takes the flags without --web, so a mount site can still ignore them", () => {
+    expect(parseCliArgs(["--port", "8080"])).toMatchObject({
       kind: "run",
       web: false,
-      webPort: 8080,
+      port: 8080,
     });
+  });
+
+  it("ignores a port that is not a positive number", () => {
+    for (const bad of ["0", "-1", "nope"]) {
+      expect(parseCliArgs(["--web", "--port", bad])).toMatchObject({ web: true, port: undefined });
+    }
+  });
+
+  it("does not read a token from the environment (mount sites do that)", () => {
+    const prev = process.env.TORLINK_API_TOKEN;
+    process.env.TORLINK_API_TOKEN = "from-env";
+    try {
+      expect(parseCliArgs(["--web"])).toMatchObject({ kind: "run", web: true, token: undefined });
+      expect(parseCliArgs(["serve", "--web"])).toMatchObject({ kind: "serve", token: undefined });
+    } finally {
+      if (prev === undefined) delete process.env.TORLINK_API_TOKEN;
+      else process.env.TORLINK_API_TOKEN = prev;
+    }
   });
 
   // --- strictness: never silently swallow an unknown flag ---
@@ -299,10 +270,10 @@ describe("web flags", () => {
     expect(parseCliArgs(["--nope", "value"])).toEqual({ kind: "invalid", arg: "--nope" });
   });
 
-  it("rejects a web value flag with no value", () => {
-    expect(parseCliArgs(["--web", "--web-port"])).toEqual({
+  it("rejects a value flag with no value", () => {
+    expect(parseCliArgs(["--web", "--port"])).toEqual({
       kind: "invalid",
-      arg: "--web-port (missing value)",
+      arg: "--port (missing value)",
     });
   });
 
@@ -317,71 +288,29 @@ describe("web flags", () => {
     expect(parseCliArgs(["--web", "hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
 
-  // --- token spellings and precedence ---
+  // --- removed spellings get a hint, not a bare "unknown argument" ---
 
-  it("accepts --web-token as a spelling of the TUI web token", () => {
-    expect(parseCliArgs(["--web", "--web-token", "s3cret"])).toMatchObject({
-      kind: "run",
-      web: true,
-      webToken: "s3cret",
+  it("hints at --host when given the removed --web-host", () => {
+    expect(parseCliArgs(["--web", "--web-host", "0.0.0.0"])).toEqual({
+      kind: "invalid",
+      arg: "--web-host",
+      hint: "--web-host is not a flag; the web ui binds --host",
     });
   });
 
-  it("prefers the more specific --web-token over --token", () => {
-    expect(parseCliArgs(["--web", "--token", "general", "--web-token", "specific"])).toMatchObject({
-      kind: "run",
-      web: true,
-      webToken: "specific",
+  it("hints at --port when given the removed --web-port", () => {
+    expect(parseCliArgs(["--web", "--web-port", "8080"])).toEqual({
+      kind: "invalid",
+      arg: "--web-port",
+      hint: "--web-port is not a flag; the web ui binds --port",
     });
   });
 
-  it("does not read a token from the environment (mount sites do that)", () => {
-    const prev = process.env.TORLINK_API_TOKEN;
-    process.env.TORLINK_API_TOKEN = "from-env";
-    try {
-      expect(parseCliArgs(["--web"])).toMatchObject({ kind: "run", web: true, webToken: undefined });
-      expect(parseCliArgs(["serve", "--web"])).toMatchObject({ kind: "serve", token: undefined });
-    } finally {
-      if (prev === undefined) delete process.env.TORLINK_API_TOKEN;
-      else process.env.TORLINK_API_TOKEN = prev;
-    }
-  });
-
-  // --- port validation on both commands ---
-
-  it("rejects a non-positive web port on both commands", () => {
-    expect(parseCliArgs(["serve", "--web", "--web-port", "0"])).toMatchObject({
-      web: true,
-      webPort: undefined,
-    });
-    expect(parseCliArgs(["--web", "--web-port", "-1"])).toMatchObject({
-      web: true,
-      webPort: undefined,
-    });
-    expect(parseCliArgs(["--web", "--web-port", "nope"])).toMatchObject({
-      web: true,
-      webPort: undefined,
-    });
-  });
-
-  it("leaves serve's api port and host alone when --web is on", () => {
-    expect(
-      parseCliArgs(["serve", "--web", "--web-port", "8080", "--port", "9999", "--host", "0.0.0.0"]),
-    ).toMatchObject({
-      kind: "serve",
-      web: true,
-      webPort: 8080,
-      port: 9999,
-      host: "0.0.0.0",
-    });
-  });
-
-  it("keeps --web out of serve's other flag values", () => {
-    // If --web were not a valueless boolean it would eat the next token.
-    expect(parseCliArgs(["serve", "--web", "--to", "/mnt/media"])).toMatchObject({
-      kind: "serve",
-      web: true,
-      downloadDir: "/mnt/media",
+  it("hints at --token when given the removed --web-token", () => {
+    expect(parseCliArgs(["--web", "--web-token", "s3cret"])).toEqual({
+      kind: "invalid",
+      arg: "--web-token",
+      hint: "--web-token is not a flag; use --token",
     });
   });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -375,7 +375,19 @@ describe("HELP_TEXT", () => {
   it("documents the web UI on both hosts", () => {
     expect(HELP_TEXT).toContain("torlnk --web");
     expect(HELP_TEXT).toContain("torlnk serve --web");
-    expect(HELP_TEXT).toContain("--web-port <n>");
-    expect(HELP_TEXT).toContain("--web-host <addr>");
+  });
+  it("documents only the canonical flags", () => {
+    expect(HELP_TEXT).toContain("--host <addr>");
+    expect(HELP_TEXT).toContain("--port <n>");
+    expect(HELP_TEXT).toContain("--token <secret>");
+    expect(HELP_TEXT).toContain("--to <dir>");
+  });
+  it("does not mention the removed spellings", () => {
+    for (const gone of ["--web-host", "--web-port", "--web-token", "--dir <dir>"]) {
+      expect(HELP_TEXT).not.toContain(gone);
+    }
+  });
+  it("shows the files folder as a positional", () => {
+    expect(HELP_TEXT).toContain("torlnk files [dir]");
   });
 });

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -76,13 +76,18 @@ describe("parseCliArgs", () => {
       deleteFiles: false,
       daemon: false,
     });
-    expect(parseCliArgs(["watch", "--dir", "/mnt/media", "/srv/blackhole"])).toEqual({
-      kind: "watch",
-      dir: "/srv/blackhole",
-      downloadDir: "/mnt/media",
-      seedTimeMs: undefined,
-      deleteFiles: false,
-      daemon: false,
+  });
+  it("rejects the removed --dir on watch with a hint", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--dir", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "--dir",
+      hint: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+    });
+  });
+  it("rejects a second positional on watch", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "/mnt/media",
     });
   });
   it("parses watch --seed-time, --delete-files, and --daemon", () => {
@@ -157,6 +162,38 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["serve", "--port", "abc"]).kind).toBe("serve");
     expect((parseCliArgs(["serve", "--port", "abc"]) as { port?: number }).port).toBeUndefined();
   });
+  it("enables the web UI on serve without a second port", () => {
+    expect(parseCliArgs(["serve", "--web", "--port", "9999", "--host", "0.0.0.0"])).toMatchObject({
+      kind: "serve",
+      web: true,
+      port: 9999,
+      host: "0.0.0.0",
+    });
+  });
+  it("rejects the removed --web-port on serve with a hint", () => {
+    expect(parseCliArgs(["serve", "--web", "--web-port", "8080"])).toEqual({
+      kind: "invalid",
+      arg: "--web-port",
+      hint: "--web-port is not a flag; the web ui binds --port",
+    });
+  });
+  it("rejects the removed --web-host on serve with a hint", () => {
+    expect(parseCliArgs(["serve", "--web", "--web-host", "0.0.0.0"])).toEqual({
+      kind: "invalid",
+      arg: "--web-host",
+      hint: "--web-host is not a flag; the web ui binds --host",
+    });
+  });
+  it("rejects a bareword on serve instead of ignoring it", () => {
+    expect(parseCliArgs(["serve", "oops"])).toEqual({ kind: "invalid", arg: "oops" });
+  });
+  it("keeps --web out of serve's other flag values", () => {
+    expect(parseCliArgs(["serve", "--web", "--to", "/mnt/media"])).toMatchObject({
+      kind: "serve",
+      web: true,
+      downloadDir: "/mnt/media",
+    });
+  });
   it("parses files with defaults", () => {
     expect(parseCliArgs(["files"])).toEqual({
       kind: "files",
@@ -167,18 +204,17 @@ describe("parseCliArgs", () => {
       daemon: false,
     });
   });
-  it("parses files flags", () => {
+  it("parses files flags with the folder as a positional", () => {
     expect(
       parseCliArgs([
         "files",
+        "/mnt/media",
         "--port",
         "9160",
         "--host",
         "0.0.0.0",
         "--token",
         "s3cret",
-        "--dir",
-        "/mnt/media",
         "--daemon",
       ]),
     ).toEqual({
@@ -188,6 +224,26 @@ describe("parseCliArgs", () => {
       token: "s3cret",
       dir: "/mnt/media",
       daemon: true,
+    });
+  });
+  it("takes the folder positionally in any position", () => {
+    expect(parseCliArgs(["files", "--port", "9160", "/mnt/media"])).toMatchObject({
+      kind: "files",
+      dir: "/mnt/media",
+      port: 9160,
+    });
+  });
+  it("rejects the removed --dir on files with a hint", () => {
+    expect(parseCliArgs(["files", "--dir", "/mnt/media"])).toEqual({
+      kind: "invalid",
+      arg: "--dir",
+      hint: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+    });
+  });
+  it("rejects a second positional on files", () => {
+    expect(parseCliArgs(["files", "/mnt/a", "/mnt/b"])).toEqual({
+      kind: "invalid",
+      arg: "/mnt/b",
     });
   });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,9 +11,10 @@ export type CliCommand =
       initialTorrent?: string;
       /** Host the browser dashboard in-process, sharing the TUI's queue. */
       web?: boolean;
-      webPort?: number;
-      webHost?: string;
-      webToken?: string;
+      /** The interface, port and token the in-process dashboard binds. */
+      host?: string;
+      port?: number;
+      token?: string;
     }
   | {
       kind: "watch";
@@ -33,49 +34,87 @@ export type CliCommand =
       deleteFiles?: boolean;
       daemon?: boolean;
       /**
-       * Also mount the browser dashboard. It binds `host` — the same interface
-       * as the add API — so one process makes one exposure decision; only the
-       * port is separately configurable, because two servers cannot share one.
+       * Serve the browser dashboard instead of the bare JSON API. Same port,
+       * same host, same token: the web server already routes the whole API
+       * (web/routes.ts), so there is nothing for a second listener to add.
        */
       web?: boolean;
-      webPort?: number;
     }
   | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
   | { kind: "attach" }
   | { kind: "update"; force?: boolean }
   | { kind: "import-netflix"; file: string }
   | { kind: "import-trakt" }
-  | { kind: "invalid"; arg: string };
+  | { kind: "invalid"; arg: string; hint?: string };
 
-// Valueless boolean flags for the headless subcommands (everything else is a
-// `--flag value` pair).
-const BOOL_FLAGS = new Set(["delete-files", "daemon", "web"]);
+/**
+ * Spellings that used to exist, mapped to the message that names their
+ * replacement. A removed flag must never read as a typo: the whole point of
+ * dropping `--web-host` was that it used to be *accepted and ignored*, so the
+ * one thing the error has to do is say where the setting went.
+ */
+const REMOVED_FLAGS: Record<string, string> = {
+  "web-host": "--web-host is not a flag; the web ui binds --host",
+  "web-port": "--web-port is not a flag; the web ui binds --port",
+  "web-token": "--web-token is not a flag; use --token",
+  dir: "--dir is not a flag; use --to, or pass the folder to `torlnk files` positionally",
+};
 
-function splitBooleans(args: string[]): { bools: Set<string>; rest: string[] } {
-  const bools = new Set<string>();
-  const rest: string[] = [];
-  for (const arg of args) {
-    if (arg.startsWith("--") && BOOL_FLAGS.has(arg.slice(2))) bools.add(arg.slice(2));
-    else rest.push(arg);
-  }
-  return { bools, rest };
+/** What one subcommand accepts: `--flag value` pairs, and valueless booleans. */
+interface FlagSpec {
+  values: readonly string[];
+  bools: readonly string[];
 }
 
-// Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
-// left in `rest` so the caller can decide what to do with them.
-function readFlags(args: string[]): { flags: Record<string, string>; rest: string[] } {
+type Scan =
+  | { ok: true; flags: Record<string, string>; bools: Set<string>; rest: string[] }
+  | { ok: false; error: CliCommand };
+
+/**
+ * The one argument reader every command uses. Strict by construction: a `--`
+ * token outside the command's own spec is an error, never a value quietly
+ * eaten off the next argument. That silent swallow is exactly how
+ * `serve --web-host 0.0.0.0` came to bind loopback and say nothing.
+ */
+function scanFlags(args: string[], spec: FlagSpec): Scan {
   const flags: Record<string, string> = {};
+  const bools = new Set<string>();
   const rest: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
-    if (arg.startsWith("--") && i + 1 < args.length) {
-      flags[arg.slice(2)] = args[++i]!;
-    } else {
+    if (!arg.startsWith("--")) {
       rest.push(arg);
+      continue;
     }
+    const name = arg.slice(2);
+    if (spec.bools.includes(name)) {
+      bools.add(name);
+      continue;
+    }
+    if (spec.values.includes(name)) {
+      const value = args[++i];
+      if (value === undefined) {
+        return { ok: false, error: { kind: "invalid", arg: `${arg} (missing value)` } };
+      }
+      flags[name] = value;
+      continue;
+    }
+    const hint = REMOVED_FLAGS[name];
+    return { ok: false, error: hint ? { kind: "invalid", arg, hint } : { kind: "invalid", arg } };
   }
-  return { flags, rest };
+  return { ok: true, flags, bools, rest };
 }
+
+const RUN_FLAGS: FlagSpec = { values: ["host", "port", "token"], bools: ["web"] };
+const WATCH_FLAGS: FlagSpec = {
+  values: ["to", "seed-time"],
+  bools: ["delete-files", "daemon"],
+};
+const SERVE_FLAGS: FlagSpec = {
+  values: ["port", "host", "token", "to", "seed-time"],
+  bools: ["delete-files", "daemon", "web"],
+};
+const FILES_FLAGS: FlagSpec = { values: ["port", "host", "token"], bools: ["daemon"] };
 
 function parsePort(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
@@ -107,56 +146,55 @@ export function parseCliArgs(argv: string[]): CliCommand {
   }
   if (a === "import-trakt") return { kind: "import-trakt" };
   if (a === "watch") {
-    const { bools, rest: r0 } = splitBooleans(args.slice(1));
-    const { flags, rest } = readFlags(r0);
-    const dir = rest[0];
+    const scan = scanFlags(args.slice(1), WATCH_FLAGS);
+    if (!scan.ok) return scan.error;
+    const dir = scan.rest[0];
     if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
+    // The folder to watch is the one positional this command takes; a second
+    // one is a `--to` the user forgot to name, not a second watch folder.
+    if (scan.rest.length > 1) return { kind: "invalid", arg: scan.rest[1]! };
     return {
       kind: "watch",
       dir,
-      downloadDir: flags.to ?? flags.dir,
-      seedTimeMs: seedTimeFrom(flags["seed-time"]),
-      deleteFiles: bools.has("delete-files"),
-      daemon: bools.has("daemon"),
+      downloadDir: scan.flags.to,
+      seedTimeMs: seedTimeFrom(scan.flags["seed-time"]),
+      deleteFiles: scan.bools.has("delete-files"),
+      daemon: scan.bools.has("daemon"),
     };
   }
   if (a === "serve") {
-    const { bools, rest: r0 } = splitBooleans(args.slice(1));
-    const { flags } = readFlags(r0);
+    const scan = scanFlags(args.slice(1), SERVE_FLAGS);
+    if (!scan.ok) return scan.error;
+    if (scan.rest.length > 0) return { kind: "invalid", arg: scan.rest[0]! };
     return {
       kind: "serve",
-      port: parsePort(flags.port),
-      host: flags.host,
-      token: flags.token,
-      downloadDir: flags.to ?? flags.dir,
-      seedTimeMs: seedTimeFrom(flags["seed-time"]),
-      deleteFiles: bools.has("delete-files"),
-      daemon: bools.has("daemon"),
-      web: bools.has("web"),
-      webPort: parsePort(flags["web-port"]),
+      port: parsePort(scan.flags.port),
+      host: scan.flags.host,
+      token: scan.flags.token,
+      downloadDir: scan.flags.to,
+      seedTimeMs: seedTimeFrom(scan.flags["seed-time"]),
+      deleteFiles: scan.bools.has("delete-files"),
+      daemon: scan.bools.has("daemon"),
+      web: scan.bools.has("web"),
     };
   }
   if (a === "files") {
-    const { bools, rest: r0 } = splitBooleans(args.slice(1));
-    const { flags } = readFlags(r0);
+    const scan = scanFlags(args.slice(1), FILES_FLAGS);
+    if (!scan.ok) return scan.error;
+    // Positional, like `watch <dir>`: across the CLI a bare directory is always
+    // the folder the command operates on, and --to is always where output goes.
+    if (scan.rest.length > 1) return { kind: "invalid", arg: scan.rest[1]! };
     return {
       kind: "files",
-      port: parsePort(flags.port),
-      host: flags.host,
-      token: flags.token,
-      dir: flags.dir,
-      daemon: bools.has("daemon"),
+      port: parsePort(scan.flags.port),
+      host: scan.flags.host,
+      token: scan.flags.token,
+      dir: scan.rest[0],
+      daemon: scan.bools.has("daemon"),
     };
   }
   return parseRun(args);
 }
-
-// The interactive command's `--flag value` pairs. Kept as an explicit set — and
-// scanned by hand rather than through readFlags — because this is the one branch
-// with no subcommand word to vouch for it: an unrecognised token here must stay
-// `invalid`, not be quietly eaten as some flag's value. `--web` itself is
-// valueless and handled separately.
-const RUN_VALUE_FLAGS = new Set(["web-port", "web-host", "web-token", "token"]);
 
 /**
  * The bare invocation: an optional magnet / info hash / .torrent path, plus the
@@ -166,23 +204,13 @@ const RUN_VALUE_FLAGS = new Set(["web-port", "web-host", "web-token", "token"]);
  * download in the other.
  */
 function parseRun(args: string[]): CliCommand {
-  let target: string | undefined;
-  let web = false;
-  const flags: Record<string, string> = {};
+  const scan = scanFlags(args, RUN_FLAGS);
+  if (!scan.ok) return scan.error;
 
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]!;
-    if (arg === "--web") {
-      web = true;
-    } else if (arg.startsWith("--") && RUN_VALUE_FLAGS.has(arg.slice(2))) {
-      const value = args[++i];
-      if (value === undefined) return { kind: "invalid", arg: `${arg} (missing value)` };
-      flags[arg.slice(2)] = value;
-    } else if (target === undefined && isRunTarget(arg)) {
-      target = arg;
-    } else {
-      return { kind: "invalid", arg };
-    }
+  let target: string | undefined;
+  for (const arg of scan.rest) {
+    if (target === undefined && isRunTarget(arg)) target = arg;
+    else return { kind: "invalid", arg };
   }
 
   const isTorrent = target !== undefined && /\.torrent$/i.test(target);
@@ -190,12 +218,10 @@ function parseRun(args: string[]): CliCommand {
     kind: "run",
     initialMagnet: isTorrent ? undefined : target,
     initialTorrent: isTorrent ? target : undefined,
-    web,
-    webPort: parsePort(flags["web-port"]),
-    webHost: flags["web-host"],
-    // The more specific spelling wins. `--token` is the muscle memory from
-    // serve/files; `--web-token` says which server it is for.
-    webToken: flags["web-token"] ?? flags.token,
+    web: scan.bools.has("web"),
+    host: scan.flags.host,
+    port: parsePort(scan.flags.port),
+    token: scan.flags.token,
   };
 }
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -238,8 +238,8 @@ usage
   torlnk --web                open the TUI and serve the browser UI on :9162
   torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk serve                headless: HTTP add API (POST /add) on :9161
-  torlnk serve --web          headless: add API plus the browser UI on :9162
-  torlnk files                headless: serve downloads over HTTP on :9160
+  torlnk serve --web          headless: the add API plus the browser UI on :9161
+  torlnk files [dir]          headless: serve downloads over HTTP on :9160
   torlnk attach               open/reattach the TUI in a persistent tmux session
   torlnk update [--force]     update to the latest release and restart any daemon
                               (--force rebuilds/restarts even if already current)
@@ -250,6 +250,14 @@ usage
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+flags, one name per thing
+  --host <addr>    the interface this process binds (default 127.0.0.1)
+  --port <n>       the port it binds (serve 9161, files 9160, --web 9162)
+  --token <secret> the shared secret; required to bind anything but loopback
+  --to <dir>       where downloads land (watch, serve)
+A bare directory argument is always the folder a command operates on
+(watch <dir>, files [dir]); --to is always where output goes.
 
 watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
 info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
@@ -270,28 +278,24 @@ serve mode (no TUI): a small HTTP API for handing torlink a magnet.
   POST /add {"magnet":"..."}   queue a magnet or info hash
   GET  /downloads              list active downloads and seeds
   GET  /health                 liveness (no auth)
-flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),
---token <secret> (required to bind a public --host; or TORLINK_API_TOKEN),
---to <dir> (where files land).
+flags: --port <n> (default 9161), --host <addr>, --token <secret> (required
+to bind a public --host; or TORLINK_API_TOKEN), --to <dir> (where files land).
 
 web ui (--web): search, posters, streaming, the queue and For You in a
 browser, over the same queue as the process hosting it.
   torlnk --web             the TUI hosts it; quitting the TUI stops it
-  torlnk serve --web       the daemon hosts it, next to the add API
-flags: --web-port <n> (default 9162; under serve, the api port + 1),
---web-host <addr> (default 127.0.0.1, TUI only), --token <secret> (also
-spelled --web-token for the TUI, or set TORLINK_API_TOKEN).
-A non-loopback host is refused without a token. Under serve the UI binds
-serve's own --host and reuses its --token, so one process makes one exposure
-decision; only the port is separate, since two servers cannot share one.
+  torlnk serve --web       the daemon hosts it, on serve's own port
+It binds --host and --port like everything else — under serve there is one
+server, not two: the dashboard's port also answers /add, /downloads and
+/control. A non-loopback host is refused without a token.
 
 files mode (no TUI): a read-only, range-aware HTTP server over the downloads
 folder, so finished files stream to a browser or media player.
   GET /            list the folder (JSON)
   GET /<path>      stream a file (supports Range for seeking/resuming)
-flags: --port <n> (default 9160), --host <addr> (default 127.0.0.1),
---token <secret> (required to bind a public --host; or TORLINK_FILES_TOKEN),
---dir <dir> (folder to serve; defaults to your downloads folder).
+flags: --port <n> (default 9160), --host <addr>, --token <secret> (required
+to bind a public --host; or TORLINK_FILES_TOKEN). Pass the folder to serve as
+a positional argument; it defaults to your downloads folder.
 
 logs: ${logFile}
 `;

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -36,10 +36,13 @@ export interface ServeOptions {
   seedTimeMs?: number;
   /** With seedTimeMs, also delete the files when the timer expires. */
   deleteFiles?: boolean;
-  /** Also serve the browser UI. */
+  /**
+   * Serve the browser UI. It binds this same host and port: the web server
+   * already routes the entire daemon API (see web/routes.ts, which delegates
+   * every non-/api/ path to handleApi), so a second listener would only be a
+   * second copy of the same surface on a port nobody asked for.
+   */
   web?: boolean;
-  /** Port for the browser UI; defaults to the API port + 1. */
-  webPort?: number;
 }
 
 // Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
@@ -291,124 +294,113 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
     return;
   }
 
-  // --web-port deliberately does NOT imply --web: a port left behind in a script
-  // would otherwise quietly start a public-facing dashboard. But accepting the
-  // flag and doing nothing is its own trap, so say so.
-  if (!options.web && options.webPort !== undefined) {
-    log(`warning: --web-port ${options.webPort} ignored without --web`);
-  }
-
-  // The two servers are separate processes' worth of exposure in one process, so
-  // catch the overlap here rather than letting the API's listen() die of
-  // EADDRINUSE on a port the user believes they configured deliberately.
-  const webPort = options.webPort ?? port + 1;
-  if (options.web && webPort === port) {
-    console.error(
-      `error: the web ui port (${webPort}) must differ from the api port (${port}). ` +
-        `Pass a different --web-port.`,
-    );
-    process.exit(1);
-    return;
-  }
-
   const runtime = await startRuntime(options.downloadDir);
 
   if (options.seedTimeMs && options.seedTimeMs > 0) {
     startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
   }
 
-  // The browser UI listens on its own port so the JSON API's port stays a stable,
-  // documented contract and can be firewalled separately. It binds the *same*
-  // host as the API: one process makes one exposure decision, so nobody who
-  // deliberately kept the API on loopback can publish the dashboard by way of a
-  // flag that reads as cosmetic.
+  // With --web there is one server, not two. It binds the port the user chose,
+  // and answers both the dashboard and the add API — one process, one address,
+  // one exposure decision.
   let web: WebServerHandle | null = null;
   if (options.web) {
     try {
       web = await startWebServer(runtime, {
-        port: webPort,
+        port,
         host,
         ...(token ? { token } : {}),
         log,
       });
     } catch (e) {
-      // A startup failure, not a degraded mode: coming up with the API live and
-      // the dashboard silently missing is worse than not coming up at all.
+      // A startup failure, not a degraded mode: coming up with the dashboard
+      // silently missing is worse than not coming up at all.
       await failStartup(
-        `error: could not start the web ui on port ${webPort}: ` +
+        `error: could not start the web ui on port ${port}: ` +
           `${e instanceof Error ? e.message : String(e)}`,
         null,
       );
       return;
     }
+    log(`listening on http://${host}:${port}  (api + web ui, downloads -> ${runtime.downloadDir})`);
+    log(token ? "auth: token required" : "auth: none (loopback only)");
   }
 
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const method = req.method ?? "GET";
-      const urlPath = (req.url ?? "/").split("?")[0]!;
-      // Tokenless means loopback-bound; require a loopback Host so a hostile
-      // webpage can't reach us through DNS rebinding.
-      if (!token && !hostHeaderOk(req.headers.host)) {
-        res.writeHead(403, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "forbidden host" }));
-        log(`${method} ${urlPath} -> 403 (host)`);
-        return;
-      }
-      // CSRF: a browser page on another origin can reach this port with a POST
-      // that passes both guards above (it sets Host itself, and tokenless means
-      // no credential to forge), which for `{"action":"delete"}` means deleting
-      // a visitor's files. Rejected only when the headers positively say
-      // cross-site, so curl and scripts — which send neither header — keep
-      // working. GETs are untouched.
-      if (method !== "GET" && method !== "HEAD" && isCrossSiteHttpRequest(req.headers)) {
-        res.writeHead(403, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "cross-site request blocked" }));
-        log(`${method} ${urlPath} -> 403 (cross-site)`);
-        return;
-      }
-      const body = method === "POST" ? await readBody(req) : { text: "", tooLarge: false };
-      if (body.tooLarge) {
-        res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
-        res.end(JSON.stringify({ error: "body too large" }));
-        res.once("finish", () => req.destroy());
-        log(`${method} ${urlPath} -> 413`);
-        return;
-      }
-      const bodyText = body.text;
-      let out: ApiResponse;
-      try {
-        out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);
-      } catch {
-        out = { status: 500, body: { error: "internal error" } };
-      }
-      const payload = JSON.stringify(out.body);
-      res.writeHead(out.status, { "Content-Type": "application/json" });
-      res.end(payload);
-      if (method !== "GET" || urlPath !== "/health") {
-        log(`${method} ${urlPath} -> ${out.status}`);
-      }
-    })();
-  });
+  // The bare JSON API, for a daemon running without the dashboard. A function
+  // rather than an inline expression so the --web case reads as one line: with
+  // --web this server is not built at all, because the web server above already
+  // answers every route it would have.
+  const createApiServer = (): http.Server =>
+    http.createServer((req, res) => {
+      void (async () => {
+        const method = req.method ?? "GET";
+        const urlPath = (req.url ?? "/").split("?")[0]!;
+        // Tokenless means loopback-bound; require a loopback Host so a hostile
+        // webpage can't reach us through DNS rebinding.
+        if (!token && !hostHeaderOk(req.headers.host)) {
+          res.writeHead(403, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "forbidden host" }));
+          log(`${method} ${urlPath} -> 403 (host)`);
+          return;
+        }
+        // CSRF: a browser page on another origin can reach this port with a POST
+        // that passes both guards above (it sets Host itself, and tokenless means
+        // no credential to forge), which for `{"action":"delete"}` means deleting
+        // a visitor's files. Rejected only when the headers positively say
+        // cross-site, so curl and scripts — which send neither header — keep
+        // working. GETs are untouched.
+        if (method !== "GET" && method !== "HEAD" && isCrossSiteHttpRequest(req.headers)) {
+          res.writeHead(403, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "cross-site request blocked" }));
+          log(`${method} ${urlPath} -> 403 (cross-site)`);
+          return;
+        }
+        const body = method === "POST" ? await readBody(req) : { text: "", tooLarge: false };
+        if (body.tooLarge) {
+          res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
+          res.end(JSON.stringify({ error: "body too large" }));
+          res.once("finish", () => req.destroy());
+          log(`${method} ${urlPath} -> 413`);
+          return;
+        }
+        const bodyText = body.text;
+        let out: ApiResponse;
+        try {
+          out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);
+        } catch {
+          out = { status: 500, body: { error: "internal error" } };
+        }
+        const payload = JSON.stringify(out.body);
+        res.writeHead(out.status, { "Content-Type": "application/json" });
+        res.end(payload);
+        if (method !== "GET" || urlPath !== "/health") {
+          log(`${method} ${urlPath} -> ${out.status}`);
+        }
+      })();
+    });
+
+  const server = options.web ? null : createApiServer();
 
   // A bind failure arrives as an 'error' event, not a throw. Unhandled it is an
   // uncaught exception — an EADDRINUSE stack trace, which reads like a crash
   // rather than "that port is taken". Turned into the same one-line refusal the
   // host/token guard above uses. Detached once listening so a later runtime error
   // still goes somewhere.
-  const listenErr = await new Promise<Error | null>((resolve) => {
-    const onError = (err: Error): void => resolve(err);
-    server.once("error", onError);
-    server.listen(port, host, () => {
-      server.off("error", onError);
-      log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
-      log(token ? "auth: token required" : "auth: none (loopback only)");
-      resolve(null);
+  if (server) {
+    const listenErr = await new Promise<Error | null>((resolve) => {
+      const onError = (err: Error): void => resolve(err);
+      server.once("error", onError);
+      server.listen(port, host, () => {
+        server.off("error", onError);
+        log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
+        log(token ? "auth: token required" : "auth: none (loopback only)");
+        resolve(null);
+      });
     });
-  });
-  if (listenErr) {
-    await failStartup(`error: could not start the api on port ${port}: ${listenErr.message}`, web);
-    return;
+    if (listenErr) {
+      await failStartup(`error: could not start the api on port ${port}: ${listenErr.message}`, web);
+      return;
+    }
   }
 
   await new Promise<void>((resolve) => {
@@ -431,18 +423,21 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
         // only shrink once no new one can be started. The queue last: it is what
         // the streams and requests were reading, so suspending it first would tear
         // state out from under work still unwinding.
-        await new Promise<void>((done) => {
-          server.close(() => done());
-          // The same fix web/server.ts documents for the web server, and for the
-          // same reason: close() stops accepting and then waits for open
-          // connections to end, and a socket that is connected with no *complete*
-          // request in flight — a browser preconnect, a TCP health probe, a port
-          // scan, half-sent headers — never ends. One bare `net.connect` used to
-          // make Ctrl-C hang here forever, which is also what made
-          // `daemon/restart.ts` give up after 10s and report stillRunning: true,
-          // leaving `torlnk update` with the old daemon still alive.
-          server.closeAllConnections();
-        });
+        if (server) {
+          await new Promise<void>((done) => {
+            server.close(() => done());
+            // The same fix web/server.ts documents for the web server, and for
+            // the same reason: close() stops accepting and then waits for open
+            // connections to end, and a socket that is connected with no
+            // *complete* request in flight — a browser preconnect, a TCP health
+            // probe, a port scan, half-sent headers — never ends. One bare
+            // `net.connect` used to make Ctrl-C hang here forever, which is also
+            // what made `daemon/restart.ts` give up after 10s and report
+            // stillRunning: true, leaving `torlnk update` with the old daemon
+            // still alive.
+            server.closeAllConnections();
+          });
+        }
         // Both are awaited so the order above is real, and both swallow a
         // rejection: a failure to tear one thing down must not skip suspend()
         // (which is what flushes state and disarms the boot marker) or leave this

--- a/src/daemon/shutdown.test.ts
+++ b/src/daemon/shutdown.test.ts
@@ -81,8 +81,9 @@ async function waitUntil(fn: () => Promise<boolean>, ms = 5000): Promise<boolean
   }
 }
 
-// A port whose successor is also free, because the default web port is `port + 1`
-// and a test that asserts that needs both ends of the pair.
+// A port whose successor is also free. serve binds one port now, but several
+// tests assert that the *next* one stays free — that is where the dashboard used
+// to land, and "no second listener" is the claim worth pinning down.
 async function freePortPair(): Promise<number> {
   for (let attempt = 0; attempt < 40; attempt++) {
     const base = 20000 + Math.floor(Math.random() * 20000);
@@ -137,73 +138,42 @@ describe("runServe web mount", () => {
     await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it("serves the api and mounts the web ui on the api port + 1", async () => {
+  it("serves the api and the web ui on one port", async () => {
     const port = await freePortPair();
     const before = new Set(process.listeners("SIGTERM"));
     const done = runServe({ port, web: true, downloadDir: dir });
     expect(await waitUntil(() => isListening(port))).toBe(true);
-    expect(await waitUntil(() => isListening(port + 1))).toBe(true);
 
+    // One port answers both surfaces: the daemon API's bare paths and the
+    // dashboard's /api/*. That is the whole point of dropping --web-port.
     const api = await fetch(`http://127.0.0.1:${port}/health`);
     expect(api.status).toBe(200);
-    const ui = await fetch(`http://127.0.0.1:${port + 1}/health`);
-    expect(ui.status).toBe(200);
-    const status = await fetch(`http://127.0.0.1:${port + 1}/api/status`);
+    const status = await fetch(`http://127.0.0.1:${port}/api/status`);
     expect(status.status).toBe(200);
     expect(await status.json()).toMatchObject({ downloads: [], seeds: [] });
+    const downloads = await fetch(`http://127.0.0.1:${port}/downloads`);
+    expect(downloads.status).toBe(200);
+
+    // Nothing on the port the old build derived for the dashboard.
+    expect(await isListening(port + 1)).toBe(false);
 
     newSignalHandler(before)();
     await done;
   });
 
-  it("uses --web-port when one is given", async () => {
+  it("serves only the api without --web", async () => {
     const port = await freePortPair();
-    const webPort = await freePortPair();
     const before = new Set(process.listeners("SIGTERM"));
-    const done = runServe({ port, web: true, webPort, downloadDir: dir });
-    expect(await waitUntil(() => isListening(webPort))).toBe(true);
-    const ui = await fetch(`http://127.0.0.1:${webPort}/health`);
-    expect(ui.status).toBe(200);
-    // The derived port stays free: an explicit --web-port replaces it.
+    const done = runServe({ port, downloadDir: dir });
+    expect(await waitUntil(() => isListening(port))).toBe(true);
+    const api = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(api.status).toBe(200);
+    // The dashboard's own routes are not mounted, and no second port is bound.
+    const ui = await fetch(`http://127.0.0.1:${port}/api/status`);
+    expect(ui.status).toBe(404);
     expect(await isListening(port + 1)).toBe(false);
     newSignalHandler(before)();
     await done;
-  });
-
-  it("does not mount the web ui without --web", async () => {
-    const port = await freePortPair();
-    // A probed port, never the literal 9162. That is torlink's own default web
-    // port, so asserting it is free failed for anyone running `torlnk --web`
-    // while testing — the single most likely process on a torlink dev machine.
-    // --web-port without --web must start nothing, which is the same claim.
-    const unusedWebPort = await freePortPair();
-    const before = new Set(process.listeners("SIGTERM"));
-    const done = runServe({ port, webPort: unusedWebPort, downloadDir: dir });
-    expect(await waitUntil(() => isListening(port))).toBe(true);
-    expect(await isListening(port + 1)).toBe(false);
-    expect(await isListening(unusedWebPort)).toBe(false);
-    newSignalHandler(before)();
-    await done;
-  });
-
-  it("warns when --web-port is set without --web", async () => {
-    const port = await freePortPair();
-    const before = new Set(process.listeners("SIGTERM"));
-    const done = runServe({ port, webPort: 31999, downloadDir: dir });
-    expect(await waitUntil(() => isListening(port))).toBe(true);
-    expect(logs.join("\n")).toContain("warning: --web-port 31999 ignored without --web");
-    newSignalHandler(before)();
-    await done;
-  });
-
-  it("refuses to start when the web port equals the api port", async () => {
-    const port = await freePortPair();
-    await runServe({ port, web: true, webPort: port, downloadDir: dir });
-    expect(exit).toHaveBeenCalledWith(1);
-    expect(errors.join("\n")).toContain("must differ from the api port");
-    // Bailed before anything was started, so nothing is left listening.
-    expect(startRuntime).not.toHaveBeenCalled();
-    expect(await isListening(port)).toBe(false);
   });
 
   // The failure mode this pair of tests guards, beyond the exit code: the real
@@ -213,10 +183,10 @@ describe("runServe web mount", () => {
   // disk — and the next launch of *any* mode came up in safe mode with every
   // download and seed paused, claiming it recovered from a crash. startRuntime is
   // stubbed in this file, so the marker is armed by hand to stand in for it.
-  it("leaves no boot marker armed when the web port is taken", async () => {
+  it("leaves no boot marker armed when the port is taken with --web", async () => {
     const port = await freePortPair();
     const squatter = net.createServer();
-    await new Promise<void>((r) => squatter.listen(port + 1, "127.0.0.1", r));
+    await new Promise<void>((r) => squatter.listen(port, "127.0.0.1", r));
     try {
       armBootMarker();
       expect(wasBootInterrupted()).toBe(true);
@@ -228,13 +198,13 @@ describe("runServe web mount", () => {
     }
   });
 
-  it("leaves no boot marker armed when the api port is taken", async () => {
+  it("leaves no boot marker armed when the port is taken without --web", async () => {
     const port = await freePortPair();
     const squatter = net.createServer();
     await new Promise<void>((r) => squatter.listen(port, "127.0.0.1", r));
     try {
       armBootMarker();
-      await runServe({ port, web: true, downloadDir: dir });
+      await runServe({ port, downloadDir: dir });
       expect(exit).toHaveBeenCalledWith(1);
       expect(wasBootInterrupted()).toBe(false);
     } finally {
@@ -242,32 +212,31 @@ describe("runServe web mount", () => {
     }
   });
 
-  it("exits non-zero with the port in the message when the web port is taken", async () => {
-    const port = await freePortPair();
-    const squatter = net.createServer();
-    await new Promise<void>((r) => squatter.listen(port + 1, "127.0.0.1", r));
-    try {
-      await runServe({ port, web: true, downloadDir: dir });
-      expect(exit).toHaveBeenCalledWith(1);
-      expect(errors.join("\n")).toContain(`could not start the web ui on port ${port + 1}`);
-      expect(errors.join("\n")).toContain("EADDRINUSE");
-      // The API never came up: a half-configured daemon is worse than none.
-      expect(await isListening(port)).toBe(false);
-    } finally {
-      await new Promise<void>((r) => squatter.close(() => r()));
-    }
-  });
-
-  it("reports a taken api port as a refusal and releases the web port again", async () => {
+  it("exits non-zero with the port in the message when --web cannot bind", async () => {
     const port = await freePortPair();
     const squatter = net.createServer();
     await new Promise<void>((r) => squatter.listen(port, "127.0.0.1", r));
     try {
       await runServe({ port, web: true, downloadDir: dir });
       expect(exit).toHaveBeenCalledWith(1);
-      expect(errors.join("\n")).toContain(`could not start the api on port ${port}`);
-      // The web server came up first; a refused API must not leave it orphaned.
+      expect(errors.join("\n")).toContain(`could not start the web ui on port ${port}`);
+      expect(errors.join("\n")).toContain("EADDRINUSE");
+      // Nothing was left half-started on the port next door, which is where the
+      // dashboard used to land: one --web daemon binds exactly one port.
       expect(await isListening(port + 1)).toBe(false);
+    } finally {
+      await new Promise<void>((r) => squatter.close(() => r()));
+    }
+  });
+
+  it("reports a taken api port as a refusal without --web", async () => {
+    const port = await freePortPair();
+    const squatter = net.createServer();
+    await new Promise<void>((r) => squatter.listen(port, "127.0.0.1", r));
+    try {
+      await runServe({ port, downloadDir: dir });
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(errors.join("\n")).toContain(`could not start the api on port ${port}`);
     } finally {
       await new Promise<void>((r) => squatter.close(() => r()));
     }
@@ -296,15 +265,15 @@ describe("runServe web mount", () => {
     await done;
   });
 
-  it("releases the web port, stops stream sessions and suspends the queue on a signal", async () => {
+  it("releases the port, stops stream sessions and suspends the queue on a signal", async () => {
     const port = await freePortPair();
     const before = new Set(process.listeners("SIGTERM"));
     const done = runServe({ port, web: true, downloadDir: dir });
-    expect(await waitUntil(() => isListening(port + 1))).toBe(true);
+    expect(await waitUntil(() => isListening(port))).toBe(true);
 
     // Hold an event stream open, like a browser would. Without the handle's
     // close() this connection keeps the web server alive forever.
-    const events = await fetch(`http://127.0.0.1:${port + 1}/api/events`);
+    const events = await fetch(`http://127.0.0.1:${port}/api/events`);
     expect(events.status).toBe(200);
 
     newSignalHandler(before)();
@@ -312,10 +281,9 @@ describe("runServe web mount", () => {
 
     expect(fake.stopAll).toHaveBeenCalled();
     expect(fake.suspend).toHaveBeenCalled();
-    // Asserted directly, not through waitUntil: runServe now resolves only after
-    // both servers' close() have called back, so anything still listening here is
-    // a real failure rather than a race worth retrying.
-    expect(await isListening(port + 1)).toBe(false);
+    // Asserted directly, not through waitUntil: runServe resolves only after
+    // close() has called back, so anything still listening here is a real
+    // failure rather than a race worth retrying.
     expect(await isListening(port)).toBe(false);
     await events.body?.cancel().catch(() => {});
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,9 @@ if (cmd.kind === "version") {
 }
 
 if (cmd.kind === "invalid") {
-  console.error(`error: unknown argument '${cmd.arg}'\n`);
+  // A removed flag gets its replacement named. "unknown argument '--web-host'"
+  // is true but useless — the user is looking for the setting, not the spelling.
+  console.error(`error: ${cmd.hint ?? `unknown argument '${cmd.arg}'`}\n`);
   console.error(HELP_TEXT);
   process.exit(1);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,6 @@ if (cmd.kind === "update") {
     seedTimeMs: cmd.seedTimeMs,
     deleteFiles: cmd.deleteFiles,
     web: cmd.web,
-    webPort: cmd.webPort,
   };
   void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
 } else if (cmd.kind === "files") {
@@ -132,17 +131,17 @@ const app = render(
     initialTorrent={cmd.initialTorrent}
     onQuit={() => forceExit(0)}
     web={cmd.web}
-    webPort={cmd.webPort}
-    webHost={cmd.webHost}
+    webPort={cmd.port}
+    webHost={cmd.host}
     // parseCliArgs is pure and never reads the environment, so the env fallback
     // the daemon paths apply above has to be applied here too — otherwise
-    // `torlnk --web --web-host 0.0.0.0` with only TORLINK_API_TOKEN set is
-    // refused for a missing token the user did supply.
+    // `torlnk --web --host 0.0.0.0` with only TORLINK_API_TOKEN set is refused
+    // for a missing token the user did supply.
     //
     // Only on the --web path: merging it unconditionally would turn a
-    // TORLINK_API_TOKEN exported for the daemon into a phantom --web-token and
-    // make App warn about a flag nobody passed.
-    webToken={cmd.web ? (cmd.webToken ?? process.env.TORLINK_API_TOKEN) : cmd.webToken}
+    // TORLINK_API_TOKEN exported for the daemon into a phantom --token and make
+    // App warn about a flag nobody passed.
+    webToken={cmd.web ? (cmd.token ?? process.env.TORLINK_API_TOKEN) : cmd.token}
   />,
   { exitOnCtrlC: false },
 );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -530,15 +530,14 @@ export function App({
     };
   }, [web, queue, webPort, webHost, webToken, startWebServerImpl]);
 
-  // `--web-port 8080` without `--web` parses fine and does nothing, which is the
-  // same trap `torlnk serve` warns about. Say so rather than silently accepting
-  // a flag the user believes turned something on.
+  // `--port 8080` without `--web` parses fine and does nothing. Say so rather
+  // than silently accepting a flag the user believes turned something on.
   useEffect(() => {
     if (web) return;
     const orphans = [
-      webPort !== undefined ? "--web-port" : null,
-      webHost ? "--web-host" : null,
-      webToken ? "--web-token" : null,
+      webPort !== undefined ? "--port" : null,
+      webHost ? "--host" : null,
+      webToken ? "--token" : null,
     ].filter((f): f is string => f !== null);
     if (orphans.length === 0) return;
     log.warn(`[web] ${orphans.join(", ")} ignored without --web`);

--- a/src/ui/App.web.test.tsx
+++ b/src/ui/App.web.test.tsx
@@ -297,12 +297,12 @@ describe("App --web mount", () => {
     const ui = renderUI(<App webPort={19002} startWebServerImpl={start} />);
     try {
       await vi.waitFor(() =>
-        expect(logSpies.warn).toHaveBeenCalledWith("[web] --web-port ignored without --web"),
+        expect(logSpies.warn).toHaveBeenCalledWith("[web] --port ignored without --web"),
       );
       expect(start).not.toHaveBeenCalled();
       await vi.waitFor(() => expect(ui.frame()).toContain("Search"));
       ui.press(TAB);
-      await vi.waitFor(() => expect(ui.frame()).toContain("--web-port ignored without --web"));
+      await vi.waitFor(() => expect(ui.frame()).toContain("--port ignored without --web"));
       expectNothingOnStdout();
     } finally {
       ui.unmount();

--- a/src/ui/components/ForYou.test.tsx
+++ b/src/ui/components/ForYou.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { render } from "ink-testing-library";
 import jpeg from "jpeg-js";
 import { ForYou } from "./ForYou";
@@ -18,11 +18,25 @@ vi.mock("../../util/openUrl", () => ({
   imdbTitleUrl: (id: string) => `https://www.imdb.com/title/${id}/`,
 }));
 
-// ink flushes React passive effects via the scheduler's MessageChannel, which
-// fake timers can't drive — so these tests need real time to settle. `flush`
-// is a short settle; debounce/fetch-dependent assertions use vi.waitFor (below)
-// so they resolve as soon as ready rather than sleeping a fixed, CI-fragile span.
-const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+// No wall-clock sleeps. `advanceTimersByTimeAsync` is the load-bearing part:
+// unlike the sync form it awaits between timers, which lets ink's React
+// scheduler drain its MessageChannel macrotask — so passive effects, the
+// recommendations fetch and the re-render all settle under fake time.
+//
+// A fixed real-time sleep used to stand here, and it lost the race on a loaded
+// CI runner: the keypress landed before the picks existed, `selectedItem` was
+// undefined, and the handler silently did nothing.
+// Captured before fake timers are installed: `setImmediate` here is a yield to
+// the real event loop, not a wall-clock sleep. ink's React scheduler drains its
+// work through a MessageChannel message — a macrotask — and awaiting fake
+// timers only drains microtasks, so without this the frame never repaints.
+const yieldToLoop = setImmediate;
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 8; i++) {
+    await vi.advanceTimersByTimeAsync(25);
+    await new Promise<void>((r) => yieldToLoop(() => r()));
+  }
+};
 const ESC = String.fromCharCode(27);
 
 const REC = { imdbId: "tt1", title: "Chernobyl", year: 2019, score: 33.4, reasons: ["highly rated classic"] };
@@ -81,6 +95,13 @@ function fetchStubFull(plot: string): { impl: FetchImpl; urls: string[] } {
 }
 
 describe("ForYou", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it("fetches and renders picks once active", async () => {
     const { impl } = fetchStub();
     const { lastFrame } = render(
@@ -253,10 +274,11 @@ describe("ForYou", () => {
   it("does not fetch a plot when no OMDb key is configured", async () => {
     const { impl, urls } = fetchStubWithPlot("A nuclear disaster.");
     render(<ForYou reccConfig={CONFIG} visible active setSection={vi.fn()} submitQuery={vi.fn()} fetchImpl={impl} />);
-    // No key ⇒ the lookup never even schedules; wait past the debounce window to
-    // be sure, then confirm nothing was requested. (Negative assertion, so there
-    // is nothing to poll for — a bounded wait is unavoidable here.)
-    await new Promise((r) => setTimeout(r, 250));
+    // No key ⇒ the lookup never even schedules. Fake time makes this negative
+    // assertion exact rather than hopeful: run the clock a full second past the
+    // 150ms debounce (see useTitlePreview) and nothing can still be pending.
+    await flush();
+    await vi.advanceTimersByTimeAsync(1000);
     expect(urls.some((u) => u.includes("omdbapi.com"))).toBe(false);
   });
 

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -127,7 +127,7 @@ describe("startWebServer", () => {
 
   // The other half of the bind rule: a token is what makes a public bind legal,
   // so the guard must be about the *pair*. A guard that only looked at the host
-  // would make --web-host 0.0.0.0 impossible however it was configured.
+  // would make --host 0.0.0.0 impossible however it was configured.
   it("binds a public host when a token is set", async () => {
     handle = await startWebServer(runtime(), {
       port: 0,


### PR DESCRIPTION
## Summary

The CLI had four names for concepts that need one, and one name (`--dir`) that meant two opposite things. The overlap wasn't cosmetic: `torlnk serve --web --web-host 0.0.0.0 --token a` bound loopback and said nothing, because `serve` never read `--web-host` and the flag reader silently ate any unrecognised `--flag value` pair.

**Breaking change.** Removed spellings are startup errors, not aliases — a wrong flag fails loudly once, and you fix your systemd unit.

- **One canonical flag per concept:** `--host`, `--port`, `--token`, `--to`. `--web-host`, `--web-port`, `--web-token` and `--dir` are removed, each with an error naming its replacement (`error: --web-host is not a flag; the web ui binds --host`).
- **One port per process:** `serve --web` no longer starts a second listener. The web server already routed the entire daemon API (`web/routes.ts` delegates every non-`/api/` path to `handleApi`), so the dashboard now binds `--port` and answers `/add`, `/downloads` and `/control` too. The UI moves from `:9162` to `:9161` under `serve`.
- **Source vs destination:** `torlnk files [dir]` takes its folder positionally, like `watch <dir>`. A bare directory is always the folder a command operates on; `--to` is always where output goes.
- **Unknown flags are hard errors** on `watch`/`serve`/`files`, via one strict `scanFlags(args, spec)` replacing the three ad-hoc readers. This is the root-cause fix.
- `--help` and the README document exactly the flags that exist; the token-precedence table is gone because precedence no longer exists.

Deliberately unchanged: the URL paths (a moved URL fails silently inside someone's script at 3am; a wrong flag fails loudly at startup) and the two env var names.

Knowingly dropped: the ability to firewall the JSON API separately from the dashboard. `serve.ts` called that separation intentional; it's over-engineered for a single-user daemon.

Spec and plan: `docs/superpowers/specs/2026-07-28-cli-flag-consolidation-design.md`, `docs/superpowers/plans/2026-07-28-cli-flag-consolidation.md`.

## Test Plan

- [x] `npm test` — 1388 tests, 108 files, all passing
- [x] `npm run typecheck`, `npx eslint .` (one pre-existing warning), `npm run build`
- [x] `serve --web --host 0.0.0.0 --token a` → one listening line on `0.0.0.0:9161`; `/health` 200, `/api/status` 200, `/downloads` 200, `/` 200; nothing on 9162; clean SIGTERM shutdown
- [x] `serve` without `--web` unchanged — API only, `/api/status` 404s
- [x] `files /tmp/<dir>` serves that folder over `:9160`
- [x] Each removed flag exits 1 with its replacement named

## Upgrade notes

- `serve --web` dashboard: `:9162` → `:9161` (bookmarks and reverse proxy config)
- `--web-host` → `--host`, `--web-port` → `--port`, `--web-token` → `--token`
- `watch`/`serve` `--dir` → `--to`; `files --dir X` → `files X`

🤖 Generated with [Claude Code](https://claude.com/claude-code)