### PR TITLE
chore: bump brace-expansion and postcss out of their advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,16 +2747,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5037,9 +5037,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5421,9 +5421,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -5441,7 +5441,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
`npm audit fix` with no `--force`, so this is a lockfile-only change to two transitive dev dependencies: brace-expansion (via eslint's minimatch) and postcss (via tsup and vite).

The other five findings are left alone deliberately. Four are the same chain -- ip -> bittorrent-tracker -> torrent-discovery -> webtorrent -- and `ip` has no patched release: 2.0.1 is the latest, the package is unmaintained, and bittorrent-tracker 11.2.3 still asks for `^2.0.1`. npm's suggested fix is webtorrent@0.7.3, which would remove the streaming core, so `npm audit fix --force` must not be run here. The fifth is esbuild's dev-server file read, which is low, dev-only, Windows-only, and reachable only through a dev server tsup never starts; tsup pins `^0.27.0` and every 0.27.x from .3 up is in range.

`npm audit` will keep reporting 5 until upstream moves.

## What and why

<!-- What does this change do, and why? The diff shows the what; tell us the why. -->

## Checklist

- [ ] `npm run typecheck` is clean
- [ ] `npm test` passes
- [ ] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [ ] OS-touching code works on Windows, macOS, and Linux
- [ ] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)

New here? [CONTRIBUTING.md](../CONTRIBUTING.md) explains each of these with examples from real merged PRs.
