### PR TITLE
A Dockerfile with ffmpeg, and compose for the web dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Keep the build context small and, more importantly, keep host state out of it.
+#
+# node_modules is the big one: it is reinstalled in the image for the image's own
+# platform, and copying a macOS build of a native module into a Linux container
+# produces a failure that reads as a torlnk bug.
+node_modules
+dist
+
+# Whole second checkouts of this repo live here — see vitest.config.ts.
+.claude
+.git
+.github
+
+# Never let a developer's own state or secrets into an image layer.
+*.log
+.env
+.env.*
+config.json
+
+# Test and docs output that the runtime has no use for.
+coverage
+preview
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
 build/
+# Where docker-compose.yml mounts the container's /state: config, tokens,
+# the queue, watch history and downloads. Host state, never committed.
+state/
 sea-prep.blob
 .DS_Store
 package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# torlnk in a container, for `serve --web`.
+#
+# Two things here are load-bearing and easy to get wrong, so they are called out
+# rather than left to be discovered:
+#
+#   1. NOT alpine. `node-datachannel` (WebRTC peers, via webtorrent) ships
+#      prebuilt binaries for glibc and not for musl, so on alpine its install
+#      script falls back to compiling from source — and `scripts/ensure-webrtc.cjs`
+#      is deliberately fail-soft, so a missing toolchain produces a WORKING
+#      torlnk that has quietly lost WebRTC peers. bookworm-slim gets the
+#      prebuild and the swarm behaves the way it does everywhere else.
+#
+#   2. ffmpeg is installed in the RUNTIME stage, not the builder. It is what
+#      `src/util/ffmpegBin.ts` looks for at request time. It stays optional in
+#      the code — absent means the web player classifies from release names and
+#      falls back to the "needs a real player" card — but a container is a
+#      controlled environment, so there is no reason to ship it without.
+
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Build tools only in this stage: needed if npm cannot find a node-datachannel
+# prebuild for this platform. They add ~250 MB, which is exactly why the runtime
+# stage below starts from a fresh base rather than inheriting this one.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates cmake g++ libssl-dev make python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+# package.json and the lockfile first, so a source-only change does not
+# invalidate the dependency layer.
+COPY package.json package-lock.json ./
+# ensure-webrtc.cjs runs as `postinstall`, so it has to be present for `npm ci`.
+COPY scripts/ensure-webrtc.cjs ./scripts/ensure-webrtc.cjs
+RUN npm ci
+
+COPY . .
+RUN npm run build \
+  # Drop devDependencies from the tree that the runtime stage copies. `prune`
+  # does not re-run install scripts, so the native module built above survives.
+  && npm prune --omit=dev
+
+FROM node:22-bookworm-slim AS runtime
+
+# ffmpeg brings ffprobe, and torlnk wants both:
+#   ffprobe — reads a stream's real container and codecs, so the web player
+#             knows up front whether a browser can play it.
+#   ffmpeg  — remuxes an MKV into HLS for the browser (where that rung exists).
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+  && rm -rf /var/lib/apt/lists/* \
+  && ffprobe -version | head -1
+
+WORKDIR /app
+
+# node:* images ship a non-root `node` user (uid 1000). Running as it means the
+# volumes below are written as a normal user, not as root — which matters
+# because those files land on the host and you have to be able to read them.
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+
+# ONE directory for every piece of persisted state. src/config/paths.ts honours
+# TORLINK_STATE_DIR by putting config/, data/ and cache/ under it, so a single
+# volume covers the token, the queue, watch history, seeds and the poster cache.
+ENV TORLINK_STATE_DIR=/state
+# HOME decides the default download directory (`$HOME/Downloads/torlink`), so
+# pointing it at /state keeps downloads on a mount too. Override `downloadDir`
+# in /state/config/config.json to put them on a different disk.
+ENV HOME=/state
+# The container has no terminal to hand a link to and no browser to open, so the
+# update check is noise here.
+ENV TORLINK_NO_UPDATE_CHECK=1
+
+RUN mkdir -p /state && chown -R node:node /state
+VOLUME ["/state"]
+USER node
+
+# 9162 is the web UI. 9161 (the add API) is deliberately NOT exposed: it is a
+# scripting surface with no browser, and anything that needs it can be published
+# explicitly.
+EXPOSE 9162
+
+# --host 0.0.0.0 is required for the port to be reachable from outside the
+# container. torlnk never exposes a non-loopback bind unauthenticated, but with
+# `--web` it MINTS a token rather than refusing (daemon/serve.ts) — there is a
+# browser to hand a working link to, so it prints one to the log:
+#
+#   token a30c…  (pass --token to pin it across restarts)
+#
+# That works, and it means the container boots with no configuration at all. Set
+# `TORLINK_API_TOKEN` anyway for anything long-lived: a minted token is new on
+# every restart, so with `restart: unless-stopped` the URL you bookmarked stops
+# working the first time the container bounces.
+CMD ["node", "dist/index.js", "serve", "--web", "--host", "0.0.0.0", "--port", "9162"]

--- a/README.md
+++ b/README.md
@@ -326,6 +326,40 @@ torlink also runs with no terminal UI at all, for servers and seedboxes:
 
 Add `--daemon` to keep watch, serve, or files running after you log out, or `--web` to `serve` for the [browser dashboard](#in-your-browser-optional) on the same port as the add API; `torlnk --help` has the full list of modes and flags.
 
+### In a container
+
+There's a `Dockerfile` and a `docker-compose.yml` for the browser dashboard:
+
+    TORLINK_API_TOKEN=$(openssl rand -hex 24) docker compose up -d
+
+Then `http://127.0.0.1:9162/#k=<that token>`. Compose publishes the port on
+loopback only, so bringing it up doesn't put your library on the LAN until you
+change that line yourself.
+
+A few things worth knowing, because each of them is a decision rather than a
+default:
+
+- **The token.** torlnk would boot without one — given `--web` it mints a token
+  and prints the link to its log rather than refusing. But a minted token is new
+  on every restart, so with `restart: unless-stopped` your bookmark breaks the
+  first time the container bounces. Set it.
+- **One volume, `/state`.** `TORLINK_STATE_DIR` puts config, data and cache under
+  a single directory, so that one mount holds your tokens, the queue, watch
+  history, seeds and the poster cache. Downloads land in
+  `/state/Downloads/torlink`; repoint that mount at a bigger disk and the files
+  follow.
+- **ffmpeg is in the image.** `ffprobe` is what lets the player know a file's real
+  container and codecs up front rather than guessing from its name. It stays
+  optional in the code — torlnk runs fine without it — but a container is a
+  controlled environment, so there's no reason to ship one without it.
+- **Not Alpine, on purpose.** The WebRTC native module ships prebuilt binaries for
+  glibc and not musl, and its install is deliberately fail-soft — so an Alpine
+  image gives you a *working* torlnk that has quietly lost WebRTC peers. The
+  image is Debian slim and about 700 MB, most of it ffmpeg's codec libraries.
+- **No BitTorrent port is published.** Outbound peers connect fine, so the swarm
+  works; nobody can dial in, so seeding ratios suffer. Publish the port you've
+  configured if that matters.
+
 ## Contributing
 
 To run or work on torlink locally:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+# torlnk's web UI in a container.
+#
+#   TORLINK_API_TOKEN=$(openssl rand -hex 24) docker compose up -d
+#
+# torlnk would boot without that: given `--web` it mints a token and prints the
+# link to its log rather than refusing. But a minted token is new on every
+# restart, and with `restart: unless-stopped` below that means the URL you
+# bookmarked breaks the first time the container bounces. So it is required here,
+# with no default — a compose file with a baked-in secret is a compose file whose
+# secret is in git.
+
+services:
+  torlnk:
+    build: .
+    image: torlnk:local
+    container_name: torlnk
+    restart: unless-stopped
+
+    ports:
+      # Host:container. Bound to 127.0.0.1 by default so bringing this up does
+      # not silently publish a media library to your whole LAN — change it to
+      # "9162:9162" once you have decided that is what you want.
+      - "127.0.0.1:9162:9162"
+
+    environment:
+      # No default. Compose refuses to start with "variable is not set", which is
+      # a better failure than a URL that silently changes on the next restart.
+      TORLINK_API_TOKEN: ${TORLINK_API_TOKEN:?set TORLINK_API_TOKEN, e.g. openssl rand -hex 24}
+      # Optional. Either can also be set once in /state/config/config.json.
+      REALDEBRID_API_TOKEN: ${REALDEBRID_API_TOKEN:-}
+      TORBOX_API_TOKEN: ${TORBOX_API_TOKEN:-}
+      TORLINK_OMDB_KEY: ${TORLINK_OMDB_KEY:-}
+
+    volumes:
+      # Everything torlnk persists: config (including tokens), the queue, watch
+      # history, seeds, the poster cache. One directory, because
+      # src/config/paths.ts puts all three of its trees under TORLINK_STATE_DIR.
+      - ./state:/state
+      # Downloads default to $HOME/Downloads/torlink and HOME is /state, so this
+      # is that path made explicit. Repoint it at a bigger disk and the files
+      # follow; no config change needed.
+      - ./state/Downloads/torlink:/state/Downloads/torlink
+
+    # Seeding wants inbound connections. Without a published BitTorrent port the
+    # swarm still works — outbound TCP/uTP and WebRTC peers connect fine — but
+    # nobody can dial in, so seeding ratios suffer. Publish the port torlnk is
+    # configured to listen on if that matters to you.
+
+    healthcheck:
+      # The web UI's own port, from inside the container, where loopback needs no
+      # token. Node rather than curl because the runtime image has no curl and
+      # adding one for a healthcheck is not worth a layer.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:9162/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3


### PR DESCRIPTION
There was no Dockerfile in the repo — the only "docker" match was a `docker0`
interface in a test fixture. This adds one, with `ffmpeg` in it.

## Why ffmpeg is in the image

`src/util/ffmpegBin.ts` looks for `ffprobe` and `ffmpeg` at request time and
treats absence as a normal answer, so torlnk runs fine without them. What you
lose without `ffprobe` is accuracy: the web player falls back to guessing a
file's container and codecs from its release name. A container is a controlled
environment, so there's no reason to ship one without it. `ffmpeg` itself is
there for a future local remux.

## Two choices that are decisions, not defaults

- **Debian slim, not Alpine.** `node-datachannel` (WebRTC peers, via webtorrent)
  ships prebuilt binaries for glibc and not musl, and `scripts/ensure-webrtc.cjs`
  is deliberately fail-soft — so an Alpine image gives you a *working* torlnk that
  has quietly lost WebRTC peers, with only a build-time warning to say so. The
  cost is size: ~700 MB, most of it ffmpeg's codec libraries.
- **One `/state` volume.** `TORLINK_STATE_DIR` already puts config, data and cache
  under a single directory, so one mount covers tokens, the queue, watch history,
  seeds and the poster cache. `HOME=/state` puts downloads beside them at
  `/state/Downloads/torlink`; repoint that mount and the files follow.

Build tools live only in the builder stage, so they aren't in the shipped image.

## On the token

I initially wrote the Dockerfile asserting that torlnk refuses a non-loopback
bind without a token. **That's wrong, and running it is what showed me** — with
`--web` it *mints* one and prints the link to its log (`daemon/serve.ts:337`),
because there's a browser to hand a working link to. So the container boots with
no configuration at all.

`TORLINK_API_TOKEN` is still required by compose, for a different reason: a minted
token is new on every restart, so with `restart: unless-stopped` the URL you
bookmarked breaks the first time the container bounces. The comments say that now
rather than the thing I assumed.

## Verified, not assumed

- Image builds; `ffprobe` 5.1.9 and `ffmpeg` present at `/usr/bin`.
- Runs as the non-root `node` user; state lands on the host as a normal user.
- `GET /` → 200 on loopback inside the container.
- From the host: **401 without a token, 200 with one.**
- `docker compose config` fails fast and legibly when the token is unset.
- Compose healthcheck reaches `healthy`; the pinned token is used rather than a
  minted one.
- `npm test` (1996), `typecheck`, `lint`, `build` all pass — nothing here touches
  application code.

## Notes

- Compose publishes on `127.0.0.1` only, so `up` doesn't put a media library on
  the LAN until someone changes that line deliberately.
- No BitTorrent port is published: outbound peers connect, so the swarm works,
  but nothing can dial in and seeding ratios suffer. Documented.
- `state/` is gitignored, since compose creates it in the repo root.
- Independent of #57 and based on `main`; the two don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
