### PR TITLE
Nest a show's results the way a show nests, and make every heading say what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ pack — and each heading **says which one it is** (`Harrowgate S03`, `Kepler S0
 because a whole season's worth of headings all reading just the show's name looks like the list failed to
 group at all.
 
+**A show nests the way a show does.** One row per season, newest first, holding the season packs and then
+each episode in order — so a search for a show is a handful of rows rather than forty siblings in seeder
+order. The season you are most likely to want opens itself; the rest stay shut until you ask. Acting on a
+collapsed season acts on its best **season pack**, so `play` on `Harrowgate S03` gets the season and not
+episode one. Inside a season the show's name is stated once, by the season row, and its children read
+`Season pack`, `S03E01`, `S03E02`. The **group** control still turns all of it off and gives you every
+release as its own row.
+
 Selecting a result shows its poster, plot and IMDb link, if you've added a free
 [OMDb](https://www.omdbapi.com/apikey.aspx) key under **Accounts** in the TUI — the same key that powers
 the terminal's preview pane. Without one everything still works; you just get the release names.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ read out of the release name, so you don't have to parse a 70-character filename
 Grouping and the badges are in **both** front ends: in the terminal, **`g`** turns grouping on or off and
 **space** expands the group under the cursor. The grouping key knows that an episode, a season pack and a
 film are different things, so `Kepler S02E04` never merges with `Kepler S02E05` or with a `Harrowgate S03`
-pack.
+pack — and each heading **says which one it is** (`Harrowgate S03`, `Kepler S02E04`, `Tin Rivers (2024)`),
+because a whole season's worth of headings all reading just the show's name looks like the list failed to
+group at all.
 
 Selecting a result shows its poster, plot and IMDb link, if you've added a free
 [OMDb](https://www.omdbapi.com/apikey.aspx) key under **Accounts** in the TUI — the same key that powers

--- a/docs/superpowers/plans/2026-07-31-tv-season-tree.md
+++ b/docs/superpowers/plans/2026-07-31-tv-season-tree.md
@@ -1,0 +1,1027 @@
+# The Season Tree (Piece A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make grouped TV results render as the tree they already are — season → episode → release — instead of a flat, seeder-ordered list where a season pack lands in the middle of its own episodes.
+
+**Architecture:** `groupResults` is untouched. A new pure pass, `seasonTree`, folds a show's single-season groups under season nodes; `groupRowPlan` walks that tree and emits rows carrying a `depth`. Both front ends gain depth-indent rendering and nothing else — every decision stays in `src/util/resultGroup.ts`, which both already render from.
+
+**Tech Stack:** TypeScript, vitest, Ink (terminal), plain DOM + tsup (browser). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-tv-season-tree-design.md`
+
+## Global Constraints
+
+- **Both front ends in the same change.** `src/ui/` and `src/web/static/` — a feature in one only is a bug report waiting to happen (`CLAUDE.md`).
+- **`src/web` must not import from `src/ui`.** Lint enforces it. Share by putting the piece in `src/util/`.
+- **No `innerHTML` / `insertAdjacentHTML` / `document.write` / `outerHTML` in `src/web/static/`.** Every node is `createElement` + `textContent`. Release names are attacker-controlled.
+- **`app.ts` is DOM wiring only.** A conditional deciding *what to show* belongs in a pure module.
+- **Never name a real film or show** in a test, helper, doc comment, example, or user-facing copy. Use the shared cast: `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`.
+- **`src/util/resultGroup.ts` must stay browser-safe** — no `node:*`, direct or transitive. `npm run build` is the only check that catches a violation.
+- **Gates before any task is done:** `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) — leave it.
+- **Conventional Commits.**
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `src/util/resultGroup.ts` | Grouping, the season tree, the row plan, headings | Modify — all new logic |
+| `src/util/resultGroup.test.ts` | Unit tests for the above | Modify |
+| `src/ui/components/Results.tsx` | Terminal list rendering + expansion state | Modify — indent, seed |
+| `src/ui/components/Results.test.tsx` | Terminal rendering tests | Modify |
+| `src/web/static/app.ts` | Browser DOM wiring | Modify — indent, seed |
+| `src/web/static/styles.css` | Browser indent styling | Modify — depth-2 rule |
+| `README.md` | User-facing description of grouping | Modify |
+
+---
+
+### Task 1: Build the season tree
+
+**Files:**
+- Modify: `src/util/resultGroup.ts`
+- Test: `src/util/resultGroup.test.ts`
+
+**Interfaces:**
+- Consumes: existing `ResultGroup<T>`, `GroupableResult`.
+- Produces: `SeasonNode<T>`, `TreeNode<T>`, `seasonTree(groups: readonly ResultGroup<T>[]): TreeNode<T>[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/util/resultGroup.test.ts`, importing `seasonTree` alongside the existing imports:
+
+```ts
+describe("seasonTree", () => {
+  const isSeason = <T,>(node: unknown): node is { kind: "season" } & Record<string, unknown> =>
+    typeof node === "object" && node !== null && "kind" in node;
+
+  it("folds a show's packs and episodes under one season node", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S03.1080p.WEB-DL"),
+          r("Harrowgate.S03.2160p.WEB-DL"),
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree).toHaveLength(1);
+    const node = tree[0]!;
+    expect(isSeason(node)).toBe(true);
+    if (!isSeason(node)) return;
+    expect(node.key).toBe("harrowgate|series|s3");
+    expect(node.season).toBe(3);
+  });
+
+  it("puts the pack before the episodes, and episodes ascending", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03.1080p.WEB-DL"),
+          r("Harrowgate.S03.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    const node = tree[0]!;
+    if (!isSeason(node)) throw new Error("expected a season node");
+    expect((node.children as { episode?: number }[]).map((c) => c.episode)).toEqual([
+      undefined,
+      1,
+      2,
+    ]);
+  });
+
+  it("orders seasons newest first", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01E01.1080p.WEB-DL"),
+          r("Harrowgate.S01E01.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree.map((n) => (isSeason(n) ? n.season : null))).toEqual([3, 1]);
+  });
+
+  it("emits a show's whole season block where its first group sat", () => {
+    // Kestrel comes between the two Harrowgate groups in input order. The show's
+    // seasons must stay contiguous, at the position of its FIRST group, so every
+    // existing sort still means what it means.
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01E01.1080p.WEB-DL"),
+          r("Harrowgate.S01E01.2160p.WEB-DL"),
+          r("Kestrel.2010.1080p.BluRay.x264"),
+          r("Kestrel.2010.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree.map((n) => (isSeason(n) ? `s${n.season}` : "film"))).toEqual([
+      "s3",
+      "s1",
+      "film",
+    ]);
+  });
+
+  it("leaves a film alone", () => {
+    const tree = seasonTree(groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")]));
+    expect(tree).toHaveLength(1);
+    expect(isSeason(tree[0])).toBe(false);
+  });
+
+  it("leaves a multi-season span pack top-level, not filed under its first season", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01-S03.COMPLETE.1080p.WEB-DL"),
+          r("Harrowgate.S01-S03.COMPLETE.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(isSeason(tree[0])).toBe(false);
+  });
+
+  it("leaves a seasonless complete-series pack top-level", () => {
+    const tree = seasonTree(
+      groupResults(
+        [r("Harrowgate.COMPLETE.SERIES.1080p.WEB-DL"), r("Harrowgate.COMPLETE.SERIES.2160p")],
+        "series",
+      ),
+    );
+    expect(isSeason(tree[0])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/util/resultGroup.test.ts`
+Expected: FAIL — `seasonTree is not a function`, and a typecheck error that `resultGroup` has no exported member `seasonTree`.
+
+- [ ] **Step 3: Implement `seasonTree`**
+
+Add to `src/util/resultGroup.ts`, after `groupResults`:
+
+```ts
+/**
+ * A season of one show, holding its packs and its episode groups.
+ *
+ * `members` is every child's members concatenated in child order, which is what
+ * lets `resultAtRow` keep working untouched: packs sort first, so the first
+ * member of a collapsed season row is the best season pack.
+ */
+export interface SeasonNode<T> {
+  kind: "season";
+  key: string;
+  title: string;
+  season: number;
+  /** Packs first, then episodes ascending. Never empty. */
+  children: ResultGroup<T>[];
+  /** Never empty. */
+  members: T[];
+}
+
+/** A top-level node: a season of a show, or a group that has no season to sit under. */
+export type TreeNode<T> = SeasonNode<T> | ResultGroup<T>;
+
+/** True for a `SeasonNode`. `ResultGroup` has no `kind`, which is the discriminator. */
+export function isSeasonNode<T>(node: TreeNode<T>): node is SeasonNode<T> {
+  return "kind" in node;
+}
+
+/**
+ * Which groups fold under a season.
+ *
+ * A group naming ONE season. A span pack ("S01-S03") names three and filing it
+ * under season 1 would claim it is a season-1 release; a "complete series" pack
+ * names none. Both stay top-level. Only the series branch of `factsFor` ever
+ * sets `season`, so this needs no separate "is a series" flag.
+ */
+function foldsUnderSeason<T>(group: ResultGroup<T>): boolean {
+  return group.season !== undefined && group.seasonEnd === undefined;
+}
+
+/** "harrowgate" out of "harrowgate|series|s3|e1" — the show's identity. */
+function showOf(key: string): string {
+  const at = key.indexOf("|series|");
+  return at === -1 ? key : key.slice(0, at);
+}
+
+/** Packs before episodes; episodes ascending. */
+function compareSeasonChild<T>(a: ResultGroup<T>, b: ResultGroup<T>): number {
+  if (a.episode === undefined && b.episode === undefined) return 0;
+  if (a.episode === undefined) return -1;
+  if (b.episode === undefined) return 1;
+  return a.episode - b.episode;
+}
+
+/**
+ * Fold a show's single-season groups under season nodes.
+ *
+ * ORDER IS PRESERVED at the top level: a show's whole season block is emitted at
+ * the position of its FIRST group, so `groupResults`' promise that groups sit
+ * where their best member sits — which every sort depends on — still holds.
+ * Within a show, seasons are newest first.
+ */
+export function seasonTree<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+): TreeNode<T>[] {
+  const byShow = new Map<string, Map<number, ResultGroup<T>[]>>();
+  for (const group of groups) {
+    if (!foldsUnderSeason(group)) continue;
+    const show = showOf(group.key);
+    let seasons = byShow.get(show);
+    if (!seasons) {
+      seasons = new Map();
+      byShow.set(show, seasons);
+    }
+    const bucket = seasons.get(group.season!) ?? [];
+    bucket.push(group);
+    seasons.set(group.season!, bucket);
+  }
+
+  const out: TreeNode<T>[] = [];
+  const done = new Set<string>();
+  for (const group of groups) {
+    if (!foldsUnderSeason(group)) {
+      out.push(group);
+      continue;
+    }
+    const show = showOf(group.key);
+    if (done.has(show)) continue;
+    done.add(show);
+    const seasons = byShow.get(show)!;
+    for (const season of [...seasons.keys()].sort((a, b) => b - a)) {
+      const children = [...seasons.get(season)!].sort(compareSeasonChild);
+      out.push({
+        kind: "season",
+        key: `${show}|series|s${season}`,
+        title: children[0]!.title,
+        season,
+        children,
+        members: children.flatMap((child) => child.members),
+      });
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/util/resultGroup.test.ts`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 5: Run the gates and commit**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+git add src/util/resultGroup.ts src/util/resultGroup.test.ts
+git commit -m "feat(util): fold a show's seasons into a tree above its groups"
+```
+
+---
+
+### Task 2: Emit season rows, with depth and short headings
+
+**Files:**
+- Modify: `src/util/resultGroup.ts`
+- Test: `src/util/resultGroup.test.ts`
+
+**Interfaces:**
+- Consumes: `seasonTree`, `isSeasonNode`, `SeasonNode<T>` from Task 1.
+- Produces: `GroupRow<T>` gains a `{ kind: "season" }` variant and a `depth: number` on every variant; `groupHeading(group, opts?: { underSeason?: boolean })`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/util/resultGroup.test.ts`:
+
+```ts
+describe("groupRowPlan with seasons", () => {
+  const SEASON = [
+    r("Harrowgate.S03.1080p.WEB-DL"),
+    r("Harrowgate.S03.2160p.WEB-DL"),
+    r("Harrowgate.S03E01.1080p.WEB-DL"),
+    r("Harrowgate.S03E01.2160p.WEB-DL"),
+  ];
+
+  it("collapses a season to one row", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("season");
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("shows the pack and the episode indented when the season is open", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set(["harrowgate|series|s3"]));
+    expect(rows.map((row) => `${row.kind}@${row.depth}`)).toEqual([
+      "season@0",
+      "group@1",
+      "group@1",
+    ]);
+  });
+
+  it("puts a release at depth 2 under an open episode inside an open season", () => {
+    const rows = groupRowPlan(
+      groupResults(SEASON, "series"),
+      new Set(["harrowgate|series|s3", "harrowgate|series|s3|e1"]),
+    );
+    expect(rows.filter((row) => row.kind === "release").every((row) => row.depth === 2)).toBe(true);
+  });
+
+  it("acts on the best season pack when the season row is collapsed", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set());
+    expect(resultAtRow(rows[0]!)?.name).toBe("Harrowgate.S03.1080p.WEB-DL");
+  });
+
+  it("falls through to the first episode when the season has no pack", () => {
+    const rows = groupRowPlan(
+      groupResults(
+        [
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+      new Set(),
+    );
+    expect(resultAtRow(rows[0]!)?.name).toBe("Harrowgate.S03E01.1080p.WEB-DL");
+  });
+
+  it("drops a season node holding only one child, so a lone release stays a plain row", () => {
+    const rows = groupRowPlan(groupResults([r("Harrowgate.S03E01.1080p.WEB-DL")], "series"), new Set());
+    expect(rows.map((row) => row.kind)).toEqual(["release"]);
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("leaves a film's rows exactly as they were", () => {
+    const rows = groupRowPlan(
+      groupResults([r("Kestrel.2010.1080p.BluRay.x264"), r("Kestrel.2010.2160p.WEB-DL")]),
+      new Set(),
+    );
+    expect(rows.map((row) => row.kind)).toEqual(["group"]);
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("gives every row a unique key at three levels", () => {
+    const rows = groupRowPlan(
+      groupResults(SEASON, "series"),
+      new Set(["harrowgate|series|s3", "harrowgate|series|s3|e1", "harrowgate|series|s3|pack"]),
+    );
+    expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length);
+  });
+});
+
+describe("groupHeading under a season", () => {
+  it("drops the show name a season row already states", () => {
+    const [group] = groupResults([r("Kepler.S02E04.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!, { underSeason: true })).toBe("S02E04");
+  });
+
+  it("names a pack as what it is", () => {
+    const [group] = groupResults([r("Harrowgate.S03.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!, { underSeason: true })).toBe("Season pack");
+  });
+
+  it("is unchanged without the option", () => {
+    const [group] = groupResults([r("Kepler.S02E04.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!)).toBe("Kepler S02E04");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/util/resultGroup.test.ts`
+Expected: FAIL — `depth` does not exist on `GroupRow`, and `groupHeading` takes one argument.
+
+- [ ] **Step 3: Add the `season` row variant and `depth`**
+
+Replace the `GroupRow` type in `src/util/resultGroup.ts`:
+
+```ts
+/**
+ * One line of the rendered list: a season heading, a group heading, or a release.
+ *
+ * `depth` is how far the row is indented — 0 top level, 1 inside an open season,
+ * 2 a release inside an episode group inside an open season. Both front ends
+ * read it rather than deriving indent themselves.
+ */
+export type GroupRow<T> =
+  | {
+      kind: "season";
+      key: string;
+      title: string;
+      season: number;
+      members: T[];
+      expanded: boolean;
+      depth: number;
+    }
+  | {
+      kind: "group";
+      key: string;
+      title: string;
+      year?: number;
+      season?: number;
+      seasonEnd?: number;
+      episode?: number;
+      members: T[];
+      expanded: boolean;
+      depth: number;
+    }
+  | { kind: "release"; key: string; result: T; inGroup: boolean; depth: number };
+```
+
+- [ ] **Step 4: Rewrite `groupRowPlan` over the tree**
+
+Replace `groupRowPlan` in `src/util/resultGroup.ts`:
+
+```ts
+/**
+ * One group's rows, at a given depth. The "group of one" rule is here: a
+ * disclosure arrow over "1 release" is noise, and it would make the common case
+ * — a search where nothing duplicates — look like a different feature.
+ */
+function pushGroupRows<T extends GroupableResult>(
+  rows: GroupRow<T>[],
+  group: ResultGroup<T>,
+  expanded: ReadonlySet<string>,
+  depth: number,
+): void {
+  const first = group.members[0];
+  if (first === undefined) return;
+  if (group.members.length === 1) {
+    rows.push({ kind: "release", key: group.key, result: first, inGroup: depth > 0, depth });
+    return;
+  }
+  const isOpen = expanded.has(group.key);
+  const row: GroupRow<T> = {
+    kind: "group",
+    key: group.key,
+    title: group.title,
+    members: group.members,
+    expanded: isOpen,
+    depth,
+  };
+  if (group.year !== undefined) row.year = group.year;
+  if (group.season !== undefined) row.season = group.season;
+  if (group.seasonEnd !== undefined) row.seasonEnd = group.seasonEnd;
+  if (group.episode !== undefined) row.episode = group.episode;
+  rows.push(row);
+  if (!isOpen) return;
+  group.members.forEach((member, i) => {
+    rows.push({
+      kind: "release",
+      key: `${group.key}#${i}`,
+      result: member,
+      inGroup: true,
+      depth: depth + 1,
+    });
+  });
+}
+
+/**
+ * Flatten the season tree into the rows to render, honouring what is expanded.
+ *
+ * A season node holding a SINGLE child is dropped and its child emitted in its
+ * place: wrapping one episode in a season row is the same noise as a disclosure
+ * over "1 release", and without this a search returning one release of one show
+ * would grow a heading it never had.
+ *
+ * Shared by both front ends deliberately. The browser renders these rows with
+ * createElement and the terminal with Ink boxes, but "which rows are there" is
+ * one decision, and this codebase records four bugs caused by copying one
+ * instead of moving it down here.
+ */
+export function groupRowPlan<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+  expanded: ReadonlySet<string>,
+): GroupRow<T>[] {
+  const rows: GroupRow<T>[] = [];
+  for (const node of seasonTree(groups)) {
+    if (!isSeasonNode(node)) {
+      pushGroupRows(rows, node, expanded, 0);
+      continue;
+    }
+    const only = node.children.length === 1 ? node.children[0] : undefined;
+    if (only) {
+      pushGroupRows(rows, only, expanded, 0);
+      continue;
+    }
+    const isOpen = expanded.has(node.key);
+    rows.push({
+      kind: "season",
+      key: node.key,
+      title: node.title,
+      season: node.season,
+      members: node.members,
+      expanded: isOpen,
+      depth: 0,
+    });
+    if (!isOpen) continue;
+    for (const child of node.children) pushGroupRows(rows, child, expanded, 1);
+  }
+  return rows;
+}
+```
+
+- [ ] **Step 5: Teach `groupHeading` the short form**
+
+Replace `groupHeading` in `src/util/resultGroup.ts`:
+
+```ts
+/**
+ * What a group heading says.
+ *
+ * Shared by both front ends because the alternative — each formatting its own —
+ * is exactly the copy-then-drift this codebase records four bugs from. The
+ * season and episode are the point: `title` alone made a pack and every episode
+ * of one season render as identical rows.
+ *
+ * `underSeason` is the form for a row nested inside a season heading, which
+ * already states the show and the season. Repeating both at every level reads as
+ * noise; "S03E01" and "Season pack" say the only thing that differs.
+ */
+export function groupHeading(
+  group: {
+    title: string;
+    year?: number;
+    season?: number;
+    seasonEnd?: number;
+    episode?: number;
+  },
+  opts?: { underSeason?: boolean },
+): string {
+  if (opts?.underSeason && group.season !== undefined) {
+    return group.episode !== undefined
+      ? `S${pad(group.season)}E${pad(group.episode)}`
+      : "Season pack";
+  }
+  if (group.season !== undefined) {
+    const span = group.seasonEnd !== undefined ? `-S${pad(group.seasonEnd)}` : "";
+    const episode = group.episode !== undefined ? `E${pad(group.episode)}` : "";
+    return `${group.title} S${pad(group.season)}${span}${episode}`;
+  }
+  // A film. The year is what tells two films sharing a title apart, which is the
+  // same job the season does for a show.
+  return group.year !== undefined ? `${group.title} (${group.year})` : group.title;
+}
+```
+
+Also update the `resultAtRow` doc comment, which currently claims the first member is best "under the current sort" — that reasoning no longer covers a season row:
+
+```ts
+/**
+ * The release a row acts on.
+ *
+ * A collapsed header resolves to its FIRST member. For a group that is its best
+ * one under the current sort; for a SEASON row it is the best season pack,
+ * because `seasonTree` sorts packs ahead of episodes for exactly this reason —
+ * `play`/`add` on a collapsed season must grab the season, not episode one.
+ * Do not "fix" that ordering away.
+ *
+ * That is what lets every existing action keep working untouched: play, add,
+ * favourite and the preview lookup all take a release, and a header hands them
+ * one without any new picking logic.
+ */
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npx vitest run src/util/resultGroup.test.ts`
+Expected: PASS. Pre-existing tests in this file that assert row kinds now also see `depth`; none of them assert on object identity, so they should pass unchanged. If `groupRowPlan` tests fail on the film path, that is a real regression — fix the code, not the test.
+
+- [ ] **Step 7: Run the gates and commit**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+git add src/util/resultGroup.ts src/util/resultGroup.test.ts
+git commit -m "feat(util): render seasons as rows, with depth and short child headings"
+```
+
+Note: `npm test` will fail in `src/ui/components/Results.test.tsx` and possibly typecheck in the two front ends, because they do not yet handle `kind: "season"`. That is expected at this point — **do not commit until Task 3 if the gates are red.** If they are red, carry this task's changes forward uncommitted and commit at the end of Task 4.
+
+---
+
+### Task 3: The default-open season
+
+**Files:**
+- Modify: `src/util/resultGroup.ts`
+- Test: `src/util/resultGroup.test.ts`
+
+**Interfaces:**
+- Consumes: `seasonTree`, `isSeasonNode`.
+- Produces: `defaultExpandedKeys(groups: readonly ResultGroup<T>[]): string[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+The fixture deliberately includes strays. A clean single-season fixture passes while the real behaviour is wrong — this is the mistake the spec records.
+
+```ts
+describe("defaultExpandedKeys", () => {
+  it("opens the highest-ranked season even when strays share the result set", () => {
+    // Shaped after a real search: the season asked for, ANOTHER show's season 4,
+    // and two unrelated episodes matching on a word. Four top-level rows, so a
+    // rule counting "is it the only row" would leave the season shut.
+    const groups = groupResults(
+      [
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.2160p.WEB-DL"),
+        r("Harrowgate.S03.1080p.WEB-DL"),
+        r("Harrowgate.S03.2160p.WEB-DL"),
+        r("Kepler.S04E02.1080p.WEB-DL"),
+        r("Kepler.S04E02.2160p.WEB-DL"),
+        r("Tin.Rivers.S01E03.1080p.WEB-DL"),
+        r("Ashfall.1999.1080p"),
+      ],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups)).toEqual(["harrowgate|series|s3"]);
+  });
+
+  it("opens nothing when there is no season to open", () => {
+    expect(
+      defaultExpandedKeys(groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")])),
+    ).toEqual([]);
+  });
+
+  it("skips a season that the row plan drops for holding one child", () => {
+    // One episode group means no season row exists to open.
+    const groups = groupResults(
+      [r("Harrowgate.S03E01.1080p.WEB-DL"), r("Harrowgate.S03E01.2160p.WEB-DL")],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t defaultExpandedKeys`
+Expected: FAIL — `defaultExpandedKeys is not a function`.
+
+- [ ] **Step 3: Implement it**
+
+Add to `src/util/resultGroup.ts`, after `groupRowPlan`:
+
+```ts
+/**
+ * The keys a fresh result set should start with open.
+ *
+ * The highest-ranked season node, and only that one. Without it a search for one
+ * season collapses to a single line, which reads as the list having failed.
+ *
+ * "Highest-ranked" rather than "the only one": a real search for one season of
+ * one show also returned a different show's season and two unrelated episodes,
+ * so a rule asking whether the season is alone would have left it shut on the
+ * very query that motivated this. Ranking needs no counting and strays cannot
+ * defeat it.
+ *
+ * A season the row plan DROPS (one child) is skipped — there is no row to open.
+ *
+ * A SEED, not a running rule: the caller puts these into the expansion set it
+ * already owns, so collapsing one behaves like collapsing anything else.
+ */
+export function defaultExpandedKeys<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+): string[] {
+  for (const node of seasonTree(groups)) {
+    if (isSeasonNode(node) && node.children.length > 1) return [node.key];
+  }
+  return [];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t defaultExpandedKeys`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (with Task 2 if its gates were red)**
+
+```bash
+git add src/util/resultGroup.ts src/util/resultGroup.test.ts
+git commit -m "feat(util): seed the highest-ranked season open"
+```
+
+---
+
+### Task 4: Terminal rendering
+
+**Files:**
+- Modify: `src/ui/components/Results.tsx`
+- Test: `src/ui/components/Results.test.tsx`
+
+**Interfaces:**
+- Consumes: `groupRowPlan`, `groupHeading`, `defaultExpandedKeys`, `resultAtRow`, `GroupRow`.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/ui/components/Results.test.tsx`, inside `describe("Results grouping", …)`:
+
+```ts
+it("renders a season row above its episodes, indented", async () => {
+  const u = await mountWide(
+    [
+      t("p1", "Harrowgate.S03.1080p.WEB-DL"),
+      t("p2", "Harrowgate.S03.2160p.WEB-DL"),
+      t("e1", "Harrowgate.S03E01.1080p.WEB-DL"),
+      t("e2", "Harrowgate.S03E01.2160p.WEB-DL"),
+      t("f1", "Harrowgate.S03E02.1080p.WEB-DL"),
+      t("f2", "Harrowgate.S03E02.2160p.WEB-DL"),
+    ],
+    120,
+  );
+  // The highest-ranked season is seeded open, so its children are on screen.
+  expect(u.frame()).toContain("Harrowgate S03");
+  expect(u.frame()).toContain("Season pack");
+  expect(u.frame()).toContain("S03E01");
+  // The show's name is stated once, by the season row — not repeated per child.
+  expect(u.frame()).not.toContain("Harrowgate S03E01");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/ui/components/Results.test.tsx -t "season row above"`
+Expected: FAIL — no `Season pack` in the frame.
+
+- [ ] **Step 3: Seed the expansion state**
+
+In `src/ui/components/Results.tsx`, the expansion state is at line 276. Add a seeding effect below it. Import `defaultExpandedKeys` from `../../util/resultGroup` alongside the existing imports.
+
+```tsx
+const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+// The highest-ranked season opens itself once per result set. Seeded rather than
+// applied every render so that collapsing it stays collapsed — the expansion set
+// means "what is open", and a running rule would fight the user.
+const seeded = useRef(false);
+useEffect(() => {
+  if (results.length === 0) {
+    seeded.current = false;
+    return;
+  }
+  if (seeded.current) return;
+  seeded.current = true;
+  const keys = defaultExpandedKeys(groupResults(results, hintForSection(section)));
+  if (keys.length > 0) setExpanded(new Set(keys));
+}, [results, section]);
+```
+
+`useEffect`, `useRef` and `useState` are already imported at `src/ui/components/Results.tsx:1`.
+`groupResults` and `hintForSection` are already imported too — the component calls both at
+line 332.
+
+- [ ] **Step 4: Render the season row and the indent**
+
+Replace the label expression at `src/ui/components/Results.tsx:786-788`:
+
+```tsx
+// groupHeading, not a local format: the browser's headings go through the same
+// call, and a show's season is the only thing telling one heading from the next.
+// Children of a season take the short form — the season row above them already
+// states the show.
+const caret = row.kind === "release" ? "" : `${row.expanded ? ICON.caretDown : ICON.caretRight} `;
+const indent = "  ".repeat(row.depth);
+const label =
+  row.kind === "season"
+    ? `${indent}${caret}${groupHeading(row)}`
+    : row.kind === "group"
+      ? `${indent}${caret}${groupHeading(row, { underSeason: row.depth > 0 })}`
+      : `${indent}${cleanText(r.name)}`;
+```
+
+Update `isGroup` on the line above it, which drives the bold styling, so a season row is styled like a heading:
+
+```tsx
+const isGroup = row.kind === "group" || row.kind === "season";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/ui/components/Results.test.tsx`
+Expected: PASS, including the pre-existing grouping and cursor-stability tests.
+
+- [ ] **Step 6: Check the 80-column case by eye**
+
+Run: `npm run dev` and search a show with a season pack and several episodes, in an 80-column terminal.
+Confirm: a depth-2 release row is still readable. `Results.tsx:779-782` records that the name cell has ~61 columns at 80 wide and is already truncated — depth-2 spends four more on indent. If it is unusable, cap the indent at `"  ".repeat(Math.min(row.depth, 1))` and note it in the commit message; do not silently ship an unreadable row.
+
+- [ ] **Step 7: Run the gates and commit**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+git add src/ui/components/Results.tsx src/ui/components/Results.test.tsx
+git commit -m "feat(ui): render the season tree in the results list"
+```
+
+---
+
+### Task 5: Browser rendering, and the docs
+
+**Files:**
+- Modify: `src/web/static/app.ts`
+- Modify: `src/web/static/searchModel.ts`
+- Modify: `src/web/static/styles.css`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: `groupRowPlan`, `groupHeading`, `defaultExpandedKeys`, `GroupRow`.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Re-export the new helper**
+
+In `src/web/static/searchModel.ts`, add `defaultExpandedKeys` to the existing re-export block from `../../util/resultGroup` (which already lists `groupCountLabel`, `groupHeading`, `resultAtRow`).
+
+- [ ] **Step 2: Carry the season fields into `GroupFacts`**
+
+In `src/web/static/app.ts`, `GroupFacts` (around line 1532) already carries `season`, `seasonEnd`, `episode`. Extend `groupFactsFor` to accept a season row as well, and record the depth so the heading can take the short form:
+
+```ts
+/** The heading facts for a season or group row, so the row and the card agree. */
+function groupFactsFor(
+  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" }>,
+): GroupFacts {
+  const facts: GroupFacts = {
+    key: row.key,
+    title: row.title,
+    count: row.members.length,
+    expanded: row.expanded,
+    depth: row.depth,
+  };
+  if (row.kind === "season") {
+    facts.season = row.season;
+    return facts;
+  }
+  if (row.year !== undefined) facts.year = row.year;
+  if (row.season !== undefined) facts.season = row.season;
+  if (row.seasonEnd !== undefined) facts.seasonEnd = row.seasonEnd;
+  if (row.episode !== undefined) facts.episode = row.episode;
+  return facts;
+}
+```
+
+Add `depth: number;` to the `GroupFacts` interface, and make `groupHeadingText` use it:
+
+```ts
+function groupHeadingText(facts: GroupFacts): string {
+  return groupHeading(facts, { underSeason: facts.depth > 0 });
+}
+```
+
+- [ ] **Step 3: Render season rows and the depth indent**
+
+At `src/web/static/app.ts:1840`, the row plan is consumed. Extend the `kind === "group"` branch to also take `"season"`, since both render as a heading card:
+
+```ts
+row.kind === "group" || row.kind === "season"
+  ? renderResultCard(row.members[0]!, row.key, groupFactsFor(row))
+  : renderResultCard(row.result, row.key, undefined, row.inGroup)
+```
+
+`renderResultCard` sets `result-member` from `inGroup` at line 1625. Replace that with a depth class so two levels are distinguishable — pass `row.depth` in as a fourth argument in both branches and set:
+
+```ts
+if (depth > 0) li.classList.add(`result-depth-${Math.min(depth, 2)}`);
+```
+
+- [ ] **Step 4: Style the second level**
+
+In `src/web/static/styles.css`, the `.result-member` rule at line 766 becomes the depth-1 rule, and depth 2 nests one step further. Keep the existing comment about the spine.
+
+```css
+/* A row inside an open season or group. Indented with a spine so the belonging is
+   visible without a second colour — and the name keeps the weight it always had,
+   so an expanded group looks like the list it is. */
+.result-depth-1 {
+  margin-left: 1.25rem;
+  border-left: 2px solid var(--line);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.result-depth-2 {
+  margin-left: 2.5rem;
+  border-left: 2px solid var(--line);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+/* The indent and spine are a LIST idiom. In the grid every card is the same size
+   by definition, so an indented one just breaks the columns — belonging is shown
+   there by the member cards following their group card instead. */
+.results-grid .result-depth-1,
+.results-grid .result-depth-2 {
+  margin-left: 0;
+  border-left: 1px solid var(--line);
+  border-radius: 0.5rem;
+}
+```
+
+Grep for any other use of `.result-member` and update it: `grep -rn "result-member" src/`.
+
+- [ ] **Step 5: Seed the expansion state**
+
+`expandedGroups.clear()` at `src/web/static/app.ts:1105` runs when a search starts, before any results exist. Seed instead on the first non-empty render. Next to `expandedGroups` (line 967) add:
+
+```ts
+// Seeded once per search, not per frame: the set means "what is open", so a
+// running rule would reopen a season the user just collapsed.
+let seededExpansion = false;
+```
+
+Set `seededExpansion = false;` immediately after `expandedGroups.clear()` at line 1105. Then in `renderResults`, before the row plan is built:
+
+```ts
+if (!seededExpansion) {
+  const groups = visibleGroups(searchView, reportsHealthLookup(sources));
+  if (groups.length > 0) {
+    seededExpansion = true;
+    for (const key of defaultExpandedKeys(groups)) expandedGroups.add(key);
+  }
+}
+```
+
+`visibleGroups` is the existing export at `src/web/static/searchModel.ts:178` — it already
+applies the right `hintForGroup` translation, and its own comment warns that passing no
+hint makes the two front ends group the same feed differently. Use it; do not call
+`groupResults` by hand here.
+
+- [ ] **Step 6: Verify by running it**
+
+There is no jsdom, deliberately — wiring is verified by running it.
+
+```bash
+npm run build && npm run dev -- serve --web --port 7391
+```
+
+Search a show by name and confirm: one collapsed row per season, newest season first, the top season open with `Season pack` first and episodes ascending beneath it, the second indent level visible on an open episode, and no console errors. Then toggle **group** off and confirm every release returns as a flat row.
+
+- [ ] **Step 7: Update the README**
+
+`README.md` around line 162 describes grouping. Extend the paragraph that ends "…because a whole season's worth of headings all reading just the show's name looks like the list failed to group at all." with the tree:
+
+```markdown
+A show's releases nest the way the show does: one row per season, newest first, holding
+the season packs and then each episode in order. The season you are most likely to want
+opens itself; the rest stay shut until you ask. Acting on a collapsed season row acts on
+its best season pack, so `play` on `Harrowgate S03` gets the season rather than episode
+one. The **group** control turns all of it off and gives you every release as its own row.
+```
+
+Check the web UI's own limitations list is still true while you are in there.
+
+- [ ] **Step 8: Run the gates and commit**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+git add src/web/static/app.ts src/web/static/searchModel.ts src/web/static/styles.css README.md
+git commit -m "feat(web): render the season tree in the browser results list"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — every section maps to a task:
+
+| Spec section | Task |
+| --- | --- |
+| Row model, `depth`, season variant | 2 |
+| What does not get a season node (span packs, seasonless packs) | 1 |
+| Ordering: between shows, seasons descending, packs-then-episodes | 1 |
+| Headings need a depth-aware form | 2 |
+| The sort control rule | 1 (written into `seasonTree`'s doc comment) |
+| Expansion defaults: highest-ranked season | 3 |
+| The toggle (no new control) | 5, step 6 verification |
+| `resultAtRow` on a collapsed season → best pack | 2 |
+| Terminal 80-column risk | 4, step 6 |
+| Row-count growth / cursor stability | 4, step 5 |
+| Season keys must not collide | 2 ("unique key at three levels") |
+| README | 5 |
+
+**Known ordering hazard:** Task 2 leaves the tree green but both front ends red, because they do not yet know `kind: "season"`. Step 7 of Task 2 says so and tells the implementer to carry the change forward rather than commit a broken tree. Tasks 2–4 can be committed together if that is cleaner.
+
+**Not covered, deliberately:** Piece B (watched marks, next-unwatched landing, per-episode plots) is a separate spec. The TUI's `g` not persisting across runs is noted in the spec as out of scope.

--- a/docs/superpowers/specs/2026-07-31-tv-season-tree-design.md
+++ b/docs/superpowers/specs/2026-07-31-tv-season-tree-design.md
@@ -1,0 +1,212 @@
+# The season tree: results that match the shape of a show
+
+Status: approved, not yet implemented.
+Scope: **Piece A (structure) only.** Piece B is sketched at the end and is a separate spec.
+
+Fixture names throughout are the repo's shared cast (`CLAUDE.md`), not the real
+show the reports came from.
+
+## The problem
+
+A search for a show's season returns a readable set of rows now that group headings
+name the season and episode — `Harrowgate S03`, `Harrowgate S03E01` — but the rows are
+still **flat and ordered by seeders**, so a season pack lands in the middle of its own
+episodes:
+
+    ▸ Harrowgate S03E04     9 releases
+    ▸ Harrowgate S03E08     9 releases
+    ▸ Harrowgate S03E05     5 releases
+    ▸ Harrowgate S03       17 releases      <- the whole season, fourth
+    ▸ Harrowgate S03E06     7 releases
+
+A broad search for the show alone is worse: about forty sibling rows covering five
+seasons, in seeder order, with no sense that seasons contain episodes.
+
+The data is a tree — show → season → episode → release — and the list is flat. Grouping
+already collapsed release→episode. The remaining noise is that **seasons and episodes of
+one show are siblings**. Reordering a flat list treats the symptom; matching the tree
+removes it.
+
+## What already exists
+
+Most of the machinery is present and merely unwired. Do not rebuild any of it:
+
+| Capability | Where |
+| --- | --- |
+| High-water mark per series (highest season + episode watched) | `src/core/streamHistory.ts` |
+| "The episode to offer next" | `nextEpisode()`, `src/core/streamHistory.ts` |
+| Opening a specific episode's file inside a season pack | `PackTarget` / `packTargetFor`, `src/util/nextEpisodeFile.ts` |
+| Per-episode plot | OMDb accepts `&Season=&Episode=`; `src/recc/omdb.ts` currently sends only `t`/`y`/`type` |
+| Grouping on/off, defaulting on | `parseGrouping()` (`searchModel.ts`), `g` (`Results.tsx`) |
+
+## The toggle
+
+**No new control.** The existing `group` toggle already defaults on — `parseGrouping`
+treats anything but the explicit opt-out as ON, and persists in `localStorage`. Off
+still means every release as its own row, which is the manual, see-everything view.
+The tree is simply what "grouped" *means* for a series, so it inherits the switch.
+
+Known asymmetry, **out of scope here**: the browser remembers the preference across
+sessions, the TUI's `g` is `useState(true)` and resets each run. Worth persisting to
+config for parity, as its own change.
+
+## Design
+
+### Row model
+
+`groupResults` keeps its current behaviour unchanged — it produces episode groups, pack
+groups and film groups, and its existing tests must not move. A **second pass** folds a
+series' groups under a season node.
+
+Rows gain a `depth`, and `GroupRow` gains a `season` variant:
+
+    ▾ Harrowgate S03                    47 releases     depth 0
+      ▸ S03 pack                        17 releases     depth 1
+      ▸ S03E01                           4 releases     depth 1
+      ▸ S03E02                           5 releases     depth 1
+          Harrowgate.S03E02.1080p.WEB-DL                depth 2
+
+Expansion continues to use the single `expanded: ReadonlySet<string>`. Season keys carry
+no episode part (`harrowgate|series|s3`), so they cannot collide with the episode keys
+(`harrowgate|series|s3|e1`) or the pack key (`harrowgate|series|s3|pack`).
+
+Films are untouched: a film group has no season node above it and renders exactly as it
+does today.
+
+### What does not get a season node
+
+Two series shapes have no single season to sit under, and both stay **top-level rows**
+rather than being forced into one:
+
+- A **multi-season span pack** — key `harrowgate|series|s1-3|pack`, heading
+  `Harrowgate S01-S03`. Folding it under S01 would claim it is a season-1 release.
+- A **series release with no season at all** — key `harrowgate|series|s|pack`, the
+  "complete series" shape. There is nothing honest to file it under.
+
+Both already key distinctly today, so this is a rule about the fold, not about keys.
+
+### Ordering
+
+- **Between shows** — unchanged. A show's block sits where its best member sits under
+  the current sort. This preserves the promise in `resultGroup.ts` that order is
+  "groups by their first member", which every existing sort depends on.
+- **Seasons within a show** — **descending**. S05, S04, S03: newest at the top.
+- **Within a season** — **packs first, then episodes ascending**. Packs first is
+  load-bearing, not cosmetic: `resultAtRow` resolves a collapsed row to `members[0]`, so
+  packs-first makes `play`/`add` on a collapsed `Harrowgate S03` act on the best season
+  pack, which is the honest reading of that row. Where a season has no pack it falls
+  through to E01's best release.
+- **Within an episode** — members as given. Unchanged.
+
+### Headings need a depth-aware form
+
+`groupHeading` returns the full `Harrowgate S03E01`. Nested under a `Harrowgate S03`
+season row that is correct but noisy — the show's name repeats at every level. A season's
+children want the short form (`S03E01`, `S03 pack`), so `groupHeading` gains a variant
+that omits the parts the parent row already states. Wiring the existing function
+unchanged is the easy mistake here, and it reads badly rather than failing.
+
+### The sort control
+
+The sort orders **releases inside a group**, and orders **unrelated results against each
+other**. A series' internal structure is structural and not re-sortable — "order these
+episodes by seeders" is not a thing anyone wants. Write this down in the module header;
+it is the kind of rule that gets "fixed" by a later reader.
+
+### Expansion defaults
+
+**The highest-ranked season node in the plan starts expanded. Every other node starts
+collapsed.**
+
+Rationale: without something like this, a search for one season collapses to a single
+line, which reads as the list having failed.
+
+An earlier draft said "the season node that is the *only* top-level row expands", and it
+was wrong on exactly the query that motivated this work. A real search for one season of
+one show also returned a *different* show's season 4, plus two unrelated episodes whose
+names merely contained a matching word. There were four top-level rows, so "only" was
+false and the season would have stayed shut. **The test fixture must therefore include
+those strays** — a clean single-season fixture passes while the real behaviour is wrong.
+`scratchpad/names.txt` from the investigation has the real shape to mirror, renamed to
+the cast.
+
+Highest-ranked needs no counting, cannot be defeated by strays, and degrades cleanly into
+Piece B, where "the season you are part-way through" takes over as the thing that opens.
+
+## Where the code lands
+
+- **`src/util/resultGroup.ts`** — tree building and row planning. Pure, unit-tested, and
+  shared: this is the module both front ends already render from, which is the whole
+  reason it exists.
+- **`src/ui/components/Results.tsx`** — depth indent in the name cell, nothing more. The
+  `space` toggle already keys off the row's key and needs no change for a third level.
+- **`src/web/static/app.ts`** — depth indent as a class, nothing more. No new decisions:
+  `app.ts` is DOM wiring, per `CLAUDE.md`.
+
+Both surfaces in the same change, per the repo's two-front-ends rule.
+
+## Testing
+
+In `src/util/resultGroup.test.ts` (pure, so it gets real tests):
+
+- A season node is built over a show's packs and episodes, with the right key.
+- Seasons come back descending; episodes within a season ascending; packs before episodes.
+- `resultAtRow` on a collapsed season resolves to the **best pack**, and to E01's best
+  release when the season has no pack.
+- A film's rows are unchanged — same keys, same shape, same order as today.
+- The highest-ranked season node starts expanded **in a fixture that also contains a
+  second show's season and two unrelated episodes**, not a clean one-season fixture.
+- A multi-season span pack and a seasonless "complete series" pack each stay top-level
+  and are not folded under a season node.
+
+In `src/ui/components/Results.test.tsx`:
+
+- A season row renders with its episodes indented beneath it.
+- Cursor stability (`selRef`) survives the deeper nesting and larger row count. There is
+  an existing test for a later frame adding a result while a group is open; extend it
+  rather than writing a parallel one.
+
+Gates before done, per `CLAUDE.md`: `npm test`, `npm run typecheck`, `npm run lint`,
+`npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`,
+`src/ui/App.tsx`) — leave it.
+
+## Risks
+
+- **`resultAtRow` semantics.** The comment at `resultGroup.ts` states a collapsed header
+  resolves to its first member because "under the current sort, that is its best one".
+  A season node breaks that reasoning — its first member is the best *pack*, chosen
+  structurally rather than by sort. Update the comment to say so, or the next reader
+  will treat packs-first as an accident and sort it away.
+- **Depth eats the name column in the terminal.** `Results.tsx:779-782` records that at
+  80 columns the list has about 61 to spend and the name is already truncated. A
+  depth-2 release row spends more of that on indent. Not solved here — but look at the
+  80-column case rather than discovering it later.
+- **Row-count growth.** Three levels expanded on a broad search is a lot of rows. The
+  TUI windows its list; confirm the window maths still holds at depth.
+- **Season keys must not collide** with pack or episode keys. Covered by test, but it is
+  the failure that would silently merge a whole season into one bucket.
+
+## Out of scope — Piece B (memory), a later spec
+
+Ships after A, and is what makes the browse-a-show flow work end to end:
+
+- Watched episodes marked in the results list, read from `streamHistory`.
+- The next unwatched episode highlighted, and its season auto-expanded to it.
+- The preview pane showing **that episode's** plot when the cursor is on an episode row,
+  via OMDb `&Season=&Episode=` — which turns "flick forward and back to see what I've
+  already watched" into ordinary arrow keys.
+
+A is a prerequisite: the marks and the landing position need somewhere to land.
+
+## Rejected
+
+**Hide season packs; episodes only, sourced from a pack when no standalone release
+exists.** The good instinct — the season is the unit people think in — is kept by the
+season node. Rejected because it removes the ability to grab a whole season, which is a
+stated use, and because sourcing one episode from a large multi-file pack needs a
+file-list resolve before you know the file is even there. Making that the primary path
+trades a healthy single-episode torrent for a slower, less certain one.
+
+**Reorder the flat list only** (packs first, episodes ascending, no nesting). Half the
+work, but a broad show search stays a forty-row wall, so it does not deliver the thing
+that was actually asked for.

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -372,10 +372,34 @@ describe("Results grouping", () => {
       ],
       120,
     );
-    expect(u.frame()).toContain("Harrowgate S03E01");
-    // The pack's heading, on its own line: "Harrowgate S03" is a prefix of
-    // "Harrowgate S03E01", so a plain toContain would pass without it.
+    // Under the season tree the show is named once, by the season row, and its
+    // children take the short form. Before the tree these were sibling rows both
+    // reading "Harrowgate" — which is the bug this test was written for, and it
+    // still catches it: two rows that say nothing distinguishing would fail here.
+    await vi.waitFor(() => expect(u.frame()).toContain("Season pack"));
     expect(u.frame()).toMatch(/Harrowgate S03(?!E)/);
+    expect(u.frame()).toContain("S03E01");
+  });
+
+  it("renders a season row above its episodes, with the show named once", async () => {
+    const u = await mountWide(
+      [
+        t("p1", "Harrowgate.S03.1080p.WEB-DL"),
+        t("p2", "Harrowgate.S03.2160p.WEB-DL"),
+        t("e1", "Harrowgate.S03E01.1080p.WEB-DL"),
+        t("e2", "Harrowgate.S03E01.2160p.WEB-DL"),
+        t("f1", "Harrowgate.S03E02.1080p.WEB-DL"),
+        t("f2", "Harrowgate.S03E02.2160p.WEB-DL"),
+      ],
+      120,
+    );
+    // The highest-ranked season is seeded open, so its children are on screen.
+    // Seeded in an effect, so the frame settles a tick after the first render.
+    await vi.waitFor(() => expect(u.frame()).toContain("Season pack"));
+    expect(u.frame()).toContain("Harrowgate S03");
+    expect(u.frame()).toContain("S03E01");
+    // The show's name is stated once, by the season row — not repeated per child.
+    expect(u.frame()).not.toContain("Harrowgate S03E01");
   });
 
   it("leaves a lone release as a plain row", async () => {

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -358,6 +358,26 @@ describe("Results grouping", () => {
     expect(u.frame()).not.toContain("WEB-DL");
   });
 
+  // The complaint this answers, in the terminal half: a season pack and every
+  // episode of that season are correctly separate groups, but while a heading was
+  // the bare parsed title they all rendered as the same row, and one search read
+  // as five identical copies of the show.
+  it("names the season and episode on a show's headings, so two never read alike", async () => {
+    const u = await mountWide(
+      [
+        t("p1", "Harrowgate.S03.1080p.WEB-DL"),
+        t("p2", "Harrowgate.S03.2160p.WEB-DL"),
+        t("e1", "Harrowgate.S03E01.1080p.WEB-DL"),
+        t("e2", "Harrowgate.S03E01.2160p.WEB-DL"),
+      ],
+      120,
+    );
+    expect(u.frame()).toContain("Harrowgate S03E01");
+    // The pack's heading, on its own line: "Harrowgate S03" is a prefix of
+    // "Harrowgate S03E01", so a plain toContain would pass without it.
+    expect(u.frame()).toMatch(/Harrowgate S03(?!E)/);
+  });
+
   it("leaves a lone release as a plain row", async () => {
     const u = await mountGrouped();
     // No heading, no count — the release name itself is the row.

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -15,7 +15,13 @@ import { parseRelease, hintForSection } from "../../util/release";
 import { releaseBadges } from "../../util/releaseBadges";
 // The grouping engine, shared with the browser's results list. `groupCountLabel`
 // is deliberately NOT used here — see the "×5" comment on the count cell below.
-import { groupHeading, groupResults, groupRowPlan, resultAtRow } from "../../util/resultGroup";
+import {
+  defaultExpandedKeys,
+  groupHeading,
+  groupResults,
+  groupRowPlan,
+  resultAtRow,
+} from "../../util/resultGroup";
 import { openUrl, imdbTitleUrl, imdbFindUrl } from "../../util/openUrl";
 import { getSource, enabledSources } from "../../sources/registry";
 import { getDebridProvider } from "../../integrations/debrid";
@@ -274,6 +280,12 @@ export function Results() {
   // Which group headings are open, by group key. Cleared with the query for the
   // reason the cursor is: the keys of one search name nothing in the next.
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+  // The highest-ranked season opens itself once per result set. SEEDED rather
+  // than applied every render, so collapsing it stays collapsed — the set means
+  // "what is open", and a running rule would fight the user. The effect itself
+  // lives BELOW the query-change effect that clears `expanded`: effects run in
+  // declaration order, and seeding above it just gets wiped on mount.
+  const seeded = useRef(false);
   // The row the user navigated to; null until they move. Keeps the cursor on
   // their row while streamed-in sources reshuffle the list.
   //
@@ -310,7 +322,22 @@ export function Results() {
     // since "kestrel|2010|movie" is the same key in every search that returns it,
     // which would silently expand a group the user never opened.
     setExpanded(new Set());
+    // Let the next result set seed its season open again.
+    seeded.current = false;
   }, [query, section]);
+
+  // Seeds the season the user most likely wants, once per result set. Declared
+  // after the clear above on purpose — see the note on `seeded`.
+  useEffect(() => {
+    if (results.length === 0) {
+      seeded.current = false;
+      return;
+    }
+    if (seeded.current) return;
+    seeded.current = true;
+    const keys = defaultExpandedKeys(groupResults(results, hintForSection(section)));
+    if (keys.length > 0) setExpanded(new Set(keys));
+  }, [results, section]);
 
 
   useEffect(() => {
@@ -330,7 +357,13 @@ export function Results() {
     () =>
       grouped
         ? groupRowPlan(groupResults(results, hintForSection(section)), expanded)
-        : results.map((result) => ({ kind: "release" as const, key: result.infoHash, result, inGroup: false })),
+        : results.map((result) => ({
+            kind: "release" as const,
+            key: result.infoHash,
+            result,
+            inGroup: false,
+            depth: 0,
+          })),
     [results, grouped, expanded, section],
   );
 
@@ -774,7 +807,7 @@ export function Results() {
                   // from the release the row would act on if you pressed `v`.
                   // Never null: groupRowPlan does not emit empty groups.
                   const r = resultAtRow(row)!;
-                  const isGroup = row.kind === "group";
+                  const isGroup = row.kind === "group" || row.kind === "season";
                   const ss = sourceStyle(r.source);
                   // The disclosure arrow and the member indent live INSIDE the
                   // name cell rather than in columns of their own. At 80 columns
@@ -782,10 +815,16 @@ export function Results() {
                   // two more fixed columns would come straight out of it.
                   // groupHeading, not a local format: the browser's headings go
                   // through the same call, and a show's season is the only thing
-                  // telling one heading from the next.
-                  const label = isGroup
-                    ? `${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row)}`
-                    : `${row.inGroup ? "  " : ""}${cleanText(r.name)}`;
+                  // telling one heading from the next. Children of a season take
+                  // the short form — the season row above them already states the
+                  // show, and repeating it at every level is noise.
+                  const indent = "  ".repeat(row.depth);
+                  const label =
+                    row.kind === "season"
+                      ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row)}`
+                      : row.kind === "group"
+                        ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row, { underSeason: row.depth > 0 })}`
+                        : `${indent}${cleanText(r.name)}`;
                   return (
                     <Box key={row.key}>
                       <Box width={GUTTER} flexShrink={0}>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -15,7 +15,7 @@ import { parseRelease, hintForSection } from "../../util/release";
 import { releaseBadges } from "../../util/releaseBadges";
 // The grouping engine, shared with the browser's results list. `groupCountLabel`
 // is deliberately NOT used here — see the "×5" comment on the count cell below.
-import { groupResults, groupRowPlan, resultAtRow } from "../../util/resultGroup";
+import { groupHeading, groupResults, groupRowPlan, resultAtRow } from "../../util/resultGroup";
 import { openUrl, imdbTitleUrl, imdbFindUrl } from "../../util/openUrl";
 import { getSource, enabledSources } from "../../sources/registry";
 import { getDebridProvider } from "../../integrations/debrid";
@@ -780,8 +780,11 @@ export function Results() {
                   // name cell rather than in columns of their own. At 80 columns
                   // the list has ~61 to spend and the name is already truncated;
                   // two more fixed columns would come straight out of it.
+                  // groupHeading, not a local format: the browser's headings go
+                  // through the same call, and a show's season is the only thing
+                  // telling one heading from the next.
                   const label = isGroup
-                    ? `${row.expanded ? ICON.caretDown : ICON.caretRight} ${row.year ? `${row.title} (${row.year})` : row.title}`
+                    ? `${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row)}`
                     : `${row.inGroup ? "  " : ""}${cleanText(r.name)}`;
                   return (
                     <Box key={row.key}>

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -5,6 +5,7 @@ import {
   groupKeyFor,
   groupResults,
   groupRowPlan,
+  defaultExpandedKeys,
   isSeasonNode,
   resultAtRow,
   seasonTree,
@@ -328,5 +329,141 @@ describe("seasonTree", () => {
       ),
     );
     expect(isSeasonNode(tree[0]!)).toBe(false);
+  });
+});
+
+describe("groupRowPlan with seasons", () => {
+  const SEASON = [
+    r("Harrowgate.S03.1080p.WEB-DL"),
+    r("Harrowgate.S03.2160p.WEB-DL"),
+    r("Harrowgate.S03E01.1080p.WEB-DL"),
+    r("Harrowgate.S03E01.2160p.WEB-DL"),
+  ];
+
+  it("collapses a season to one row", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("season");
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("shows the pack and the episode indented when the season is open", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set(["harrowgate|series|s3"]));
+    expect(rows.map((row) => `${row.kind}@${row.depth}`)).toEqual([
+      "season@0",
+      "group@1",
+      "group@1",
+    ]);
+  });
+
+  it("puts a release at depth 2 under an open episode inside an open season", () => {
+    const rows = groupRowPlan(
+      groupResults(SEASON, "series"),
+      new Set(["harrowgate|series|s3", "harrowgate|series|s3|e1"]),
+    );
+    const releases = rows.filter((row) => row.kind === "release");
+    expect(releases.length).toBeGreaterThan(0);
+    expect(releases.every((row) => row.depth === 2)).toBe(true);
+  });
+
+  it("acts on the best season pack when the season row is collapsed", () => {
+    const rows = groupRowPlan(groupResults(SEASON, "series"), new Set());
+    expect(resultAtRow(rows[0]!)?.name).toBe("Harrowgate.S03.1080p.WEB-DL");
+  });
+
+  it("falls through to the first episode when the season has no pack", () => {
+    const rows = groupRowPlan(
+      groupResults(
+        [
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+      new Set(),
+    );
+    expect(resultAtRow(rows[0]!)?.name).toBe("Harrowgate.S03E01.1080p.WEB-DL");
+  });
+
+  it("drops a season node holding only one child, so a lone release stays a plain row", () => {
+    const rows = groupRowPlan(
+      groupResults([r("Harrowgate.S03E01.1080p.WEB-DL")], "series"),
+      new Set(),
+    );
+    expect(rows.map((row) => row.kind)).toEqual(["release"]);
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("leaves a film's rows exactly as they were", () => {
+    const rows = groupRowPlan(
+      groupResults([r("Kestrel.2010.1080p.BluRay.x264"), r("Kestrel.2010.2160p.WEB-DL")]),
+      new Set(),
+    );
+    expect(rows.map((row) => row.kind)).toEqual(["group"]);
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("gives every row a unique key at three levels", () => {
+    const rows = groupRowPlan(
+      groupResults(SEASON, "series"),
+      new Set(["harrowgate|series|s3", "harrowgate|series|s3|e1", "harrowgate|series|s3|pack"]),
+    );
+    expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length);
+  });
+});
+
+describe("groupHeading under a season", () => {
+  it("drops the show name a season row already states", () => {
+    const [group] = groupResults([r("Kepler.S02E04.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!, { underSeason: true })).toBe("S02E04");
+  });
+
+  it("names a pack as what it is", () => {
+    const [group] = groupResults([r("Harrowgate.S03.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!, { underSeason: true })).toBe("Season pack");
+  });
+
+  it("is unchanged without the option", () => {
+    const [group] = groupResults([r("Kepler.S02E04.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!)).toBe("Kepler S02E04");
+  });
+});
+
+describe("defaultExpandedKeys", () => {
+  it("opens the highest-ranked season even when strays share the result set", () => {
+    // Shaped after a real search: the season asked for, ANOTHER show's season,
+    // and unrelated episodes matching on a word. Four top-level rows, so a rule
+    // counting "is it the only row" would leave the season shut.
+    const groups = groupResults(
+      [
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.2160p.WEB-DL"),
+        r("Harrowgate.S03.1080p.WEB-DL"),
+        r("Harrowgate.S03.2160p.WEB-DL"),
+        r("Kepler.S04E02.1080p.WEB-DL"),
+        r("Kepler.S04E02.2160p.WEB-DL"),
+        r("Tin.Rivers.S01E03.1080p.WEB-DL"),
+        r("Ashfall.1999.1080p"),
+      ],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups)).toEqual(["harrowgate|series|s3"]);
+  });
+
+  it("opens nothing when there is no season to open", () => {
+    expect(
+      defaultExpandedKeys(groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")])),
+    ).toEqual([]);
+  });
+
+  it("skips a season that the row plan drops for holding one child", () => {
+    // One episode group means no season row exists to open.
+    const groups = groupResults(
+      [r("Harrowgate.S03E01.1080p.WEB-DL"), r("Harrowgate.S03E01.2160p.WEB-DL")],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups)).toEqual([]);
   });
 });

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -5,7 +5,9 @@ import {
   groupKeyFor,
   groupResults,
   groupRowPlan,
+  isSeasonNode,
   resultAtRow,
+  seasonTree,
 } from "./resultGroup";
 
 const r = (name: string) => ({ name });
@@ -214,5 +216,117 @@ describe("groupCountLabel", () => {
   it("says releases, and gets the singular right", () => {
     expect(groupCountLabel(2)).toBe("2 releases");
     expect(groupCountLabel(1)).toBe("1 release");
+  });
+});
+
+describe("seasonTree", () => {
+  it("folds a show's packs and episodes under one season node", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S03.1080p.WEB-DL"),
+          r("Harrowgate.S03.2160p.WEB-DL"),
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree).toHaveLength(1);
+    const node = tree[0]!;
+    expect(isSeasonNode(node)).toBe(true);
+    if (!isSeasonNode(node)) return;
+    expect(node.key).toBe("harrowgate|series|s3");
+    expect(node.season).toBe(3);
+    expect(node.title).toBe("Harrowgate");
+  });
+
+  it("puts the pack before the episodes, and episodes ascending", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.2160p.WEB-DL"),
+          r("Harrowgate.S03.1080p.WEB-DL"),
+          r("Harrowgate.S03.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    const node = tree[0]!;
+    if (!isSeasonNode(node)) throw new Error("expected a season node");
+    expect(node.children.map((c) => c.episode)).toEqual([undefined, 1, 2]);
+  });
+
+  it("orders seasons newest first", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01E01.1080p.WEB-DL"),
+          r("Harrowgate.S01E01.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree.map((n) => (isSeasonNode(n) ? n.season : null))).toEqual([3, 1]);
+  });
+
+  it("emits a show's whole season block where its first group sat", () => {
+    // Kestrel comes between the two Harrowgate groups in input order. The show's
+    // seasons must stay contiguous, at the position of its FIRST group, so every
+    // existing sort still means what it means.
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01E01.1080p.WEB-DL"),
+          r("Harrowgate.S01E01.2160p.WEB-DL"),
+          r("Kestrel.2010.1080p.BluRay.x264"),
+          r("Kestrel.2010.2160p.WEB-DL"),
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E01.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree.map((n) => (isSeasonNode(n) ? `s${n.season}` : "film"))).toEqual([
+      "s3",
+      "s1",
+      "film",
+    ]);
+  });
+
+  it("leaves a film alone", () => {
+    const tree = seasonTree(groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")]));
+    expect(tree).toHaveLength(1);
+    expect(isSeasonNode(tree[0]!)).toBe(false);
+  });
+
+  it("leaves a multi-season span pack top-level, not filed under its first season", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S01-S03.COMPLETE.1080p.WEB-DL"),
+          r("Harrowgate.S01-S03.COMPLETE.2160p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(isSeasonNode(tree[0]!)).toBe(false);
+  });
+
+  it("leaves a seasonless complete-series pack top-level", () => {
+    const tree = seasonTree(
+      groupResults(
+        [r("Harrowgate.COMPLETE.SERIES.1080p.WEB-DL"), r("Harrowgate.COMPLETE.SERIES.2160p")],
+        "series",
+      ),
+    );
+    expect(isSeasonNode(tree[0]!)).toBe(false);
   });
 });

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   groupCountLabel,
+  groupHeading,
   groupKeyFor,
   groupResults,
   groupRowPlan,
@@ -60,6 +61,40 @@ describe("groupKeyFor", () => {
   it("drops a leading article after punctuation is normalised, not before", () => {
     expect(groupKeyFor("(Кестрел) The Kestrel 2010 1080p")).toBe(
       groupKeyFor("Kestrel.2010.1080p.BluRay.x264"),
+    );
+  });
+
+  // Four shapes that each stranded one release of a season into a group of its
+  // own. They look like separate rows with the same heading, which is the whole
+  // complaint this file exists to answer.
+  it("strips a bracketed release-group prefix", () => {
+    expect(groupKeyFor("[Judas] Harrowgate S03 (1080p WEB-DL)")).toBe(
+      groupKeyFor("Harrowgate.S03.1080p.WEB-DL"),
+    );
+  });
+
+  it("does not strip a bracket when the title itself is the bracketed part", () => {
+    // The strip must not eat a title down to a bare number: every numeric residue
+    // would then share one group.
+    expect(groupKeyFor("(Ashfall) 1999 1080p")).toBe(groupKeyFor("Ashfall.1999.1080p"));
+  });
+
+  it("does not read a season number out of a resolution", () => {
+    // "COMPLETE.SEASON.1080p" parses as season 10: the parser reads "SEASON" and
+    // then the "10" of "1080p". The name's own S03 marker is the truth.
+    expect(groupKeyFor("Harrowgate.S03.COMPLETE.SEASON.1080p.WEB.DL")).toBe(
+      groupKeyFor("Harrowgate.S03.1080p.WEB-DL"),
+    );
+  });
+
+  it("keeps pack filler out of the title", () => {
+    expect(groupKeyFor("Harrowgate.Complete.Series.S01-S03.1080p")).toContain("harrowgate|");
+    expect(groupKeyFor("Harrowgate.Complete.Series.S01-S03.1080p")).not.toContain("complete");
+  });
+
+  it("keys a multi-season pack apart from the first season it contains", () => {
+    expect(groupKeyFor("Harrowgate.S01-S03.COMPLETE.1080p.WEB-DL")).not.toBe(
+      groupKeyFor("Harrowgate.S01.1080p.WEB-DL"),
     );
   });
 
@@ -134,6 +169,44 @@ describe("resultAtRow", () => {
     ]);
     const rows = groupRowPlan(groups, new Set());
     expect(resultAtRow(rows[0]!)?.name).toBe("Kestrel.2010.1080p.BluRay.x264");
+  });
+});
+
+// The bug this answers: a season pack and each episode of that season are
+// CORRECTLY separate groups, but every heading rendered as the bare parsed
+// title, so one search read as five identical rows saying "Harrowgate".
+describe("groupHeading", () => {
+  const headingOf = (...names: string[]) => {
+    const [group] = groupResults(names.map(r), "series");
+    return groupHeading(group!);
+  };
+
+  it("names the season on a season pack", () => {
+    expect(headingOf("Harrowgate.S03.1080p.WEB-DL")).toBe("Harrowgate S03");
+  });
+
+  it("names season and episode on an episode", () => {
+    expect(headingOf("Kepler.S02E04.1080p.WEB-DL")).toBe("Kepler S02E04");
+  });
+
+  it("gives a pack and an episode of the same season different headings", () => {
+    expect(headingOf("Harrowgate.S03.1080p.WEB-DL")).not.toBe(
+      headingOf("Harrowgate.S03E01.1080p.WEB-DL"),
+    );
+  });
+
+  it("spans a multi-season pack", () => {
+    expect(headingOf("Harrowgate.S01-S03.COMPLETE.1080p.WEB-DL")).toBe("Harrowgate S01-S03");
+  });
+
+  it("keeps the year form for a film, which has no season to name", () => {
+    const [group] = groupResults([r("Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP")]);
+    expect(groupHeading(group!)).toBe("Tin Rivers (2024)");
+  });
+
+  it("falls back to the title alone when nothing is known", () => {
+    const [group] = groupResults([r("Harrowgate.COMPLETE.SERIES.1080p.WEB-DL")], "series");
+    expect(groupHeading(group!)).toBe("Harrowgate");
   });
 });
 

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -248,6 +248,114 @@ export function groupResults<T extends GroupableResult>(
 }
 
 /**
+ * A season of one show, holding its packs and its episode groups.
+ *
+ * `members` is every child's members concatenated in child order, which is what
+ * lets `resultAtRow` keep working untouched: packs sort first, so the first
+ * member of a collapsed season row is the best season pack.
+ */
+export interface SeasonNode<T> {
+  kind: "season";
+  key: string;
+  title: string;
+  season: number;
+  /** Packs first, then episodes ascending. Never empty. */
+  children: ResultGroup<T>[];
+  /** Never empty. */
+  members: T[];
+}
+
+/** A top-level node: a season of a show, or a group with no season to sit under. */
+export type TreeNode<T> = SeasonNode<T> | ResultGroup<T>;
+
+/** True for a `SeasonNode`. `ResultGroup` has no `kind`, which is the discriminator. */
+export function isSeasonNode<T>(node: TreeNode<T>): node is SeasonNode<T> {
+  return "kind" in node;
+}
+
+/**
+ * Which groups fold under a season.
+ *
+ * A group naming ONE season. A span pack ("S01-S03") names three and filing it
+ * under season 1 would claim it is a season-1 release; a "complete series" pack
+ * names none. Both stay top-level. Only the series branch of `factsFor` ever
+ * sets `season`, so this needs no separate "is a series" flag.
+ */
+function foldsUnderSeason<T>(group: ResultGroup<T>): boolean {
+  return group.season !== undefined && group.seasonEnd === undefined;
+}
+
+/** "harrowgate" out of "harrowgate|series|s3|e1" — the show's identity. */
+function showOf(key: string): string {
+  const at = key.indexOf("|series|");
+  return at === -1 ? key : key.slice(0, at);
+}
+
+/** Packs before episodes; episodes ascending. */
+function compareSeasonChild<T>(a: ResultGroup<T>, b: ResultGroup<T>): number {
+  if (a.episode === undefined && b.episode === undefined) return 0;
+  if (a.episode === undefined) return -1;
+  if (b.episode === undefined) return 1;
+  return a.episode - b.episode;
+}
+
+/**
+ * Fold a show's single-season groups under season nodes.
+ *
+ * ORDER IS PRESERVED at the top level: a show's whole season block is emitted at
+ * the position of its FIRST group, so `groupResults`' promise that groups sit
+ * where their best member sits — which every sort depends on — still holds.
+ * Within a show, seasons are newest first.
+ *
+ * The sort control therefore orders releases INSIDE a group, and orders
+ * unrelated results against each other. A series' internal structure is
+ * structural and not re-sortable: "order these episodes by seeders" is not a
+ * thing anyone wants.
+ */
+export function seasonTree<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+): TreeNode<T>[] {
+  const byShow = new Map<string, Map<number, ResultGroup<T>[]>>();
+  for (const group of groups) {
+    if (!foldsUnderSeason(group)) continue;
+    const show = showOf(group.key);
+    let seasons = byShow.get(show);
+    if (!seasons) {
+      seasons = new Map();
+      byShow.set(show, seasons);
+    }
+    const bucket = seasons.get(group.season!) ?? [];
+    bucket.push(group);
+    seasons.set(group.season!, bucket);
+  }
+
+  const out: TreeNode<T>[] = [];
+  const done = new Set<string>();
+  for (const group of groups) {
+    if (!foldsUnderSeason(group)) {
+      out.push(group);
+      continue;
+    }
+    const show = showOf(group.key);
+    if (done.has(show)) continue;
+    done.add(show);
+    const seasons = byShow.get(show)!;
+    for (const season of [...seasons.keys()].sort((a, b) => b - a)) {
+      const children = [...seasons.get(season)!].sort(compareSeasonChild);
+      out.push({
+        kind: "season",
+        key: `${show}|series|s${season}`,
+        title: children[0]!.title,
+        season,
+        children,
+        members: children.flatMap((child) => child.members),
+      });
+    }
+  }
+  return out;
+}
+
+/**
  * Flatten groups into the rows to render, honouring what is expanded.
  *
  * A group of one is emitted as a plain release row: a disclosure arrow over

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -38,8 +38,23 @@ export interface ResultGroup<T> {
   members: T[];
 }
 
-/** One line of the rendered list: a group heading, or a release. */
+/**
+ * One line of the rendered list: a season heading, a group heading, or a release.
+ *
+ * `depth` is how far the row is indented — 0 top level, 1 inside an open season,
+ * 2 a release inside an episode group inside an open season. Both front ends
+ * read it rather than deriving indent themselves.
+ */
 export type GroupRow<T> =
+  | {
+      kind: "season";
+      key: string;
+      title: string;
+      season: number;
+      members: T[];
+      expanded: boolean;
+      depth: number;
+    }
   | {
       kind: "group";
       key: string;
@@ -50,8 +65,9 @@ export type GroupRow<T> =
       episode?: number;
       members: T[];
       expanded: boolean;
+      depth: number;
     }
-  | { kind: "release"; key: string; result: T; inGroup: boolean };
+  | { kind: "release"; key: string; result: T; inGroup: boolean; depth: number };
 
 /**
  * Normalise a parsed title before it becomes a key.
@@ -199,14 +215,26 @@ function pad(n: number): string {
  * is exactly the copy-then-drift this codebase records four bugs from. The
  * season and episode are the point: `title` alone made a pack and every episode
  * of one season render as identical rows.
+ *
+ * `underSeason` is the form for a row nested inside a season heading, which
+ * already states the show and the season. Repeating both at every level reads as
+ * noise; "S03E01" and "Season pack" say the only thing that differs.
  */
-export function groupHeading(group: {
-  title: string;
-  year?: number;
-  season?: number;
-  seasonEnd?: number;
-  episode?: number;
-}): string {
+export function groupHeading(
+  group: {
+    title: string;
+    year?: number;
+    season?: number;
+    seasonEnd?: number;
+    episode?: number;
+  },
+  opts?: { underSeason?: boolean },
+): string {
+  if (opts?.underSeason && group.season !== undefined) {
+    return group.episode !== undefined
+      ? `S${pad(group.season)}E${pad(group.episode)}`
+      : "Season pack";
+  }
   if (group.season !== undefined) {
     const span = group.seasonEnd !== undefined ? `-S${pad(group.seasonEnd)}` : "";
     const episode = group.episode !== undefined ? `E${pad(group.episode)}` : "";
@@ -372,41 +400,117 @@ export function groupRowPlan<T extends GroupableResult>(
   expanded: ReadonlySet<string>,
 ): GroupRow<T>[] {
   const rows: GroupRow<T>[] = [];
-  for (const group of groups) {
-    const first = group.members[0];
-    if (first === undefined) continue;
-    if (group.members.length === 1) {
-      rows.push({ kind: "release", key: group.key, result: first, inGroup: false });
+  for (const node of seasonTree(groups)) {
+    if (!isSeasonNode(node)) {
+      pushGroupRows(rows, node, expanded, 0);
       continue;
     }
-    const isOpen = expanded.has(group.key);
-    const row: GroupRow<T> = {
-      kind: "group",
-      key: group.key,
-      title: group.title,
-      members: group.members,
+    // A season node holding a SINGLE child is dropped and its child emitted in
+    // its place: wrapping one episode in a season row is the same noise as a
+    // disclosure over "1 release", and without this a search returning one
+    // release of one show would grow a heading it never had.
+    const only = node.children.length === 1 ? node.children[0] : undefined;
+    if (only) {
+      pushGroupRows(rows, only, expanded, 0);
+      continue;
+    }
+    const isOpen = expanded.has(node.key);
+    rows.push({
+      kind: "season",
+      key: node.key,
+      title: node.title,
+      season: node.season,
+      members: node.members,
       expanded: isOpen,
-    };
-    if (group.year !== undefined) row.year = group.year;
-    if (group.season !== undefined) row.season = group.season;
-    if (group.seasonEnd !== undefined) row.seasonEnd = group.seasonEnd;
-    if (group.episode !== undefined) row.episode = group.episode;
-    rows.push(row);
-    if (!isOpen) continue;
-    group.members.forEach((member, i) => {
-      rows.push({ kind: "release", key: `${group.key}#${i}`, result: member, inGroup: true });
+      depth: 0,
     });
+    if (!isOpen) continue;
+    for (const child of node.children) pushGroupRows(rows, child, expanded, 1);
   }
   return rows;
 }
 
 /**
+ * The keys a fresh result set should start with open.
+ *
+ * The highest-ranked season node, and only that one. Without it a search for one
+ * season collapses to a single line, which reads as the list having failed.
+ *
+ * "Highest-ranked" rather than "the only one": a real search for one season of
+ * one show also returned a different show's season and two unrelated episodes,
+ * so a rule asking whether the season is alone would have left it shut on the
+ * very query that motivated this. Ranking needs no counting and strays cannot
+ * defeat it.
+ *
+ * A season the row plan DROPS (one child) is skipped — there is no row to open.
+ *
+ * A SEED, not a running rule: the caller puts these into the expansion set it
+ * already owns, so collapsing one behaves like collapsing anything else.
+ */
+export function defaultExpandedKeys<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+): string[] {
+  for (const node of seasonTree(groups)) {
+    if (isSeasonNode(node) && node.children.length > 1) return [node.key];
+  }
+  return [];
+}
+
+/**
+ * One group's rows, at a given depth. The "group of one" rule is here: a
+ * disclosure arrow over "1 release" is noise, and it would make the common case
+ * — a search where nothing duplicates — look like a different feature.
+ */
+function pushGroupRows<T extends GroupableResult>(
+  rows: GroupRow<T>[],
+  group: ResultGroup<T>,
+  expanded: ReadonlySet<string>,
+  depth: number,
+): void {
+  const first = group.members[0];
+  if (first === undefined) return;
+  if (group.members.length === 1) {
+    rows.push({ kind: "release", key: group.key, result: first, inGroup: depth > 0, depth });
+    return;
+  }
+  const isOpen = expanded.has(group.key);
+  const row: GroupRow<T> = {
+    kind: "group",
+    key: group.key,
+    title: group.title,
+    members: group.members,
+    expanded: isOpen,
+    depth,
+  };
+  if (group.year !== undefined) row.year = group.year;
+  if (group.season !== undefined) row.season = group.season;
+  if (group.seasonEnd !== undefined) row.seasonEnd = group.seasonEnd;
+  if (group.episode !== undefined) row.episode = group.episode;
+  rows.push(row);
+  if (!isOpen) return;
+  group.members.forEach((member, i) => {
+    rows.push({
+      kind: "release",
+      key: `${group.key}#${i}`,
+      result: member,
+      inGroup: true,
+      depth: depth + 1,
+    });
+  });
+}
+
+/**
  * The release a row acts on.
  *
- * A collapsed header resolves to its FIRST member, which under the current sort
- * is its best one. That is what lets every existing action keep working
- * untouched: play, add, favourite and the preview lookup all take a release, and
- * a header hands them one without any new picking logic.
+ * A collapsed header resolves to its FIRST member. For a group that is its best
+ * one under the current sort; for a SEASON row it is the best season pack,
+ * because `seasonTree` sorts packs ahead of episodes for exactly this reason —
+ * `play`/`add` on a collapsed season must grab the season, not episode one. Do
+ * not "fix" that ordering away.
+ *
+ * That is what lets every existing action keep working untouched: play, add,
+ * favourite and the preview lookup all take a release, and a header hands them
+ * one without any new picking logic.
  */
 export function resultAtRow<T>(row: GroupRow<T>): T | null {
   return row.kind === "release" ? row.result : (row.members[0] ?? null);

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -23,13 +23,34 @@ export interface ResultGroup<T> {
   /** Display title, from the parser — "Tin Rivers", not "Tin.Rivers.2024…". */
   title: string;
   year?: number;
+  /**
+   * What the group covers, when it is a series. THESE EXIST TO BE RENDERED.
+   * Without them every heading of a show is the bare title, so a season pack and
+   * five episodes of that season — six correctly distinct groups — draw six rows
+   * that all read "Harrowgate", and the list looks duplicated when it is not.
+   * `seasonEnd` is set only for a span ("S01-S03"); `episode` only for a single
+   * episode, so a season pack is `season` with no `episode`.
+   */
+  season?: number;
+  seasonEnd?: number;
+  episode?: number;
   /** Never empty. In the order the caller supplied. */
   members: T[];
 }
 
 /** One line of the rendered list: a group heading, or a release. */
 export type GroupRow<T> =
-  | { kind: "group"; key: string; title: string; year?: number; members: T[]; expanded: boolean }
+  | {
+      kind: "group";
+      key: string;
+      title: string;
+      year?: number;
+      season?: number;
+      seasonEnd?: number;
+      episode?: number;
+      members: T[];
+      expanded: boolean;
+    }
   | { kind: "release"; key: string; result: T; inGroup: boolean };
 
 /**
@@ -41,19 +62,70 @@ export type GroupRow<T> =
  * first, and splits off into a group of its own.
  */
 function normaliseTitle(raw: string): string {
-  return (
-    raw
-      // "www.uindex.org    -    Kestrel 2010": a tracker stamps its own domain on
-      // the front of the release name. Five of 129 live results for one film were
-      // stranded in a group of their own by this alone.
-      .replace(/^\s*(?:www\.)?[a-z0-9-]+\.[a-z]{2,12}\s*[-–—]\s*/i, "")
-      .replace(/\.(?:mkv|mp4|m4v|avi|7z|zip|iso)$/i, "")
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, " ")
-      .trim()
-      .replace(/^(?:the|a|an)\s+/, "")
-      .trim()
-  );
+  const base = raw
+    // "www.uindex.org    -    Kestrel 2010": a tracker stamps its own domain on
+    // the front of the release name. Five of 129 live results for one film were
+    // stranded in a group of their own by this alone.
+    .replace(/^\s*(?:www\.)?[a-z0-9-]+\.[a-z]{2,12}\s*[-–—]\s*/i, "")
+    // "[Judas] Harrowgate S03": see BRACKET_PREFIX.
+    .replace(BRACKET_PREFIX, "")
+    .replace(/\.(?:mkv|mp4|m4v|avi|7z|zip|iso)$/i, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/^(?:the|a|an)\s+/, "")
+    .trim();
+  // "Harrowgate Complete Series" is the same show as "Harrowgate": the parser
+  // leaves pack words in the title when no season number follows them to anchor
+  // on. Stripped only from the END and never down to nothing, so a title that is
+  // genuinely one of these words survives.
+  const trimmed = base.replace(PACK_FILLER, "").trim();
+  return trimmed || base;
+}
+
+const PACK_FILLER = /(?:[\s._-]+(?:complete|full|series|seasons?|packs?))+$/i;
+
+/**
+ * A release group in brackets on the front, the convention for fansubbed shows.
+ *
+ * The lookahead demands a LETTER in what is left, not merely a non-space: a film
+ * actually titled "(Ashfall) 1999" would otherwise reduce to "1999", and a title
+ * eaten down to a bare number groups with every other numeric residue. Bracketed
+ * junk in front of nothing is not a prefix, it IS the name.
+ */
+const BRACKET_PREFIX = /^\s*[[({][^\])}]*[\])}]\s*(?=[^a-z]*[a-z])/i;
+
+/**
+ * The same two strips, on the DISPLAY title, which keeps its own case.
+ *
+ * A heading reading "Harrowgate COMPLETE SERIES" while the group beside it reads
+ * "Harrowgate" is the duplicate-looking-rows complaint again, one layer up: the
+ * key already treats them as one thing, so the label has to as well.
+ */
+function tidyTitle(raw: string): string {
+  const base = raw.replace(BRACKET_PREFIX, "").trim();
+  return base.replace(PACK_FILLER, "").trim() || base;
+}
+
+/**
+ * The season the NAME ITSELF states, which beats the parser when they disagree.
+ *
+ * "Harrowgate.S03.COMPLETE.SEASON.1080p" parses as season 10 — the parser sees
+ * "SEASON" and takes the "10" out of "1080p" — and that one release then sits in
+ * a group of its own. The name's first explicit marker is the honest answer.
+ *
+ * Returns a span for "S01-S03", which is a multi-season pack and must not land
+ * in the same group as season 1 alone.
+ */
+function seasonFromName(name: string): { season: number; seasonEnd?: number } | null {
+  const marker = /(?:^|[^a-z0-9])s(?:eason)?[\s._-]*(\d{1,2})(?![\d])/i.exec(name);
+  if (!marker?.[1]) return null;
+  const season = Number(marker[1]);
+  // "S01-S03", "S01-03": a range, from the marker we just matched onwards.
+  const rest = name.slice(marker.index + marker[0].length);
+  const span = /^[\s._-]*[-–—][\s._-]*s?(\d{1,2})(?![\d])/i.exec(rest);
+  const end = span?.[1] ? Number(span[1]) : undefined;
+  return end !== undefined && end > season ? { season, seasonEnd: end } : { season };
 }
 
 /**
@@ -65,21 +137,84 @@ function normaliseTitle(raw: string): string {
  * and year (so `Ashfall.1999` and `Ashfall.2024` stay apart); episodes key down
  * to the episode; a season pack keys distinctly from any episode within it.
  */
