### PR TITLE
chore: gitignore the Claude Code worktrees under .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ sea-prep.blob
 .DS_Store
 package-lock.json
 !nix/package-lock.json
+
+# Claude Code keeps its git worktrees here — whole checkouts with their own
+# node_modules, hundreds of MB of them, and not project files. Scoped to
+# worktrees/ rather than all of .claude/ so shared config (settings.json, agents,
+# skills) can still be committed if we ever add any.
+.claude/worktrees/


### PR DESCRIPTION
## What and why

`.claude/worktrees/` holds Claude Code's git worktrees — whole checkouts, each with its own `node_modules`. That's **657 MB** right now, and it was showing up as untracked in `git status` on the main checkout, which makes it easy to `git add` by accident.

6cea61e already kept these out of eslint and vitest; this does the same for git itself.

Scoped to `worktrees/` rather than all of `.claude/`, so shared project config (`settings.json`, agents, skills) can still be committed if we ever add any.

Verified the pattern actually matches rather than assuming it:

```
$ git check-ignore -v --no-index .claude/worktrees/wondrous-imagining-crab
.gitignore:13:.claude/worktrees/   .claude/worktrees/wondrous-imagining-crab
```

Nothing is currently tracked under that path, so no `git rm --cached` is needed — the rule takes effect immediately on merge.

## Checklist

- [x] `npm test` passes (1892 tests)
- [ ] `npm run typecheck` / new logic has a test — n/a, this is a one-line ignore rule with no code
- [ ] Keys / `Store` fields — n/a
- [x] One concern, Conventional Commits title

Split out from #58 rather than bundled into it, per "one concern per pull request".

🤖 Generated with [Claude Code](https://claude.com/claude-code)