### PR TITLE
Order the browser's file picker like the terminal's, and give it the sort toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ terminal row has space for: how long ago you streamed it and the last episode yo
 **When a torrent holds several files**, the file picker opens on the suggested next episode rather than
 the first file — which for a season pack is usually the one you just watched. That applies to any release
 of a show you're part-way through, whether you played it from here, from a search, or from your library.
+The list itself is in title order, so a season pack reads E01, E02, E03 whatever order the torrent happens
+to name its files in — press **s** in the terminal, or the **sort** button in the browser, to switch to
+largest-first instead.
 
 **There's no resume position.** torlink can't see into mpv, iina, vlc, or a browser tab, so this remembers
 *what* you were watching, not *where* you got to.

--- a/src/ui/components/StreamFilePrompt.tsx
+++ b/src/ui/components/StreamFilePrompt.tsx
@@ -4,8 +4,11 @@ import { Panel } from "./Panel";
 import { COLOR, GUTTER, ICON } from "../theme";
 import { formatBytes, cleanText, truncate } from "../../util/format";
 import type { StreamFile } from "../../util/player";
-
-type SortMode = "name" | "size";
+// The ordering rule itself, which used to be a `sortFiles` local to this file.
+// It moved down to src/util when the browser's picker needed it: a season pack
+// listed E01…E10 here and in torrent order there is the copy-then-drift bug this
+// codebase has recorded four times, arrived at by omission instead of by copy.
+import { nextSort, sortStreamFiles, type StreamFileSort } from "../../util/streamFileSort";
 
 interface StreamFilePromptProps {
   width: number;
@@ -41,22 +44,6 @@ interface StreamFilePromptProps {
   favourited?: boolean;
 }
 
-// Order the candidates by title (case/number-aware) or by size, largest-first.
-function sortFiles(files: StreamFile[], mode: SortMode): StreamFile[] {
-  const copy = [...files];
-  if (mode === "name") {
-    copy.sort((a, b) =>
-      cleanText(a.filename).localeCompare(cleanText(b.filename), undefined, {
-        numeric: true,
-        sensitivity: "base",
-      }),
-    );
-  } else {
-    copy.sort((a, b) => b.bytes - a.bytes);
-  }
-  return copy;
-}
-
 // Pick a file to stream when a torrent holds several videos. Defaults to sorting
 // by title; press "s" to toggle between title and size ordering.
 export function StreamFilePrompt({
@@ -74,8 +61,8 @@ export function StreamFilePrompt({
   // highlight. Any keypress makes the cursor a number and the preselection stops
   // being consulted.
   const [cursor, setCursor] = useState<number | null>(null);
-  const [sortMode, setSortMode] = useState<SortMode>("name");
-  const sorted = useMemo(() => sortFiles(files, sortMode), [files, sortMode]);
+  const [sortMode, setSortMode] = useState<StreamFileSort>("name");
+  const sorted = useMemo(() => sortStreamFiles(files, sortMode), [files, sortMode]);
   const preselectUrl = preselect !== undefined ? files[preselect]?.url : undefined;
   const opening = preselectUrl !== undefined
     ? Math.max(0, sorted.findIndex((f) => f.url === preselectUrl))
@@ -95,10 +82,10 @@ export function StreamFilePrompt({
     if (input === "s" || input === "S") {
       // Keep the highlighted file selected across the re-sort.
       const current = sorted[clamped];
-      const next: SortMode = sortMode === "name" ? "size" : "name";
+      const next = nextSort(sortMode);
       setSortMode(next);
       if (current) {
-        const idx = sortFiles(files, next).findIndex((f) => f.url === current.url);
+        const idx = sortStreamFiles(files, next).findIndex((f) => f.url === current.url);
         if (idx >= 0) setCursor(idx);
       }
       return;

--- a/src/util/streamFileSort.test.ts
+++ b/src/util/streamFileSort.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { nextSort, sortStreamFiles } from "./streamFileSort";
+
+const f = (filename: string, bytes = 1024) => ({ filename, bytes });
+
+describe("sortStreamFiles", () => {
+  // The reported bug: a season pack arrives in whatever order the torrent
+  // happens to list its files, and the picker showed E08 above E02.
+  it("puts episodes in episode order, whatever order the torrent listed them", () => {
+    const files = [
+      f("Harrowgate - S03E08 - The Long Way Down.mkv"),
+      f("Harrowgate - S03E02 - Salt.mkv"),
+      f("Harrowgate - S03E01 - Low Tide.mkv"),
+      f("Harrowgate - S03E10 - Last Light.mkv"),
+    ];
+    expect(sortStreamFiles(files, "name").map((x) => x.filename)).toEqual([
+      "Harrowgate - S03E01 - Low Tide.mkv",
+      "Harrowgate - S03E02 - Salt.mkv",
+      "Harrowgate - S03E08 - The Long Way Down.mkv",
+      "Harrowgate - S03E10 - Last Light.mkv",
+    ]);
+  });
+
+  // Numeric collation, not byte order: "10" after "2" — the whole reason the
+  // compare passes `numeric: true`. Plain string order would put E10 second.
+  it("collates numbers as numbers", () => {
+    const files = [f("Bonus Gag Reel 10.mkv"), f("Bonus Gag Reel 2.mkv")];
+    expect(sortStreamFiles(files, "name").map((x) => x.filename)).toEqual([
+      "Bonus Gag Reel 2.mkv",
+      "Bonus Gag Reel 10.mkv",
+    ]);
+  });
+
+  // Case is not a sort key: sensitivity "base". A release that shouts one
+  // filename should not have it float to the top.
+  it("ignores case when ordering by title", () => {
+    const files = [f("beta.mkv"), f("ALPHA.mkv")];
+    expect(sortStreamFiles(files, "name").map((x) => x.filename)).toEqual([
+      "ALPHA.mkv",
+      "beta.mkv",
+    ]);
+  });
+
+  // The names come out of a stranger's torrent, so they get cleanText's
+  // treatment before being compared — otherwise a decorative glyph nobody can
+  // see in the rendered row silently decides the order.
+  it("compares the cleaned name, so junk glyphs do not decide the order", () => {
+    const files = [f("Kestrel.2010.mkv"), f("\u{1f3ac} Ashfall.1999.mkv")];
+    expect(sortStreamFiles(files, "name").map((x) => x.filename)).toEqual([
+      "\u{1f3ac} Ashfall.1999.mkv",
+      "Kestrel.2010.mkv",
+    ]);
+  });
+
+  it("orders by size largest-first", () => {
+    const files = [f("small.mkv", 10), f("big.mkv", 900), f("middling.mkv", 100)];
+    expect(sortStreamFiles(files, "size").map((x) => x.filename)).toEqual([
+      "big.mkv",
+      "middling.mkv",
+      "small.mkv",
+    ]);
+  });
+
+  // Both callers hold the list they were given (the TUI keeps `files` to resolve
+  // a preselect back to a row; the browser re-sorts the same array on toggle),
+  // so sorting in place would corrupt the caller's own indexes.
+  // Two modes, so the toggle both pickers offer is one rule rather than a `? :`
+  // written once per surface.
+  it("toggles between the two modes", () => {
+    expect(nextSort("name")).toBe("size");
+    expect(nextSort("size")).toBe("name");
+  });
+
+  it("does not mutate the caller's array", () => {
+    const files = [f("b.mkv"), f("a.mkv")];
+    const before = files.map((x) => x.filename);
+    sortStreamFiles(files, "name");
+    expect(files.map((x) => x.filename)).toEqual(before);
+  });
+
+  it("returns the caller's own element type, extras and all", () => {
+    const files = [
+      { filename: "b.mkv", bytes: 1, index: 7 },
+      { filename: "a.mkv", bytes: 2, index: 3 },
+    ];
+    expect(sortStreamFiles(files, "name").map((x) => x.index)).toEqual([3, 7]);
+  });
+});

--- a/src/util/streamFileSort.ts
+++ b/src/util/streamFileSort.ts
@@ -1,0 +1,59 @@
+/**
+ * How a file picker orders the files inside one torrent — the rule, shared.
+ *
+ * WHY IT MOVED HERE. This was module-private in `src/ui/components/StreamFilePrompt.tsx`
+ * and the browser's picker had no equivalent at all, so a season pack that the
+ * terminal listed E01…E10 was listed in the browser in whatever order the
+ * torrent happened to name its files: E08, E02, E03 … E01, then the extras. Two
+ * front ends over one core are not allowed to disagree about that (CLAUDE.md),
+ * and the fix is the one this codebase keeps reaching for after four recorded
+ * copy-then-drift bugs — move the helper down, don't copy it.
+ *
+ * IT MUST STAY BROWSER-SAFE. It is imported by `src/web/static/streamFlow.ts`,
+ * which tsup bundles with `platform: "browser"`, so no `node:*` import may
+ * appear here or in anything it reaches. `./format` is import-free and stays
+ * that way; `npm run build` is the enforcement.
+ *
+ * Generic over the *shape* for the same reason `videoFiles.ts` is: Node holds
+ * `StreamFile` (with an upstream `url`), the browser holds `PublicStreamFile`
+ * (with a `handle` and the session's own `index`), and returning the caller's
+ * own element type is what lets each keep the field that addresses the file.
+ */
+import { cleanText } from "./format";
+import type { SizedFile } from "./videoFiles";
+
+/** Title order, or biggest-first. The two modes the picker's toggle swaps. */
+export type StreamFileSort = "name" | "size";
+
+/** The other mode — the toggle both pickers offer, written once. */
+export function nextSort(mode: StreamFileSort): StreamFileSort {
+  return mode === "name" ? "size" : "name";
+}
+
+/**
+ * The files in display order. A copy: both callers keep the list they were
+ * given (the TUI resolves a preselect back to a row through it, the browser
+ * re-sorts the same array when the mode changes), so sorting in place would
+ * move rows out from under an index someone still holds.
+ *
+ * Title order compares `cleanText`ed names with numeric collation and no case
+ * sensitivity, so "Reel 2" precedes "Reel 10" and a decorative glyph nobody can
+ * see in the rendered row does not decide where the row goes.
+ */
+export function sortStreamFiles<T extends SizedFile>(
+  files: readonly T[],
+  mode: StreamFileSort,
+): T[] {
+  const copy = [...files];
+  if (mode === "name") {
+    copy.sort((a, b) =>
+      cleanText(a.filename).localeCompare(cleanText(b.filename), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    );
+  } else {
+    copy.sort((a, b) => b.bytes - a.bytes);
+  }
+  return copy;
+}

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -17,10 +17,13 @@ import {
 import {
   fileLabel,
   isPlayable,
+  nextSort,
+  pickerRows,
   playerPath,
   runPlay,
   wantedEpisodeFor,
   type EpisodeRef,
+  type StreamFileSort,
   type PublicStreamFile,
   type PublicStreamSession,
   type StartResult,
@@ -169,6 +172,7 @@ const picker = el<HTMLDivElement>("picker");
 const pickerTitle = el<HTMLParagraphElement>("picker-title");
 const pickerFiles = el<HTMLUListElement>("picker-files");
 const pickerCancel = el<HTMLButtonElement>("picker-cancel");
+const pickerSort = el<HTMLButtonElement>("picker-sort");
 
 const prefsBlock = el<HTMLDetailsElement>("prefs");
 const prefsResSelect = el<HTMLSelectElement>("pref-res");
@@ -451,6 +455,17 @@ const playing = new Set<string>();
 // without stopping it would leave that running until the idle reaper notices.
 let pickerSession: string | null = null;
 
+// How the open picker's list is ordered, and how to draw it again. Both are
+// module-level for the same reason `pickerSession` is: there is one picker card
+// in the page, so a second play() replaces the list wholesale and these follow
+// it. (The infoHash deliberately does NOT live up here — see showPicker.)
+//
+// The mode survives a second play() on purpose: someone who prefers biggest-first
+// prefers it for the next torrent too, exactly as the TUI's `s` sticks for as long
+// as its picker is open. It is not persisted to config — the TUI's isn't either.
+let pickerMode: StreamFileSort = "name";
+let drawPicker: (() => void) | null = null;
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function startSession(row: DashRow, confirmed: boolean): Promise<StartResult> {
@@ -550,6 +565,7 @@ function openPlayer(path: string): void {
 
 function hidePicker(): void {
   pickerSession = null;
+  drawPicker = null;
   picker.hidden = true;
   pickerFiles.replaceChildren();
 }
@@ -572,6 +588,10 @@ function hidePicker(): void {
 // wiring. All this does with it is mark the row, say so in a word, and put the
 // keyboard on it — pressing Enter then plays the episode the Continue-watching
 // row promised, which is the browser's equivalent of the TUI's opening cursor.
+//
+// The ORDER rows appear in is `pickerRows`' decision for the same reason, and the
+// re-draw the sort button triggers goes through it too: which row is which after a
+// re-sort is exactly the sort of conditional that must not live in this file.
 function showPicker(
   infoHash: string,
   sessionId: string,
@@ -582,54 +602,91 @@ function showPicker(
 ): void {
   pickerSession = sessionId;
   pickerTitle.textContent = `Which file from “${shortName(name)}”?`;
-  pickerFiles.replaceChildren(
-    ...files.map((file, index) => {
-      const li = document.createElement("li");
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "picker-file";
-      button.textContent = fileLabel(file);
-      button.title = file.filename;
-      if (index === preselect) {
-        button.classList.add("picker-file-next");
-        button.setAttribute("aria-current", "true");
-        // createElement + textContent, as everywhere on this page.
-        const tag = document.createElement("span");
-        tag.className = "picker-next";
-        tag.textContent = "next";
-        button.append(tag);
-      }
-      button.addEventListener("click", () => {
-        // hidePicker() clears pickerSession, so the Cancel handler can no longer
-        // stop the session we are about to hand to the player.
-        hidePicker();
-        // Fire-and-forget, and only once a file was actually chosen. The server
-        // no-ops when this torrent is not favourited, so there is nothing to
-        // check here and nothing to wait for — the same shape as the TUI's
-        // markPlayed, which also records only after a player launches.
-        void postSaved(
-          "/api/library",
-          libraryBody({ infoHash, name }, "watched", file.filename),
-        );
-        openPlayer(playerPath(sessionId, file, capability));
-      });
-      li.append(button);
-      return li;
-    }),
-  );
+
+  // `keep` is the file the user already had the keyboard on, as an index into
+  // `files` — read out of the live DOM rather than tracked, so nothing here has
+  // to stay in step with focus moving by tab, click or arrow key. Omitted on the
+  // first draw, which is a different thing from "nothing focused"; pickerRows
+  // owns that distinction.
+  const draw = (keep?: number | null): void => {
+    const rows = pickerRows(files, pickerMode, preselect, keep);
+    pickerSort.textContent = `sort: ${pickerMode}`;
+    pickerFiles.replaceChildren(
+      ...rows.files.map((file, index) => {
+        const li = document.createElement("li");
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "picker-file";
+        button.textContent = fileLabel(file);
+        button.title = file.filename;
+        // Which file this row is, for the focus lookup on the next re-sort.
+        // The session's own index, which is what identifies a file everywhere
+        // else on the wire.
+        button.dataset["file"] = String(file.index);
+        if (index === rows.preselect) {
+          button.classList.add("picker-file-next");
+          button.setAttribute("aria-current", "true");
+          // createElement + textContent, as everywhere on this page.
+          const tag = document.createElement("span");
+          tag.className = "picker-next";
+          tag.textContent = "next";
+          button.append(tag);
+        }
+        button.addEventListener("click", () => {
+          // hidePicker() clears pickerSession, so the Cancel handler can no longer
+          // stop the session we are about to hand to the player.
+          hidePicker();
+          // Fire-and-forget, and only once a file was actually chosen. The server
+          // no-ops when this torrent is not favourited, so there is nothing to
+          // check here and nothing to wait for — the same shape as the TUI's
+          // markPlayed, which also records only after a player launches.
+          void postSaved(
+            "/api/library",
+            libraryBody({ infoHash, name }, "watched", file.filename),
+          );
+          openPlayer(playerPath(sessionId, file, capability));
+        });
+        li.append(button);
+        return li;
+      }),
+    );
+    // After the list is in the document, and read back out of the DOM rather than
+    // closed over: a focus() on a hidden element does nothing at all.
+    if (rows.focus !== null) {
+      const target = pickerFiles.children[rows.focus]?.firstElementChild;
+      if (target instanceof HTMLElement) target.focus();
+    }
+  };
+
   picker.hidden = false;
-  // After un-hiding, and read back out of the DOM rather than closed over: a
-  // focus() on a hidden element does nothing at all.
-  if (preselect !== null) {
-    const target = pickerFiles.children[preselect]?.firstElementChild;
-    if (target instanceof HTMLElement) target.focus();
-  }
+  // Only a re-sort has a file to keep; opening the picker follows the preselect.
+  drawPicker = () => draw(focusedPickerFile(files));
+  draw();
+}
+
+// The row the keyboard is on, as an index into `files`, or null when focus is
+// somewhere else on the page entirely (the sort button itself, most often).
+function focusedPickerFile(files: PublicStreamFile[]): number | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  const at = active.dataset["file"];
+  if (at === undefined) return null;
+  const found = files.findIndex((f) => String(f.index) === at);
+  return found >= 0 ? found : null;
 }
 
 pickerCancel.addEventListener("click", () => {
   const sessionId = pickerSession;
   hidePicker();
   if (sessionId) stopSession(sessionId);
+});
+
+// The TUI picker's `s` key. The mode flips (nextSort, shared with that picker) and
+// the open list is drawn again; with no picker open there is nothing to draw and
+// the button is not on screen to be pressed.
+pickerSort.addEventListener("click", () => {
+  pickerMode = nextSort(pickerMode);
+  drawPicker?.();
 });
 
 // The flow itself is runPlay in streamFlow.ts, where a unit test can reach it —

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -70,7 +70,12 @@
       <div id="picker" class="card picker" hidden>
         <p id="picker-title" class="picker-title"></p>
         <ul id="picker-files" class="picker-files"></ul>
-        <button id="picker-cancel" type="button">Cancel</button>
+        <div class="picker-actions">
+          <!-- The terminal picker's "s" key, as a button: title order or
+               largest-first. Its label is set by app.js from the current mode. -->
+          <button id="picker-sort" type="button"></button>
+          <button id="picker-cancel" type="button">Cancel</button>
+        </div>
       </div>
 
       <!-- ---- search ------------------------------------------------------ -->

--- a/src/web/static/streamFlow.test.ts
+++ b/src/web/static/streamFlow.test.ts
@@ -8,6 +8,7 @@ import {
   playerPath,
   pollDecision,
   runPlay,
+  pickerRows,
   streamOutcome,
   wantedEpisodeFor,
   type PlayEffects,
@@ -176,6 +177,52 @@ describe("streamOutcome", () => {
     expect(out.preselect).toBe(1);
   });
 
+  // THE REPORTED BUG: the browser listed the candidates in whatever order the
+  // torrent named them, so a season pack showed E08 above E02 while the TUI's
+  // picker showed the same pack in title order. One shared sort, both surfaces.
+  it("lists the candidates in the same title order the TUI's picker uses", () => {
+    const out = streamOutcome(
+      session({
+        files: [
+          file("Harrowgate - S03E08 - The Long Way Down.mkv", 0),
+          file("Harrowgate - S03E02 - Salt.mkv", 1),
+          file("Season 3 Gag Reel.mkv", 2),
+          file("Harrowgate - S03E01 - Low Tide.mkv", 3),
+          file("Harrowgate - S03E10 - Last Light.mkv", 4),
+        ],
+      }),
+    );
+    expect(out.kind).toBe("choose");
+    if (out.kind !== "choose") return;
+    expect(out.files.map((f) => f.filename)).toEqual([
+      "Harrowgate - S03E01 - Low Tide.mkv",
+      "Harrowgate - S03E02 - Salt.mkv",
+      "Harrowgate - S03E08 - The Long Way Down.mkv",
+      "Harrowgate - S03E10 - Last Light.mkv",
+      "Season 3 Gag Reel.mkv",
+    ]);
+  });
+
+  // The preselection is an index into the list the picker DRAWS, so it has to be
+  // counted after the sort — counting it before would badge, and focus, whatever
+  // file happened to land in that row.
+  it("counts the preselection over the sorted list, not the torrent's order", () => {
+    const out = streamOutcome(
+      session({
+        files: [
+          file("Harrowgate - S03E08 - The Long Way Down.mkv", 0),
+          file("Harrowgate - S03E01 - Low Tide.mkv", 1),
+          file("Harrowgate - S03E02 - Salt.mkv", 2),
+        ],
+      }),
+      { season: 3, episode: 2 },
+    );
+    expect(out.kind).toBe("choose");
+    if (out.kind !== "choose") return;
+    expect(out.preselect).toBe(1);
+    expect(out.files[out.preselect!]!.filename).toContain("S03E02");
+  });
+
   it("has no preselection without a wanted episode, or when nothing matches", () => {
     const files = [file("Harrowgate.S03E04.1080p.mkv", 0), file("Harrowgate.S03E05.1080p.mkv", 1)];
     const noNext = streamOutcome(session({ files }));
@@ -335,6 +382,63 @@ describe("wantedEpisodeFor", () => {
 describe("fileLabel", () => {
   it("shows the name and a human size", () => {
     expect(fileLabel(file("movie.mkv", 0, 1536))).toBe("movie.mkv · 1.50 KB");
+  });
+});
+
+// The browser's equivalent of the TUI picker's `s` key. Rows, the badge and the
+// keyboard target all come from here so app.ts stays wiring.
+describe("pickerRows", () => {
+  const pack = [
+    file("Harrowgate - S03E01 - Low Tide.mkv", 0, 2_000_000),
+    file("Harrowgate - S03E02 - Salt.mkv", 1, 3_000_000),
+    file("Season 3 Gag Reel.mkv", 2, 40_000),
+  ];
+
+  it("draws title order, and largest-first for size", () => {
+    expect(pickerRows(pack, "name", null).files.map((f) => f.index)).toEqual([0, 1, 2]);
+    expect(pickerRows(pack, "size", null).files.map((f) => f.index)).toEqual([1, 0, 2]);
+  });
+
+  // The badge follows the FILE across a re-sort, exactly as the TUI's highlight
+  // does. A preselect index left pointing at the old row would mark, and focus,
+  // an unrelated episode the moment someone pressed sort.
+  it("carries the preselected file across a re-sort", () => {
+    const rows = pickerRows(pack, "size", 0);
+    expect(rows.preselect).toBe(1);
+    expect(rows.files[rows.preselect!]!.index).toBe(0);
+    expect(rows.focus).toBe(1);
+  });
+
+  // `keep` is the file the user already had the keyboard on. It wins over the
+  // preselection, so toggling sort does not yank focus back to "next".
+  it("keeps the focused file focused, in preference to the preselection", () => {
+    const rows = pickerRows(pack, "size", 0, 2);
+    expect(rows.preselect).toBe(1);
+    expect(rows.focus).toBe(2);
+    expect(rows.files[rows.focus!]!.index).toBe(2);
+  });
+
+  // The state right after the sort button is clicked: the keyboard is on the
+  // button, not on a file. Focusing the "next" row then would steal it from under
+  // the press, so an explicit null keeps focus where it is.
+  it("focuses nothing when asked to keep a focus that is not on a file row", () => {
+    const rows = pickerRows(pack, "size", 0, null);
+    expect(rows.preselect).toBe(1);
+    expect(rows.focus).toBeNull();
+  });
+
+  it("has nothing to badge or focus when there is no preselection and nothing kept", () => {
+    const rows = pickerRows(pack, "name", null);
+    expect(rows.preselect).toBeNull();
+    expect(rows.focus).toBeNull();
+  });
+
+  // A file that is not in the list at all (a stale index from a picker that has
+  // since been replaced) is "no opinion", not a crash and not row 0.
+  it("ignores a preselection or a kept file that is not in the list", () => {
+    const rows = pickerRows(pack, "name", 99, 42);
+    expect(rows.preselect).toBeNull();
+    expect(rows.focus).toBeNull();
   });
 });
 

--- a/src/web/static/streamFlow.ts
+++ b/src/web/static/streamFlow.ts
@@ -21,6 +21,13 @@
 // unit). That module is dependency-free and stays that way — `platform:
 // "browser"` in tsup.web.config.ts fails the build if it ever isn't.
 import { streamCandidates } from "../../util/videoFiles";
+// The fifth, same argument, and this one was a bug report rather than a
+// prediction: the ORDER a picker lists a torrent's files in used to be private to
+// `src/ui/components/StreamFilePrompt.tsx`, so the browser listed a season pack
+// in whatever order the torrent named its files — E08 above E02 — while the
+// terminal listed it E01…E10. The rule moved down to src/util rather than being
+// written a second time here.
+import { nextSort, sortStreamFiles, type StreamFileSort } from "../../util/streamFileSort";
 // The second, and the same argument: which
 // file is the next episode is a decision both front ends make, so it is shared
 // rather than copied. It pulls in `release.ts` (and so parse-torrent-title),
@@ -173,11 +180,76 @@ export function streamOutcome(
   if (session.state !== "ready") {
     return { kind: "error", message: "The stream is still starting." };
   }
-  const files = streamCandidates(session.files);
-  if (files.length === 0) return { kind: "empty" };
-  if (files.length === 1) return { kind: "single", file: files[0]! };
+  const candidates = streamCandidates(session.files);
+  if (candidates.length === 0) return { kind: "empty" };
+  if (candidates.length === 1) return { kind: "single", file: candidates[0]! };
+  // Sorted BEFORE the preselection is counted, because `preselect` is an index
+  // into the list the picker draws: counting it over the torrent's own order and
+  // then drawing a different order badges — and focuses — an unrelated episode.
+  // Safe to do here, unlike in the TUI (which sorts at display and remaps by
+  // `url`), because `nextEpisodeIndex`'s only position-sensitive branch is its
+  // `watched` fallback, and the browser is not given watched filenames — see the
+  // note above about the half of the preselection that stays TUI-only.
+  const files = sortStreamFiles(candidates, "name");
   return { kind: "choose", files, preselect: nextEpisodeIndex(files, { next }) };
 }
+
+/** One rendering of the picker list: what to draw, what to badge, where the keyboard goes. */
+export interface PickerRows {
+  /** The files in display order. */
+  files: PublicStreamFile[];
+  /** The row to badge "next", as an index into `files` above, or null. */
+  preselect: number | null;
+  /** The row to put the keyboard on, as an index into `files` above, or null. */
+  focus: number | null;
+}
+
+/**
+ * The picker's list for one sort mode — the browser's equivalent of the TUI
+ * picker's `s` key, and here rather than in app.ts because it is three decisions
+ * and app.ts is wiring.
+ *
+ * Both `marked` and `keep` are indexes into `files` AS GIVEN (`streamOutcome`'s
+ * list), and both are resolved to the FILE and looked up again in the sorted
+ * list: an index into an order the user is no longer looking at points at the
+ * wrong row. Same rule, and the same reason, as `StreamFilePrompt`'s remap by
+ * `url` — the identity here is the session's own file index.
+ *
+ * `keep` is the file the user already had focused and WINS over `marked`, so
+ * pressing sort re-orders the list under the keyboard instead of yanking it back
+ * to the "next" episode.
+ *
+ * OMITTING `keep` AND PASSING NULL MEAN DIFFERENT THINGS, and the difference is
+ * the sort button itself. Omitted is "opening the picker": focus follows the
+ * preselection, which is what makes Enter play the episode Continue-watching
+ * promised. Null — or an index naming a file not in the list, e.g. a stale one
+ * from a picker since replaced — is "asked, and the keyboard is not on a file
+ * row", which is exactly the state after clicking sort: `focus` is then null and
+ * nothing is stolen from the button that was just pressed.
+ */
+export function pickerRows(
+  files: readonly PublicStreamFile[],
+  mode: StreamFileSort,
+  marked: number | null,
+  keep?: number | null,
+): PickerRows {
+  const sorted = sortStreamFiles(files, mode);
+  const rowOf = (at: number | null | undefined): number | null => {
+    if (at === null || at === undefined) return null;
+    const file = files[at];
+    if (!file) return null;
+    const row = sorted.findIndex((f) => f.index === file.index);
+    return row >= 0 ? row : null;
+  };
+  const preselect = rowOf(marked);
+  const focus = keep === undefined ? preselect : rowOf(keep);
+  return { files: sorted, preselect, focus };
+}
+
+// Re-exported for app.ts, for the reason the file header gives: one import site,
+// and no opportunity for the browser bundle to redeclare either the mode union or
+// the toggle rule. See src/util/streamFileSort.ts.
+export { nextSort, type StreamFileSort };
 
 /**
  * Which episode to open the picker on for a release the user pressed Play on.

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -325,6 +325,14 @@ button:hover {
   overflow-wrap: anywhere;
 }
 
+/* Sort and Cancel sit on one row under the list, wrapping on a narrow phone
+   rather than stretching to full width the way .picker-file deliberately does. */
+.picker-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
 /* The file the Continue-watching row said was next. It is also focused, so the
    keyboard is already on it; this is the same information for eyes. */
 .picker-file-next {


### PR DESCRIPTION
Pressing **play** on a season pack in the browser listed its files in whatever order the torrent named them — E08, E02, E03 … E01, then the extras — while the terminal's picker listed the same pack E01…E10. Reported from live use.

The ordering rule was private to `src/ui/components/StreamFilePrompt.tsx` (a module-local `sortFiles`), so the browser's picker simply never had one: `streamOutcome` handed `streamCandidates(session.files)` straight to the DOM.

## What changed

- **`src/util/streamFileSort.ts` (new)** — the rule moved down rather than being written a second time, for the reason this repo keeps recording (uploadSpeed, the byte formatter, the progress unit, the API path table): the fifth copy would drift too. Title order compares `cleanText`ed names with numeric collation and no case sensitivity ("Reel 2" before "Reel 10"); size order is largest-first. Dependency-free apart from `cleanText`, so it stays reachable from the browser bundle — `npm run build` is the enforcement.
- **`streamOutcome` sorts before counting the preselection.** `preselect` is an index into the list the picker *draws*, so counting it over the torrent's own order and then drawing another would badge — and focus — an unrelated episode. Safe here and not in the TUI (which sorts at display and remaps by `url`): `nextEpisodeIndex`'s only position-sensitive branch is its `watched` fallback, and the browser is deliberately not given watched filenames.
- **The terminal's `s` key gets its browser equivalent**, a **sort** button under the list, so the feature lands on both surfaces rather than one. Which row is which after a re-sort is `pickerRows`' decision in `streamFlow.ts`, where a unit test can reach it; `app.ts` stays DOM wiring, and every node is still `createElement` + `textContent`.
- `README.md` — one sentence on the ordering and the two ways to toggle it.

The rule `pickerRows` holds around focus: a re-sort never yanks the keyboard back to the "next" row. A click on sort leaves focus on the button in Chrome (verified in the running app), and "asked to keep a focus that is not on a file row" is no opinion, so nothing is stolen. Where a browser does leave focus on the list, the file it was on keeps the keyboard across the re-sort.

## Worth knowing

Extras sort **above** the episodes in title order — `Bonus Gag Reel 1/2/3`, `Deleted Scenes`, `Season 3 Gag Reel`, then `S03E01…E08`. That is what the terminal has always shown, and the `next` badge plus focus still land on the right episode, so this PR is parity rather than a redesign. Hoisting episodes above extras would be a change to both pickers and a separate call.

## Testing

`npm test` (2041 pass; 12 new across `streamFileSort.test.ts` and `streamFlow.test.ts`, the ordering ones written failing first), `npm run typecheck`, `npm run lint` (only the known pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx`), `npm run build`.

`app.ts` is not reachable by a unit test here, so the wiring was checked by running `serve --web`: the page initialises with an empty console (which is what proves the new `picker-sort` binding resolves — a missing id throws at module init and takes the whole dashboard with it), and the `.picker-actions` row lays out correctly beside Cancel.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