-export function groupKeyFor(name: string, hint?: OmdbType): string {
+interface GroupFacts {
+  key: string;
+  title: string;
+  year?: number;
+  season?: number;
+  seasonEnd?: number;
+  episode?: number;
+}
+
+/**
+ * Everything a group needs from one release name, parsed once.
+ *
+ * One function rather than a `groupKeyFor` and a second parse inside
+ * `groupResults`: the key and the heading have to agree about which season a
+ * release is in, and two call sites deriving that separately is how they drift.
+ */
+function factsFor(name: string, hint?: OmdbType): GroupFacts {
   const parsed = parseRelease(name, hint);
   // parseRelease returns null for some real names (a Korean-titled release in
   // live data). A group of one is the right answer, not a crash.
-  if (!parsed) return `raw|${normaliseTitle(name) || name.trim().toLowerCase()}`;
-  const title = normaliseTitle(parsed.title) || parsed.title.trim().toLowerCase();
-  if (parsed.type === "series") {
-    const season = parsed.season !== undefined ? `s${parsed.season}` : "s";
-    // No episode number on a series release means a season pack — the edge case
-    // that catches "next episode" bugs elsewhere in this codebase, and the one
-    // that must not share a key with S03E01.
-    const episode = parsed.episode !== undefined ? `e${parsed.episode}` : "pack";
-    return `${title}|series|${season}|${episode}`;
+  if (!parsed) {
+    const raw = normaliseTitle(name) || name.trim().toLowerCase();
+    return { key: `raw|${raw}`, title: name };
   }
-  return `${title}|${parsed.year ?? ""}|${parsed.type ?? ""}`;
+  const norm = normaliseTitle(parsed.title) || parsed.title.trim().toLowerCase();
+  const facts: GroupFacts = { key: "", title: tidyTitle(parsed.title) || parsed.title };
+  if (parsed.year !== undefined) facts.year = parsed.year;
+  if (parsed.type !== "series") {
+    facts.key = `${norm}|${parsed.year ?? ""}|${parsed.type ?? ""}`;
+    return facts;
+  }
+  const stated = seasonFromName(name);
+  const season = stated?.season ?? parsed.season;
+  if (season !== undefined) facts.season = season;
+  if (stated?.seasonEnd !== undefined) facts.seasonEnd = stated.seasonEnd;
+  if (parsed.episode !== undefined) facts.episode = parsed.episode;
+  const span = facts.seasonEnd !== undefined ? `-${facts.seasonEnd}` : "";
+  const seasonPart = season !== undefined ? `s${season}${span}` : "s";
+  // No episode number on a series release means a season pack — the edge case
+  // that catches "next episode" bugs elsewhere in this codebase, and the one
+  // that must not share a key with S03E01.
+  const episodePart = facts.episode !== undefined ? `e${facts.episode}` : "pack";
+  facts.key = `${norm}|series|${seasonPart}|${episodePart}`;
+  return facts;
+}
+
+export function groupKeyFor(name: string, hint?: OmdbType): string {
+  return factsFor(name, hint).key;
+}
+
+/** Zero-padded to two digits, the form every release name uses. */
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/**
+ * What a group heading says.
+ *
+ * Shared by both front ends because the alternative — each formatting its own —
+ * is exactly the copy-then-drift this codebase records four bugs from. The
+ * season and episode are the point: `title` alone made a pack and every episode
+ * of one season render as identical rows.
+ */
+export function groupHeading(group: {
+  title: string;
+  year?: number;
+  season?: number;
+  seasonEnd?: number;
+  episode?: number;
+}): string {
+  if (group.season !== undefined) {
+    const span = group.seasonEnd !== undefined ? `-S${pad(group.seasonEnd)}` : "";
+    const episode = group.episode !== undefined ? `E${pad(group.episode)}` : "";
+    return `${group.title} S${pad(group.season)}${span}${episode}`;
+  }
+  // A film. The year is what tells two films sharing a title apart, which is the
+  // same job the season does for a show.
+  return group.year !== undefined ? `${group.title} (${group.year})` : group.title;
 }
 
 /**
@@ -96,20 +231,18 @@ export function groupResults<T extends GroupableResult>(
 ): ResultGroup<T>[] {
   const byKey = new Map<string, ResultGroup<T>>();
   for (const item of list) {
-    const key = groupKeyFor(item.name, hint);
-    const existing = byKey.get(key);
+    const facts = factsFor(item.name, hint);
+    const existing = byKey.get(facts.key);
     if (existing) {
       existing.members.push(item);
       continue;
     }
-    const parsed = parseRelease(item.name, hint);
-    const group: ResultGroup<T> = {
-      key,
-      title: parsed?.title ?? item.name,
-      members: [item],
-    };
-    if (parsed?.year !== undefined) group.year = parsed.year;
-    byKey.set(key, group);
+    const group: ResultGroup<T> = { key: facts.key, title: facts.title, members: [item] };
+    if (facts.year !== undefined) group.year = facts.year;
+    if (facts.season !== undefined) group.season = facts.season;
+    if (facts.seasonEnd !== undefined) group.seasonEnd = facts.seasonEnd;
+    if (facts.episode !== undefined) group.episode = facts.episode;
+    byKey.set(facts.key, group);
   }
   return [...byKey.values()];
 }
@@ -147,6 +280,9 @@ export function groupRowPlan<T extends GroupableResult>(
       expanded: isOpen,
     };
     if (group.year !== undefined) row.year = group.year;
+    if (group.season !== undefined) row.season = group.season;
+    if (group.seasonEnd !== undefined) row.seasonEnd = group.seasonEnd;
+    if (group.episode !== undefined) row.episode = group.episode;
     rows.push(row);
     if (!isOpen) continue;
     group.members.forEach((member, i) => {

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -40,6 +40,7 @@ import {
   debridAddedNotice,
   debridAddLabel,
   emptyView,
+  defaultExpandedKeys,
   groupCountLabel,
   groupHeading,
   modeForQuery,
@@ -57,6 +58,7 @@ import {
   sourceLabel,
   statusLineHidden,
   tabClickPlan,
+  visibleGroups,
   visibleResults,
   type AddVia,
   type GroupRow,
@@ -965,6 +967,9 @@ function readStoredGrouping(): boolean {
 // gesture, and a remembered set of keys from an earlier query would expand
 // nothing recognisable on the next one.
 const expandedGroups = new Set<string>();
+// Seeded once per search, not per frame: the set means "what is open", so a
+// running rule would reopen a season the user just collapsed.
+let seededExpansion = false;
 
 // The rows currently on screen, as the plan produced them. The keydown handler
 // navigates THIS, not `visibleResults` — with grouping on those two disagree
@@ -1103,6 +1108,7 @@ function startSearch(raw: string): void {
   // would expand whichever groups of the new search happen to key the same —
   // "Kestrel 2010" is the same key in every search that returns it.
   expandedGroups.clear();
+  seededExpansion = false;
   // The box and the state must not disagree: without this, submitting "   "
   // leaves #query showing whitespace while searchView.query (and the URL sent
   // to the server) is already trimmed.
@@ -1539,6 +1545,8 @@ interface GroupFacts {
   episode?: number;
   count: number;
   expanded: boolean;
+  /** 0 top level, 1 inside an open season. Chooses the heading's form. */
+  depth: number;
 }
 
 /**
@@ -1549,7 +1557,7 @@ interface GroupFacts {
  * and two front ends deciding that separately is how they drift apart.
  */
 function groupHeadingText(facts: GroupFacts): string {
-  return groupHeading(facts);
+  return groupHeading(facts, { underSeason: facts.depth > 0 });
 }
 
 /**
@@ -1579,14 +1587,21 @@ function groupToggleButton(facts: GroupFacts): HTMLButtonElement {
   return toggle;
 }
 
-/** The heading facts for a group row, so the row and the card agree. */
-function groupFactsFor(row: Extract<GroupRow<PublicSearchResult>, { kind: "group" }>): GroupFacts {
+/** The heading facts for a season or group row, so the row and the card agree. */
+function groupFactsFor(
+  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" }>,
+): GroupFacts {
   const facts: GroupFacts = {
     key: row.key,
     title: row.title,
     count: row.members.length,
     expanded: row.expanded,
+    depth: row.depth,
   };
+  if (row.kind === "season") {
+    facts.season = row.season;
+    return facts;
+  }
   if (row.year !== undefined) facts.year = row.year;
   if (row.season !== undefined) facts.season = row.season;
   if (row.seasonEnd !== undefined) facts.seasonEnd = row.seasonEnd;
@@ -1610,11 +1625,21 @@ function groupCountChip(count: number): HTMLSpanElement {
 // layout exists to show artwork, so a collapsed group has to stay a CARD here —
 // rendering the list-shaped heading into the grid turned a poster wall into 69
 // full-width rows, which is the list with extra steps.
+/**
+ * Marks a row nested under a heading. Purely structural — the CSS indents it and
+ * draws a spine rather than recolouring it: a nested row must still read as the
+ * same kind of row it was before grouping existed. Capped at 2, which is as deep
+ * as the plan goes (season > episode > release).
+ */
+function applyDepth(li: HTMLElement, depth: number): void {
+  if (depth > 0) li.classList.add(`result-depth-${Math.min(depth, 2)}`);
+}
+
 function renderResultCard(
   result: PublicSearchResult,
   rowKey: string,
   group?: GroupFacts,
-  inGroup = false,
+  depth = 0,
 ): HTMLLIElement {
   const li = document.createElement("li");
   li.className = "row result-card";
@@ -1622,7 +1647,7 @@ function renderResultCard(
   // A member card must say so as well. Without this an expanded group's cards
   // were indistinguishable from top-level ones — the grid just grew four more
   // posters with nothing to say they belonged to the card above.
-  if (inGroup) li.classList.add("result-member");
+  applyDepth(li, depth);
   li.setAttribute("aria-selected", String(result.infoHash === selectedHash));
 
   // The poster is the card's primary target and what it does is select the
@@ -1669,14 +1694,11 @@ function renderResultCard(
 function renderResult(
   result: PublicSearchResult,
   rowKey: string,
-  inGroup: boolean,
+  depth: number,
 ): HTMLLIElement {
   const li = document.createElement("li");
   li.className = "row";
-  // Marks a release that belongs to the heading above it. Purely structural — the
-  // CSS indents it and draws a spine, rather than recolouring it: a member row
-  // must still read as the same kind of row it was before grouping existed.
-  if (inGroup) li.classList.add("result-member");
+  applyDepth(li, depth);
   li.setAttribute("aria-selected", String(result.infoHash === selectedHash));
 
   const head = document.createElement("div");
@@ -1733,10 +1755,13 @@ function renderResult(
  * Every action here acts on `resultAtRow(row)`, the group's first member, which
  * under the current sort is its best one. No new picking logic.
  */
-function renderGroupRow(row: Extract<GroupRow<PublicSearchResult>, { kind: "group" }>): HTMLLIElement {
+function renderGroupRow(
+  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" }>,
+): HTMLLIElement {
   const best = row.members[0]!;
   const li = document.createElement("li");
   li.className = "row result-group";
+  applyDepth(li, row.depth);
   // ONLY WHILE COLLAPSED. A heading stands in for its best release, so it reads
   // as selected when that release is — but an EXPANDED group also renders that
   // same release as a member row, and both would claim the selection: two
@@ -1813,6 +1838,17 @@ function renderResults(): void {
   // them from here. Deriving them from `shown` instead compiles fine and passes
   // every unit test, and then silently pins the tab stop to row one, navigates
   // 210 results across ~40 rendered rows, and drops focus after every re-render.
+  // BEFORE the row plan: seeding after it renders one collapsed frame first.
+  // The season the user most likely wants opens itself once the first results
+  // land, into the set the toggles already own, so collapsing it behaves like
+  // collapsing anything else.
+  if (!seededExpansion) {
+    const groups = visibleGroups(searchView, reportsHealthLookup(sources));
+    if (groups.length > 0) {
+      seededExpansion = true;
+      for (const key of defaultExpandedKeys(groups)) expandedGroups.add(key);
+    }
+  }
   currentRows = resultRowPlan(searchView, reportsHealthLookup(sources), expandedGroups);
   const rowKeys = currentRows.map((row) => row.key);
   // The selected ROW, not the selected hash: a heading's key is a group key, so
@@ -1825,7 +1861,8 @@ function renderResults(): void {
   const selectedRowKey =
     currentRows.find(
       (row) =>
-        !(row.kind === "group" && row.expanded) && resultAtRow(row)?.infoHash === selectedHash,
+        !((row.kind === "group" || row.kind === "season") && row.expanded) &&
+        resultAtRow(row)?.infoHash === selectedHash,
     )?.key ?? null;
 
   // Read BEFORE replaceChildren: afterwards the focused node is detached and
@@ -1833,16 +1870,16 @@ function renderResults(): void {
   const focusBefore = captureRowFocus(resultsList);
   resultsList.replaceChildren(
     ...currentRows.map((row) => {
-      if (row.kind === "group") {
-        // Grid layout keeps a group as a CARD — it exists to show artwork, and a
-        // list-shaped heading in there turns a poster wall back into a list.
+      if (row.kind === "group" || row.kind === "season") {
+        // Grid layout keeps a heading as a CARD — it exists to show artwork, and
+        // a list-shaped heading in there turns a poster wall back into a list.
         return effective === "grid"
-          ? renderResultCard(row.members[0]!, row.key, groupFactsFor(row))
+          ? renderResultCard(row.members[0]!, row.key, groupFactsFor(row), row.depth)
           : renderGroupRow(row);
       }
       return effective === "grid"
-        ? renderResultCard(row.result, row.key, undefined, row.inGroup)
-        : renderResult(row.result, row.key, row.inGroup);
+        ? renderResultCard(row.result, row.key, undefined, row.depth)
+        : renderResult(row.result, row.key, row.depth);
     }),
   );
   applyRovingTabIndex(rowKeys, selectedRowKey);

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -41,6 +41,7 @@ import {
   debridAddLabel,
   emptyView,
   groupCountLabel,
+  groupHeading,
   modeForQuery,
   parseGrouping,
   parseLayout,
@@ -1533,13 +1534,22 @@ interface GroupFacts {
   key: string;
   title: string;
   year?: number;
+  season?: number;
+  seasonEnd?: number;
+  episode?: number;
   count: number;
   expanded: boolean;
 }
 
-/** The heading's display title: "Tin Rivers (2024)", or just the title. */
+/**
+ * The heading's display title: "Tin Rivers (2024)", "Harrowgate S03E01".
+ *
+ * The formatting itself is `groupHeading` in src/util/resultGroup.ts, shared
+ * with the terminal — a show's season is what tells one heading from the next,
+ * and two front ends deciding that separately is how they drift apart.
+ */
 function groupHeadingText(facts: GroupFacts): string {
-  return facts.year ? `${facts.title} (${facts.year})` : facts.title;
+  return groupHeading(facts);
 }
 
 /**
@@ -1555,7 +1565,10 @@ function groupToggleButton(facts: GroupFacts): HTMLButtonElement {
   toggle.setAttribute("aria-expanded", String(facts.expanded));
   toggle.setAttribute(
     "aria-label",
-    `${facts.expanded ? "Collapse" : "Expand"} ${groupCountLabel(facts.count)} of ${facts.title}`,
+    // The heading, not the bare title: a screen reader hearing "Expand 8
+    // releases of Harrowgate" three times in a row has the same problem the
+    // sighted list had.
+    `${facts.expanded ? "Collapse" : "Expand"} ${groupCountLabel(facts.count)} of ${groupHeadingText(facts)}`,
   );
   tagControl(toggle, facts.key, "disclosure");
   toggle.addEventListener("click", () => {
@@ -1575,6 +1588,9 @@ function groupFactsFor(row: Extract<GroupRow<PublicSearchResult>, { kind: "group
     expanded: row.expanded,
   };
   if (row.year !== undefined) facts.year = row.year;
+  if (row.season !== undefined) facts.season = row.season;
+  if (row.seasonEnd !== undefined) facts.seasonEnd = row.seasonEnd;
+  if (row.episode !== undefined) facts.episode = row.episode;
   return facts;
 }
 

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -54,6 +54,7 @@ export {
   type SortField,
 } from "../../util/resultSort";
 export {
+  defaultExpandedKeys,
   groupCountLabel,
   groupHeading,
   resultAtRow,
@@ -211,6 +212,7 @@ export function resultRowPlan(
     return shown.map((result) => ({
       kind: "release" as const,
       key: result.infoHash,
+      depth: 0,
       result,
       inGroup: false,
     }));

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -55,6 +55,7 @@ export {
 } from "../../util/resultSort";
 export {
   groupCountLabel,
+  groupHeading,
   resultAtRow,
   type GroupRow,
   type ResultGroup,

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -763,8 +763,16 @@ select:focus-visible {
 /* A release inside an open group. Indented with a spine so the belonging is
    visible without a second colour — and the name keeps the weight it always had,
    so an expanded group looks like the list it is. */
-.result-member {
+.result-depth-1 {
   margin-left: 1.25rem;
+  border-left: 2px solid var(--line);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+/* One step further in: an episode's releases, inside an open season. */
+.result-depth-2 {
+  margin-left: 2.5rem;
   border-left: 2px solid var(--line);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
@@ -773,7 +781,8 @@ select:focus-visible {
 /* The indent and spine are a LIST idiom. In the grid every card is the same size
    by definition, so an indented one just breaks the columns — belonging is shown
    there by the member cards following their group card instead. */
-.results-grid .result-member {
+.results-grid .result-depth-1,
+.results-grid .result-depth-2 {
   margin-left: 0;
   border-left: 1px solid var(--line);
   border-radius: 0.5rem;


### PR DESCRIPTION
## What and why

A search for a show's season came back looking like it had failed to group: nine rows
that all read the same show name, and a season pack sitting fourth, in the middle of its
own episodes.

Two separate causes, fixed in that order.

**The headings said nothing.** A season pack and each episode of that season are
*correctly* separate groups — but `GroupRow` carried only `title` and `year`, so every
one of them drew a heading reading just the show's name. `groupHeading()` now formats
headings once, shared by both front ends, and the row carries the season/episode it needs
to do it.

Four key splitters found in live data are folded in too, each of which stranded a release
in a group of its own: a bracketed release-group prefix (`[Judas] …`); `COMPLETE.SEASON.1080p`,
which parses as *season 10* because the parser reads "SEASON" and then takes the "10" out of
"1080p"; "Complete Series" bleeding into the title; and `S01-S03` merging with season 1
rather than keying as a span. Country suffixes (`US`/`UK`) are deliberately left splitting —
they are sometimes genuinely different shows.

**The list was flat but the data is a tree.** Show → season → episode → release. Grouping
had already collapsed release→episode; seasons and episodes of one show were still
siblings in seeder order. `seasonTree()` folds a show's single-season groups under season
nodes, and rows carry a `depth` both front ends indent from.

- Seasons **newest first**; within a season, **packs then episodes ascending**.
- A show's block sits where its *first* group sat, so `groupResults`' promise that groups
  follow the selected sort still holds. The sort orders releases inside a group and
  unrelated results against each other; a series' internal structure is not re-sortable.
- Packs-first is load-bearing: `resultAtRow` resolves a collapsed row to `members[0]`, so
  `play`/`add` on a collapsed season grabs the **season pack**, not episode one.
- A season's children take a short heading (`Season pack`, `S03E01`) — the season row
  already states the show.
- The highest-ranked season **seeds itself open**. Ranked rather than "the only one": a
  real search for one season also returned another show's season and two unrelated
  episodes, so an "is it alone" rule would have left it shut on the very query this came
  from. The test fixture includes those strays for that reason.
- A multi-season span pack and a seasonless "complete series" pack name no single season
  and stay top-level rather than being filed under one that would misrepresent them.
- A season node holding one child is dropped — wrapping a lone episode in a season row is
  the same noise as a disclosure over "1 release".

No new control: the existing **group** toggle already defaults on and still turns all of
it off, giving every release as its own row.

Measured on a live TV search: ~40 rows → 17, one per season.

Verified by running both front ends, not only by tests — the browser list, and the
terminal at **80 columns**, the width where the name cell is tightest. The short headings
more than pay for the indent there, and a depth-2 release row truncates exactly as it did.

Spec and plan are in `docs/superpowers/`.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (2173)
- [x] New logic has a test (vitest; the decisions are all in `src/util/resultGroup.ts`)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, no new key
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a, no new field
- [x] OS-touching code works on Windows, macOS, and Linux — no OS-touching code
- [x] One concern, with a Conventional Commits title
