### PR TITLE
Stop the web player freezing in silence when a provider's transcode can't keep up

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,17 @@ give up after twelve seconds:
 - **mp4/H.264** plays inline. The video element streams it directly, and seeking works properly because
   the server honours range requests.
 - **mkv, HEVC, DTS** — most of the scene — will not decode in Chrome or Firefox; no browser ships those
-  codecs. Where your **debrid provider will transcode it for you**, the player uses their stream and it
-  simply plays, with full seeking, and without a byte passing through the machine running torlnk.
+  codecs. Where your **debrid provider will transcode it for you**, the player uses their stream, with full
+  seeking, and without a byte passing through the machine running torlnk.
   Real-Debrid does this. TorBox publishes no equivalent, so a TorBox stream falls through to the next line.
+  **A provider offering a transcode is not the same as one that can keep up with it**, though: their
+  transcoder works on demand, from the start of the file, and for a big HEVC release it can fall behind
+  real time — at which point it serves the part of a segment it has finished as though it were the whole
+  thing, and the browser has no way to tell. That used to show up as a video that played for a few seconds
+  and then froze with nothing on screen to explain it. So the player now checks a segment before offering
+  the transcode at all, and a provider that is not keeping up falls through to the next line instead. If
+  one stalls anyway — the check can be fooled by a file whose opening the provider has already transcoded —
+  playback says so and points you at the `.m3u`, rather than freezing in silence.
   Turning on [relaying](#relaying-streams-through-this-machine) switches this off on purpose: their stream
   is played from *their* servers by your browser, which is the one thing relaying exists to prevent — so
   while it's on, these releases fall through to the next line too.

--- a/src/core/hlsVerdictCache.test.ts
+++ b/src/core/hlsVerdictCache.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { HlsVerdictCache } from "./hlsVerdictCache";
+
+describe("HlsVerdictCache", () => {
+  it("returns what was stored, keyed by session and index together", () => {
+    const cache = new HlsVerdictCache(4);
+    cache.set("sid-1", 0, true);
+    cache.set("sid-1", 1, false);
+    expect(cache.get("sid-1", 0)).toBe(true);
+    expect(cache.get("sid-1", 1)).toBe(false);
+    expect(cache.get("sid-2", 0)).toBeUndefined();
+  });
+
+  // The distinction the whole cache turns on: "no" must not read as "not asked",
+  // or a manifest already found unusable is re-probed on every page load and the
+  // probe segment is pulled through this machine again each time.
+  it("keeps a stored false distinguishable from never having asked", () => {
+    const cache = new HlsVerdictCache(4);
+    cache.set("sid-1", 0, false);
+    expect(cache.get("sid-1", 0)).toBe(false);
+    expect(cache.get("sid-1", 0)).not.toBeUndefined();
+    expect(cache.get("sid-1", 9)).toBeUndefined();
+  });
+
+  it("does not confuse a session id containing the separator", () => {
+    const cache = new HlsVerdictCache(4);
+    cache.set("a:1", 0, true);
+    expect(cache.get("a", 1)).toBeUndefined();
+  });
+
+  it("evicts the oldest entry past its bound, so it cannot grow forever", () => {
+    const cache = new HlsVerdictCache(2);
+    cache.set("s", 0, true);
+    cache.set("s", 1, true);
+    cache.set("s", 2, false);
+    expect(cache.get("s", 0)).toBeUndefined();
+    expect(cache.get("s", 2)).toBe(false);
+  });
+
+  it("re-setting a key refreshes its position rather than adding a second entry", () => {
+    const cache = new HlsVerdictCache(2);
+    cache.set("s", 0, true);
+    cache.set("s", 1, true);
+    cache.set("s", 0, false);
+    cache.set("s", 2, true);
+    // "s,0" was rewritten last of the first two, so "s,1" is the oldest and goes.
+    expect(cache.get("s", 1)).toBeUndefined();
+    expect(cache.get("s", 0)).toBe(false);
+    expect(cache.get("s", 2)).toBe(true);
+  });
+});

--- a/src/core/hlsVerdictCache.ts
+++ b/src/core/hlsVerdictCache.ts
@@ -1,0 +1,43 @@
+// Remembers whether a provider's HLS manifest was worth offering, so reloading a
+// player page does not pull another probe segment through this machine.
+//
+// Same shape and same reasoning as ProbeCache — bounded rather than tied to
+// session lifetime, because a bound needs no teardown hook and a stale entry for
+// a dead session is harmless while session ids are never reused.
+//
+// The value is the verdict, so `undefined` (never asked) stays distinguishable
+// from `false` (asked, and the answer was no). A single boolean field could not
+// express that, and re-probing every load would defeat the point.
+
+const DEFAULT_MAX = 64;
+
+export class HlsVerdictCache {
+  private readonly entries = new Map<string, boolean>();
+
+  constructor(private readonly max: number = DEFAULT_MAX) {}
+
+  // JSON-encoded rather than `${sid}:${index}`: a session id containing the
+  // separator would otherwise collide with a different (sid, index) pair.
+  private key(sid: string, index: number): string {
+    return JSON.stringify([sid, index]);
+  }
+
+  get(sid: string, index: number): boolean | undefined {
+    return this.entries.get(this.key(sid, index));
+  }
+
+  set(sid: string, index: number, usable: boolean): void {
+    const key = this.key(sid, index);
+    // Delete first so a re-set moves the entry to the end of the insertion order
+    // rather than leaving it where it was — otherwise the most recently written
+    // entry could be the next one evicted.
+    this.entries.delete(key);
+    this.entries.set(key, usable);
+    // Map iterates in insertion order, so the first key is the oldest.
+    while (this.entries.size > this.max) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+}

--- a/src/web/hlsHealth.test.ts
+++ b/src/web/hlsHealth.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PROBE_ORDINAL,
+  SEGMENT_QUANTUM,
+  looksTruncated,
+  makeCheckHls,
+  probeTarget,
+  segmentUris,
+} from "./hlsHealth";
+
+// A media playlist in the shape Real-Debrid actually serves: no version tag, no
+// stream-inf, relative segment names, ENDLIST at the bottom.
+const manifest = (count: number): string => {
+  const lines = ["#EXTM3U", "#EXT-X-TARGETDURATION:6", "#EXT-X-ALLOW-CACHE:YES", "#EXT-X-MEDIA-SEQUENCE:0"];
+  for (let n = 0; n < count; n++) {
+    lines.push("#EXTINF:5, nodesc", `${String(n).padStart(5, "0")}.ts`);
+  }
+  lines.push("#EXT-X-ENDLIST");
+  return lines.join("\n");
+};
+
+const MANIFEST_URL = "https://28.stream.example.test/t/ABCDEF/eng1/none/aac/full.m3u8";
+
+describe("segmentUris", () => {
+  it("returns the URI lines in order and nothing else", () => {
+    expect(segmentUris(manifest(3))).toEqual(["00000.ts", "00001.ts", "00002.ts"]);
+  });
+
+  it("ignores comments, tags and blank lines", () => {
+    const body = "#EXTM3U\n\n#EXT-X-TARGETDURATION:6\n#EXTINF:5,\n00000.ts\n   \n#EXT-X-ENDLIST\n";
+    expect(segmentUris(body)).toEqual(["00000.ts"]);
+  });
+
+  it("survives CRLF, which some providers emit", () => {
+    expect(segmentUris("#EXTM3U\r\n#EXTINF:5,\r\n00000.ts\r\n#EXT-X-ENDLIST\r\n")).toEqual(["00000.ts"]);
+  });
+
+  it("is empty for something that is not a playlist", () => {
+    expect(segmentUris("")).toEqual([]);
+    expect(segmentUris("#EXTM3U\n#EXT-X-ENDLIST\n")).toEqual([]);
+  });
+});
+
+describe("looksTruncated", () => {
+  // The measured signature: Real-Debrid flushes whatever the transcoder has
+  // produced, rounded to a 256 KiB boundary. Genuine finished segments are
+  // irregular sizes.
+  it("flags an exact multiple of the 256 KiB quantum", () => {
+    for (const n of [1, 2, 3, 4, 8, 10, 13]) {
+      expect(looksTruncated(SEGMENT_QUANTUM * n)).toBe(true);
+    }
+  });
+
+  it("passes the irregular sizes a finished segment actually has", () => {
+    for (const n of [4639088, 3216116, 3135464, 5193124, 3390016]) {
+      expect(looksTruncated(n)).toBe(false);
+    }
+  });
+
+  // An empty body is a different failure and the caller reports it as one; it
+  // must not be read as "an exact multiple of the quantum", which 0 is.
+  it("does not call an empty body truncated", () => {
+    expect(looksTruncated(0)).toBe(false);
+  });
+});
+
+describe("probeTarget", () => {
+  it("picks a segment past the transcoder's opening burst", () => {
+    expect(probeTarget(MANIFEST_URL, manifest(704))).toBe(
+      `https://28.stream.example.test/t/ABCDEF/eng1/none/aac/${String(PROBE_ORDINAL).padStart(5, "0")}.ts`,
+    );
+  });
+
+  // A short file has no segment at the chosen ordinal. The last one is the best
+  // available answer and is still past the burst on anything worth probing.
+  it("falls back to the last segment of a short playlist", () => {
+    expect(probeTarget(MANIFEST_URL, manifest(3))).toBe(
+      "https://28.stream.example.test/t/ABCDEF/eng1/none/aac/00002.ts",
+    );
+  });
+
+  it("is null when there is nothing to probe", () => {
+    expect(probeTarget(MANIFEST_URL, "#EXTM3U\n#EXT-X-ENDLIST\n")).toBeNull();
+  });
+
+  // The segment name comes from a provider response, so it is not trusted to be
+  // a bare filename. Anything that would leave the manifest's own directory —
+  // or its host — is refused rather than fetched.
+  it("refuses a segment URI that escapes the manifest's origin", () => {
+    for (const bad of ["https://evil.test/x.ts", "//evil.test/x.ts", "http://28.stream.example.test/x.ts"]) {
+      const body = `#EXTM3U\n#EXTINF:5,\n${bad}\n#EXT-X-ENDLIST\n`;
+      expect(probeTarget(MANIFEST_URL, body)).toBeNull();
+    }
+  });
+
+  it("refuses a segment URI that climbs out of the directory", () => {
+    const body = "#EXTM3U\n#EXTINF:5,\n../../other/00000.ts\n#EXT-X-ENDLIST\n";
+    expect(probeTarget(MANIFEST_URL, body)).toBeNull();
+  });
+});
+
+describe("makeCheckHls", () => {
+  const okSegment = { status: 200, bytes: 4639088 };
+
+  const fetcher = (
+    manifestBody: string | null,
+    segment: { status: number; bytes: number } | "timeout" | null,
+  ) =>
+    vi.fn(async (url: string) => {
+      if (url.endsWith(".m3u8")) {
+        return manifestBody === null ? null : { status: 200, bytes: manifestBody.length, body: manifestBody };
+      }
+      if (segment === "timeout" || segment === null) return null;
+      return { status: segment.status, bytes: segment.bytes, body: "" };
+    });
+
+  it("offers a manifest whose probe segment came back whole", async () => {
+    const fetchImpl = fetcher(manifest(704), okSegment);
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(true);
+  });
+
+  // The bug this exists for: the transcoder cannot sustain realtime, so it hands
+  // over a partial segment as a complete 200 and the browser silently freezes.
+  it("refuses a manifest whose probe segment came back truncated", async () => {
+    const fetchImpl = fetcher(manifest(704), { status: 200, bytes: SEGMENT_QUANTUM * 4 });
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("refuses a manifest whose probe segment never arrived", async () => {
+    const fetchImpl = fetcher(manifest(704), "timeout");
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("refuses a probe segment that answered with an error status", async () => {
+    const fetchImpl = fetcher(manifest(704), { status: 404, bytes: 0 });
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("refuses an empty probe segment", async () => {
+    const fetchImpl = fetcher(manifest(704), { status: 200, bytes: 0 });
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("refuses when the manifest itself cannot be read", async () => {
+    await expect(makeCheckHls({ fetchImpl: fetcher(null, okSegment) })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("refuses a manifest with no segments in it", async () => {
+    const fetchImpl = fetcher("#EXTM3U\n#EXT-X-ENDLIST\n", okSegment);
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  // Never throws: every caller's next move for a "no" is the same, and an
+  // exception escaping here would fail a whole `.info` request.
+  it("answers false rather than throwing when the fetch blows up", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("socket hang up");
+    });
+    await expect(makeCheckHls({ fetchImpl })(MANIFEST_URL)).resolves.toBe(false);
+  });
+
+  it("fetches the manifest and exactly one segment, and no more", async () => {
+    const fetchImpl = fetcher(manifest(704), okSegment);
+    await makeCheckHls({ fetchImpl })(MANIFEST_URL);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/web/hlsHealth.ts
+++ b/src/web/hlsHealth.ts
@@ -1,0 +1,263 @@
+// Whether a debrid provider's HLS manifest is one the browser can actually
+// finish watching — asked before the player page is told the manifest exists.
+//
+// WHY THIS FILE EXISTS, measured against Real-Debrid on 2026-07-31:
+//
+// The provider transcodes linearly and on demand, and for a 1080p HEVC file its
+// transcoder cannot sustain realtime. Pulling segments patiently and
+// sequentially — one request at a time, no aborts — produced **60 seconds of
+// video in 92.9 seconds of wall clock (0.65x)** and then stopped answering
+// altogether. That is not a timing problem with a client-side fix: below 1.0x
+// nothing the browser or this server does can win, because a 59-minute episode
+// outruns any buffer either could build.
+//
+// What the browser sees on the way down is worse than a plain failure. A segment
+// the transcoder has not finished is served as a **complete HTTP 200 whose
+// Content-Length matches a truncated body** — not a hang, not a chunked early
+// close, not a partial-transfer error. So hls.js cannot tell it from a real
+// fragment: it appends it, gets a buffer hole, and playback freezes with no
+// error event at all. Retry and timeout tuning cannot help, because there is
+// nothing to retry on.
+//
+// Hence a probe rather than a repair. The transcode is still genuinely useful
+// for files the provider CAN keep up with (H.264, smaller files), so the rung
+// stays — it is offered only when a segment past the transcoder's opening burst
+// comes back whole.
+//
+// Nothing here throws. Every "no" is the same `false`, because the caller's next
+// move is identical for all of them: fall to the next rung.
+
+/**
+ * The boundary the provider rounds a partial segment to.
+ *
+ * Measured: truncated bodies were 262144, 524288, 786432, 1048576, 2097152,
+ * 2621440, 3145728 and 3407872 bytes — every one an exact multiple of 256 KiB.
+ * Genuine finished segments in the same playlist were 4639088, 3216116, 3135464,
+ * 5193124 and 3390016, none of which is.
+ */
+export const SEGMENT_QUANTUM = 262144;
+
+/**
+ * Which segment to probe.
+ *
+ * NOT the first, and that is the whole subtlety. The transcoder's opening burst
+ * is fast — segments 0 to 4 measured 3.4x to 8.1x realtime — so probing the head
+ * of the file says "healthy" about a transcode that collapses moments later. The
+ * decline began at segment 5 and every segment from there was truncated, so the
+ * probe sits just past the burst.
+ *
+ * NOT deep into the file either. The provider transcodes from the start, so a
+ * request for segment 300 has to seek and re-transcode and will look broken even
+ * for a file it could stream perfectly in order — a far seek measured 90 seconds
+ * with no response headers at all.
+ *
+ * Ordinal 6 against `PROBE_TIMEOUT_MS` sets the bar this actually enforces: 35
+ * seconds of video that must materialise inside 8 seconds, so a transcoder
+ * sustaining roughly 4x realtime or better passes. That is the threshold worth
+ * having — playback needs better than 1x, and the margin covers the decline
+ * measured on the way down (8.1x at segment 4, 1.8x by segment 11).
+ *
+ * WHAT THIS CANNOT DO, measured rather than assumed: if the provider has ALREADY
+ * transcoded the head of this file — a previous process, a previous playback
+ * attempt — those segments are cached and answer instantly, and the probe passes
+ * a file whose transcoder will still stall further in. Verified: a job whose
+ * first twelve segments had been pulled returned a whole segment 6 in 268ms and
+ * this check said yes.
+ *
+ * There is no cheap fix for that, and it is worth writing down why rather than
+ * leaving the next person to rediscover it. The transcoder does no work until
+ * asked, so "is segment 100 ready?" is no for a fast provider and a slow one
+ * alike; and the provider ignores `Range` on a segment (a `bytes=0-1` request
+ * returns 200 and the entire body), so the frontier cannot be located cheaply
+ * either. The only honest measure is pulling consecutive segments and timing
+ * them, which takes the better part of a minute and is not a page load.
+ *
+ * What limits the damage is the mid-playback stall notice in `player.ts`: a false
+ * pass degrades to playback that runs and then explains itself, rather than to
+ * the silent freeze this all started as.
+ *
+ * `HlsVerdictCache` holds a verdict for the life of ONE server process, so a
+ * reload cannot re-probe and flip the answer. It is not durable, and a restart
+ * therefore can: a failed attempt is itself what warms the provider's head, so
+ * the sequence "play, freeze, restart `serve --web`, play again" can be offered a
+ * manifest that was refused the first time. Making that impossible would mean
+ * persisting verdicts across restarts, which is more machinery than this is
+ * worth while the notice covers the outcome.
+ */
+export const PROBE_ORDINAL = 6;
+
+/**
+ * How long the probe segment gets. Deliberately short: this runs inside a
+ * `.info` request that a player page is blocked on, and a provider that needs
+ * longer than this for a segment six is already failing the test.
+ */
+export const PROBE_TIMEOUT_MS = 8000;
+
+/** How long the manifest itself gets. It is 19 KB of text; this is generous. */
+export const MANIFEST_TIMEOUT_MS = 5000;
+
+/**
+ * The URI lines of a media playlist, in order.
+ *
+ * Everything that is blank or starts with `#` is a tag or a comment; per RFC
+ * 8216 every other line is a URI. No validation here — `probeTarget` is where a
+ * URI has to earn being fetched.
+ */
+export function segmentUris(manifest: string): string[] {
+  const out: string[] = [];
+  for (const raw of manifest.split("\n")) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Whether a segment body is one the provider flushed early rather than finished.
+ *
+ * A genuine segment landing exactly on the quantum is possible and costs
+ * nothing: roughly one chance in 262144 per segment, and the only consequence is
+ * that a perfectly good manifest is not offered and the user gets the card and
+ * the `.m3u` — the same place they end up today for every mkv.
+ *
+ * Zero is excluded explicitly. It IS a multiple of the quantum, but an empty
+ * body is a different failure and the caller reports it as one.
+ */
+export function looksTruncated(bytes: number): boolean {
+  return bytes > 0 && bytes % SEGMENT_QUANTUM === 0;
+}
+
+/**
+ * The absolute URL of the segment to probe, or null.
+ *
+ * The segment URI comes out of a provider's HTTP response, so it is not trusted
+ * to be the bare `00006.ts` that Real-Debrid happens to send. It is resolved
+ * against the manifest and then required to still be **inside the manifest's own
+ * directory on the manifest's own origin** — which refuses an absolute URL to
+ * another host, a scheme-relative `//host/…`, a downgrade to http, and a
+ * `../` climb, without this module needing to guess which of those a provider
+ * might one day emit.
+ */
+export function probeTarget(manifestUrl: string, manifest: string): string | null {
+  const uris = segmentUris(manifest);
+  if (uris.length === 0) return null;
+  // The chosen ordinal when the playlist is long enough, otherwise the last
+  // segment there is — still past the opening burst for anything long enough to
+  // be worth watching, and for a two-segment playlist the question is moot.
+  const uri = uris[Math.min(PROBE_ORDINAL, uris.length - 1)];
+  if (uri === undefined) return null;
+
+  let base: URL;
+  let target: URL;
+  try {
+    base = new URL(manifestUrl);
+    target = new URL(uri, base);
+  } catch {
+    return null;
+  }
+  if (target.origin !== base.origin) return null;
+  if (target.protocol !== base.protocol) return null;
+  // The directory the manifest itself lives in, e.g. `/t/ID/eng1/none/aac/`.
+  const dir = base.pathname.slice(0, base.pathname.lastIndexOf("/") + 1);
+  // `new URL` has already normalised any `..`, so a climb shows up here as a
+  // pathname that no longer starts with the manifest's directory.
+  if (!target.pathname.startsWith(dir)) return null;
+  return target.toString();
+}
+
+/** What one fetch told us. `null` for a timeout, a socket error, anything. */
+export interface ProbeResponse {
+  status: number;
+  /** Bytes actually received, counted — never the Content-Length header. */
+  bytes: number;
+  body: string;
+}
+
+export interface CheckHlsDeps {
+  /**
+   * Fetch one URL and report status and byte count, or null for any failure.
+   * Injected so the suite never reaches the network, and so the timeouts below
+   * are the production policy rather than something a test has to wait out.
+   */
+  fetchImpl: (url: string, timeoutMs: number) => Promise<ProbeResponse | null>;
+}
+
+/**
+ * Build the check: manifest URL in, "is this worth offering" out.
+ *
+ * Exactly two requests, and never more. This runs while a player page waits, and
+ * the cost is already a segment's worth of bytes through this machine; a
+ * multi-segment throughput measurement would be the honest test but would take
+ * the better part of a minute, which is not a page load.
+ *
+ * NOTE the byte count comes from counting the body, not from Content-Length.
+ * Content-Length is exactly what the provider gets right while getting the body
+ * wrong — it reports the truncated length faithfully — so trusting the header
+ * here would still be measuring the right number, but counting is what makes
+ * that independent of the provider's honesty rather than dependent on it.
+ */
+/**
+ * How much of a body to keep as text.
+ *
+ * The manifest is ~19 KB and is needed in full; a segment's bytes need counting
+ * but its contents are never read, and holding 5 MB of binary decoded as UTF-8
+ * would be pure waste. One cap covers both without the caller having to say
+ * which kind of response it expects.
+ */
+const MAX_TEXT_BYTES = 1024 * 1024;
+
+/**
+ * The production `fetchImpl`: count the bytes, keep the first megabyte as text.
+ *
+ * Redirects are followed — a provider CDN answering a manifest URL with a 302 to
+ * a regional node is normal and is not what this module is testing for.
+ *
+ * The byte count is the length of what actually arrived, deliberately not the
+ * Content-Length header, because the header is precisely what the provider
+ * reports correctly while the body is wrong.
+ */
+export async function probeFetch(url: string, timeoutMs: number): Promise<ProbeResponse | null> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), redirect: "follow" });
+    let bytes = 0;
+    // Budgeted in BYTES read, not in string length: the two differ for anything
+    // non-ASCII, and the point of the cap is to avoid decoding megabytes of a
+    // segment body that nothing ever reads.
+    let decoded = 0;
+    let text = "";
+    const decoder = new TextDecoder("utf-8");
+    const body = res.body;
+    if (body) {
+      for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+        bytes += chunk.length;
+        if (decoded < MAX_TEXT_BYTES) {
+          text += decoder.decode(chunk, { stream: true });
+          decoded += chunk.length;
+        }
+      }
+    }
+    return { status: res.status, bytes, body: text };
+  } catch {
+    // A timeout, a reset, a DNS failure and a body that died mid-flight are all
+    // the same answer to the only question being asked.
+    return null;
+  }
+}
+
+export function makeCheckHls(deps: CheckHlsDeps): (manifestUrl: string) => Promise<boolean> {
+  return async (manifestUrl) => {
+    try {
+      const manifest = await deps.fetchImpl(manifestUrl, MANIFEST_TIMEOUT_MS);
+      if (!manifest || manifest.status !== 200) return false;
+      const target = probeTarget(manifestUrl, manifest.body);
+      if (!target) return false;
+      const segment = await deps.fetchImpl(target, PROBE_TIMEOUT_MS);
+      if (!segment || segment.status !== 200) return false;
+      if (segment.bytes === 0) return false;
+      return !looksTruncated(segment.bytes);
+    } catch {
+      return false;
+    }
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -29,6 +29,8 @@ import {
   type StreamDeps,
 } from "./stream";
 import { ProbeCache } from "../core/probeCache";
+import { HlsVerdictCache } from "../core/hlsVerdictCache";
+import { makeCheckHls, probeFetch } from "./hlsHealth";
 import { makeResolveHls } from "./hlsSource";
 import { contentTypeFor, findStaticDir, resolveAssetPath } from "./staticDir";
 import { readBody, statusPayload } from "../daemon/serve";
@@ -87,15 +89,19 @@ export interface WebServerOptions {
   webDeps?: Omit<Partial<WebDeps>, "runtime" | "token">;
   /**
    * Overrides for the stream handle's injectable seams — today the ffprobe call
-   * behind `.info`, the debrid transcode lookup, and the debrid-proxying branch
-   * a test drives without a real provider. `sessions`, `log`, `probeCache` and
-   * `trustProxy` are owned by this server and cannot be overridden.
+   * behind `.info`, the debrid transcode lookup and its health check, and the
+   * debrid-proxying branch a test drives without a real provider. `sessions`,
+   * `log`, `probeCache`, `hlsVerdictCache` and `trustProxy` are owned by this
+   * server and cannot be overridden.
    *
    * Same reasoning as `webDeps`: without it, a test of `.info` would spawn
    * ffprobe against a URL that does not exist, and the interesting cases (no
    * binary, a probe that disagrees with the filename) would be unreachable.
    */
-  streamDeps?: Omit<Partial<StreamDeps>, "sessions" | "log" | "probeCache" | "trustProxy">;
+  streamDeps?: Omit<
+    Partial<StreamDeps>,
+    "sessions" | "log" | "probeCache" | "hlsVerdictCache" | "trustProxy"
+  >;
 }
 
 export interface WebServerHandle {
@@ -253,6 +259,14 @@ export async function startWebServer(
   // transcoding or carrying a byte. Built once; it reads config per call, so a
   // token changed in the TUI is picked up without a restart.
   const resolveHls = makeResolveHls();
+
+  // ...and the check that it is worth offering. A manifest existing does not mean
+  // the provider's transcoder can keep up with it; measured against Real-Debrid,
+  // 1080p HEVC runs at 0.65x realtime and hands out truncated segments as
+  // complete responses, which freezes a browser a few seconds in. One verdict per
+  // (session, file), cached, so a reload costs nothing.
+  const checkHls = makeCheckHls({ fetchImpl: probeFetch });
+  const hlsVerdictCache = new HlsVerdictCache();
 
   // Live SSE responses, so close() can end them. Without this, http's close()
   // waits for every connection to end and an event stream never does.
@@ -432,6 +446,7 @@ export async function startWebServer(
         // real debrid provider) still wins over the config read.
         const streamDeps: StreamDeps = {
           resolveHls,
+          checkHls,
           // Spread after the default so a test can override it, and before the
           // fields below so it cannot override those.
           ...options.streamDeps,
@@ -439,6 +454,7 @@ export async function startWebServer(
           log,
           trustProxy: options.trustProxy === true,
           probeCache,
+          hlsVerdictCache,
           proxyDebrid:
             options.streamDeps?.proxyDebrid ??
             (await (options.webDeps?.loadConfigImpl ?? loadConfig)()).proxyDebridStreams === true,

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -13,14 +13,17 @@
 // whoever made it — and there is no innerHTML, insertAdjacentHTML or
 // document.write in this file, and there must never be one.
 import {
+  PLAYBACK_STALL_MS,
   STALL_MS,
   absoluteUrl,
   chooseSource,
   detectPlatform,
   fallbackMessage,
   infoPath,
+  interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  routeFailure,
   streamPath,
   vlcLinks,
   type FallbackReason,
@@ -39,14 +42,30 @@ const NOTICE_MS = 4000;
 
 let noticeTimer: ReturnType<typeof setTimeout> | null = null;
 
-function showNotice(message: string): void {
+/**
+ * `persist` for a notice the user must still be able to read after they look
+ * back at the screen. The copy-button notices are acknowledgements of something
+ * the user just did and self-clear; a stream that died mid-playback is not, and
+ * a four-second explanation of a video that is going to stay frozen is worse
+ * than none — they would be left with the silence this notice exists to break.
+ */
+function showNotice(message: string, opts: { persist?: boolean } = {}): void {
   notice.textContent = message;
   notice.hidden = false;
   if (noticeTimer !== null) clearTimeout(noticeTimer);
+  noticeTimer = null;
+  if (opts.persist === true) return;
   noticeTimer = setTimeout(() => {
     noticeTimer = null;
     notice.hidden = true;
   }, NOTICE_MS);
+}
+
+function hideNotice(): void {
+  if (noticeTimer !== null) clearTimeout(noticeTimer);
+  noticeTimer = null;
+  notice.hidden = true;
+  notice.textContent = "";
 }
 
 function button(label: string, onClick: () => void): HTMLButtonElement {
@@ -115,12 +134,26 @@ function createVideo(): HTMLVideoElement {
  * `loadeddata`. So the timer is the primary detector and the event is the fast
  * path, and the first of them to fire wins.
  */
-function watch(video: HTMLVideoElement, target: PlayerTarget): { fail: (r: FallbackReason) => void } {
-  let settled = false;
+function watch(video: HTMLVideoElement, target: PlayerTarget): { report: (r: FallbackReason) => void } {
+  // THREE states, not one flag. Collapsing them into a single `settled` latch is
+  // the bug this shape replaces: the latch was set by the first `playing` event
+  // and then swallowed every subsequent failure, so a stream that died partway
+  // through left a frozen <video> and told the user nothing at all.
+  //
+  // - `started`: a frame arrived, so the start-up stall timer is wrong now.
+  // - `replaced`: a card has taken the element's place; there is nothing to
+  //   annotate and nothing to fail a second time.
+  // - `notified`: a mid-playback failure is already on screen, so a burst of
+  //   error events produces one notice rather than a flicker of them.
+  let started = false;
+  let replaced = false;
+  let notified = false;
+
   const fail = (reason: FallbackReason): void => {
-    if (settled) return;
-    settled = true;
+    if (replaced) return;
+    replaced = true;
     clearTimeout(timer);
+    clearTimeout(stallTimer);
     // Removing the src and calling load() is what actually stops an in-flight
     // fetch; dropping the element alone leaves the request running in some
     // browsers, and behind it a range request against a live torrent.
@@ -128,17 +161,70 @@ function watch(video: HTMLVideoElement, target: PlayerTarget): { fail: (r: Fallb
     video.load();
     showFallback(reason, target.filename);
   };
+
+  /**
+   * Report one failure, to whichever half of the player's life it belongs to.
+   *
+   * `routeFailure` makes the choice and is unit-tested; this is the wiring for
+   * its two answers. The notice branch deliberately leaves the element alone:
+   * the user has already watched some of this, and destroying it would throw
+   * away their position to tell them something untrue about what they saw.
+   */
+  const report = (reason: FallbackReason): void => {
+    if (routeFailure(started) === "card") {
+      fail(reason);
+      return;
+    }
+    if (replaced || notified) return;
+    notified = true;
+    showNotice(interruptedNotice(reason), { persist: true });
+  };
+
   const ok = (): void => {
-    if (settled) return;
-    settled = true;
+    if (replaced) return;
+    started = true;
     clearTimeout(timer);
   };
 
-  const timer = setTimeout(() => fail("stall"), STALL_MS);
-  video.addEventListener("error", () => fail("error"));
+  // The start-up watchdog: no frame at all, ever. Disarmed by `ok`.
+  const timer = setTimeout(() => report("stall"), STALL_MS);
+
+  // The other watchdog, and the one this file previously had no answer for: a
+  // player that ran and then stopped advancing. `waiting` is the browser saying
+  // it has run out of buffered media, which is exactly the shape of a provider
+  // transcode that stops producing segments — and on that path hls.js may report
+  // nothing fatal, so without this timer there is no event to react to at all.
+  let stallTimer: ReturnType<typeof setTimeout> | undefined;
+  const armStall = (): void => {
+    if (replaced || !started) return;
+    clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => report("stall"), PLAYBACK_STALL_MS);
+  };
+  // Progress is the all-clear. If a gap filled itself after we spoke, the notice
+  // is now false, so it goes — and `notified` resets, because the next stall is
+  // news again.
+  const progressing = (): void => {
+    clearTimeout(stallTimer);
+    stallTimer = undefined;
+    if (notified) {
+      notified = false;
+      hideNotice();
+    }
+  };
+
+  video.addEventListener("error", () => report("error"));
   video.addEventListener("loadeddata", ok);
   video.addEventListener("playing", ok);
-  return { fail };
+  video.addEventListener("waiting", armStall);
+  video.addEventListener("stalled", armStall);
+  video.addEventListener("timeupdate", progressing);
+  video.addEventListener("playing", progressing);
+  // A file that reaches its end has not stalled, and must not be accused of it.
+  video.addEventListener("ended", () => {
+    clearTimeout(stallTimer);
+    stallTimer = undefined;
+  });
+  return { report };
 }
 
 // autoplay is blocked without a user gesture in every browser that matters; the
@@ -210,7 +296,7 @@ async function render(): Promise<void> {
     stage.replaceChildren(video);
     // The manifest is on the provider's own host, so no capability is appended:
     // it is already a capability, being an unguessable URL minted for this file.
-    await mountHls(video, info.hls, { onError: () => settle.fail("error") });
+    await mountHls(video, info.hls, { onError: () => settle.report("error") });
     tryPlay(video);
     return;
   }

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -6,8 +6,10 @@ import {
   extensionOf,
   fallbackMessage,
   infoPath,
+  interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  routeFailure,
   streamPath,
   vlcLinks,
   type PlayerTarget,
@@ -285,5 +287,40 @@ describe("fallbackMessage", () => {
 
   it("tells a user with a capability-less link what to do", () => {
     expect(fallbackMessage("no-link", "")).toContain("reopen the player");
+  });
+});
+
+describe("routeFailure", () => {
+  it("replaces a player that never started", () => {
+    expect(routeFailure(false)).toBe("card");
+  });
+
+  // The regression this whole pair exists for: the wiring used to latch on the
+  // first `playing` event and then drop every later failure, so a stream that
+  // died partway through froze in silence.
+  it("annotates a player that had already started, rather than destroying it", () => {
+    expect(routeFailure(true)).toBe("notice");
+  });
+});
+
+// A failure that arrives AFTER playback started is a different message from the
+// startup card: the user has already seen the film run, so "browsers can't play
+// this container" would be a lie. It also has to point somewhere useful, because
+// the frozen <video> is staying on screen.
+describe("interruptedNotice", () => {
+  it("says playback stopped rather than blaming the container", () => {
+    const notice = interruptedNotice("error");
+    expect(notice).toContain("stopped");
+    expect(notice).not.toContain("container");
+  });
+
+  it("points at the hand-off that does work", () => {
+    for (const reason of ["error", "stall"] as const) {
+      expect(interruptedNotice(reason)).toMatch(/\.m3u|VLC/);
+    }
+  });
+
+  it("distinguishes a stall from an outright failure", () => {
+    expect(interruptedNotice("stall")).not.toBe(interruptedNotice("error"));
   });
 });

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -266,3 +266,65 @@ export function fallbackMessage(reason: FallbackReason, filename: string): strin
   }
   return `${name} isn't playing here — the browser has taken it but produced nothing. Open it in a real player instead.`;
 }
+
+/** Where a failure should be reported: replace the player, or annotate it. */
+export type FailureRoute = "card" | "notice";
+
+/**
+ * Which of the two a failure goes to, given whether playback ever started.
+ *
+ * One line, and it lives here rather than in `player.ts` because it decides
+ * *what the user sees* — the rule in CLAUDE.md that keeps such conditionals out
+ * of the DOM-wiring files where no test can reach them. This one was a bug: the
+ * wiring latched a single `settled` flag on the first `playing` event and then
+ * dropped every later failure on the floor, so a stream that died mid-playback
+ * left a frozen `<video>` and no explanation anywhere.
+ *
+ * `card` destroys the element, which is right for a file that was never going to
+ * play and wrong for one that already did — the user would lose their position
+ * to be told something that is not true of what they just watched.
+ */
+export function routeFailure(started: boolean): FailureRoute {
+  return started ? "notice" : "card";
+}
+
+/**
+ * How long a starved player may sit without advancing before we say so.
+ *
+ * Distinct from `STALL_MS`, which covers *start-up* — an element that never
+ * produced a frame — and is disarmed as soon as one arrives. This one covers the
+ * opposite half: playback that ran and then stopped advancing.
+ *
+ * Thirty seconds, and the number is set by hls.js rather than by taste. Its
+ * default `fragLoadPolicy.errorRetry` is 6 attempts with a delay backing off to
+ * 8s, so a fragment it can eventually recover can legitimately take upwards of
+ * twenty seconds to arrive. Anything shorter would cry stall over a gap that was
+ * about to fill itself.
+ */
+export const PLAYBACK_STALL_MS = 30_000;
+
+/**
+ * What to say when playback that had ALREADY STARTED dies partway through.
+ *
+ * A separate message from `fallbackMessage` because the causes are disjoint and
+ * so is the honest wording. The startup card explains why a file was never going
+ * to play here ("browsers can't play this container"); by the time this fires the
+ * user has watched the thing run, so that explanation would be a plain lie. What
+ * actually happened is upstream: a provider transcode that stopped producing
+ * segments, or a stream that died mid-flight.
+ *
+ * Deliberately does NOT name the file. The card is a full replacement for the
+ * video and has room; this is a one-line notice sitting under a player the user
+ * is still looking at, and they know what they were watching.
+ *
+ * Both branches point at the `.m3u` and VLC, because those buttons are still on
+ * screen and — for the provider-transcode failure this exists for — they are the
+ * route that genuinely works: the playlist streams the original file rather than
+ * anything the provider had to transcode first.
+ */
+export function interruptedNotice(reason: FallbackReason): string {
+  if (reason === "stall") {
+    return "Playback stopped — no more of the stream arrived. Download the .m3u or open it in VLC to carry on watching.";
+  }
+  return "Playback stopped partway through — the stream failed upstream. Download the .m3u or open it in VLC to carry on watching.";
+}

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1020,11 +1020,16 @@ describe("GET /stream/:sid/:idx.info", () => {
     expect(body.facts.audioCodec).toBe("dts");
   });
 
-  it("reports the provider's manifest in .info when one is offered", async () => {
+  it("reports the provider's manifest in .info when one is offered and usable", async () => {
     const { base, capability, id } = await infoSession({
       streamDeps: {
         probeImpl: async () => null,
         resolveHls: async () => "https://4.stream.real-debrid.example/t/ID20/eng1/none/aac/full.m3u8",
+        // Injected, because the real check fetches a probe segment: without this
+        // the suite would go to the network for a host that does not exist and
+        // the manifest would be withheld for that reason rather than the one
+        // under test.
+        checkHls: async () => true,
       },
     });
     const body = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).json();
@@ -1052,6 +1057,64 @@ describe("GET /stream/:sid/:idx.info", () => {
     expect(JSON.parse(text).hls).toBeNull();
     // Not merely absent from the field — absent from the body.
     expect(text).not.toContain("real-debrid.example");
+  });
+
+  // A manifest existing is not a manifest working. Real-Debrid's transcoder
+  // measured 0.65x realtime on 1080p HEVC and serves the segments it has not
+  // finished as complete 200s with a Content-Length matching a truncated body —
+  // so the browser cannot tell, plays a few seconds and freezes. Offering such a
+  // manifest is worse than the card, which at least points at VLC.
+  it("withholds a manifest the provider cannot actually keep up with", async () => {
+    const { base, capability, id } = await infoSession({
+      streamDeps: {
+        probeImpl: async () => null,
+        resolveHls: async () => "https://4.stream.real-debrid.example/t/ID20/eng1/none/aac/full.m3u8",
+        checkHls: async () => false,
+      },
+    });
+    const text = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).text();
+    expect(JSON.parse(text).hls).toBeNull();
+    // Not merely nulled in the field — the URL is a minted capability and must
+    // not appear anywhere in the body.
+    expect(text).not.toContain("real-debrid.example");
+  });
+
+  it("checks once and remembers, so a reload pulls no second probe segment", async () => {
+    let checks = 0;
+    const { base, capability, id } = await infoSession({
+      streamDeps: {
+        probeImpl: async () => null,
+        resolveHls: async () => "https://4.stream.real-debrid.example/t/ID20/eng1/none/aac/full.m3u8",
+        checkHls: async () => {
+          checks++;
+          return false;
+        },
+      },
+    });
+    for (let i = 0; i < 3; i++) {
+      const body = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).json();
+      expect(body.hls).toBeNull();
+    }
+    // A remembered "no" must not read as "never asked" — that is the whole point
+    // of the verdict cache holding a boolean rather than a truthy flag.
+    expect(checks).toBe(1);
+  });
+
+  it("does not ask the provider to be checked when it offered nothing", async () => {
+    let checks = 0;
+    const { base, capability, id } = await infoSession({
+      streamDeps: {
+        probeImpl: async () => null,
+        resolveHls: async () => null,
+        checkHls: async () => {
+          checks++;
+          return true;
+        },
+      },
+    });
+    const body = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).json();
+    expect(body.hls).toBeNull();
+    expect(checks).toBe(0);
   });
 
   it("still reports null hls when the resolver declines", async () => {

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -24,6 +24,7 @@ import { streamHandle } from "./routes";
 import { probeUrl } from "../core/probe";
 import { blockersFor, classifyFromName, extensionOf, type MediaFacts } from "../util/playability";
 import type { ProbeCache } from "../core/probeCache";
+import type { HlsVerdictCache } from "../core/hlsVerdictCache";
 import type { StreamSession, StreamSessionRegistry } from "../core/streamSession";
 import type { StreamInfoResponse } from "./wire";
 import {
@@ -68,6 +69,17 @@ export interface StreamDeps {
    * with a perfectly good manifest show a card claiming it cannot be played.
    */
   resolveHls?: (session: StreamSession, index: number) => Promise<string | null>;
+  /**
+   * Whether that manifest is one a browser can actually finish watching, rather
+   * than merely one that exists. Injected, and absent means "offer whatever
+   * `resolveHls` returned" — the behaviour before the provider was measured.
+   */
+  checkHls?: (manifestUrl: string) => Promise<boolean>;
+  /**
+   * Remembers the answer above, so a page reload does not pull a second probe
+   * segment through this machine. Optional for the same reason `probeCache` is.
+   */
+  hlsVerdictCache?: HlsVerdictCache;
   /**
    * Proxy debrid media through this server rather than redirecting to the
    * provider. Resolved per request by the caller — this module never loads
@@ -370,10 +382,34 @@ export async function handleStreamRequest(
     // most likely to be a big remux — around the relay the user asked for, and
     // show the provider the viewer's address. The ladder falls to a direct play
     // through this handle instead.
-    const hls =
+    const resolved =
       deps.resolveHls && deps.proxyDebrid !== true
         ? await deps.resolveHls(session, parsed.index)
         : null;
+    // A manifest existing is not the same as a manifest working. Measured
+    // against Real-Debrid: for 1080p HEVC its transcoder runs at 0.65x realtime
+    // and serves the segments it has not finished as complete 200s with a
+    // Content-Length matching a truncated body — so the browser cannot tell, and
+    // playback freezes a few seconds in with no error event to react to. See
+    // `hlsHealth.ts` for the measurements.
+    //
+    // So the rung is offered only when a segment past the transcoder's opening
+    // burst comes back whole. The check is skipped entirely when nothing injected
+    // one, which keeps a caller that has not wired it on the previous behaviour
+    // rather than silently dropping every manifest.
+    let hls = resolved;
+    if (resolved !== null && deps.checkHls) {
+      const remembered = deps.hlsVerdictCache?.get(parsed.sid, parsed.index);
+      const usable = remembered ?? (await deps.checkHls(resolved));
+      deps.hlsVerdictCache?.set(parsed.sid, parsed.index, usable);
+      if (!usable) {
+        // The verdict, never the URL: a transcode manifest is an unguessable URL
+        // minted for one file, i.e. a capability, and belongs in a log line no
+        // more than an unrestricted link does.
+        deps.log("stream: provider transcode is not keeping up; not offering HLS");
+        hls = null;
+      }
+    }
     const body: StreamInfoResponse = { facts, blockers: blockersFor(facts), hls };
     // Note what is NOT in that body: `file.url`. That is a debrid unrestricted
     // link, i.e. a credential against the user's account. The page plays through


### PR DESCRIPTION
Playing an mkv/HEVC release in the browser worked for about seven seconds and then froze, with nothing on screen explaining why. Downloading the `.m3u` and opening it in VLC played the whole thing — which made this look like a proxy or range bug in `src/web/stream.ts`.

It was neither. The `.m3u` is not a comparison: it points at `/stream/:sid/:idx`, the original file, so VLC gets untouched bytes and never touches the transcode. The browser was on a completely different rung.

## What is actually happening

`.info` for the file in question:

```json
{"facts":{"container":"mkv","videoCodec":"hevc","audioCodec":"eac3"},
 "blockers":["container","video","audio"],
 "hls":"https://…/eng1/none/aac/full.m3u8"}
```

So the player took rung 2, the provider's own transcode. Measured against the live Real-Debrid API rather than inferred:

**Its transcoder cannot sustain realtime.** Pulled patiently and sequentially — one request at a time, no aborts, generous timeouts:

```
00000  bytes=4639088        took=1454ms   ratio=3.44
00004  bytes=5262120        took=99ms     ratio=8.14
00005  bytes=3407872 TRUNC  took=2079ms   ratio=5.83
00006  bytes=1048576 TRUNC  took=4055ms   ratio=3.80
00007  bytes=262144  TRUNC  took=5163ms   ratio=2.78
00011  bytes=524288  TRUNC  took=4147ms   ratio=1.82
00012  FAILED after 60s

RESULT: 60s of video in 92.9s wall = 0.65x realtime
```

**And a segment it has not finished is served as a complete response.** HTTP 200, with a `Content-Length` that matches the truncated body. Not a hang, not a chunked early close, not a partial-transfer error — so hls.js has no way to know it got a fragment; it appends it, gets a buffer hole, and stops. Truncated bodies were always exact multiples of 256 KiB (512 KiB, 768 KiB, 2 MiB, 3 MiB); genuine finished segments in the same playlist were irregular (4639088, 3216116, 3135464). Segment 1 came back at exactly 2 MiB of its real 3216116 — 5s of segment 0 plus ~3s of segment 1, which is the seven seconds.

Not rate-limiting: segment 0 still served in 2.4s while segment 12 — instant ten minutes earlier — timed out. A block would have killed both.

Below 1.0x nothing on this side can win, so timeout and retry tuning are irrelevant: there is no error to retry on.

## The silence was a second, worse defect

`watch()` in `player.ts` latched a single `settled` flag in `ok()` on the first `playing` event, and `fail()` returned early whenever it was set. So once playback had begun **every** later failure was a no-op — including the fatal-hls.js path from `mountHls`. Nothing was logged either. A frozen `<video>` with the controls still sitting there and no explanation was the designed outcome, which is exactly why this read as a proxy bug.

It now tracks three states (`started`, `replaced`, `notified`) and adds a **mid-playback stall watchdog** on `waiting`/`timeupdate` — necessary because this failure emits no event at all, so there would otherwise be nothing to react to:

- a failure **before** playback still replaces the element with the card, as now;
- a failure **after** it shows a persistent notice pointing at the `.m3u`/VLC and leaves the element — and the user's position — alone;
- if a gap fills itself, the notice clears.

`routeFailure` and `interruptedNotice` are pure and unit-tested in `playerModel.ts`, per the rule about conditionals that decide what the user sees living outside the DOM-wiring files.

## The rung is now checked before it is offered

New `src/web/hlsHealth.ts`: fetch the manifest, fetch one segment past the transcoder's opening burst, refuse the manifest if it comes back truncated (or empty, or late, or not at all). Verdict cached per `(session, file)` so a reload costs nothing.

Ordinal 6 against an 8s timeout is the threshold: 35s of video that must materialise in 8s, so a transcoder holding roughly 4x realtime passes and the measured decline does not. Not the head of the file — the opening burst measured 3.4x–8.1x and would pass anything. Not deep either — the provider transcodes from the start, so a far seek looks broken even for a file it could stream in order (90s with no response headers at all).

**This also fixes a second user-visible bug:** with relaying on, the rung was skipped entirely and every mkv went straight to the card. That guard is unchanged and still correct, but the check means a provider that *can* keep up is no longer the same case as one that cannot.

## Two limitations, stated rather than left to be rediscovered

**The check can be fooled, and I measured it.** If the provider has already transcoded the head of a file, segment 6 answers instantly and the check passes — and a previous failed attempt is itself enough to cause that. A warmed job returned a whole segment 6 in 268ms and the check said yes. There is no cheap robust version: the transcoder does no work until asked, so no deep-segment probe separates fast from slow, and RD **ignores `Range` on a segment** (`bytes=0-1` returns 200 and the entire body), so the frontier cannot be located cheaply either. The only honest measure is the 93-second one above. The verdict is sticky for the life of one server process, but a `serve --web` restart re-probes and can pass a warmed job. The notice above is the backstop, and `hlsHealth.ts` says all of this in the file.

**It costs bytes through the box.** ~5 MB on the first `.info` for each debrid mkv, on a path that was previously a zero-byte 302. Unavoidable given `Range` is ignored. Direct play is untouched and still a 302.

If the residual case is not worth it, dropping the rung entirely is a small change from here.

## Surfaces

Browser-only, by the "a surface can't express it" rule in CLAUDE.md — the terminal UI has no `<video>` and no source ladder. No TUI counterpart exists to keep in step.

## Checks

`npm test` (2059 passing, 134 files), `npm run typecheck`, `npm run lint` (only the known pre-existing `react-hooks/exhaustive-deps` in `src/ui/App.tsx`), `npm run build`. Smoke-run with `npm run dev -- serve --web` to confirm the wiring and that the rebuilt bundle carries the new strings.

Two test notes: the production `checkHls` default now reaches tests that do not override it, so the pre-existing "reports the provider's manifest" case injects `checkHls` and says why — otherwise it went to the network for a host that does not exist and withheld the manifest for the wrong reason. README's "it simply plays" claim was left false by this and is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
