### PR TITLE
Title autocomplete from reccd, in both front ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ anything other than loopback requires a token.
   automatically when a row names one — it just can't resume *where* you left off, because nothing here
   reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
 - **No settings page, but there is a settings control.** Tokens, sources, limits and folders are still
-  TUI-only — the browser has no page for them. Playback preference is the exception: the header's
+  TUI-only — the browser has no page for them, and that includes reccd's own URL and bearer token; the
+  browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the
+  **For You** tab), never its address or token. Playback preference is the exception: the header's
   disclosure reads and writes it directly, over the same Origin-checked API as everything else here.
   Counting that, the browser writes four things: your saved searches, your library, your
   continue-watching list (the same searches, favourites and stream history the TUI's `w`, `b`, and
@@ -505,6 +507,23 @@ picked each one ("because you liked Harrowgate"). Rate a pick watched, liked or 
 search** to add it to your Saved searches — the same choice the terminal's `w` makes on a For You pick,
 so a pick you rate here and one you rate in the terminal land in the same place. Ratings feed back into
 reccd exactly as they do from the terminal.
+
+### Title autocomplete
+
+With reccd connected, both search boxes suggest titles as you type — the catalog's own
+spelling and year, so you don't have to remember either. In the terminal, press `⇥` to take the
+top suggestion; in the browser, arrow to one and press Enter, or click it. Picking one searches
+for the title *and* its year, which is what separates a remake from the original. A hit matched
+through an alternate title shows an "also known as" line, and picking it searches the *primary*
+title, not the alias you typed.
+
+Suggestions are **titles, not releases**: reccd's catalog holds films and shows, so you'll be
+offered `Harrowgate` and never `Harrowgate S03` — narrow to a season yourself once the results
+are in. There's no typo tolerance either; the match is on the start of any word, so `dark kni`
+finds a `Dark Knight…`-shaped title but `dark knght` finds nothing.
+
+Without reccd, both boxes behave exactly as they always have — nothing is requested and nothing
+changes on screen.
 
 ### Import your history
 

--- a/README.md
+++ b/README.md
@@ -519,8 +519,8 @@ title, not the alias you typed.
 
 Suggestions are **titles, not releases**: reccd's catalog holds films and shows, so you'll be
 offered `Harrowgate` and never `Harrowgate S03` — narrow to a season yourself once the results
-are in. There's no typo tolerance either; the match is on the start of any word, so `dark kni`
-finds a `Dark Knight…`-shaped title but `dark knght` finds nothing.
+are in. There's no typo tolerance either; the match is on the start of any word, so `tin riv`
+finds `Tin Rivers` but `tin rivrs` finds nothing.
 
 Without reccd, both boxes behave exactly as they always have — nothing is requested and nothing
 changes on screen.

--- a/docs/superpowers/notes/2026-07-31-reccd-search-wishlist.md
+++ b/docs/superpowers/notes/2026-07-31-reccd-search-wishlist.md
@@ -1,0 +1,126 @@
+# What reccd could add to make title search better
+
+**Date:** 2026-07-31
+**Written after** shipping title autocomplete in both torlink front ends against reccd's
+`GET /search`. Everything below is grounded in something that actually came up while
+building it, not speculation about what an API "should" have.
+
+## First, three things reccd must NOT change
+
+These are load-bearing for torlink's client as shipped. Worth stating before the wishlist,
+because a well-meaning cleanup would break a working feature.
+
+1. **`matchedAka` must stay an explicit `null`, never an omitted field.** The primary-title
+   branch selects `NULL::text AS matched_aka` (`src/db/titleSearch.ts:139`), so the JSON
+   carries `"matchedAka": null`. torlink's type guard accepts `null | string` and rejects
+   `undefined` — it is all-or-nothing by design, so omitting the key for primary-title hits
+   would make the guard reject **every** primary hit and silently kill the feature. A green
+   test suite on reccd's side would not notice.
+2. **`q` must keep being parsed for a trailing year server-side.** torlink forwards `q`
+   verbatim and deliberately does no client-side year parsing, precisely so the two systems
+   cannot disagree about what `"kestrel 2010"` means. The literal-interpretation fallback
+   for titles that genuinely end in a year is part of that contract.
+3. **`SEARCH_MIN_QUERY_LENGTH` is duplicated in torlink** as `SUGGEST_MIN_QUERY_LENGTH`,
+   with a comment pointing at `src/api/server.ts:70`. If it changes, torlink either fires
+   requests guaranteed to return `[]` or hides results reccd would have given. Changing it
+   is fine — telling us is the ask. See also the capability endpoint below, which would let
+   a client stop guessing.
+
+## The wishlist, most valuable first
+
+### 1. A `type=movie|tv` filter
+
+`type` comes back on every hit but cannot be filtered on. Both torlink front ends already
+know which the user wants: the browser has category tabs (**movies**, **tv**) and the
+terminal has the equivalent sections. So a user who has explicitly narrowed to TV and types
+three characters still gets films offered, and there is nothing the client can do about it
+short of filtering after the fact — which silently shrinks a `limit`-capped list, sometimes
+to nothing.
+
+Cheapest useful change on this list, and the design doc already notes `type` was included
+"even though there is no `type` filter".
+
+### 2. Artwork on a hit
+
+torlink's browser suggestions are text-only, and that is the **only** reason: showing a
+thumbnail per row would mean a second OMDb round trip per row, on every keystroke. reccd
+already holds the `imdbId`; a `posterUrl` (even nullable, even lazily populated) would let
+the browser's suggestion rows carry poster art, which is the whole point of that surface.
+
+The terminal cannot use this — no posters in a text field — so it is browser-only value,
+but the browser is where autocomplete is most used.
+
+### 3. Typo tolerance on the zero-result case
+
+`tin rivrs` returns nothing. reccd's own design doc already flags a trigram similarity pass
+over the zero-result case as purely additive, and it is right — nothing in torlink's client
+would need to change, because "some hits" and "some hits after a fuzzy retry" are the same
+response shape.
+
+Worth doing because autocomplete is typed fast and loosely. This is the difference between
+"the search box is clever" and "the search box is picky".
+
+### 4. Tell a client that a title is a series, and which seasons exist
+
+The sharpest limitation torlink had to document rather than solve: **suggestions are titles,
+not releases.** `parseBasicsLine` drops `tvEpisode`, so `Harrowgate S03` can never be
+suggested — a user gets `Harrowgate` and has to narrow to a season by hand once torrent
+results are in.
+
+reccd need not index episodes to help here. Even a `seasons: number` or
+`seasonRange: [1, 4]` on a `type: "tv"` hit would let both front ends offer "which season?"
+straight from the suggestion, turning one round of manual narrowing into a click. Full
+episode titles would be better still, but the cheap version captures most of the value.
+
+### 5. Accept a release name, not just a partial title
+
+torlink parses release names locally (`parseRelease`) to get a title and year out of
+strings like `Kestrel.2010.1080p.BluRay.x264`. reccd has `/resolve` for canonicalising full
+release names, but it returns a single best guess with a confidence score — built for
+canonicalisation, not for a picker.
+
+If `/search` accepted a release-name-shaped `q` (or `/resolve` gained a `limit` and returned
+a ranked list), torlink could canonicalise a filename through the same catalog that powers
+its suggestions, and the two systems would stop having independent opinions about what a
+release is. Today they can disagree, and when they do there is no way to tell which is right.
+
+### 6. An optional popularity floor, as a client-supplied hint
+
+reccd deliberately applies no hard `minVotes` filter, and that is the right default — an
+obscure title stays findable if you type enough of its name. But the measured cost of that
+choice lands on the broadest queries: **~311ms for a two-character prefix** on a 2M-row
+seed, against ~71ms for a realistic multi-token one.
+
+With torlink's 250ms debounce, a two-character query is roughly 560ms from last keystroke to
+first row. An **optional** `minVotes=` that a client can pass for short queries only — and
+omit as soon as the query is specific — would let the client trade completeness for latency
+exactly where completeness matters least, without changing reccd's default behaviour at all.
+
+Explicitly not asking for the default to change. The design doc's reasoning for no hard
+filter is sound, and its analysis of why a votes-based fallback breaks tier ordering is
+correct — which is why this should be a client-supplied parameter rather than an internal
+heuristic.
+
+### 7. A capability or version endpoint
+
+torlink treats a `404` from `GET /search` as "this reccd predates the endpoint" and silently
+degrades to the old search box. That works, but it is inference from an error code, and it
+costs one wasted request per debounced keystroke against an older server.
+
+A `GET /capabilities` returning something like
+`{ "search": true, "searchMinQueryLength": 2, "resolve": true, "recommendations": true }`
+would let a client light up features it knows are present, stop probing for ones that are
+not, and read `searchMinQueryLength` instead of hard-coding a copy of it — which retires
+constraint 3 above outright.
+
+This is the item with the best ratio of "small change" to "future coupling removed".
+
+## Deliberately not asking for
+
+- **A different `limit` cap.** 25 is plenty; torlink asks for 8.
+- **Server-side debouncing or rate limiting on `/search`.** Debouncing is the client's job
+  and torlink does it at 250ms. A server-side limiter would be invisible to the user as
+  "suggestions sometimes don't appear".
+- **Removing the `to_tsquery` metacharacter escaping.** torlink does not sanitise `q` before
+  sending, on purpose — the server owning that is correct, and a test on reccd's side already
+  pins `"dark & kni"` and `"!"` not erroring.

--- a/docs/superpowers/plans/2026-07-31-title-autocomplete.md
+++ b/docs/superpowers/plans/2026-07-31-title-autocomplete.md
@@ -1399,29 +1399,71 @@ git commit -m "feat(web): suggestion list model for the search box"
 
 In `src/web/static/index.html`, inside `<form id="search" class="card">`, immediately after the `<input id="query" …>` line, add:
 
+In `src/web/static/index.html`, wrap the input and the list together — the wrapper is
+load-bearing, see the CSS note below:
+
 ```html
-          <!-- Title suggestions from reccd, when it is configured. A full-width
-               row inside the card's flex layout so it sits under the input
-               rather than beside it. Empty and `hidden` until there is
-               something to show; app.ts fills it with createElement +
-               textContent, never innerHTML. -->
-          <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
+          <div class="suggest-wrap">
+            <input id="query" type="search" placeholder="…" autocomplete="off" />
+            <!-- Title suggestions from reccd, when it is configured. An OVERLAY,
+                 positioned against .suggest-wrap: opening it must never push the
+                 Search / save-search buttons around while the user is still
+                 typing. Empty and `hidden` until there is something to show;
+                 app.ts fills it with createElement + textContent, never
+                 innerHTML. -->
+            <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
+          </div>
 ```
 
 In `src/web/static/styles.css`, append:
 
 ```css
-/* The search box's title suggestions. `flex: 1 0 100%` breaks it onto its own
-   row inside .card, which lays its children out as a strip of controls. */
+/* An overlay, not a flow row. The first cut used `flex: 1 0 100%` to break the
+   list onto its own row inside .card — which reflowed the Search / save-search
+   buttons down a row every time the list opened, moving click targets under the
+   user's cursor mid-keystroke. Verified in a browser, then changed.
+   .suggest is positioned against this wrapper rather than .card, because #query
+   is a flex CHILD of .card and positioning against .card would misalign the
+   list with the input. */
+.suggest-wrap {
+  position: relative;
+  flex: 1;
+  /* NOT min-width: 0. The bare #query used to occupy this flex slot carrying
+     `input { flex: 1; min-width: 12rem }` (styles.css:237), and that 12rem is
+     what makes .card wrap instead of crushing the search box. The wrapper holds
+     that slot now, so it inherits the job. */
+  min-width: 12rem;
+}
+
+.suggest-wrap #query {
+  width: 100%;
+  /* The generic `input` rule's min-width: 12rem beats width: 100% once the
+     wrapper is narrower than 12rem — the input then overflows the wrapper and
+     the overlay comes out narrower than the input above it (measured: 91px list
+     under a 192px input). The wrapper enforces the floor; the input just fills
+     it. Do not "simplify" this line away. */
+  min-width: 0;
+}
+
 .suggest {
-  flex: 1 0 100%;
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  /* Opaque, or the tab strip shows through the suggestions. */
+  background: var(--raised);
+  max-height: 16rem;
+  overflow-y: auto;
   list-style: none;
   margin: 0;
   padding: 0;
   border: 1px solid var(--line);
   border-radius: 0.5rem;
-  overflow: hidden;
 }
+/* Never set `display` on .suggest — `[hidden] { display: none !important }` at
+   the top of the file is what makes the hidden attribute work against author
+   rules, and a display declaration here would defeat it. */
 
 .suggest li {
   padding: 0.4rem 0.6rem;

--- a/docs/superpowers/plans/2026-07-31-title-autocomplete.md
+++ b/docs/superpowers/plans/2026-07-31-title-autocomplete.md
@@ -1,0 +1,2416 @@
+# Title Autocomplete From reccd — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When reccd is configured, both torlink front ends offer live title suggestions as you type in the search box, and picking one puts the canonical title and year into the search.
+
+**Architecture:** A new `fetchTitleSuggestions` in `src/recc/client.ts` calls reccd's `GET /search`. The TUI calls it directly (same process, same config); the browser goes through a new `GET /api/title-search` proxy in `src/web/routes.ts`, because `reccToken` must never reach a browser. Every decision — the min-length gate, the labels, what a pick submits, and the stale-reply guard — lives in pure modules (`src/util/titleSuggest.ts`, `src/web/static/suggestModel.ts`) that have real tests. `src/ui` renders them through a hook; `src/web/static/app.ts` is DOM wiring only.
+
+**Tech Stack:** TypeScript, React + Ink (terminal), vanilla DOM + TS (browser), vitest, `ink-testing-library`.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-title-autocomplete-design.md`
+
+## Global Constraints
+
+These apply to **every** task below. They are not restated per task.
+
+- **`src/web` must never import from `src/ui`, and `src/core` from neither.** Lint enforces it (`eslint.config.js`). Share by putting the shared piece in `src/util/`.
+- **No `innerHTML`, `insertAdjacentHTML`, `outerHTML` or `document.write` anywhere in `src/web/static/`.** Every node is `createElement` + `textContent`. This is a stored-XSS rule, not a style preference.
+- **`src/web/static/` must not import `node:*`.** `npm run build` is the only thing that checks this — run it.
+- **`app.ts` is DOM wiring only.** A conditional deciding *what to show* or *what to send* belongs in a pure module. This has been caught in review twice.
+- **Config writes from the web are read-modify-write per request:** `loadConfig()` → change → `saveConfig()`. Never hold a snapshot between requests. (This feature only reads config, but the same per-request `loadConfig()` rule applies — a reccd URL can be pasted into the Accounts pane at any moment.)
+- **Test fixtures name invented titles only.** Reuse this cast, do not invent more: `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`. Never a real film or show.
+- **Conventional Commits.** Commit messages in this plan are given verbatim; use them.
+- **Verified constants from reccd, do not change them:** `SEARCH_MIN_QUERY_LENGTH = 2`, `SEARCH_LIMIT_DEFAULT = 10`, `SEARCH_LIMIT_MAX = 25` (`reccd/src/api/server.ts:68-70`).
+- **Before saying it is done:** `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) stays — do not fix it.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/util/titleSuggest.ts` **new** | The domain type `TitleSuggestion`, the tuning constants, the min-length gate, display labels, `submitTextFor`, and the stale-reply reducer. Pure. Imported by **both** front ends and by `src/recc/client.ts`. |
+| `src/util/titleSuggest.test.ts` **new** | Tests for the above, including the out-of-order mutation guard. |
+| `src/recc/client.ts` | Gains `fetchTitleSuggestions` + `isTitleSuggestion`. |
+| `src/recc/client.test.ts` | Gains a `fetchTitleSuggestions` describe block. |
+| `src/web/wire.ts` | `PublicTitleSuggestions`; `reccConfigured` on `SourcesResponse`. |
+| `src/web/routes.ts` | `GET /api/title-search` handler + dispatch entry; `reccConfigured` in `sourcesResponse`; a `fetchTitleSuggestionsImpl` dep. |
+| `src/web/routes.test.ts` | Tests for both. |
+| `src/web/static/suggestModel.ts` **new** | Browser list state: open/closed, highlight index and its wrap, and what an accept sends. Pure. |
+| `src/web/static/suggestModel.test.ts` **new** | Tests for the above. |
+| `src/web/static/index.html` | The listbox container inside the search card. |
+| `src/web/static/styles.css` | Its styling. |
+| `src/web/static/app.ts` | DOM wiring: debounce timer, fetch, render rows, key handling. |
+| `src/ui/hooks/useTitleSuggest.ts` **new** | Debounce + fetch + seq for the terminal, modelled on `useTitlePreview`. |
+| `src/ui/components/TextField.tsx` | Gains `completion` / `onComplete` so Tab can complete. |
+| `src/ui/components/SearchBar.tsx` | Renders the suggestion rows; passes completion through. |
+| `src/ui/components/Results.tsx` | Owns the hook for the results pane; guards its Esc handler. |
+| `src/ui/views/Splash.tsx` | Owns the hook for the splash; guards its Esc and Tab handlers; hint label. |
+| `src/ui/keymap.ts` | The Tab-completes entry in `HELP_GROUPS`. |
+| `README.md` | Both surfaces; the browser limitations list. |
+
+---
+
+## Task 1: The shared pure module
+
+**Files:**
+- Create: `src/util/titleSuggest.ts`
+- Test: `src/util/titleSuggest.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  export type TitleSuggestionType = "movie" | "tv";
+  export interface TitleSuggestion {
+    imdbId: string;
+    title: string;
+    year: number;
+    type: TitleSuggestionType;
+    matchedAka: string | null;
+  }
+  export const SUGGEST_MIN_QUERY_LENGTH: 2;
+  export const SUGGEST_LIMIT: 8;
+  export const SUGGEST_DEBOUNCE_MS: 250;
+  export const SUGGEST_TIMEOUT_MS: 2500;
+  export const SUGGEST_ROWS_TERMINAL: 5;
+  export interface SuggestState {
+    items: TitleSuggestion[];
+    appliedSeq: number;
+    suppressedText: string | null;
+  }
+  export function emptySuggestState(): SuggestState;
+  export function shouldQuery(raw: string): boolean;
+  export function shouldQueryFor(state: SuggestState, raw: string): boolean;
+  export function applyReply(state: SuggestState, seq: number, items: TitleSuggestion[]): SuggestState;
+  export function suppressFor(state: SuggestState, raw: string): SuggestState;
+  export function topSuggestion(state: SuggestState): TitleSuggestion | null;
+  export function suggestionLabel(hit: TitleSuggestion): string;
+  export function akaNote(hit: TitleSuggestion): string | null;
+  export function submitTextFor(hit: TitleSuggestion): string;
+  export function tabHintLabel(open: boolean): string;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/titleSuggest.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  emptySuggestState,
+  shouldQuery,
+  shouldQueryFor,
+  applyReply,
+  suppressFor,
+  topSuggestion,
+  suggestionLabel,
+  akaNote,
+  submitTextFor,
+  tabHintLabel,
+  SUGGEST_MIN_QUERY_LENGTH,
+  type TitleSuggestion,
+} from "./titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001",
+  title: "Kestrel",
+  year: 2010,
+  type: "movie",
+  matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002",
+  title: "Kepler",
+  year: 2019,
+  type: "tv",
+  matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003",
+  title: "Ashfall",
+  year: 1999,
+  type: "movie",
+  matchedAka: "Ashfall Rising",
+};
+
+describe("shouldQuery", () => {
+  // Must agree with reccd's SEARCH_MIN_QUERY_LENGTH exactly: a lower number
+  // fires requests guaranteed to return [], a higher one hides results reccd
+  // would have given.
+  it("matches reccd's minimum query length", () => {
+    expect(SUGGEST_MIN_QUERY_LENGTH).toBe(2);
+  });
+
+  it("refuses anything shorter than two characters after trimming", () => {
+    expect(shouldQuery("")).toBe(false);
+    expect(shouldQuery(" ")).toBe(false);
+    expect(shouldQuery("k")).toBe(false);
+    expect(shouldQuery("  k  ")).toBe(false);
+  });
+
+  it("accepts two or more characters", () => {
+    expect(shouldQuery("ke")).toBe(true);
+    expect(shouldQuery("kestrel")).toBe(true);
+    expect(shouldQuery("  ke  ")).toBe(true);
+  });
+});
+
+describe("suggestionLabel", () => {
+  // reccd's vocabulary is movie/tv; torlink says film/show everywhere else.
+  it("renders a film with its year", () => {
+    expect(suggestionLabel(KESTREL)).toBe("Kestrel (2010) · film");
+  });
+
+  it("renders a series as a show", () => {
+    expect(suggestionLabel(KEPLER)).toBe("Kepler (2019) · show");
+  });
+});
+
+describe("akaNote", () => {
+  it("is null for a primary-title hit", () => {
+    expect(akaNote(KESTREL)).toBeNull();
+  });
+
+  it("names the alternate title that caused the hit", () => {
+    expect(akaNote(ASHFALL_AKA)).toBe('also known as "Ashfall Rising"');
+  });
+});
+
+describe("submitTextFor", () => {
+  // THE YEAR IS THE POINT. Canonicalising through a catalog is only worth
+  // doing if it separates a remake from its original, and torrent release
+  // names carry the year.
+  it("includes the year", () => {
+    expect(submitTextFor(KESTREL)).toBe("Kestrel 2010");
+  });
+
+  it("uses the primary title even when the hit came via an AKA", () => {
+    expect(submitTextFor(ASHFALL_AKA)).toBe("Ashfall 1999");
+  });
+});
+
+describe("applyReply", () => {
+  it("applies a reply newer than the last one applied", () => {
+    const next = applyReply(emptySuggestState(), 1, [KESTREL]);
+    expect(next.items).toEqual([KESTREL]);
+    expect(next.appliedSeq).toBe(1);
+  });
+
+  /**
+   * MUTATION GUARD — the stale-response bug, which is real here rather than
+   * hypothetical. reccd answers q="th" in ~311ms and q="dark kni" in ~71ms
+   * (its own measured numbers), so the broad, stale reply lands AFTER the
+   * narrow fresh one and would overwrite it: the list would disagree with the
+   * input box. Debouncing does not fix this — two keystroke bursts separated
+   * by more than the debounce window both fire, and nothing orders the replies.
+   */
+  it("discards a reply older than the newest one applied", () => {
+    const fresh = applyReply(emptySuggestState(), 2, [KEPLER]);
+    const stale = applyReply(fresh, 1, [KESTREL]);
+    expect(stale.items).toEqual([KEPLER]);
+    expect(stale.appliedSeq).toBe(2);
+    expect(stale).toBe(fresh);
+  });
+
+  it("discards a reply whose seq equals the one already applied", () => {
+    const first = applyReply(emptySuggestState(), 3, [KEPLER]);
+    expect(applyReply(first, 3, [KESTREL]).items).toEqual([KEPLER]);
+  });
+
+  it("applies an empty reply, clearing what was there", () => {
+    const some = applyReply(emptySuggestState(), 1, [KESTREL]);
+    expect(applyReply(some, 2, []).items).toEqual([]);
+  });
+});
+
+describe("shouldQueryFor", () => {
+  it("defers to shouldQuery when nothing is suppressed", () => {
+    expect(shouldQueryFor(emptySuggestState(), "ke")).toBe(true);
+    expect(shouldQueryFor(emptySuggestState(), "k")).toBe(false);
+  });
+
+  // Accepting a suggestion writes its text into the box, which fires the
+  // change handler again — without this the list would immediately reopen on
+  // the text the user just picked. Escape reuses the same latch.
+  it("refuses the exact text that was suppressed", () => {
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    expect(shouldQueryFor(s, "Kestrel 2010")).toBe(false);
+    expect(shouldQueryFor(s, "  Kestrel 2010  ")).toBe(false);
+  });
+
+  it("queries again as soon as the text changes", () => {
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    expect(shouldQueryFor(s, "Kestrel 2010 1080p")).toBe(true);
+  });
+});
+
+describe("suppressFor", () => {
+  it("clears the list so nothing is left on screen", () => {
+    const some = applyReply(emptySuggestState(), 1, [KESTREL, KEPLER]);
+    expect(suppressFor(some, "ke").items).toEqual([]);
+  });
+
+  // The seq must survive: a request fired before Escape is still in flight,
+  // and resetting the counter would let its reply reopen the dismissed list.
+  it("keeps the applied seq so an in-flight reply cannot reopen the list", () => {
+    const some = applyReply(emptySuggestState(), 4, [KESTREL]);
+    const dismissed = suppressFor(some, "ke");
+    expect(dismissed.appliedSeq).toBe(4);
+    expect(applyReply(dismissed, 3, [KEPLER]).items).toEqual([]);
+  });
+});
+
+describe("topSuggestion", () => {
+  it("is null with no items", () => {
+    expect(topSuggestion(emptySuggestState())).toBeNull();
+  });
+
+  it("is reccd's best-first first item", () => {
+    const s = applyReply(emptySuggestState(), 1, [KESTREL, KEPLER]);
+    expect(topSuggestion(s)).toEqual(KESTREL);
+  });
+});
+
+describe("tabHintLabel", () => {
+  it("offers completion while a list is open and browse otherwise", () => {
+    expect(tabHintLabel(true)).toBe("complete");
+    expect(tabHintLabel(false)).toBe("browse");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/util/titleSuggest.test.ts`
+Expected: FAIL — `Failed to resolve import "./titleSuggest"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/util/titleSuggest.ts`:
+
+```ts
+// Title autocomplete against reccd's `GET /search`, shared by both front ends.
+//
+// Everything here is pure and free of I/O and DOM, because both surfaces need
+// the same answers and neither one's wiring is unit-testable: `app.ts` has no
+// jsdom to run in, and the Ink tree is verified by rendering it. So the
+// decisions live here, where they can be pinned by a test.
+
+/** reccd's own vocabulary for what a title is. */
+export type TitleSuggestionType = "movie" | "tv";
+
+/**
+ * One hit from reccd's `GET /search`, narrowed to what torlink renders.
+ *
+ * reccd also returns `genres`, `rating` and `votes` (its `SearchHit extends
+ * CatalogTitle`). They are dropped at the client boundary: nothing on screen
+ * uses them, and carrying unused fields through `wire.ts` invites a future
+ * reader to assume something does.
+ */
+export interface TitleSuggestion {
+  imdbId: string;
+  title: string;
+  year: number;
+  type: TitleSuggestionType;
+  /**
+   * The alternate title that caused the hit, or null for a primary-title hit.
+   * This is what lets the UI say "you typed X, we mean Y" — the reason reccd
+   * returns it at all.
+   */
+  matchedAka: string | null;
+}
+
+/**
+ * Matches reccd's `SEARCH_MIN_QUERY_LENGTH` (`reccd/src/api/server.ts:70`)
+ * exactly. A smaller number fires requests reccd answers with `[]` and no DB
+ * round trip; a larger one hides results reccd would have given.
+ */
+export const SUGGEST_MIN_QUERY_LENGTH = 2;
+
+/** Asked for. The terminal renders 5 of these and the browser all 8. */
+export const SUGGEST_LIMIT = 8;
+
+/**
+ * reccd's own measured latency is 174–311ms for broad prefixes, so this is
+ * deliberately slower than the 150ms `useTitlePreview` uses against OMDb —
+ * at 150ms the requests would queue behind each other.
+ */
+export const SUGGEST_DEBOUNCE_MS = 250;
+
+/**
+ * Not the 10s `fetchRecommendations` uses. A suggestion arriving after ten
+ * seconds is noise: the user has finished typing and pressed Enter.
+ */
+export const SUGGEST_TIMEOUT_MS = 2500;
+
+/** Vertical space is scarce in a terminal; the browser has no such limit. */
+export const SUGGEST_ROWS_TERMINAL = 5;
+
+export interface SuggestState {
+  items: TitleSuggestion[];
+  /**
+   * The sequence number of the newest reply applied. Replies arrive out of
+   * order (see `applyReply`), and this is what makes that harmless.
+   */
+  appliedSeq: number;
+  /**
+   * Text the user has already resolved — by accepting a suggestion or by
+   * dismissing the list — for which no further request should fire.
+   * Trimmed. Null when nothing is suppressed.
+   */
+  suppressedText: string | null;
+}
+
+export function emptySuggestState(): SuggestState {
+  return { items: [], appliedSeq: 0, suppressedText: null };
+}
+
+export function shouldQuery(raw: string): boolean {
+  return raw.trim().length >= SUGGEST_MIN_QUERY_LENGTH;
+}
+
+export function shouldQueryFor(state: SuggestState, raw: string): boolean {
+  if (!shouldQuery(raw)) return false;
+  return raw.trim() !== state.suppressedText;
+}
+
+/**
+ * Fold a reply into the state, ignoring it if a newer one already landed.
+ *
+ * THIS GUARD IS LOAD-BEARING. reccd answers a two-character query in ~311ms
+ * and an eight-character one in ~71ms, so typing through a broad prefix leaves
+ * the slow, stale reply to land after the fast, fresh one. Without the
+ * sequence check the visible list would disagree with the input box, and
+ * debouncing does not help: two bursts separated by more than the debounce
+ * window both fire and nothing orders their replies.
+ */
+export function applyReply(state: SuggestState, seq: number, items: TitleSuggestion[]): SuggestState {
+  if (seq <= state.appliedSeq) return state;
+  return { ...state, items, appliedSeq: seq };
+}
+
+/**
+ * Close the list and stop asking about `raw`. Used by both accepting a
+ * suggestion and dismissing with escape — accepting writes the suggestion's
+ * text into the box, which fires the change handler again, and without this
+ * the list would reopen on the text just picked.
+ *
+ * `appliedSeq` deliberately survives, so a request fired before this cannot
+ * reopen the list when it answers.
+ */
+export function suppressFor(state: SuggestState, raw: string): SuggestState {
+  return { ...state, items: [], suppressedText: raw.trim() };
+}
+
+export function topSuggestion(state: SuggestState): TitleSuggestion | null {
+  return state.items[0] ?? null;
+}
+
+/** e.g. `Kestrel (2010) · film`. */
+export function suggestionLabel(hit: TitleSuggestion): string {
+  // reccd says movie/tv; torlink says film/show everywhere a user can read it.
+  const kind = hit.type === "tv" ? "show" : "film";
+  return `${hit.title} (${hit.year}) · ${kind}`;
+}
+
+/** The "you typed X, we mean Y" line, or null for a primary-title hit. */
+export function akaNote(hit: TitleSuggestion): string | null {
+  return hit.matchedAka === null ? null : `also known as "${hit.matchedAka}"`;
+}
+
+/**
+ * What accepting this suggestion puts in the search box.
+ *
+ * Title AND year. The year is why canonicalising through a catalog is worth
+ * doing: it separates a remake from its original, and torrent release names
+ * carry it. Note `ForYou` submits title only — see the spec's known limits.
+ */
+export function submitTextFor(hit: TitleSuggestion): string {
+  return `${hit.title} ${hit.year}`;
+}
+
+/** The splash's Tab hint, which changes meaning while a list is open. */
+export function tabHintLabel(open: boolean): string {
+  return open ? "complete" : "browse";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/util/titleSuggest.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/titleSuggest.ts src/util/titleSuggest.test.ts
+git commit -m "feat(util): title suggestion model, with the stale-reply guard"
+```
+
+---
+
+## Task 2: Fetch suggestions from reccd
+
+**Files:**
+- Modify: `src/recc/client.ts` (append after `fetchRecommendations`, which ends at line 138)
+- Test: `src/recc/client.test.ts` (append a new `describe`)
+
+**Interfaces:**
+- Consumes: `TitleSuggestion`, `SUGGEST_LIMIT`, `SUGGEST_TIMEOUT_MS` from `src/util/titleSuggest.ts` (Task 1). `ReccClientConfig` and `FetchImpl` already exist in this file.
+- Produces:
+  ```ts
+  export type FetchTitleSuggestionsResult =
+    | { ok: true; items: TitleSuggestion[] }
+    | { ok: false; error: string };
+  export function fetchTitleSuggestions(
+    config: ReccClientConfig,
+    query: { q: string; limit?: number },
+    opts?: { fetchImpl?: FetchImpl; timeoutMs?: number },
+  ): Promise<FetchTitleSuggestionsResult>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/recc/client.test.ts`. Also extend its import line to
+`import { postEvent, fetchRecommendations, fetchTitleSuggestions } from "./client.js";`
+
+```ts
+describe("fetchTitleSuggestions", () => {
+  const HIT = {
+    imdbId: "tt0000001",
+    title: "Kestrel",
+    year: 2010,
+    type: "movie",
+    matchedAka: null,
+  };
+  // reccd returns more than torlink models — this is what actually comes back.
+  const WIRE_HIT = { ...HIT, genres: ["Drama"], rating: 7.4, votes: 90000 };
+
+  it("gets {reccUrl}/search with q, limit and a bearer token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT]));
+    const res = await fetchTitleSuggestions(
+      { reccUrl: "http://localhost:4100", reccToken: "dev-token" },
+      { q: "kes" },
+      { fetchImpl },
+    );
+    expect(res).toEqual({ ok: true, items: [HIT] });
+    const [url, init] = fetchImpl.mock.calls[0] as [string, { method: string; headers: Record<string, string> }];
+    expect(url).toBe("http://localhost:4100/search?q=kes&limit=8");
+    expect(init.method).toBe("GET");
+    expect(init.headers.authorization).toBe("Bearer dev-token");
+  });
+
+  it("drops the fields torlink does not render", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.items[0]).not.toHaveProperty("votes");
+    expect(res.items[0]).not.toHaveProperty("rating");
+    expect(res.items[0]).not.toHaveProperty("genres");
+  });
+
+  // reccd parses a trailing year out of q itself, and its own fallback rescues
+  // titles that genuinely end in a year. Stripping it here would break both.
+  it("forwards a year in the query verbatim rather than parsing it out", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kestrel 2010" }, { fetchImpl });
+    const [url] = fetchImpl.mock.calls[0] as [string];
+    expect(url).toBe("http://r/search?q=kestrel+2010&limit=8");
+  });
+
+  it("does not call fetch at all when reccUrl is not configured", async () => {
+    const fetchImpl = vi.fn();
+    const res = await fetchTitleSuggestions({}, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("reports a rejected token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(401, { error: "unauthorized" }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "bad" }, { q: "kes" }, { fetchImpl });
+    expect(res).toEqual({ ok: false, error: "reccd rejected the token — check reccToken" });
+  });
+
+  // A reccd predating GET /search 404s. That is "this feature is unavailable",
+  // not a fault, and must leave the search box behaving exactly as it does now.
+  it("treats a 404 as an older reccd without the endpoint", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(404, { error: "not found" }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res).toEqual({ ok: false, error: "this reccd has no title search" });
+  });
+
+  it("reports any other non-ok status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a body that is not an array", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, { items: [WIRE_HIT] }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  // All-or-nothing, matching isRecommendation: a body we only half understand
+  // is a contract change, and silently rendering the half we parsed would hide
+  // it until someone noticed rows missing.
+  it("rejects the whole array when one member is malformed", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT, { imdbId: "tt2" }]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a hit whose type is neither movie nor tv", async () => {
+    const bad = { ...WIRE_HIT, type: "tvEpisode" };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [bad]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts a hit that matched on an AKA", async () => {
+    const aka = { ...WIRE_HIT, matchedAka: "Ashfall Rising" };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [aka]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "ash" }, { fetchImpl });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.items[0]?.matchedAka).toBe("Ashfall Rising");
+  });
+
+  it("never throws on a network error", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("honours an explicit limit", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes", limit: 3 }, { fetchImpl });
+    const [url] = fetchImpl.mock.calls[0] as [string];
+    expect(url).toBe("http://r/search?q=kes&limit=3");
+  });
+
+  it("still fires with an empty bearer token when reccToken is omitted", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r" }, { q: "kes" }, { fetchImpl });
+    const [, init] = fetchImpl.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(init.headers.authorization).toBe("Bearer ");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/recc/client.test.ts`
+Expected: FAIL — `fetchTitleSuggestions is not a function` (or an import error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/recc/client.ts`, and add to its imports at the top:
+
+```ts
+import {
+  SUGGEST_LIMIT,
+  SUGGEST_TIMEOUT_MS,
+  type TitleSuggestion,
+  type TitleSuggestionType,
+} from "../util/titleSuggest";
+```
+
+Then append:
+
+```ts
+export type FetchTitleSuggestionsResult =
+  | { ok: true; items: TitleSuggestion[] }
+  | { ok: false; error: string };
+
+function isSuggestionType(v: unknown): v is TitleSuggestionType {
+  return v === "movie" || v === "tv";
+}
+
+// All-or-nothing, like isRecommendation above: a body we only half understand
+// is a contract change, and rendering the half we parsed would hide it.
+function isTitleSuggestion(v: unknown): v is TitleSuggestion & Record<string, unknown> {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.imdbId === "string" &&
+    typeof r.title === "string" &&
+    typeof r.year === "number" &&
+    isSuggestionType(r.type) &&
+    (r.matchedAka === null || typeof r.matchedAka === "string")
+  );
+}
+
+/**
+ * reccd's `GET /search` — partial input to a ranked list of catalog titles.
+ *
+ * A blocking read like `fetchRecommendations`, and a discriminated result for
+ * the same reason. But the CALLERS treat failure differently: this fires per
+ * keystroke, so every one of these errors is rendered as "no suggestions" and
+ * nothing else. An error banner per keystroke is worse than no suggestions.
+ *
+ * `q` is sent verbatim. reccd parses a trailing year out of it itself and has
+ * its own literal-interpretation fallback for titles that genuinely end in a
+ * year, so stripping one here would break both.
+ */
+export async function fetchTitleSuggestions(
+  config: ReccClientConfig,
+  query: { q: string; limit?: number },
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchTitleSuggestionsResult> {
+  if (!config.reccUrl) return { ok: false, error: "title search not configured" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  const params = new URLSearchParams();
+  params.set("q", query.q);
+  params.set("limit", String(query.limit ?? SUGGEST_LIMIT));
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/search?${params.toString()}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? SUGGEST_TIMEOUT_MS),
+    });
+    if (res.status === 401) return { ok: false, error: "reccd rejected the token — check reccToken" };
+    // A reccd older than the /search endpoint. Not a fault — the feature is
+    // simply unavailable, and the search box must behave as it did before.
+    if (res.status === 404) return { ok: false, error: "this reccd has no title search" };
+    if (!res.ok) return { ok: false, error: `title search unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!Array.isArray(body) || !body.every(isTitleSuggestion)) {
+      return { ok: false, error: "unexpected response from reccd" };
+    }
+    // Narrowed deliberately: reccd also sends genres, rating and votes, and
+    // nothing here renders them.
+    const items: TitleSuggestion[] = body.map((r) => ({
+      imdbId: r.imdbId,
+      title: r.title,
+      year: r.year,
+      type: r.type,
+      matchedAka: r.matchedAka,
+    }));
+    return { ok: true, items };
+  } catch (err) {
+    log.debug(
+      `recc fetchTitleSuggestions: failed to reach ${config.reccUrl}/search: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, error: "couldn't reach reccd" };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/recc/client.test.ts`
+Expected: PASS, including the pre-existing `postEvent` and `fetchRecommendations` blocks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/recc/client.ts src/recc/client.test.ts
+git commit -m "feat(recc): fetch title suggestions from reccd's GET /search"
+```
+
+---
+
+## Task 3: The browser's proxy route and capability flag
+
+**Files:**
+- Modify: `src/web/wire.ts` (`SourcesResponse` at line 340; append the new response type near `PublicRecommendations`, around line 541)
+- Modify: `src/web/routes.ts` (`WebDeps` around line 153; `sourcesResponse` around line 726; a new handler beside `recommendations` around line 1426; dispatch beside `/api/recommendations` at line 1627)
+- Test: `src/web/routes.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchTitleSuggestions`, `FetchTitleSuggestionsResult` (Task 2); `TitleSuggestion`, `SUGGEST_LIMIT` (Task 1); the existing `resolveReccConfig` (`src/config/config.ts:257`).
+- Produces:
+  ```ts
+  // src/web/wire.ts
+  export type PublicTitleSuggestions =
+    | { status: "ok"; items: TitleSuggestion[] }
+    | { status: "not-configured" }
+    | { status: "error"; error: string };
+  // SourcesResponse gains:
+  reccConfigured: boolean;
+  // src/web/routes.ts WebDeps gains:
+  fetchTitleSuggestionsImpl?: (
+    config: ReccClientConfig,
+    query: { q: string; limit?: number },
+  ) => Promise<FetchTitleSuggestionsResult>;
+  // route: GET /api/title-search?q=
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/web/routes.test.ts`. Reuse that file's existing `deps`, `searchConfig`, `handleWebApi` and `AUTH` helpers exactly as the `GET /api/recommendations` block at line 1910 does.
+
+```ts
+describe("GET /api/title-search", () => {
+  const HIT = {
+    imdbId: "tt0000001",
+    title: "Kestrel",
+    year: 2010,
+    type: "movie" as const,
+    matchedAka: null,
+  };
+
+  beforeEach(() => {
+    // Both override the config file inside resolveReccConfig, so a developer
+    // with a real reccd exported would never see the not-configured path — and
+    // the "configured" tests would talk to their actual service.
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+  });
+
+  function suggestDeps(over: Partial<WebDeps> = {}): WebDeps {
+    return deps({
+      loadConfigImpl: async () => searchConfig({ reccUrl: "http://recc.local", reccToken: "t" }),
+      fetchTitleSuggestionsImpl: async () => ({ ok: true, items: [HIT] }),
+      ...over,
+    });
+  }
+
+  function look(d: WebDeps, qs = "q=kes"): Promise<WebResponse> {
+    return handleWebApi(d, "GET", "/api/title-search", new URLSearchParams(qs), AUTH, "");
+  }
+
+  // The gate is the only thing between an anonymous caller and the user's
+  // reccd: this route does not delegate to handleApi, so nothing re-checks.
+  it("rejects an unauthenticated caller when a token is set", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await handleWebApi(
+      suggestDeps({ token: "secret", fetchTitleSuggestionsImpl }),
+      "GET",
+      "/api/title-search",
+      new URLSearchParams("q=kes"),
+      undefined,
+      "",
+    );
+    expect(res.status).toBe(401);
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns reccd's hits", async () => {
+    const res = await look(suggestDeps());
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "ok", items: [HIT] });
+  });
+
+  /**
+   * 200 with its own status, NOT a 500 — the same call `/api/recommendations`
+   * and `/api/title` make. Nothing is broken: the user has no reccd, and the
+   * browser needs to be able to tell that apart from the server falling over.
+   */
+  it("answers not-configured without asking reccd", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(
+      suggestDeps({ loadConfigImpl: async () => searchConfig({}), fetchTitleSuggestionsImpl }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "not-configured" });
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("reports a reccd failure as a status, not a 500", async () => {
+    const res = await look(
+      suggestDeps({ fetchTitleSuggestionsImpl: async () => ({ ok: false, error: "couldn't reach reccd" }) }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "error", error: "couldn't reach reccd" });
+  });
+
+  /**
+   * THE WHOLE REASON THIS ROUTE EXISTS. The browser must never be able to read
+   * the reccd token or URL — if it could, the TUI's proxy would be pointless
+   * and a shared link would leak the user's server.
+   *
+   * Asserted against the SERIALISED body, and with a token value that appears
+   * nowhere else in the fixture, so the negative cannot quietly go vacuous.
+   */
+  it("leaks neither the reccd token nor its URL", async () => {
+    const res = await look(
+      suggestDeps({
+        loadConfigImpl: async () =>
+          searchConfig({ reccUrl: "http://recc.internal:4100", reccToken: "zzq-secret-9317" }),
+      }),
+    );
+    const body = JSON.stringify(res.json);
+    expect(body).not.toContain("zzq-secret-9317");
+    expect(body).not.toContain("recc.internal");
+  });
+
+  it("400s a missing q rather than asking reccd for everything", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(suggestDeps({ fetchTitleSuggestionsImpl }), "");
+    expect(res.status).toBe(400);
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  // reccd answers a short q with [] and no DB round trip; not asking at all is
+  // the same answer for free.
+  it("answers a too-short q with an empty ok, without asking reccd", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(suggestDeps({ fetchTitleSuggestionsImpl }), "q=k");
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "ok", items: [] });
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("forwards the query verbatim, year and all", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [] }));
+    await look(suggestDeps({ fetchTitleSuggestionsImpl }), "q=kestrel+2010");
+    expect(fetchTitleSuggestionsImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ reccUrl: "http://recc.local" }),
+      { q: "kestrel 2010", limit: 8 },
+    );
+  });
+});
+
+describe("GET /api/sources reccConfigured", () => {
+  beforeEach(() => {
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+  });
+
+  async function flag(config: Parameters<typeof searchConfig>[0]): Promise<boolean> {
+    const res = await handleWebApi(
+      deps({ loadConfigImpl: async () => searchConfig(config) }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    return (res.json as { reccConfigured: boolean }).reccConfigured;
+  }
+
+  it("is false with no reccd", async () => {
+    expect(await flag({})).toBe(false);
+  });
+
+  it("is true with a configured reccUrl", async () => {
+    expect(await flag({ reccUrl: "http://recc.local", reccToken: "t" })).toBe(true);
+  });
+
+  // resolveReccConfig, not raw config.reccUrl — the browser must agree with the
+  // TUI about whether reccd is on, and the TUI resolves it this way.
+  it("counts TORLINK_RECC_URL", async () => {
+    vi.stubEnv("TORLINK_RECC_URL", "http://recc.env");
+    expect(await flag({})).toBe(true);
+  });
+
+  it("never carries the URL or token alongside the flag", async () => {
+    const res = await handleWebApi(
+      deps({
+        loadConfigImpl: async () =>
+          searchConfig({ reccUrl: "http://recc.internal:4100", reccToken: "zzq-secret-9317" }),
+      }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    const body = JSON.stringify(res.json);
+    expect(body).not.toContain("zzq-secret-9317");
+    expect(body).not.toContain("recc.internal");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: FAIL — `fetchTitleSuggestionsImpl` is not a known `WebDeps` property, and `reccConfigured` is `undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+**3a.** In `src/web/wire.ts`, add the import at the top:
+
+```ts
+import type { TitleSuggestion } from "../util/titleSuggest";
+```
+
+Add to `SourcesResponse` (after `omdbConfigured`, around line 389):
+
+```ts
+  /**
+   * Whether reccd is configured (file or `TORLINK_RECC_URL`), which is what
+   * makes title autocomplete available.
+   *
+   * A capability flag, never the URL or the token — the same contract as
+   * `debridConfigured` and `omdbConfigured`, and here for the same reason:
+   * this is the one payload the browser fetches before it can render anything.
+   *
+   * WHAT IT SAVES. Without it, a reccd-less server has every keystroke in the
+   * search box fire `/api/title-search` purely to be told
+   * `{status: "not-configured"}` — a request per character to learn a fact
+   * that is true for the whole session.
+   */
+  reccConfigured: boolean;
+```
+
+Add near `PublicRecommendations`:
+
+```ts
+/**
+ * The body of `GET /api/title-search?q=`.
+ *
+ * THE SAME THREE-WAY SHAPE AS `PublicRecommendations` AND `PublicTitleMeta`,
+ * deliberately: "the server has no reccd" is a thing the UI must be able to
+ * say, not a failure, and a fourth bespoke encoding of that idea would be
+ * drift.
+ *
+ * `"error"` carries reccd's own message so the browser and the TUI could show
+ * the same sentence — but the browser deliberately does not. This fires per
+ * keystroke, and an error banner per character is worse than no suggestions,
+ * so the browser renders every non-`"ok"` status as an empty list. The field
+ * is here because throwing the reason away at the wire would make a broken
+ * reccd indistinguishable from a working one with no matches.
+ */
+export type PublicTitleSuggestions =
+  | { status: "ok"; items: TitleSuggestion[] }
+  | { status: "not-configured" }
+  | { status: "error"; error: string };
+```
+
+**3b.** In `src/web/routes.ts`, extend the imports:
+
+```ts
+import { fetchTitleSuggestions, type FetchTitleSuggestionsResult } from "../recc/client";
+import { shouldQuery, SUGGEST_LIMIT } from "../util/titleSuggest";
+import type { PublicTitleSuggestions } from "./wire";
+```
+
+(`fetchRecommendations`, `postEvent`, `ReccClientConfig`, `resolveReccConfig` and `PublicRecommendations` are already imported — extend the existing import statements rather than adding duplicates.)
+
+Add to `WebDeps`, after `fetchRecommendationsImpl`:
+
+```ts
+  /** reccd's title search, for `/api/title-search`. Injected to keep tests off the network. */
+  fetchTitleSuggestionsImpl?: (
+    config: ReccClientConfig,
+    query: { q: string; limit?: number },
+  ) => Promise<FetchTitleSuggestionsResult>;
+```
+
+In `sourcesResponse`, after the `omdbConfigured` line:
+
+```ts
+    // resolveReccConfig, not config.reccUrl, so TORLINK_RECC_URL counts — the
+    // browser must agree with the TUI about whether reccd is on, and the TUI
+    // resolves it the same way. A boolean, never the URL or the token.
+    reccConfigured: resolveReccConfig(config).reccUrl !== undefined,
+```
+
+Add the handler after `recommendations` / before `RECC_EVENTS`:
+
+```ts
+/**
+ * `GET /api/title-search?q=` — reccd's catalog search, proxied.
+ *
+ * THIS ROUTE EXISTS SO THE BROWSER NEVER SEES `reccToken`. The TUI calls
+ * `fetchTitleSuggestions` directly; a page cannot, and handing it the token so
+ * it could would put the user's reccd credentials in a tab.
+ *
+ * `loadConfig()` per request, not a boot snapshot, for the same reason
+ * `recommendations` does it: a reccd URL can be pasted into the Accounts pane
+ * at any moment, and `serve --web` is a separate process from any running TUI.
+ */
+async function titleSearch(deps: WebDeps, query: URLSearchParams): Promise<WebResponse> {
+  const raw = query.get("q");
+  // Absent, not empty: a client that forgot the param is a bug worth a 400,
+  // and it matches reccd's own behaviour for a missing q.
+  if (raw === null) return { status: 400, json: { error: "missing q" } };
+
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const reccConfig = resolveReccConfig(config);
+  if (!reccConfig.reccUrl) {
+    const out: PublicTitleSuggestions = { status: "not-configured" };
+    return { status: 200, json: out };
+  }
+
+  // reccd answers a shorter query with [] and no DB round trip. Not asking is
+  // the same answer without the round trip, and it keeps the min-length rule in
+  // exactly one place (util/titleSuggest.ts) for both front ends.
+  if (!shouldQuery(raw)) {
+    const out: PublicTitleSuggestions = { status: "ok", items: [] };
+    return { status: 200, json: out };
+  }
+
+  // `fetchTitleSuggestions` never throws and bounds itself with its own
+  // timeout, so a reccd that is down or hanging costs this request that timeout
+  // and nothing else.
+  const result = await (deps.fetchTitleSuggestionsImpl ?? fetchTitleSuggestions)(reccConfig, {
+    q: raw,
+    limit: SUGGEST_LIMIT,
+  });
+  if (!result.ok) {
+    const out: PublicTitleSuggestions = { status: "error", error: result.error };
+    return { status: 200, json: out };
+  }
+  // Assigned, not re-mapped: the client already narrowed reccd's row to the
+  // fields torlink renders, and this assignment is where the compiler checks
+  // that `TitleSuggestion` and the wire type still agree.
+  const out: PublicTitleSuggestions = { status: "ok", items: result.items };
+  return { status: 200, json: out };
+}
+```
+
+Add the dispatch entry immediately after the `/api/recommendations` one, inside the same past-the-token-gate block:
+
+```ts
+  if (method === "GET" && urlPath === "/api/title-search") {
+    return titleSearch(deps, query);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: PASS. If pre-existing `/api/sources` tests fail on an exact-object match, add `reccConfigured` to their expected objects — do not weaken the assertion to `objectContaining`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/wire.ts src/web/routes.ts src/web/routes.test.ts
+git commit -m "feat(web): proxy reccd title search, and report reccConfigured"
+```
+
+---
+
+## Task 4: The browser's list model
+
+**Files:**
+- Create: `src/web/static/suggestModel.ts`
+- Test: `src/web/static/suggestModel.test.ts`
+
+**Interfaces:**
+- Consumes: everything from `src/util/titleSuggest.ts` (Task 1).
+- Produces:
+  ```ts
+  export interface ListState { suggest: SuggestState; highlight: number } // -1 = none
+  export function emptyListState(): ListState;
+  export function isOpen(s: ListState): boolean;
+  export function withReply(s: ListState, seq: number, items: TitleSuggestion[]): ListState;
+  export function moveHighlight(s: ListState, delta: 1 | -1): ListState;
+  export function highlightAt(s: ListState, index: number): ListState;
+  export function closedFor(s: ListState, raw: string): ListState;
+  export function acceptPlan(s: ListState, raw: string): { kind: "suggestion" | "raw"; text: string };
+  export function rowPlan(s: ListState): { label: string; aka: string | null; highlighted: boolean }[];
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web/static/suggestModel.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  emptyListState,
+  isOpen,
+  withReply,
+  moveHighlight,
+  highlightAt,
+  closedFor,
+  acceptPlan,
+  rowPlan,
+} from "./suggestModel";
+import { shouldQueryFor, type TitleSuggestion } from "../../util/titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001", title: "Kestrel", year: 2010, type: "movie", matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002", title: "Kepler", year: 2019, type: "tv", matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003", title: "Ashfall", year: 1999, type: "movie", matchedAka: "Ashfall Rising",
+};
+
+const THREE = [KESTREL, KEPLER, ASHFALL_AKA];
+
+describe("isOpen", () => {
+  it("is closed with nothing to show", () => {
+    expect(isOpen(emptyListState())).toBe(false);
+  });
+
+  it("is open once there are hits", () => {
+    expect(isOpen(withReply(emptyListState(), 1, [KESTREL]))).toBe(true);
+  });
+
+  it("is closed again when a reply brings nothing", () => {
+    const open = withReply(emptyListState(), 1, [KESTREL]);
+    expect(isOpen(withReply(open, 2, []))).toBe(false);
+  });
+});
+
+describe("withReply", () => {
+  it("starts with nothing highlighted, so Enter still submits what was typed", () => {
+    expect(withReply(emptyListState(), 1, THREE).highlight).toBe(-1);
+  });
+
+  it("drops a highlight that a new, shorter reply would put out of range", () => {
+    const moved = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(moved.highlight).toBe(0);
+    expect(withReply(moved, 2, [KEPLER]).highlight).toBe(-1);
+  });
+
+  // The stale-reply guard belongs to the shared model; this proves the browser
+  // wrapper actually routes through it rather than assigning items directly.
+  it("ignores a reply older than the newest applied", () => {
+    const fresh = withReply(emptyListState(), 2, [KEPLER]);
+    expect(withReply(fresh, 1, [KESTREL]).suggest.items).toEqual([KEPLER]);
+  });
+});
+
+describe("moveHighlight", () => {
+  it("enters the list from nothing on down", () => {
+    expect(moveHighlight(withReply(emptyListState(), 1, THREE), 1).highlight).toBe(0);
+  });
+
+  it("enters at the last row from nothing on up", () => {
+    expect(moveHighlight(withReply(emptyListState(), 1, THREE), -1).highlight).toBe(2);
+  });
+
+  it("wraps past the end", () => {
+    let s = withReply(emptyListState(), 1, THREE);
+    s = moveHighlight(s, 1);
+    s = moveHighlight(s, 1);
+    s = moveHighlight(s, 1);
+    expect(s.highlight).toBe(2);
+    expect(moveHighlight(s, 1).highlight).toBe(0);
+  });
+
+  it("wraps past the start", () => {
+    const first = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(moveHighlight(first, -1).highlight).toBe(2);
+  });
+
+  it("does nothing with a closed list", () => {
+    expect(moveHighlight(emptyListState(), 1).highlight).toBe(-1);
+  });
+});
+
+describe("highlightAt", () => {
+  it("highlights the clicked row", () => {
+    const s = highlightAt(withReply(emptyListState(), 1, THREE), 2);
+    expect(s.highlight).toBe(2);
+    expect(acceptPlan(s, "ash")).toEqual({ kind: "suggestion", text: "Ashfall 1999" });
+  });
+
+  // Ignored, not clamped: the only caller is a row's own listener, so an
+  // out-of-range index means the rows changed under the click — and searching a
+  // DIFFERENT title than the one clicked is worse than doing nothing.
+  it("ignores an index the list no longer has", () => {
+    const s = withReply(emptyListState(), 1, [KESTREL]);
+    expect(highlightAt(s, 3).highlight).toBe(-1);
+    expect(highlightAt(s, -1).highlight).toBe(-1);
+  });
+});
+
+describe("acceptPlan", () => {
+  // Enter with nothing highlighted must submit what the user typed. Silently
+  // substituting a suggestion for their own words is the one thing autocomplete
+  // must never do.
+  it("submits the raw text when nothing is highlighted", () => {
+    const s = withReply(emptyListState(), 1, THREE);
+    expect(acceptPlan(s, "kes")).toEqual({ kind: "raw", text: "kes" });
+  });
+
+  it("submits the highlighted suggestion's title and year", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(acceptPlan(s, "kes")).toEqual({ kind: "suggestion", text: "Kestrel 2010" });
+  });
+
+  it("uses the primary title when the highlight matched via an AKA", () => {
+    let s = withReply(emptyListState(), 1, THREE);
+    s = moveHighlight(s, -1);
+    expect(acceptPlan(s, "ashfall ris")).toEqual({ kind: "suggestion", text: "Ashfall 1999" });
+  });
+
+  it("submits the raw text when the list is closed", () => {
+    expect(acceptPlan(emptyListState(), "kes")).toEqual({ kind: "raw", text: "kes" });
+  });
+});
+
+describe("closedFor", () => {
+  it("closes the list and clears the highlight", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    const shut = closedFor(s, "kes");
+    expect(isOpen(shut)).toBe(false);
+    expect(shut.highlight).toBe(-1);
+  });
+
+  // Escape must stick. Without the suppression latch the next debounce tick
+  // would re-fire the same query and reopen what the user just dismissed.
+  it("stops the same text being queried again", () => {
+    const shut = closedFor(withReply(emptyListState(), 1, THREE), "kes");
+    expect(shouldQueryFor(shut.suggest, "kes")).toBe(false);
+    expect(shouldQueryFor(shut.suggest, "kest")).toBe(true);
+  });
+});
+
+describe("rowPlan", () => {
+  it("is empty for a closed list", () => {
+    expect(rowPlan(emptyListState())).toEqual([]);
+  });
+
+  it("labels every row and marks the highlighted one", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(rowPlan(s)).toEqual([
+      { label: "Kestrel (2010) · film", aka: null, highlighted: true },
+      { label: "Kepler (2019) · show", aka: null, highlighted: false },
+      { label: 'Ashfall (1999) · film', aka: 'also known as "Ashfall Rising"', highlighted: false },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/static/suggestModel.test.ts`
+Expected: FAIL — `Failed to resolve import "./suggestModel"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/web/static/suggestModel.ts`:
+
+```ts
+import {
+  akaNote,
+  applyReply,
+  emptySuggestState,
+  submitTextFor,
+  suggestionLabel,
+  suppressFor,
+  type SuggestState,
+  type TitleSuggestion,
+} from "../../util/titleSuggest";
+
+// The search box's suggestion list, as state plus transitions.
+//
+// It lives here rather than in app.ts because every function below answers
+// either "what should be on screen" or "what should be sent" — the two
+// questions app.ts is not allowed to decide, since nothing in it is reachable
+// by a test.
+
+export interface ListState {
+  suggest: SuggestState;
+  /** Index into `suggest.items`, or -1 for "nothing highlighted". */
+  highlight: number;
+}
+
+export function emptyListState(): ListState {
+  return { suggest: emptySuggestState(), highlight: -1 };
+}
+
+export function isOpen(s: ListState): boolean {
+  return s.suggest.items.length > 0;
+}
+
+/**
+ * Fold in a reply from `/api/title-search`.
+ *
+ * The highlight resets to -1 rather than being preserved: the rows have
+ * changed, so a kept index would point at a different title than the one the
+ * user was looking at — and pressing Enter would then search for something
+ * they never highlighted.
+ */
+export function withReply(s: ListState, seq: number, items: TitleSuggestion[]): ListState {
+  const suggest = applyReply(s.suggest, seq, items);
+  if (suggest === s.suggest) return s;
+  return { suggest, highlight: -1 };
+}
+
+/** Move the highlight, wrapping, and entering the list from -1. */
+export function moveHighlight(s: ListState, delta: 1 | -1): ListState {
+  const n = s.suggest.items.length;
+  if (n === 0) return s;
+  if (s.highlight === -1) return { ...s, highlight: delta === 1 ? 0 : n - 1 };
+  return { ...s, highlight: (s.highlight + delta + n) % n };
+}
+
+/**
+ * Highlight a specific row — what a click means, before it accepts.
+ *
+ * Out-of-range indices are ignored rather than clamped: the only caller is a
+ * row's own listener, so an out-of-range index means the rows changed under the
+ * click, and accepting a *different* title than the one clicked is worse than
+ * doing nothing.
+ */
+export function highlightAt(s: ListState, index: number): ListState {
+  if (index < 0 || index >= s.suggest.items.length) return s;
+  return { ...s, highlight: index };
+}
+
+/** Close the list, and stop asking about `raw` so it cannot reopen itself. */
+export function closedFor(s: ListState, raw: string): ListState {
+  return { suggest: suppressFor(s.suggest, raw), highlight: -1 };
+}
+
+/**
+ * What to search for on Enter or a click.
+ *
+ * With nothing highlighted this is the raw text, always. Substituting a
+ * suggestion for what the user actually typed is the one thing autocomplete
+ * must never do silently.
+ */
+export function acceptPlan(s: ListState, raw: string): { kind: "suggestion" | "raw"; text: string } {
+  const hit = s.highlight >= 0 ? s.suggest.items[s.highlight] : undefined;
+  if (!hit) return { kind: "raw", text: raw };
+  return { kind: "suggestion", text: submitTextFor(hit) };
+}
+
+/** One entry per row to render. Strings only — the caller sets textContent. */
+export function rowPlan(s: ListState): { label: string; aka: string | null; highlighted: boolean }[] {
+  return s.suggest.items.map((hit, i) => ({
+    label: suggestionLabel(hit),
+    aka: akaNote(hit),
+    highlighted: i === s.highlight,
+  }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/web/static/suggestModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/suggestModel.ts src/web/static/suggestModel.test.ts
+git commit -m "feat(web): suggestion list model for the search box"
+```
+
+---
+
+## Task 5: Wire the browser's search box
+
+**Files:**
+- Modify: `src/web/static/index.html` (the search card, lines 83-88)
+- Modify: `src/web/static/styles.css`
+- Modify: `src/web/static/app.ts` (element refs around line 230; a new section before the `searchForm` submit handler at line 1243)
+
+**Interfaces:**
+- Consumes: everything from `suggestModel.ts` (Task 4); `SUGGEST_DEBOUNCE_MS`, `shouldQueryFor` from `src/util/titleSuggest.ts` (Task 1); `PublicTitleSuggestions` from `./wire` (Task 3); the existing `authHeaders()` (`app.ts:301`), `sources` (the `SourcesResponse | null` module variable), and `searchForTitle(title, group?)` (`app.ts:2452`).
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Add the markup and styling**
+
+In `src/web/static/index.html`, inside `<form id="search" class="card">`, immediately after the `<input id="query" …>` line, add:
+
+```html
+          <!-- Title suggestions from reccd, when it is configured. A full-width
+               row inside the card's flex layout so it sits under the input
+               rather than beside it. Empty and `hidden` until there is
+               something to show; app.ts fills it with createElement +
+               textContent, never innerHTML. -->
+          <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
+```
+
+In `src/web/static/styles.css`, append:
+
+```css
+/* The search box's title suggestions. `flex: 1 0 100%` breaks it onto its own
+   row inside .card, which lays its children out as a strip of controls. */
+.suggest {
+  flex: 1 0 100%;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.suggest li {
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+}
+
+.suggest li + li {
+  border-top: 1px solid var(--line);
+}
+
+.suggest li[aria-selected="true"],
+.suggest li:hover {
+  background: var(--line);
+}
+
+.suggest .aka {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--dim);
+}
+```
+
+- [ ] **Step 2: Wire it in `app.ts`**
+
+Add to the element refs near line 230, after `queryInput`:
+
+```ts
+const suggestList = el<HTMLUListElement>("suggest");
+```
+
+Add the imports to the existing import block:
+
+```ts
+import {
+  emptyListState,
+  isOpen as suggestOpen,
+  withReply,
+  moveHighlight,
+  highlightAt,
+  closedFor,
+  acceptPlan,
+  rowPlan,
+  type ListState,
+} from "./suggestModel.js";
+import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest.js";
+import type { PublicTitleSuggestions } from "../wire.js";
+```
+
+(Match the extension convention the file already uses for its relative imports.)
+
+Add this section immediately before the `searchForm.addEventListener("submit", …)` handler at line 1243:
+
+```ts
+// ---- title suggestions -------------------------------------------------
+
+// Every decision here belongs to suggestModel.ts; this block is the timer, the
+// fetch, the DOM, and the key handling. If you find yourself writing an `if`
+// that decides what to show or what to send, it goes in the model.
+let suggestState: ListState = emptyListState();
+let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+// Monotonic, and the reason a slow reply cannot overwrite a fast one — see
+// applyReply. A 2-char query costs reccd ~311ms and an 8-char one ~71ms, so
+// out-of-order arrival is the normal case, not the edge case.
+let suggestSeq = 0;
+
+function renderSuggest(): void {
+  suggestList.replaceChildren();
+  const rows = rowPlan(suggestState);
+  for (const [index, row] of rows.entries()) {
+    const li = document.createElement("li");
+    li.setAttribute("role", "option");
+    li.setAttribute("aria-selected", row.highlighted ? "true" : "false");
+    // textContent, not innerHTML: a title is a string from a catalog we do not
+    // control, and src/web/static has no innerHTML path anywhere by rule.
+    const label = document.createElement("span");
+    label.textContent = row.label;
+    li.append(label);
+    if (row.aka !== null) {
+      const aka = document.createElement("span");
+      aka.className = "aka";
+      aka.textContent = row.aka;
+      li.append(aka);
+    }
+    // mousedown, not click: click lands after the input has already blurred,
+    // and a blur that closes the list would cancel the pick.
+    li.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      // Reuse the keyboard path rather than a second accept: highlight the
+      // clicked row, then accept, so a click and an Enter cannot drift apart.
+      suggestState = highlightAt(suggestState, index);
+      acceptSuggest();
+    });
+    suggestList.append(li);
+  }
+  suggestList.hidden = rows.length === 0;
+}
+
+function closeSuggest(): void {
+  if (suggestTimer !== null) clearTimeout(suggestTimer);
+  suggestTimer = null;
+  suggestState = closedFor(suggestState, queryInput.value);
+  renderSuggest();
+}
+
+/** Run whatever the model says this keypress or click means. */
+function acceptSuggest(): void {
+  const plan = acceptPlan(suggestState, queryInput.value);
+  // Latch before searching: accepting writes text into the box, which fires the
+  // input handler again, and without the latch the list would reopen on the
+  // text just picked.
+  suggestState = closedFor(suggestState, plan.text);
+  renderSuggest();
+  searchForTitle(plan.text);
+}
+
+async function loadSuggest(raw: string, seq: number): Promise<void> {
+  try {
+    const res = await fetch(`/api/title-search?q=${encodeURIComponent(raw)}`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as PublicTitleSuggestions;
+    // Every non-ok status renders as no suggestions. This fires per keystroke,
+    // so a banner per character would be worse than silence — and the Accounts
+    // pane is where a reccd problem belongs.
+    const items = body.status === "ok" ? body.items : [];
+    suggestState = withReply(suggestState, seq, items);
+    renderSuggest();
+  } catch {
+    // A suggestion we cannot fetch is a search box that behaves exactly as it
+    // did before this feature existed. Nothing to report.
+  }
+}
+
+queryInput.addEventListener("input", () => {
+  if (suggestTimer !== null) clearTimeout(suggestTimer);
+  // The capability flag from /api/sources, so a reccd-less server never spends
+  // a request per character discovering that again.
+  if (sources?.reccConfigured !== true) return;
+  const raw = queryInput.value;
+  if (!shouldQueryFor(suggestState.suggest, raw)) {
+    suggestState = withReply(suggestState, ++suggestSeq, []);
+    renderSuggest();
+    return;
+  }
+  const seq = ++suggestSeq;
+  suggestTimer = setTimeout(() => void loadSuggest(raw, seq), SUGGEST_DEBOUNCE_MS);
+});
+
+queryInput.addEventListener("keydown", (event) => {
+  if (!suggestOpen(suggestState)) return;
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    suggestState = moveHighlight(suggestState, 1);
+    renderSuggest();
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    suggestState = moveHighlight(suggestState, -1);
+    renderSuggest();
+    return;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeSuggest();
+    return;
+  }
+  if (event.key === "Enter") {
+    // Only intercept when a row is actually highlighted; otherwise let the form
+    // submit normally with what the user typed.
+    if (suggestState.highlight < 0) {
+      closeSuggest();
+      return;
+    }
+    event.preventDefault();
+    acceptSuggest();
+  }
+});
+
+// Leaving the box closes the list — an open dropdown over a pane the user has
+// moved on from is a stuck artefact, not a suggestion.
+queryInput.addEventListener("blur", () => closeSuggest());
+```
+
+- [ ] **Step 3: Typecheck, lint, and build**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+Expected: PASS. `npm run build` is the only check that `src/web/static/` pulls in no `node:*` — `titleSuggest.ts` and `suggestModel.ts` must both be node-free.
+
+- [ ] **Step 4: Verify by running it**
+
+Nothing in `app.ts` is reachable by a unit test — there is no jsdom, deliberately. So run it:
+
+```bash
+npm run dev -- serve --web
+```
+
+With reccd configured, in the search box:
+1. Type `ke` — suggestions appear after a beat.
+2. `↓` highlights the first row; `↑` from nothing highlights the last; both wrap.
+3. `Enter` on a highlight searches `Title Year`; `Enter` with nothing highlighted searches what you typed.
+4. `Escape` closes the list and it stays closed until you type something different.
+5. Clicking a row searches it.
+6. An AKA hit shows the "also known as" line.
+
+Then **without** reccd configured (unset `TORLINK_RECC_URL` and clear it from config): typing fires no `/api/title-search` requests at all — check the network panel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/index.html src/web/static/styles.css src/web/static/app.ts
+git commit -m "feat(web): title suggestions in the search box"
+```
+
+---
+
+## Task 6: The terminal's hook, field and bar
+
+**Files:**
+- Create: `src/ui/hooks/useTitleSuggest.ts`
+- Modify: `src/ui/components/TextField.tsx` (props at lines 5-20; the `useInput` tab arm at line 141)
+- Modify: `src/ui/components/SearchBar.tsx`
+- Test: `src/ui/components/SearchBar.test.tsx` **new**
+
+**Interfaces:**
+- Consumes: `TitleSuggestion`, `SuggestState`, `emptySuggestState`, `applyReply`, `suppressFor`, `shouldQueryFor`, `topSuggestion`, `submitTextFor`, `suggestionLabel`, `akaNote`, `SUGGEST_DEBOUNCE_MS`, `SUGGEST_ROWS_TERMINAL` (Task 1); `fetchTitleSuggestions` (Task 2); `ReccClientConfig` from `src/recc/client`; `FetchImpl` from `src/util/net`.
+- Produces:
+  ```ts
+  // src/ui/hooks/useTitleSuggest.ts
+  export interface TitleSuggest {
+    items: TitleSuggestion[];   // already capped at SUGGEST_ROWS_TERMINAL
+    open: boolean;
+    completion: string | null;  // submitTextFor(top), or null
+    dismiss: () => void;
+    accept: (text: string) => void;
+  }
+  export function useTitleSuggest(args: {
+    reccConfig: ReccClientConfig;
+    query: string;
+    enabled: boolean;
+    fetchImpl?: FetchImpl;
+    debounceMs?: number;
+  }): TitleSuggest;
+  // TextField gains props:  completion?: string | null;  onComplete?: (text: string) => void;
+  // SearchBar gains props:  suggestions?: TitleSuggestion[];  completion?: string | null;
+  //                         onComplete?: (text: string) => void;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/ui/components/SearchBar.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { SearchBar } from "./SearchBar";
+import type { TitleSuggestion } from "../../util/titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001", title: "Kestrel", year: 2010, type: "movie", matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002", title: "Kepler", year: 2019, type: "tv", matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003", title: "Ashfall", year: 1999, type: "movie", matchedAka: "Ashfall Rising",
+};
+
+describe("SearchBar suggestions", () => {
+  it("shows nothing extra when there are no suggestions", () => {
+    const { lastFrame } = render(
+      <SearchBar width={60} value="kes" editing onSubmit={() => {}} />,
+    );
+    expect(lastFrame()).not.toContain("Kestrel");
+  });
+
+  it("lists each suggestion with its year and kind", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing
+        suggestions={[KESTREL, KEPLER]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Kestrel (2010) · film");
+    expect(frame).toContain("Kepler (2019) · show");
+  });
+
+  it("shows the aka note on a hit that matched an alternate title", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ashfall ris"
+        editing
+        suggestions={[ASHFALL_AKA]}
+        completion="Ashfall 1999"
+        onSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("Ashfall Rising");
+  });
+
+  // Suggestions belong to the box you are typing in. Leaving them under a
+  // collapsed bar would leave a stale list on screen with nothing editing it.
+  it("shows no suggestions when the bar is not being edited", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing={false}
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame() ?? "").not.toContain("Kestrel (2010)");
+  });
+
+  /**
+   * TAB COMPLETES ONLY WHEN THERE IS SOMETHING TO COMPLETE. The rest of the
+   * time it must still leave the field — that is what it has always done
+   * (TextField's onExitDown), and both the results pane and the splash depend
+   * on it.
+   */
+  it("completes to the top suggestion on tab", async () => {
+    const onComplete = vi.fn();
+    const onExitDown = vi.fn();
+    const { stdin } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing
+        suggestions={[KESTREL, KEPLER]}
+        completion="Kestrel 2010"
+        onComplete={onComplete}
+        onExitDown={onExitDown}
+        onSubmit={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\t");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onComplete).toHaveBeenCalledWith("Kestrel 2010");
+    expect(onExitDown).not.toHaveBeenCalled();
+  });
+
+  it("still leaves the field on tab with no completion available", async () => {
+    const onComplete = vi.fn();
+    const onExitDown = vi.fn();
+    const { stdin } = render(
+      <SearchBar width={60} value="ke" editing onComplete={onComplete} onExitDown={onExitDown} onSubmit={() => {}} />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\t");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onExitDown).toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  // The arrows are search history's and stay that way — a suggestion list is
+  // not worth taking a working binding away from.
+  it("leaves the up arrow to search history even with a list open", async () => {
+    const { stdin, lastFrame } = render(
+      <SearchBar
+        width={60}
+        value=""
+        editing
+        history={["Tin Rivers 2024"]}
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("Tin Rivers 2024");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/ui/components/SearchBar.test.tsx`
+Expected: FAIL — `suggestions`, `completion` and `onComplete` are not valid `SearchBarProps`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+**3a.** In `src/ui/components/TextField.tsx`, add to `TextFieldProps` after `history`:
+
+```ts
+  /**
+   * What tab should complete the field to, or null for "nothing to complete".
+   * When set, tab completes instead of calling `onExitDown` — see the tab arm
+   * in `useInput` for why that swap is safe.
+   */
+  completion?: string | null;
+  /** Called after tab completed the field, with the text written into it. */
+  onComplete?: (text: string) => void;
+```
+
+Add both to the destructured parameter list, with `completion = null`.
+
+Replace the tab arm (currently lines 141-144):
+
+```ts
+      if (key.tab) {
+        // Completion wins over leaving the field, but ONLY when there is
+        // something to complete: the rest of the time tab still exits, which is
+        // what the results pane and the splash both rely on. Both callers read
+        // the same `completion` value this does, so no ordering between Ink's
+        // input handlers matters.
+        if (completion !== null) {
+          recall(completion);
+          onComplete?.(completion);
+          return;
+        }
+        onExitDown?.();
+        return;
+      }
+```
+
+Escape is deliberately **not** handled here. `Results` and `Splash` already own it (`setMode("list")` and `quitAll()` respectively), Ink runs every `useInput` handler for a keypress so this one could not swallow it, and the parents hold the suggestion state anyway.
+
+**3b.** Rewrite `src/ui/components/SearchBar.tsx`:
+
+```tsx
+import { Box, Text } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { COLOR, ICON } from "../theme";
+import { akaNote, suggestionLabel, type TitleSuggestion } from "../../util/titleSuggest";
+
+interface SearchBarProps {
+  width: number;
+  value: string;
+  placeholder?: string;
+  editing: boolean;
+  history?: string[];
+  /**
+   * Title suggestions from reccd, already capped by the caller. Rendered only
+   * while editing — a list under a collapsed bar is a stale artefact with
+   * nothing editing it.
+   */
+  suggestions?: TitleSuggestion[];
+  /** What tab completes to, or null. */
+  completion?: string | null;
+  onComplete?: (text: string) => void;
+  onSubmit: (value: string) => void;
+  onChange?: (value: string) => void;
+  onExitDown?: () => void;
+  onExitLeft?: () => void;
+}
+
+export function SearchBar({
+  width,
+  value,
+  placeholder = "Search torrents…",
+  editing,
+  history,
+  suggestions,
+  completion = null,
+  onComplete,
+  onSubmit,
+  onChange,
+  onExitDown,
+  onExitLeft,
+}: SearchBarProps) {
+  const rows = editing ? (suggestions ?? []) : [];
+  return (
+    <Box flexDirection="column">
+      <Panel title="search" width={width} focused={editing} height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            {editing ? (
+              <TextField
+                defaultValue={value}
+                placeholder={placeholder}
+                history={history}
+                completion={completion}
+                onComplete={onComplete}
+                width={Math.max(1, width - 6)}
+                onSubmit={onSubmit}
+                onChange={onChange}
+                onExitDown={onExitDown}
+                onExitLeft={onExitLeft}
+              />
+            ) : value ? (
+              <Text wrap="truncate-end">{value}</Text>
+            ) : (
+              <Text dimColor>{placeholder}</Text>
+            )}
+          </Box>
+        </Box>
+      </Panel>
+      {/* Rendered only when there is something to show, so an empty list costs
+          no vertical space and the layout does not jitter as replies arrive. */}
+      {rows.map((hit, i) => {
+        const aka = akaNote(hit);
+        return (
+          <Box key={hit.imdbId} paddingLeft={2}>
+            <Text dimColor wrap="truncate-end">
+              {suggestionLabel(hit)}
+              {aka ? ` · ${aka}` : ""}
+              {/* The top row is what tab takes, so it says so. */}
+              {i === 0 && completion !== null ? "   ⇥" : ""}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+```
+
+**3c.** Create `src/ui/hooks/useTitleSuggest.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FetchImpl } from "../../util/net";
+import { fetchTitleSuggestions, type ReccClientConfig } from "../../recc/client";
+import {
+  applyReply,
+  emptySuggestState,
+  shouldQueryFor,
+  submitTextFor,
+  suppressFor,
+  topSuggestion,
+  SUGGEST_DEBOUNCE_MS,
+  SUGGEST_ROWS_TERMINAL,
+  type SuggestState,
+  type TitleSuggestion,
+} from "../../util/titleSuggest";
+
+export interface TitleSuggest {
+  /** Already capped at SUGGEST_ROWS_TERMINAL. */
+  items: TitleSuggestion[];
+  open: boolean;
+  /** What tab completes to, or null when there is nothing to complete. */
+  completion: string | null;
+  /** Escape: close the list, and do not reopen it for the current text. */
+  dismiss: () => void;
+  /** Tab completed the field — stop asking about the text now in it. */
+  accept: (text: string) => void;
+}
+
+interface Args {
+  reccConfig: ReccClientConfig;
+  /** The live draft in the field, not the submitted query. */
+  query: string;
+  /** False on a pane that is not being edited, so nothing fires off screen. */
+  enabled: boolean;
+  fetchImpl?: FetchImpl;
+  debounceMs?: number;
+}
+
+/**
+ * Title suggestions from reccd for the terminal's search box, debounced.
+ *
+ * Modelled on `useTitlePreview`, with one deliberate difference: no cache. That
+ * hook caches by a stable selection key because scrolling revisits the same
+ * rows; here every keystroke is a different query, so a cache would only grow.
+ *
+ * State lives here and NOT in `Store`: a `Store` field needs matching entries
+ * in `makeStore` (scripts/render-previews-impl.tsx) and `makeTestStore`
+ * (src/ui/testHarness.ts) or `npm run previews` and `npm run typecheck` break
+ * respectively — the right price for state other panes read, and no other pane
+ * reads this.
+ */
+export function useTitleSuggest(args: Args): TitleSuggest {
+  const { reccConfig, query, enabled, fetchImpl, debounceMs = SUGGEST_DEBOUNCE_MS } = args;
+  const [state, setState] = useState<SuggestState>(emptySuggestState);
+  // Monotonic, and the reason a slow reply cannot overwrite a fast one. reccd
+  // answers a 2-char query in ~311ms and an 8-char one in ~71ms, so
+  // out-of-order arrival is the normal case. A ref, not state: bumping it must
+  // not itself cause a render.
+  const seq = useRef(0);
+  // The effect keys on `query`, but must read the *current* suppression latch
+  // without listing `state` as a dependency — which would re-run it on every
+  // reply and re-fire the request that produced it.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (!enabled || !reccConfig.reccUrl) return;
+    if (!shouldQueryFor(stateRef.current, query)) {
+      // Clear anything on screen for a query too short to ask about, so
+      // backspacing out of a search does not leave stale rows behind.
+      const s = ++seq.current;
+      setState((prev) => applyReply(prev, s, []));
+      return;
+    }
+    let cancelled = false;
+    const s = ++seq.current;
+    const t = setTimeout(() => {
+      void fetchTitleSuggestions(reccConfig, { q: query }, { fetchImpl }).then((res) => {
+        if (cancelled) return;
+        // Every failure renders as no suggestions. This fires per keystroke, so
+        // surfacing the reason would mean an error line per character — and the
+        // Accounts pane is where a reccd problem belongs.
+        setState((prev) => applyReply(prev, s, res.ok ? res.items : []));
+      });
+    }, debounceMs);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+    // `reccConfig` is rebuilt each render by resolveReccConfig, so depend on its
+    // fields rather than the object — otherwise this re-fires every render.
+  }, [enabled, reccConfig.reccUrl, reccConfig.reccToken, query, fetchImpl, debounceMs]);
+
+  const dismiss = useCallback(() => {
+    setState((prev) => suppressFor(prev, query));
+  }, [query]);
+
+  const accept = useCallback((text: string) => {
+    setState((prev) => suppressFor(prev, text));
+  }, []);
+
+  // Capped here rather than in the fetch: reccd is asked for SUGGEST_LIMIT so
+  // both surfaces send it the same question, and the terminal renders fewer.
+  const items = enabled ? state.items.slice(0, SUGGEST_ROWS_TERMINAL) : [];
+  const top = topSuggestion({ ...state, items });
+  return {
+    items,
+    open: items.length > 0,
+    completion: top ? submitTextFor(top) : null,
+    dismiss,
+    accept,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/ui/components/SearchBar.test.tsx src/ui/components/TextField.test.ts`
+Expected: PASS both — the pre-existing `TextField` tests must be untouched by the tab change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/hooks/useTitleSuggest.ts src/ui/components/TextField.tsx src/ui/components/SearchBar.tsx src/ui/components/SearchBar.test.tsx
+git commit -m "feat(ui): title suggestions under the search bar, completed with tab"
+```
+
+---
+
+## Task 7: Wire the terminal's two search boxes
+
+**Files:**
+- Modify: `src/ui/components/Results.tsx` (the escape handler at lines 583-588; the `SearchBar` element at line 708)
+- Modify: `src/ui/views/Splash.tsx` (the `useInput` handler at lines 59-73; the `SearchBar` at line 128; the hint row at lines 137-149)
+- Test: `src/ui/components/Results.test.tsx` (append), `src/ui/views/Splash.test.tsx` (append — the file already exists)
+
+**Interfaces:**
+- Consumes: `useTitleSuggest` / `TitleSuggest` (Task 6); `tabHintLabel` (Task 1); `resolveReccConfig` (`src/config/config.ts:257`).
+- Produces: nothing other tasks consume.
+
+**How `reccConfig` and `fetchImpl` reach these two components: as PROPS, not through the store.**
+
+Both `Results` and `Splash` currently take everything from `useStore()` — including `omdbApiKey` — so the store looks like the obvious route. It is the wrong one here, for two reasons:
+
+1. A new `Store` field needs a matching entry in **`makeStore`** (`scripts/render-previews-impl.tsx`) *and* **`makeTestStore`** (`src/ui/testHarness.ts`), or `npm run previews` and `npm run typecheck` break respectively. That is the right price for state other panes read — and nothing else reads this.
+2. There is already a precedent for exactly this pair of values in exactly this file. `App.tsx:2871-2882` passes `ForYou` a `reccConfig={resolveReccConfig(store.config)}` prop and `ForYou` declares `reccConfig: ReccClientConfig` plus an optional `fetchImpl?: FetchImpl` (`src/ui/components/ForYou.tsx:18,26`) — the `fetchImpl` existing precisely so its tests never dial out.
+
+So: give `Results` and `Splash` the same two props, and pass them from `App.tsx` the same way `ForYou`'s are passed. `Results` is currently rendered with no props at all and `Splash` with three, so both call sites in `App.tsx` need editing.
+
+**The two key collisions this task exists to handle.** Ink runs *every* active `useInput` handler for a keypress — one handler cannot swallow a key from another. So both of these are resolved by having each handler read the same `suggest` value, which makes the outcome independent of the order they run in:
+
+| Key | Existing owner | New behaviour |
+|---|---|---|
+| `Esc` in the results search box | `Results.tsx:585` → `setMode("list")` | List open → `dismiss()`. Otherwise unchanged. |
+| `Esc` on the splash | `Splash.tsx:70` → `quitAll()` | List open → `dismiss()`. Otherwise **still quits.** |
+| `Tab` on the splash | `Splash.tsx:65` → `setView("browser")` **and** `TextField` → `onExitDown` | Completion available → the splash handler returns early and `TextField` completes. |
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/ui/components/Results.test.tsx` (reuse that file's existing render harness and store helpers):
+
+```tsx
+describe("Results search suggestions", () => {
+  // Escape has two jobs now, and the order matters to the user: the first
+  // escape puts the list away, the second leaves the box. Collapsing both into
+  // one keypress would make dismissing a list cost you your place.
+  it("dismisses the suggestion list before leaving the search box", async () => {
+    // Render with reccd configured and a fetchImpl that returns one hit, enter
+    // search mode, type two characters, wait past the debounce, then send
+    // escape twice — asserting the list is gone after the first and the pane
+    // has left search mode after the second.
+  });
+});
+```
+
+> **Implementer:** fill this body in using the harness already in `Results.test.tsx` — its store factory, its `render`, and the debounce-waiting pattern from `ForYou.test.tsx:279` and `:303`, which **polls until the chain settles rather than sleeping a fixed time**. Copy that; a fixed `setTimeout(300)` here would be flaky on a loaded machine. Inject the suggestion fetch through the new `fetchImpl` prop from the note above — never the real network.
+
+Append the same for `Splash`:
+
+```tsx
+describe("Splash search suggestions", () => {
+  it("dismisses the suggestion list on escape rather than quitting", async () => {
+    // With a list open, escape must not call quitAll.
+  });
+
+  it("still quits on escape with no list open", async () => {
+    // The unchanged behaviour, pinned so the guard above cannot swallow it.
+  });
+
+  it("completes on tab with a suggestion available, instead of entering the app", async () => {
+    // setView must not be called; the field's value becomes "Kestrel 2010".
+  });
+
+  it("still enters the app on tab with no suggestions", async () => {
+    // The unchanged behaviour.
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/ui/components/Results.test.tsx src/ui/views/Splash.test.tsx`
+Expected: FAIL — escape leaves search mode with the list still open; tab enters the app instead of completing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+**3a.** In `src/ui/components/Results.tsx`:
+
+```tsx
+// The live draft, which is what suggestions are for — `query` is the last
+// SUBMITTED search, and suggesting against that would lag a whole search behind.
+const [draft, setDraft] = useState(query);
+const suggest = useTitleSuggest({
+  reccConfig,
+  query: draft,
+  enabled: mode === "search",
+  fetchImpl,
+});
+```
+
+Replace the search/filter escape handler:
+
+```tsx
+  useInput(
+    (_input, key) => {
+      if (!key.escape) return;
+      // Escape escalates: the first one puts the suggestion list away, the
+      // second leaves the box. Doing both at once would make dismissing a list
+      // cost you your place in the pane.
+      if (mode === "search" && suggest.open) {
+        suggest.dismiss();
+        return;
+      }
+      setMode("list");
+    },
+    { isActive: focused && (mode === "search" || mode === "filter") },
+  );
+```
+
+And the `SearchBar`:
+
+```tsx
+      <SearchBar
+        width={contentWidth}
+        value={query}
+        editing={mode === "search"}
+        placeholder={PLACEHOLDER}
+        history={searchHistory}
+        suggestions={suggest.items}
+        completion={suggest.completion}
+        onChange={setDraft}
+        onComplete={(text) => {
+          setDraft(text);
+          suggest.accept(text);
+        }}
+        onSubmit={onSubmit}
+        onExitDown={() => setMode("list")}
+        onExitLeft={() => setRegion("sidebar")}
+      />
+```
+
+`reccConfig` reaches `Results` the way `omdbApiKey` already does — from `App.tsx`, via `resolveReccConfig(store.config)`. Add the prop and pass it at the call site.
+
+**3b.** In `src/ui/views/Splash.tsx`:
+
+```tsx
+const [draft, setDraft] = useState("");
+const suggest = useTitleSuggest({ reccConfig, query: draft, enabled: true, fetchImpl });
+```
+
+Rewrite its `useInput`:
+
+```tsx
+  useInput(
+    (input, key) => {
+      // The search field is always focused on the splash, so it owns every
+      // printable keystroke — no single-key shortcuts here, or typing a query
+      // like "alex" would trigger them. Tab drops into the app's sidebar menu
+      // (where the shortcuts live); esc / ^c quit.
+      if (key.tab) {
+        // With something to complete, tab belongs to the field: TextField reads
+        // the same `completion` value this does, so which handler Ink runs first
+        // does not matter.
+        if (suggest.completion !== null) return;
+        setView("browser");
+        setRegion("sidebar");
+        return;
+      }
+      // Escape escalates rather than quitting outright — putting a suggestion
+      // list away must not be able to close the app.
+      if (key.escape && suggest.open) {
+        suggest.dismiss();
+        return;
+      }
+      if (key.escape || (key.ctrl && input === "c")) quitAll();
+    },
+    { isActive: isRawModeSupported },
+  );
+```
+
+The `SearchBar` gains the same six props as in 3a (`suggestions`, `completion`, `onChange`, `onComplete`, plus its existing ones). And the hint row's Tab label becomes honest:
+
+```tsx
+          <Text color={COLOR.alt}>⇥</Text>
+          <Text dimColor>{` ${tabHintLabel(suggest.open)}`}</Text>
+```
+
+`reccConfig` reaches `Splash` from `App.tsx` the same way, via `resolveReccConfig(store.config)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/ui/`
+Expected: PASS, including the pre-existing `Results.test.tsx` and `Sidebar.test.tsx`.
+
+- [ ] **Step 5: Verify by running it**
+
+```bash
+npm run dev
+```
+
+On the splash: type `ke`, see the list, press Tab — the field becomes `Kestrel 2010` and the app does **not** switch to the sidebar. Press Tab again with the list closed — it does. Press Esc with a list open — the app does **not** quit. Press Esc again — it does.
+
+Then in the results pane, press `/`, type `ke`, and check the same Tab and two-stage Esc behaviour. Confirm `↑` still recalls your last search with a list on screen.
+
+Finally, with reccd **unconfigured**, confirm both boxes behave exactly as they did before.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/components/Results.tsx src/ui/components/Results.test.tsx src/ui/views/Splash.tsx src/ui/views/Splash.test.tsx src/ui/App.tsx
+git commit -m "feat(ui): wire title suggestions into the results and splash search boxes"
+```
+
+---
+
+## Task 8: Help, docs and the full check
+
+**Files:**
+- Modify: `src/ui/keymap.ts` (the `Search` group in `HELP_GROUPS`, line 45)
+- Modify: `README.md` (the browser limitations list at line 207; the Recommendations section at line 497)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the help entry**
+
+In `src/ui/keymap.ts`, in the `Search` group's `hints`, immediately after the `↑` recall line:
+
+```ts
+      { keys: "⇥", label: "Complete to the top title suggestion (needs reccd)" },
+```
+
+**`footerHints` is deliberately not changed, and this is the reason.** It takes `region` and `section`, not the search box's editing mode, so it cannot express "tab completes right now" — and its `tab` entry is the shared `SWITCH` hint used by every pane. Threading an editing-mode parameter through it for one conditional label would be disproportionate, and the footer is already not mode-aware: while you are typing a search it advertises `d`, `r` and `v`, none of which apply. The splash's own hint row *is* mode-aware and *was* updated (Task 7). Say this in the PR body — it is a stated deviation from the "a new key goes in both halves of keymap.ts" rule, not an oversight.
+
+- [ ] **Step 2: Check the existing keymap test still passes**
+
+Run: `npx vitest run src/ui/keymap.test.ts`
+Expected: PASS. If it asserts an exact hint count or list for the `Search` group, update it to include the new entry.
+
+- [ ] **Step 3: Document it**
+
+In `README.md`'s Recommendations section (after the paragraph about the browser's **for you** tab, around line 507), add:
+
+```markdown
+### Title autocomplete
+
+With reccd connected, both search boxes suggest titles as you type — the catalog's own
+spelling and year, so you don't have to remember either. In the terminal, press `⇥` to take the
+top suggestion; in the browser, arrow to one and press Enter, or click it. Picking one searches
+for the title *and* its year, which is what separates a remake from the original.
+
+Suggestions are **titles, not releases**: reccd's catalog holds films and shows, so you'll be
+offered `Harrowgate` and never `Harrowgate S03` — narrow to a season yourself once the results
+are in. There's no typo tolerance either; the match is on the start of any word, so `dark kni`
+finds a `The Dark Kni…` but `dark knght` finds nothing.
+
+Without reccd, both boxes behave exactly as they always have — nothing is requested and nothing
+changes on screen.
+```
+
+In the **What the browser can't do yet** list, extend the settings bullet's parenthetical so the reccd URL is covered by the same "TUI-only" statement as tokens, or add to that bullet: reccd's URL and token are configured in the terminal, and the browser only learns *whether* one is set.
+
+- [ ] **Step 4: Run the full check**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+```
+
+Expected: all green, with the single known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) and nothing else.
+
+Then re-read the CLAUDE.md completeness sweep and do it:
+- `grep -rn "reccConfigured" src/` — every consumer updated?
+- `grep -rn "SearchBar" src/` — both call sites pass the new props?
+- `grep -rn "not.toContain" src/web/routes.test.ts` — does each still name something the test actually puts in play?
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/keymap.ts src/ui/keymap.test.ts README.md
+git commit -m "docs: title autocomplete in the help overlay and the README"
+```
+
+---
+
+## Task 9: The reccd wishlist
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-07-31-reccd-search-wishlist.md`
+
+**Interfaces:**
+- Consumes: everything learned building Tasks 1-8.
+- Produces: a note to hand to reccd.
+
+- [ ] **Step 1: Write it up**
+
+Having built the client, write down what reccd could add that would measurably improve this
+feature. Write it as a short note with a reason per item, not a feature list. Cover at least:
+
+- **A `type=movie|tv` filter on `/search`.** `type` is returned but not filterable, and the
+  browser's category tabs already know whether the user is after a film or a show.
+- **A poster or artwork URL on each hit.** The browser currently needs a second OMDb round trip
+  per row to show a thumbnail, which is why suggestions are text-only.
+- **Typo tolerance for the zero-result case** — reccd's own design doc already flags a trigram
+  similarity pass as additive.
+- **Accepting a release name**, so torlink could canonicalise `Kestrel.2010.1080p.BluRay.x264`
+  into `Kestrel (2010)` through the same endpoint instead of parsing it locally.
+- Anything else that came up while implementing. Latency on 2-character queries is the obvious
+  candidate — reccd measured it at ~311ms and left the fix as a product call.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-07-31-reccd-search-wishlist.md
+git commit -m "docs: what reccd could add to make title search better"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — every section of the spec maps to a task:
+
+| Spec section | Task |
+|---|---|
+| What reccd actually returns | 1 (type), 2 (guard, dropped fields) |
+| Data path — TUI direct | 6, 7 |
+| Data path — browser proxy | 3 |
+| Tuning table | 1 (constants), 2 (timeout), 5 + 6 (debounce) |
+| Failure cases table | 2 (401/404/malformed/timeout), 3 (not-configured), 5 + 6 (silent) |
+| No unavailability latch | 2 — none written, by design |
+| Stale responses | 1 (`applyReply` + guard test), 4, 5, 6 |
+| Capability flag | 3 |
+| `src/util/titleSuggest.ts` | 1 |
+| `src/web/static/suggestModel.ts` | 4 |
+| Terminal UI, keys, both call sites, hook-not-Store | 6, 7 |
+| Browser UI, listbox, no `innerHTML` | 4, 5 |
+| Testing | every task |
+| Known limits | 8 (README) |
+| Before it is done | 8 |
+| The "what else could reccd add" ask | 9 |
+
+**Type consistency** — checked across tasks: `TitleSuggestion` is defined once (Task 1) and imported by `client.ts` (2), `wire.ts` (3), `suggestModel.ts` (4) and `SearchBar.tsx` (6). `suppressFor` is used under that name in 1, 4 and 6. `shouldQueryFor` in 1, 5 and 6. `highlightAt` is declared, implemented, tested and consumed in 4 and 5. `isOpen` is aliased to `suggestOpen` at its `app.ts` import (5) to avoid shadowing, and used unaliased in `suggestModel.test.ts` (4).
+
+**Two places the plan is deliberately less prescriptive**, both flagged inline rather than left silent:
+
+- **Task 7's test bodies are described, not written.** They need `Results.test.tsx`'s existing store/render harness and its debounce-polling pattern, which an implementer must read to use correctly — writing a body against a harness I have not read would produce a test that does not compile. The assertions themselves are fully specified.
+- **`footerHints` is not updated**, with the reason stated in Task 8 and required in the PR body. This is a stated deviation from a CLAUDE.md rule, made because that function has no parameter that could express the condition.

--- a/docs/superpowers/specs/2026-07-31-title-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-07-31-title-autocomplete-design.md
@@ -1,0 +1,319 @@
+# Title Autocomplete From reccd — Design
+
+**Date:** 2026-07-31
+**Status:** Approved, not yet implemented
+
+## Problem
+
+Both search boxes are blind. You type a title from memory, and if you misremember the
+spelling or the year, the torrent search returns nothing and says nothing about why. The
+recovery is to leave torlink, look the title up somewhere else, and come back.
+
+reccd already has the catalog that answers this. It shipped `GET /search?q=&limit=` — a
+prefix and word-prefix lookup over IMDb's ~1.5M-title catalog, ranked by popularity,
+returning canonical titles with years. torlink talks to reccd already (`/recommendations`,
+`/events`, `/profile`) but not to `/search`.
+
+So: when reccd is configured, both front ends offer live title suggestions as you type,
+and picking one puts the canonical title and year into the search.
+
+**Note on reccd's own docs.** `reccd/docs/superpowers/specs/2026-07-31-search-autocomplete-design.md`
+is headed "Approved, not yet implemented". That header is stale — the route is live at
+`reccd/src/api/server.ts:370` with `reccd/src/db/titleSearch.ts` behind it. Read the code,
+not the header. Everything below was verified against the code.
+
+## What reccd actually returns
+
+Verified at `reccd/src/api/server.ts:68-70` and `reccd/src/db/titleSearch.ts`:
+
+| Constant | Value |
+|---|---|
+| `SEARCH_MIN_QUERY_LENGTH` | 2 — shorter than this returns `[]` with no DB round trip |
+| `SEARCH_LIMIT_DEFAULT` | 10 |
+| `SEARCH_LIMIT_MAX` | 25 — oversized `limit` is clamped, not rejected |
+
+A hit is `SearchHit extends CatalogTitle`:
+
+```json
+{
+  "imdbId": "tt0000001",
+  "title": "Kestrel",
+  "year": 2010,
+  "type": "movie",
+  "genres": ["Drama"],
+  "rating": 7.4,
+  "votes": 90000,
+  "matchedAka": null
+}
+```
+
+- `title` is always the **primary** catalog title.
+- `matchedAka` is the alternate title that caused the hit, so a client can render the
+  "you typed X, we mean Y" affordance. `null` for primary-title hits.
+- `q` absent from the query string → `400`. A non-integer or negative `limit` → `400`.
+- reccd parses a trailing year out of `q` itself, so `"kestrel 2010"` works with no
+  client-side parsing. We must not strip years before sending.
+
+torlink models only the fields it renders. `genres` and `rating` are dropped at the client
+boundary — nothing on screen uses them, and carrying unused fields through
+`wire.ts` invites a future reader to assume something reads them.
+
+## Data path
+
+```
+TUI   ─ useTitleSuggest ──────────────────────────────► reccd GET /search
+Web   ─ app.ts ─► GET /api/title-search ─► routes.ts ─┘
+```
+
+The TUI calls reccd directly: same process, same config, exactly as `ForYou` already calls
+`fetchRecommendations`.
+
+The browser cannot. It must never see `reccToken`, so `src/web/routes.ts` proxies. This is
+not a new pattern — it is `recommendations()` with a different reccd path, and it copies
+that route's two load-bearing details:
+
+- **`loadConfig()` per request**, never a snapshot. A reccd URL can be pasted into the
+  Accounts pane at any moment, and `serve --web` is a separate process from the TUI.
+- **`status: "not-configured"` at HTTP 200** when there is no `reccUrl`. Not a 500 —
+  nothing is broken, and the browser needs to distinguish "you have no reccd" from "the
+  server fell over".
+
+### Tuning, with reasons
+
+| Setting | Value | Why this value |
+|---|---|---|
+| Debounce | **250ms** | reccd's own measured latency is 174–311ms for broad prefixes. The 150ms `useTitlePreview` uses is tuned for OMDb and would queue requests behind each other here. |
+| Min query length | **2** | Matches `SEARCH_MIN_QUERY_LENGTH` exactly. A different number either fires requests guaranteed to return `[]` or hides results reccd would have given. |
+| `limit` | **8** | The terminal renders 5 rows (vertical space is scarce there) and the browser renders all 8. One `limit` for both keeps the two surfaces asking reccd the same question. |
+| Timeout | **2500ms** | Not the 10s `fetchRecommendations` uses. A suggestion that arrives after 10 seconds is noise — the user has finished typing and pressed Enter. |
+| On failure | **silent** | Unlike `/api/recommendations`, which surfaces `{status:"error"}` to a pane the user deliberately opened. An error banner per keystroke is worse than no suggestions. |
+
+### Failure cases, enumerated
+
+| Case | Behaviour |
+|---|---|
+| No `reccUrl` | Never fires. TUI checks `resolveReccConfig`; the browser checks `reccConfigured` (below). |
+| `401` | No suggestions. Silent — the Accounts pane already reports `badToken` via `checkReccConnection`, which is where a token problem belongs. |
+| `404` | No suggestions, treated as "this reccd predates the endpoint" rather than as an error. A user running an older reccd gets a search box that behaves exactly as it does today. |
+| Timeout / network error | No suggestions. Logged at debug only. |
+| Malformed body | No suggestions. The type guard rejects the whole array rather than filtering it, matching `isRecommendation`'s all-or-nothing check. |
+
+**No unavailability latch.** A 404 does not disable future requests for the process
+lifetime. It could — but that means module-level mutable state in `client.ts` with a
+test-only reset, and the cost it saves is one cheap 404 per debounced keystroke against a
+service on the user's own network. Noted as an option if it ever matters.
+
+### Stale responses are a real bug here
+
+reccd's measured numbers make this concrete, not hypothetical: `q="th"` costs ~311ms and
+`q="dark kni"` costs ~71ms. Type the second while the first is in flight and the broad,
+stale result lands **after** the fresh one and overwrites it — the list contents disagree
+with the input box.
+
+Debouncing does not fix this. Two keystroke bursts separated by more than the debounce
+window both fire, and nothing orders their replies.
+
+The fix is a monotonic request sequence number: every request carries one, and a reply is
+applied only if its sequence is the highest yet applied. This lives in the pure model with
+a named test, because it is exactly the kind of thing that is invisible when it regresses.
+
+## Capability flag
+
+`/api/sources` gains **`reccConfigured: boolean`**, joining `debridConfigured`,
+`debridProvider`, `debridCachedCheck` and `omdbConfigured`.
+
+The browser fetches `/api/sources` on load, so this costs nothing extra and means a user
+without reccd never spends a request per keystroke discovering that again. It follows the
+established rule for that response: a capability boolean, never a credential — the URL and
+token stay server-side.
+
+Resolved through `resolveReccConfig(config)`, not raw `config.reccUrl`, so
+`TORLINK_RECC_URL` counts. The browser must agree with the TUI about whether reccd is on,
+and the TUI resolves it that way.
+
+Touches `SourcesResponse` in `wire.ts` (`src/web/wire.ts:340`) and the fixtures in
+`routes.test.ts`.
+
+## Module layout
+
+| File | Change |
+|---|---|
+| `src/recc/client.ts` | **New export.** `fetchTitleSuggestions(config, {q, limit}, opts)` plus an `isTitleSuggestion` guard, mirroring `fetchRecommendations` / `isRecommendation`: injected `fetchImpl`, `AbortSignal.timeout`, discriminated `{ok:true, items} | {ok:false, error}`. |
+| `src/util/titleSuggest.ts` | **New.** Shared pure logic — see below. |
+| `src/web/routes.ts` | **New route** `GET /api/title-search`. Plus `reccConfigured` on the sources response. |
+| `src/web/wire.ts` | Response type for the new route; `reccConfigured` on `PublicSources`. |
+| `src/web/static/suggestModel.ts` | **New.** Browser list state — see below. |
+| `src/web/static/index.html` | The listbox container under `#query`. |
+| `src/web/static/app.ts` | DOM wiring only. |
+| `src/ui/hooks/useTitleSuggest.ts` | **New.** Debounce + fetch + seq, modelled on `useTitlePreview`. |
+| `src/ui/components/SearchBar.tsx` | Renders the suggestion rows; Tab-completes. |
+| `src/ui/components/Results.tsx`, `src/ui/views/Splash.tsx` | Pass the hook's state in. |
+| `src/ui/keymap.ts` | Tab-completes, in **both** `HELP_GROUPS` and `footerHints`. |
+| `README.md` | Both surfaces; re-check the web UI's limitations list. |
+
+`src/util/titleSuggest.ts` rather than a helper inside `src/ui/` that the web later copies.
+This codebase records four bugs caused by copy-then-drift, and `resultSort.ts`,
+`resultFilter.ts`, `favouriteList.ts` and `savedSearchList.ts` all moved down for exactly
+this reason. It goes to `src/util/` on day one.
+
+### `src/util/titleSuggest.ts`
+
+Pure, no I/O, no DOM, imported by both front ends.
+
+- `shouldQuery(raw: string): boolean` — trimmed length ≥ 2. The one place the min-length
+  rule is written down.
+- `suggestionLabel(hit): string` — `"Kestrel (2010) · film"`. `type` is mapped to
+  `film`/`show` for display; reccd's `movie`/`tv` are its vocabulary, not torlink's.
+- `akaNote(hit): string | null` — the "you typed X, we mean Y" line, `null` when
+  `matchedAka` is `null`.
+- `submitTextFor(hit): string` — `"Kestrel 2010"`. **Title and year.** The year is why
+  canonicalising through a catalog is worth doing at all: it separates a remake from its
+  original, and torrent release names carry it.
+- `applyReply(state, seq, items)` — the sequence guard. Returns state unchanged when `seq`
+  is not the newest.
+
+### `src/web/static/suggestModel.ts`
+
+Browser list state, so that `app.ts` contains no conditional deciding what to show or what
+to send. That rule is explicit in `CLAUDE.md` and has been caught in review twice.
+
+Owns: open/closed, highlight index (and its wrap behaviour), which sequence is
+authoritative, and what a click or an Enter press submits.
+
+## Terminal UI
+
+`SearchBar` gains an optional suggestion block: up to **5** dim rows below the panel,
+rendered only when there are suggestions, so an empty list costs no vertical space and the
+layout does not jitter as replies arrive.
+
+```
+┌─ search ────────────────────────────┐
+│ › dark kni                          │
+└─────────────────────────────────────┘
+  Kestrel (2010) · film      ← tab
+  Ashfall (1999) · film
+  Kepler (2019) · show
+```
+
+### Keys
+
+The search box already spends its arrows and its Tab (`TextField.tsx:118-144`): `↑`/`↓`
+recall search history, `Tab` calls `onExitDown()`. So:
+
+| Key | Meaning |
+|---|---|
+| `Tab`, list open | Complete to the **top** suggestion. |
+| `Tab`, list closed | Exit the field, exactly as today. |
+| `↑` / `↓` | Search history. **Unchanged.** |
+| `Esc` | Dismiss the list. |
+| `Enter` | Submit whatever is in the box. **Unchanged** — Enter never silently substitutes a suggestion for what the user typed. |
+
+The list is not navigable. A navigable list means overloading `↑`, `↓` and `Enter` — three
+bindings that already work — and gains one thing: reaching row 3 instead of row 1. Tab-to-
+top-hit is a fraction of the code, collides with nothing, and changes no existing key's
+meaning. Rejected deliberately, not for time.
+
+### Both call sites
+
+`Results.tsx:708` and `Splash.tsx:128`. Splash is the larger win — it is the box you land
+on at launch, before any results exist to narrow.
+
+### State lives in the hook, not the `Store`
+
+A `Store` field would need matching entries in `makeStore`
+(`scripts/render-previews-impl.tsx`) and `makeTestStore` (`src/ui/testHarness.ts`), or
+`npm run previews` and `npm run typecheck` break respectively. That is the right cost for
+state other panes read. No other pane reads this, so `useTitleSuggest` owns it.
+
+## Browser UI
+
+A listbox under `#query`. Arrows are free in a browser, so it is fully navigable:
+
+| Key | Meaning |
+|---|---|
+| `↓` / `↑` | Move the highlight. Wraps. |
+| `Enter` | Accept the highlighted suggestion; with nothing highlighted, submit the raw text. |
+| `Esc` | Close the list. |
+| Click | Accept that suggestion. |
+
+Accepting fills the input with `submitTextFor(hit)` and submits the search.
+
+The asymmetry with the TUI is the sanctioned kind: the terminal has no free arrows here and
+the browser has no keybinding budget to protect. Each surface expresses the same feature
+the way it can.
+
+Rows render `suggestionLabel(hit)` and, when `matchedAka` is set, `akaNote(hit)`.
+
+**Every node is `createElement` + `textContent`.** No `innerHTML`, `insertAdjacentHTML`,
+`outerHTML` or `document.write`. Catalog titles are less hostile than release names, but the
+rule in `src/web/static/` is absolute for a reason and a suggestion row is not the place to
+start making exceptions.
+
+## Testing
+
+TDD — failing test first.
+
+**`src/util/titleSuggest.test.ts`:**
+- `shouldQuery` — `""`, `"k"`, `" k "` → false; `"ke"`, `"kestrel"` → true.
+- `suggestionLabel` — movie → `"Kestrel (2010) · film"`; tv → `"Kepler (2019) · show"`.
+- `akaNote` — `null` when `matchedAka` is null; the note when it is set.
+- `submitTextFor` — `"Kestrel 2010"`, year included.
+- `applyReply` — a reply with a stale sequence is **discarded**; the newest is applied;
+  out-of-order arrival (seq 2 then seq 1) leaves seq 2's items in place. This is the
+  mutation guard for the stale-response bug.
+
+**`src/web/static/suggestModel.test.ts`:**
+- Highlight moves and wraps at both ends.
+- Accepting with a highlight sends `submitTextFor` of that hit; with none, the raw input.
+- A new query closes the list and resets the highlight.
+- Escape closes without changing the input.
+
+**`src/recc/client.test.ts`:**
+- Happy path — query string carries `q` and `limit`; `authorization: Bearer …` is sent.
+- No `reccUrl` → `{ok:false}` without calling fetch.
+- `401` → `ok:false`.
+- `404` → `ok:false` (older reccd).
+- Non-array body, and an array with one malformed member → `ok:false`.
+- Abort/timeout → `ok:false`, no throw.
+- A year in `q` is forwarded verbatim, not stripped — reccd parses it.
+
+**`src/web/routes.test.ts`:**
+- No `reccUrl` → 200 `{status:"not-configured"}`, and reccd is not called.
+- Configured → items proxied.
+- **The response body contains neither `reccToken` nor `reccUrl`.** Assert against the
+  serialised body, not the object, and assert on a token value that appears nowhere else in
+  the fixture so the negative cannot go vacuous.
+- Missing `q` → 400.
+- `reccConfigured` is `true`/`false` on `/api/sources` per config, and resolves
+  `TORLINK_RECC_URL`.
+
+**Fixtures use the repo cast** — `Kestrel.2010`, `Ashfall.1999`, `Kepler.S02E04`,
+`Harrowgate.S03`, `Tin.Rivers.2024`. No real titles.
+
+**Wiring is not unit-testable and is not pretended to be.** There is no jsdom. `app.ts` and
+the Ink render are verified by running them: `npm run dev -- serve --web` for the browser,
+`npm run dev` for the terminal. `npm run build` is the only check that
+`src/web/static/` imports no `node:*`.
+
+## Known limits, stated rather than discovered later
+
+**Suggestions are catalog titles, not torrents.** `Harrowgate S03` will never appear as a
+suggestion — reccd's catalog holds titles, and `parseBasicsLine` drops `tvEpisode`
+entirely. You get `Harrowgate`, then narrow by hand. This is the season-pack edge case the
+fixture cast exists to keep in view, and it is worth putting in the README so the first
+person to notice does not file it as a bug.
+
+**No typo tolerance.** `"kestrl"` returns nothing. That is reccd's design (prefix matching,
+no trigram pass), and reccd's own doc flags typo tolerance as an additive change on their
+side. Nothing here needs to change if they add it.
+
+**`ForYou` and autocomplete now submit different things.** `ForYou.tsx:119` and `:133`
+submit `selectedItem.title` — title only, no year. Autocomplete submits title and year.
+Left alone deliberately: changing a shipped pick path is not in scope for this change.
+Recorded here as a follow-up so the divergence is a decision on the record rather than an
+inconsistency someone finds.
+
+## Before it is done
+
+`npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing
+lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) stays.

--- a/src/recc/client.test.ts
+++ b/src/recc/client.test.ts
@@ -151,8 +151,29 @@ describe("fetchTitleSuggestions", () => {
     type: "movie",
     matchedAka: null,
   };
+  // A series, so a PASSING case carries both of reccd's two type values. Without
+  // one, `isSuggestionType`'s `|| v === "tv"` arm could be deleted with the whole
+  // suite still green — and the consequence is not "TV stops suggesting":
+  // `isTitleSuggestion` is all-or-nothing over `body.every`, so ONE series in the
+  // top 8 would reject the entire array and the user would get no suggestions at
+  // all, films included.
+  const SHOW = {
+    imdbId: "tt0000002",
+    title: "Kepler",
+    year: 2019,
+    type: "tv",
+    matchedAka: null,
+  };
   // reccd returns more than torlink models — this is what actually comes back.
   const WIRE_HIT = { ...HIT, genres: ["Drama"], rating: 7.4, votes: 90000 };
+  const WIRE_SHOW = { ...SHOW, genres: ["Mystery"], rating: 8.1, votes: 40000 };
+
+  it("accepts both of reccd's types in one reply", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT, WIRE_SHOW]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "ke" }, { fetchImpl });
+    // Asserted as the whole result: a series rejected here takes the film with it.
+    expect(res).toEqual({ ok: true, items: [HIT, SHOW] });
+  });
 
   it("gets {reccUrl}/search with q, limit and a bearer token", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT]));
@@ -173,6 +194,9 @@ describe("fetchTitleSuggestions", () => {
     const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
     expect(res.ok).toBe(true);
     if (!res.ok) return;
+    // Length first: `not.toHaveProperty` on `items[0]` is satisfied by an empty
+    // array, so without this the three negatives below pass for no items at all.
+    expect(res.items).toHaveLength(1);
     expect(res.items[0]).not.toHaveProperty("votes");
     expect(res.items[0]).not.toHaveProperty("rating");
     expect(res.items[0]).not.toHaveProperty("genres");
@@ -208,10 +232,14 @@ describe("fetchTitleSuggestions", () => {
     expect(res).toEqual({ ok: false, error: "this reccd has no title search" });
   });
 
+  // The body is `[]` and the error is asserted exactly, so this can only be
+  // satisfied by the status check. `jsonRes(500)` defaults its body to `{}`,
+  // which is not an array — so the old version passed with the whole `!res.ok`
+  // branch deleted, failing on the array check instead and for the wrong reason.
   it("reports any other non-ok status", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500));
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500, []));
     const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
-    expect(res.ok).toBe(false);
+    expect(res).toEqual({ ok: false, error: "title search unavailable (HTTP 500)" });
   });
 
   it("rejects a body that is not an array", async () => {

--- a/src/recc/client.test.ts
+++ b/src/recc/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { postEvent, fetchRecommendations } from "./client.js";
+import { postEvent, fetchRecommendations, fetchTitleSuggestions } from "./client.js";
 import type { FetchImpl } from "../util/net";
 
 function jsonRes(status: number, body: unknown = {}) {
@@ -140,5 +140,128 @@ describe("fetchRecommendations", () => {
   it("returns a not-configured error when reccUrl is missing", async () => {
     const res = await fetchRecommendations({ reccToken: "t" }, {});
     expect(res).toEqual({ ok: false, error: "recommendations not configured" });
+  });
+});
+
+describe("fetchTitleSuggestions", () => {
+  const HIT = {
+    imdbId: "tt0000001",
+    title: "Kestrel",
+    year: 2010,
+    type: "movie",
+    matchedAka: null,
+  };
+  // reccd returns more than torlink models — this is what actually comes back.
+  const WIRE_HIT = { ...HIT, genres: ["Drama"], rating: 7.4, votes: 90000 };
+
+  it("gets {reccUrl}/search with q, limit and a bearer token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT]));
+    const res = await fetchTitleSuggestions(
+      { reccUrl: "http://localhost:4100", reccToken: "dev-token" },
+      { q: "kes" },
+      { fetchImpl },
+    );
+    expect(res).toEqual({ ok: true, items: [HIT] });
+    const [url, init] = fetchImpl.mock.calls[0] as [string, { method: string; headers: Record<string, string> }];
+    expect(url).toBe("http://localhost:4100/search?q=kes&limit=8");
+    expect(init.method).toBe("GET");
+    expect(init.headers.authorization).toBe("Bearer dev-token");
+  });
+
+  it("drops the fields torlink does not render", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.items[0]).not.toHaveProperty("votes");
+    expect(res.items[0]).not.toHaveProperty("rating");
+    expect(res.items[0]).not.toHaveProperty("genres");
+  });
+
+  // reccd parses a trailing year out of q itself, and its own fallback rescues
+  // titles that genuinely end in a year. Stripping it here would break both.
+  it("forwards a year in the query verbatim rather than parsing it out", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kestrel 2010" }, { fetchImpl });
+    const [url] = fetchImpl.mock.calls[0] as [string];
+    expect(url).toBe("http://r/search?q=kestrel+2010&limit=8");
+  });
+
+  it("does not call fetch at all when reccUrl is not configured", async () => {
+    const fetchImpl = vi.fn();
+    const res = await fetchTitleSuggestions({}, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("reports a rejected token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(401, { error: "unauthorized" }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "bad" }, { q: "kes" }, { fetchImpl });
+    expect(res).toEqual({ ok: false, error: "reccd rejected the token — check reccToken" });
+  });
+
+  // A reccd predating GET /search 404s. That is "this feature is unavailable",
+  // not a fault, and must leave the search box behaving exactly as it does now.
+  it("treats a 404 as an older reccd without the endpoint", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(404, { error: "not found" }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res).toEqual({ ok: false, error: "this reccd has no title search" });
+  });
+
+  it("reports any other non-ok status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(500));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a body that is not an array", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, { items: [WIRE_HIT] }));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  // All-or-nothing, matching isRecommendation: a body we only half understand
+  // is a contract change, and silently rendering the half we parsed would hide
+  // it until someone noticed rows missing.
+  it("rejects the whole array when one member is malformed", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [WIRE_HIT, { imdbId: "tt2" }]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a hit whose type is neither movie nor tv", async () => {
+    const bad = { ...WIRE_HIT, type: "tvEpisode" };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [bad]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts a hit that matched on an AKA", async () => {
+    const aka = { ...WIRE_HIT, matchedAka: "Ashfall Rising" };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, [aka]));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "ash" }, { fetchImpl });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.items[0]?.matchedAka).toBe("Ashfall Rising");
+  });
+
+  it("never throws on a network error", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes" }, { fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("honours an explicit limit", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r", reccToken: "t" }, { q: "kes", limit: 3 }, { fetchImpl });
+    const [url] = fetchImpl.mock.calls[0] as [string];
+    expect(url).toBe("http://r/search?q=kes&limit=3");
+  });
+
+  it("still fires with an empty bearer token when reccToken is omitted", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, []));
+    await fetchTitleSuggestions({ reccUrl: "http://r" }, { q: "kes" }, { fetchImpl });
+    const [, init] = fetchImpl.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(init.headers.authorization).toBe("Bearer ");
   });
 });

--- a/src/recc/client.ts
+++ b/src/recc/client.ts
@@ -1,5 +1,11 @@
 import type { FetchImpl } from "../util/net";
 import { log } from "../util/logger";
+import {
+  SUGGEST_LIMIT,
+  SUGGEST_TIMEOUT_MS,
+  type TitleSuggestion,
+  type TitleSuggestionType,
+} from "../util/titleSuggest";
 
 export type ReccEventType =
   | "started"
@@ -132,6 +138,83 @@ export async function fetchRecommendations(
   } catch (err) {
     log.debug(
       `recc fetchRecommendations: failed to reach ${config.reccUrl}/recommendations: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, error: "couldn't reach reccd" };
+  }
+}
+
+export type FetchTitleSuggestionsResult =
+  | { ok: true; items: TitleSuggestion[] }
+  | { ok: false; error: string };
+
+function isSuggestionType(v: unknown): v is TitleSuggestionType {
+  return v === "movie" || v === "tv";
+}
+
+// All-or-nothing, like isRecommendation above: a body we only half understand
+// is a contract change, and rendering the half we parsed would hide it.
+function isTitleSuggestion(v: unknown): v is TitleSuggestion & Record<string, unknown> {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.imdbId === "string" &&
+    typeof r.title === "string" &&
+    typeof r.year === "number" &&
+    isSuggestionType(r.type) &&
+    (r.matchedAka === null || typeof r.matchedAka === "string")
+  );
+}
+
+/**
+ * reccd's `GET /search` — partial input to a ranked list of catalog titles.
+ *
+ * A blocking read like `fetchRecommendations`, and a discriminated result for
+ * the same reason. But the CALLERS treat failure differently: this fires per
+ * keystroke, so every one of these errors is rendered as "no suggestions" and
+ * nothing else. An error banner per keystroke is worse than no suggestions.
+ *
+ * `q` is sent verbatim. reccd parses a trailing year out of it itself and has
+ * its own literal-interpretation fallback for titles that genuinely end in a
+ * year, so stripping one here would break both.
+ */
+export async function fetchTitleSuggestions(
+  config: ReccClientConfig,
+  query: { q: string; limit?: number },
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchTitleSuggestionsResult> {
+  if (!config.reccUrl) return { ok: false, error: "title search not configured" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  const params = new URLSearchParams();
+  params.set("q", query.q);
+  params.set("limit", String(query.limit ?? SUGGEST_LIMIT));
+  try {
+    const res = await fetchImpl(`${config.reccUrl}/search?${params.toString()}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.reccToken ?? ""}` },
+      signal: AbortSignal.timeout(opts.timeoutMs ?? SUGGEST_TIMEOUT_MS),
+    });
+    if (res.status === 401) return { ok: false, error: "reccd rejected the token — check reccToken" };
+    // A reccd older than the /search endpoint. Not a fault — the feature is
+    // simply unavailable, and the search box must behave as it did before.
+    if (res.status === 404) return { ok: false, error: "this reccd has no title search" };
+    if (!res.ok) return { ok: false, error: `title search unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!Array.isArray(body) || !body.every(isTitleSuggestion)) {
+      return { ok: false, error: "unexpected response from reccd" };
+    }
+    // Narrowed deliberately: reccd also sends genres, rating and votes, and
+    // nothing here renders them.
+    const items: TitleSuggestion[] = body.map((r) => ({
+      imdbId: r.imdbId,
+      title: r.title,
+      year: r.year,
+      type: r.type,
+      matchedAka: r.matchedAka,
+    }));
+    return { ok: true, items };
+  } catch (err) {
+    log.debug(
+      `recc fetchTitleSuggestions: failed to reach ${config.reccUrl}/search: ${err instanceof Error ? err.message : String(err)}`,
     );
     return { ok: false, error: "couldn't reach reccd" };
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2322,7 +2322,12 @@ export function App({
     return (
       <StoreContext.Provider value={store}>
         <TabTitle />
-        <Splash updateVersion={updateVersion} recovered={recovered} webStatus={webStatus} />
+        <Splash
+          updateVersion={updateVersion}
+          recovered={recovered}
+          webStatus={webStatus}
+          reccConfig={resolveReccConfig(store.config)}
+        />
       </StoreContext.Provider>
     );
   }
@@ -2813,7 +2818,7 @@ export function App({
               flexDirection="column"
               display={isCategory(section) ? "flex" : "none"}
             >
-              <Results />
+              <Results reccConfig={resolveReccConfig(store.config)} />
             </Box>
             <Box
               flexGrow={1}

--- a/src/ui/components/Results.ratePrompt.test.tsx
+++ b/src/ui/components/Results.ratePrompt.test.tsx
@@ -72,7 +72,7 @@ describe("Results — rate-prompt input isolation", () => {
     const store = baseStore({ region: "content" });
     const { stdin } = render(
       <StoreContext.Provider value={store}>
-        <Results />
+        <Results reccConfig={{}} />
       </StoreContext.Provider>,
     );
     await flush();
@@ -88,7 +88,7 @@ describe("Results — rate-prompt input isolation", () => {
     const store = baseStore({ region: "help" });
     const { stdin } = render(
       <StoreContext.Provider value={store}>
-        <Results />
+        <Results reccConfig={{}} />
       </StoreContext.Provider>,
     );
     await flush();

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -717,4 +717,93 @@ describe("Results search suggestions on entering the box", () => {
     expect(urls).toHaveLength(1);
     expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
   });
+
+  /**
+   * ESCAPE MUST STICK EVEN WITH A REQUEST STILL OUT, and this is the test that
+   * pins the WIRING \u2014 `dismiss` handing the hook's live seq counter to
+   * `suppressFor`, not the seq of the last reply applied. The module's own unit
+   * tests pass either way; only a render distinguishes them.
+   *
+   * Dismissing does not change an effect dependency, so the pending request is
+   * neither cancelled nor cleared: it fires, answers, and (before the fix)
+   * applied, because its number was higher than anything yet applied. The list
+   * the user had just closed came back, and leaving the box then cost a THIRD
+   * escape \u2014 against help text promising one.
+   */
+  it("does not reopen a dismissed list when the request already in flight answers", async () => {
+    const { impl, urls } = suggestStub();
+    searchState.current = settled(LIST);
+    ui = renderUI(
+      <StoreContext.Provider value={makeTestStore({ query: "" })}>
+        <Results reccConfig={SUGGEST_CFG} fetchImpl={impl} />
+      </StoreContext.Provider>,
+    );
+    const u = ui;
+    await settleFrames();
+
+    u.press("/");
+    await settleFrames();
+    u.press("ke");
+    await tick(1000);
+    expect(u.frame()).toContain("Kestrel (2010) \u00b7 film");
+
+    // One more character, so a second request is queued for "ker", then escape
+    // WITHOUT moving the clock \u2014 the fast-typist case, where the reply is still
+    // owed when the list is dismissed.
+    u.press("r");
+    await settleFrames();
+    u.press(KEY.esc);
+    // 50ms, well inside the 250ms debounce, so the request for "ker" is still
+    // pending: enough for ink to settle an escape byte, not enough to send it.
+    await tick(50);
+    expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
+
+    // Now let the owed reply land. Two requests really were made, so the negative
+    // below is about a reply being DISCARDED and not about one never arriving.
+    await tick(2000);
+    expect(urls).toHaveLength(2);
+    expect(urls[1]).toEqual(expect.stringContaining("q=ker&limit="));
+    expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
+
+    // And leaving costs the promised second press, not a third.
+    expect(editing(u)).toBe(true);
+    u.press(KEY.esc);
+    await tick(100);
+    expect(editing(u)).toBe(false);
+  });
+
+  /**
+   * Backspacing out of a search must not leave stale rows behind. Five rows
+   * hanging under a one-character box is the symptom; the min-length branch in
+   * `useTitleSuggest` is what prevents it, and nothing covered it.
+   *
+   * Backspaces to exactly ONE character on purpose. Emptying the box entirely
+   * would make `shouldSuggestFor("", "")`... \u2014 well, here the submitted query is
+   * empty, so an empty draft turns `enabled` off and the rows would clear via the
+   * cap on `items` instead, with the branch under test never running.
+   */
+  it("clears the rows when backspacing below the minimum query length", async () => {
+    const { impl, urls } = suggestStub();
+    searchState.current = settled(LIST);
+    ui = renderUI(
+      <StoreContext.Provider value={makeTestStore({ query: "" })}>
+        <Results reccConfig={SUGGEST_CFG} fetchImpl={impl} />
+      </StoreContext.Provider>,
+    );
+    const u = ui;
+    await settleFrames();
+
+    u.press("/");
+    await settleFrames();
+    u.press("ke");
+    await tick(1000);
+    expect(u.frame()).toContain("Kestrel (2010) \u00b7 film");
+
+    // One backspace: "ke" -> "k", one character, below reccd's minimum.
+    u.press("\u007f");
+    await tick(1000);
+    expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
+    // And nothing was asked about a query reccd would answer with [] anyway.
+    expect(urls).toHaveLength(1);
+  });
 });

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -668,4 +668,53 @@ describe("Results search suggestions on entering the box", () => {
     expect(urls).toHaveLength(0);
     expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
   });
+
+  it("holds when the box reaches the submitted text without entering search mode", async () => {
+    // THE POINT OF THE DERIVED GUARD. `enterSearch` resyncing the draft is not
+    // what keeps the list shut \u2014 the `draft === query` condition is, and it is
+    // re-read every render. This drives the box to `draft === query` by TYPING,
+    // so `enterSearch` is provably not the thing suppressing anything, and no
+    // latch is involved either (no tab, no escape, so `suppressedText` stays
+    // null). Whatever path a future caller takes into search mode, it lands in
+    // this same state and gets this same answer.
+    //
+    // It doubles as documentation of the one behaviour the guard gives up:
+    // clearing the box and retyping your last search exactly gets no suggestions.
+    const { impl, urls } = suggestStub();
+    searchState.current = settled(LIST);
+    ui = renderUI(
+      <StoreContext.Provider value={makeTestStore({ query: "kestrel" })}>
+        <Results reccConfig={SUGGEST_CFG} fetchImpl={impl} />
+      </StoreContext.Provider>,
+    );
+    const u = ui;
+    await settleFrames();
+
+    u.press("/");
+    await tick(1000);
+    expect(urls).toHaveLength(0); // nothing asked for the text already there
+
+    // Clear it and type most of the same search back: the drafts differ, so
+    // suggestions work normally. The two presses are separated by a tick because
+    // TextField's input closure only refreshes on render \u2014 same-batch keys apply
+    // against the pre-clear value (a pre-existing trait this file already
+    // documents on the filter tests), which would insert into "kestrel" rather
+    // than into an empty box.
+    u.press(KEY.ctrlU);
+    await tick(1000);
+    u.press("kestre");
+    await tick(1000);
+    // Pinned with the trailing separator so it cannot be satisfied by a longer
+    // query that merely starts the same way \u2014 the first version of this
+    // assertion passed against "q=kestrelkestre".
+    expect(urls).toEqual([expect.stringContaining("q=kestre&limit=")]);
+    expect(u.frame()).toContain("Kestrel (2010) \u00b7 film");
+
+    // One more character and the draft equals the submitted search again. The
+    // list must close and nothing more may be asked \u2014 reached purely by typing.
+    u.press("l");
+    await tick(1000);
+    expect(urls).toHaveLength(1);
+    expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
+  });
 });

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -547,9 +547,15 @@ describe("Results search suggestions", () => {
   it("leaves the search box on tab when there is nothing to complete", async () => {
     // reccd configured, and ONE character typed \u2014 below the two reccd will answer
     // \u2014 so there is no list and tab must behave exactly as it did before
-    // suggestions existed. A character really is typed: with an empty box the
-    // emptiness of `urls` would follow from nothing having happened at all.
-    const { impl, urls } = suggestStub();
+    // suggestions existed. The subject is tab, and `editing` is what pins it.
+    //
+    // Deliberately asserts NOTHING about requests. This describe runs on real
+    // timers, where `vi.waitFor` resolves in tens of milliseconds and the
+    // debounce is 250ms, so "no request fired" here would only mean "the timer
+    // has not fired yet" \u2014 vacuous, as the comment above the fake-timer describe
+    // below says. The min-length gate is covered there instead, by
+    // "clears the rows when backspacing below the minimum query length".
+    const { impl } = suggestStub();
     const u = await mountSuggest(impl);
 
     u.press("/");
@@ -558,7 +564,6 @@ describe("Results search suggestions", () => {
     await vi.waitFor(() => expect(u.frame()).toContain("\u276f k"));
     u.press("\t");
     await vi.waitFor(() => expect(editing(u)).toBe(false));
-    expect(urls).toHaveLength(0);
   });
 
   it("still recalls the previous search on the up arrow with a list on screen", async () => {

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -11,6 +11,7 @@ import {
 import { Results } from "./Results";
 import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
 import type { TorrentResult } from "../../sources/types";
+import type { FetchImpl } from "../../util/net";
 
 const searchState = vi.hoisted(() => ({ current: null as unknown }));
 
@@ -81,7 +82,7 @@ async function mount(results: TorrentResult[] = LIST): Promise<RenderedUI> {
   searchState.current = settled(results);
   ui = renderUI(
     <StoreContext.Provider value={makeTestStore({ query: "linux iso" })}>
-      <Results />
+      <Results reccConfig={{}} />
     </StoreContext.Provider>,
   );
   const u = ui;
@@ -215,7 +216,7 @@ describe("Results preview pane", () => {
       <StoreContext.Provider
         value={makeTestStore({ query: "harrowgate", omdbApiKey: "KEY", contentWidth: 96, ...overrides })}
       >
-        <Results />
+        <Results reccConfig={{}} />
       </StoreContext.Provider>,
       { cols: 110 },
     );
@@ -284,7 +285,7 @@ async function mountWide(results: TorrentResult[], contentWidth: number): Promis
   searchState.current = settled(results);
   ui = renderUI(
     <StoreContext.Provider value={makeTestStore({ query: "linux iso", contentWidth, cols: contentWidth + 19 })}>
-      <Results />
+      <Results reccConfig={{}} />
     </StoreContext.Provider>,
     { cols: contentWidth + 19 },
   );
@@ -400,7 +401,7 @@ describe("Results grouping", () => {
     searchState.current = settled(GROUPABLE);
     ui = renderUI(
       <StoreContext.Provider value={makeTestStore({ query: "linux iso", contentWidth: 120, cols: 139, copyMagnet })}>
-        <Results />
+        <Results reccConfig={{}} />
       </StoreContext.Provider>,
       { cols: 139 },
     );
@@ -439,5 +440,148 @@ describe("Results grouping keeps the cursor put", () => {
 
     // Still on the member, not yanked up to the heading above it.
     expect(u.frame()).toMatch(/\u276f.*BluRay/);
+  });
+});
+
+// Title suggestions. reccd's replies are injected through the `fetchImpl` prop \u2014
+// exactly the escape hatch ForYou's tests use \u2014 so nothing here dials out.
+const SUGGEST_CFG = { reccUrl: "http://recc.invalid:4100", reccToken: "tok" };
+const KESTREL = { imdbId: "tt1", title: "Kestrel", year: 2010, type: "movie", matchedAka: null };
+
+// `fetchTitleSuggestions` validates EVERY element and fails the whole reply on
+// one bad one, which the hook renders as an empty list \u2014 so `matchedAka` is not
+// optional decoration here, it is what makes the stub a valid reply.
+function suggestStub(items: unknown[] = [KESTREL]): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    return { ok: true, status: 200, json: async () => items } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+// Browsing (an empty submitted query) so the draft starts empty and the only
+// request the hook makes is the one the test types.
+async function mountSuggest(
+  impl: FetchImpl,
+  overrides: Parameters<typeof makeTestStore>[0] = {},
+): Promise<RenderedUI> {
+  searchState.current = settled(LIST);
+  ui = renderUI(
+    <StoreContext.Provider value={makeTestStore({ query: "", ...overrides })}>
+      <Results reccConfig={SUGGEST_CFG} fetchImpl={impl} />
+    </StoreContext.Provider>,
+  );
+  const u = ui;
+  await vi.waitFor(() => expect(u.frame()).toContain(`Latest (${LIST.length})`));
+  return u;
+}
+
+describe("Results search suggestions", () => {
+  // Escape has two jobs now, and the order matters to the user: the first
+  // escape puts the list away, the second leaves the box. Collapsing both into
+  // one keypress would make dismissing a list cost you your place.
+  it("dismisses the suggestion list before leaving the search box", async () => {
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl);
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("ke");
+    // Polls the whole keystroke -> debounce -> reply -> repaint chain rather
+    // than sleeping past it, which is fragile on a loaded machine.
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
+
+    // First escape: the list goes, the box stays.
+    u.press(KEY.esc);
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Kestrel (2010)"));
+    expect(editing(u)).toBe(true);
+
+    // Second escape: now the pane leaves search mode.
+    u.press(KEY.esc);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+  });
+
+  it("completes the field to the top suggestion on tab instead of leaving the box", async () => {
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl);
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("ke");
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
+
+    u.press("\t");
+    // Title AND year \u2014 the whole point of canonicalising through a catalog.
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel 2010"));
+    // Still editing: tab completed rather than exiting downward.
+    expect(editing(u)).toBe(true);
+    // Accepting suppresses the text just taken, so the list does not
+    // immediately reopen on it.
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film"));
+  });
+
+  it("leaves the search box on tab when there is nothing to complete", async () => {
+    // reccd configured, but two characters never typed \u2014 so no list, and tab
+    // must behave exactly as it did before suggestions existed.
+    const { impl, urls } = suggestStub();
+    const u = await mountSuggest(impl);
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("\t");
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+    expect(urls).toHaveLength(0);
+  });
+
+  it("still recalls the previous search on the up arrow with a list on screen", async () => {
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl, { searchHistory: ["harrowgate s03"] });
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("ke");
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
+
+    // The suggestion rows are not a list the arrows walk \u2014 history recall still
+    // owns the up arrow inside the field.
+    u.press(`${KEY.esc}[A`);
+    await vi.waitFor(() => expect(u.frame()).toContain("harrowgate s03"));
+  });
+
+  it("does not reopen the list on abandoned text when the box is re-entered", async () => {
+    // The draft is separate state from the submitted query, and entering search
+    // mode REMOUNTS the TextField with `query` in it. Without a resync, leaving
+    // the box with text in it and coming back would suggest against the
+    // abandoned text under a box showing something else.
+    //
+    // Committed with ENTER, not escape, on purpose: escape sets `suppressedText`
+    // and would make this pass whether the resync exists or not.
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl);
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("ke");
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+
+    // Back into an empty box: nothing to suggest on, so no list. A waitFor, not
+    // a bare assertion \u2014 the rows the previous visit left in state can survive
+    // one frame, and without the resync they never go away at all.
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    await vi.waitFor(() => expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
   });
 });

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { SOURCES } from "../../sources/registry";
 import { StoreContext } from "../store";
 import {
@@ -12,6 +12,12 @@ import { Results } from "./Results";
 import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
 import type { TorrentResult } from "../../sources/types";
 import type { FetchImpl } from "../../util/net";
+
+// Captured BEFORE the fake timers installed by one describe near the bottom of
+// this file: `setImmediate` is faked too, and ink's React scheduler drains its
+// work through a MessageChannel message — a macrotask — so advancing fake timers
+// alone never repaints the frame. Same reasoning as ForYou.test.tsx.
+const yieldToLoop = setImmediate;
 
 const searchState = vi.hoisted(() => ({ current: null as unknown }));
 
@@ -473,7 +479,9 @@ async function mountSuggest(
     </StoreContext.Provider>,
   );
   const u = ui;
-  await vi.waitFor(() => expect(u.frame()).toContain(`Latest (${LIST.length})`));
+  // The count, not the panel title: the title is "Latest" while browsing and
+  // "Results" once a query has been submitted, and these tests use both.
+  await vi.waitFor(() => expect(u.frame()).toContain(`(${LIST.length})`));
   return u;
 }
 
@@ -583,5 +591,81 @@ describe("Results search suggestions", () => {
     await vi.waitFor(() => expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film"), {
       timeout: 5000,
     });
+  });
+
+  it("still opens a list once the text in the box is actually changed", async () => {
+    // The regression guard on the suppression above: "suppress everything
+    // forever" would satisfy the no-unbidden-dropdown test, and would also
+    // silently turn suggestions off on this screen for anyone who searched once.
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl, { query: "kestrel 2010" });
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    // One new character is enough: the text no longer equals the latched string.
+    u.press("x");
+    await vi.waitFor(() => expect(u.frame()).toContain("Kestrel (2010) \u00b7 film"), {
+      timeout: 5000,
+    });
+  });
+
+  it("leaves the search box on a single escape when no list was ever opened", async () => {
+    // Half the point of suppressing the resynced text: escape escalates only
+    // when there is really something on screen to put away. Entering a box that
+    // shows a previous search must not cost two presses to leave.
+    const { impl } = suggestStub();
+    const u = await mountSuggest(impl, { query: "kestrel 2010" });
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press(KEY.esc);
+    await vi.waitFor(() => expect(editing(u)).toBe(false));
+  });
+});
+
+// The unbidden-dropdown fix can only be proved EXACTLY under fake time: on real
+// timers "no request fired" after a few awaits is unbounded, and therefore
+// vacuous. Scoped to this describe \u2014 the rest of the file polls with `vi.waitFor`
+// on real timers and a file-level install would change every test in it.
+describe("Results search suggestions on entering the box", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  // Lets ink's MessageChannel-scheduled render and the fetch promise chain drain
+  // without moving the clock.
+  const settleFrames = async (): Promise<void> => {
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+      await new Promise<void>((r) => yieldToLoop(() => r()));
+    }
+  };
+  const tick = async (ms: number): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(ms);
+    await settleFrames();
+  };
+
+  it("asks reccd nothing about text that was already in the box", async () => {
+    // Entering the box after a search resyncs the draft to the submitted query.
+    // That text is not a question the user just asked, so it must be suppressed
+    // as well as resynced \u2014 otherwise `/` pops a dropdown nobody opened.
+    const { impl, urls } = suggestStub();
+    searchState.current = settled(LIST);
+    ui = renderUI(
+      <StoreContext.Provider value={makeTestStore({ query: "kestrel 2010" })}>
+        <Results reccConfig={SUGGEST_CFG} fetchImpl={impl} />
+      </StoreContext.Provider>,
+    );
+    const u = ui;
+    await settleFrames();
+    u.press("/");
+    // A full second of fake time \u2014 four debounce windows \u2014 so nothing can still
+    // be pending. This is what makes the negative exact rather than hopeful.
+    await tick(1000);
+    expect(urls).toHaveLength(0);
+    expect(u.frame()).not.toContain("Kestrel (2010) \u00b7 film");
   });
 });

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -453,6 +453,17 @@ describe("Results grouping keeps the cursor put", () => {
 // exactly the escape hatch ForYou's tests use \u2014 so nothing here dials out.
 const SUGGEST_CFG = { reccUrl: "http://recc.invalid:4100", reccToken: "tok" };
 const KESTREL = { imdbId: "tt1", title: "Kestrel", year: 2010, type: "movie", matchedAka: null };
+// Enough hits to fill SUGGEST_ROWS_TERMINAL, for the height-budget test.
+const KEPLER = { imdbId: "tt2", title: "Kepler", year: 2019, type: "tv", matchedAka: null };
+const ASHFALL = { imdbId: "tt3", title: "Ashfall", year: 1999, type: "movie", matchedAka: null };
+const HARROWGATE = { imdbId: "tt4", title: "Harrowgate", year: 2021, type: "tv", matchedAka: null };
+const TIN_RIVERS = { imdbId: "tt5", title: "Tin Rivers", year: 2024, type: "movie", matchedAka: null };
+// The row budget App.tsx hands this view (it passes `listRows === bodyH`), stated
+// here rather than inherited from the harness default so the assertions below and
+// the store cannot drift apart. Roomy enough that `resultsPanelOuter`'s 5-row
+// floor is not what is being measured — on a terminal too short for both the
+// panel minimum and a full list, the floor wins and clipping is unavoidable.
+const TEST_LIST_ROWS = 24;
 
 // `fetchTitleSuggestions` validates EVERY element and fails the whole reply on
 // one bad one, which the hook renders as an empty list \u2014 so `matchedAka` is not
@@ -620,6 +631,53 @@ describe("Results search suggestions", () => {
     await vi.waitFor(() => expect(editing(u)).toBe(true));
     u.press(KEY.esc);
     await vi.waitFor(() => expect(editing(u)).toBe(false));
+  });
+
+  /**
+   * THE HEIGHT BUDGET, which had no coverage at all.
+   *
+   * App.tsx gives this view a `height={bodyH}` box with `overflow="hidden"`, and
+   * `listRows === bodyH`. `resultsPanelOuter` subtracts `searchH + 2` from that
+   * budget, and `searchH + 2` is exactly the SearchBar's rendered rows plus its
+   * one-row `marginTop` — so the column consumes precisely the budget with the
+   * deliberate one row of slack (see `resultsPanelOuter`'s own comment on issue
+   * #21) and nothing to spare. The suggestion rows sit ABOVE the results panel,
+   * so rows they add come out of the panel below them: Yoga shrinks it, or the
+   * parent's clip takes its bottom border off. Either way the results panel
+   * loses rows while a list is open and gets them back when it closes — jitter
+   * per keystroke, which the spec explicitly promises does not happen.
+   *
+   * Asserted against `listRows` from the store rather than a literal, and the
+   * closed-list height is asserted too, so this cannot pass by the view being
+   * uniformly short.
+   */
+  it("keeps the results panel inside the row budget while a list is open", async () => {
+    const { impl } = suggestStub([KESTREL, KEPLER, ASHFALL, HARROWGATE, TIN_RIVERS]);
+    const u = await mountSuggest(impl, { listRows: TEST_LIST_ROWS });
+    const height = (): number => u.frame().split("\n").length;
+    // Two: the search bar's and the results panel's. The results panel's is the
+    // LAST line of the view, so losing it to a clip or a shrink shows up here.
+    const bottomBorders = (): number => u.frame().split("\n").filter((l) => l.includes("╰")).length;
+    const endsWithPanelBottom = (): boolean => (u.frame().split("\n").at(-1) ?? "").includes("╰");
+
+    u.press("/");
+    await vi.waitFor(() => expect(editing(u)).toBe(true));
+    const closedHeight = height();
+    // The whole budget, exactly — this view has no slack in it to lend.
+    expect(closedHeight).toBe(TEST_LIST_ROWS);
+    expect(bottomBorders()).toBe(2);
+    expect(endsWithPanelBottom()).toBe(true);
+
+    u.press("ke");
+    await vi.waitFor(() => expect(u.frame()).toContain("Tin Rivers (2024) · film"), {
+      timeout: 5000,
+    });
+    // Five suggestion rows are on screen and the view is still inside its budget.
+    expect(u.frame()).toContain("Kestrel (2010) · film");
+    expect(height()).toBe(closedHeight);
+    // And the panel is intact rather than clipped out of its own bottom border.
+    expect(bottomBorders()).toBe(2);
+    expect(endsWithPanelBottom()).toBe(true);
   });
 });
 

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -545,13 +545,17 @@ describe("Results search suggestions", () => {
   });
 
   it("leaves the search box on tab when there is nothing to complete", async () => {
-    // reccd configured, but two characters never typed \u2014 so no list, and tab
-    // must behave exactly as it did before suggestions existed.
+    // reccd configured, and ONE character typed \u2014 below the two reccd will answer
+    // \u2014 so there is no list and tab must behave exactly as it did before
+    // suggestions existed. A character really is typed: with an empty box the
+    // emptiness of `urls` would follow from nothing having happened at all.
     const { impl, urls } = suggestStub();
     const u = await mountSuggest(impl);
 
     u.press("/");
     await vi.waitFor(() => expect(editing(u)).toBe(true));
+    u.press("k");
+    await vi.waitFor(() => expect(u.frame()).toContain("\u276f k"));
     u.press("\t");
     await vi.waitFor(() => expect(editing(u)).toBe(false));
     expect(urls).toHaveLength(0);

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -421,7 +421,18 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     if (byHash >= 0) setCursor(byHash);
   }, [rows]);
 
-  const searchH = 3;
+  // The SearchBar's own rows PLUS whatever suggestion rows it is currently
+  // emitting, because those sit above the results panel in the same column and
+  // the parent gives this view exactly `listRows` rows with overflow hidden. Left
+  // at a constant 3, an open list pushed the panel out by its own row count: Yoga
+  // shrank the panel or the clip took its bottom border, and it grew back when the
+  // list closed — jitter per keystroke.
+  //
+  // `resultsPanelOuter` floors the panel at 5 rows, so on a very short terminal a
+  // long list still cannot fit and the floor wins. That is the pre-existing
+  // minimum rather than something this adds, and shrinking a panel to nothing
+  // would be worse than clipping.
+  const searchH = 3 + suggest.items.length;
   const filterH = mode === "filter" || textFilter.trim() ? 1 : 0;
   const panelOuter = resultsPanelOuter(listRows, searchH + filterH);
   const listHeight = Math.max(3, panelOuter - 4);

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -347,13 +347,37 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     if (!focused) setMode("list");
   }, [focused]);
 
-  // Entering search mode remounts the TextField with `query` in it, so the draft
-  // has to be reset to match. Without this, leaving the box with text in it and
-  // arrowing back up into it would suggest against the abandoned text while the
-  // box shows something else.
-  useEffect(() => {
-    if (mode === "search") setDraft(query);
-  }, [mode, query]);
+  // EVERY path into search mode goes through here — there is no bare
+  // `setMode("search")` in this file, on purpose.
+  //
+  // Two things have to happen in the same batch as the mode change:
+  //
+  // 1. The draft is resynced, because entering search mode remounts the
+  //    TextField with `query` in it. Otherwise leaving the box with text in it
+  //    and arrowing back up into it would suggest against the abandoned text
+  //    while the box shows something else.
+  // 2. That same text is suppressed. Text already sitting in the box is not a
+  //    question the user just asked, so opening a list for it would pop an
+  //    unbidden dropdown on every `/` after a search — and then cost two escapes
+  //    to get back out of a box you never typed in. Typing anything new changes
+  //    the text, which clears the latch and suggests normally.
+  //
+  // `accept` here means "treat this text as already resolved", which is what the
+  // latch is for generally (`dismiss` is its other caller); it does not imply the
+  // user picked a suggestion.
+  //
+  // THIS CANNOT BE AN EFFECT, and that was measured rather than assumed. By the
+  // time an effect runs, the hook has already seen `enabled` flip true for a
+  // draft that equals `query` and has scheduled its debounced request; setting
+  // the latch afterwards changes none of that effect's dependencies, so nothing
+  // cancels the timeout and the reply still lands and still opens the list.
+  // Setting it here puts `suppressedText` in place during the very render in
+  // which `enabled` becomes true, which is the only point early enough.
+  const enterSearch = (): void => {
+    setDraft(query);
+    suggest.accept(query);
+    setMode("search");
+  };
 
   // The rows on screen: group headings and releases, in order. The SAME
   // groupRowPlan the browser's list renders — "which rows are there" is one
@@ -520,12 +544,12 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
   useInput(
     (input, key) => {
       if (input === "/") {
-        setMode("search");
+        enterSearch();
         return;
       }
       if (key.upArrow || input === "k") {
         if (rows.length > 0 && clamped > 0) moveTo(clamped - 1);
-        else setMode("search");
+        else enterSearch();
         return;
       }
       if (input === "g") {

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -9,6 +9,7 @@ import { Rule } from "./Rule";
 import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
 import { useTitlePreview } from "../hooks/useTitlePreview";
 import { useTitleSuggest } from "../hooks/useTitleSuggest";
+import { shouldSuggestFor } from "../../util/titleSuggest";
 import { PreviewPane } from "./PreviewPane";
 import { parseRelease, hintForSection } from "../../util/release";
 // The same badges the browser's rows show, from the same table the quality
@@ -286,7 +287,11 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
   const suggest = useTitleSuggest({
     reccConfig,
     query: draft,
-    enabled: mode === "search",
+    // Editing, AND the text has actually moved on from the last submitted search.
+    // The second half is what stops `/` popping a list over the search you are
+    // already looking at — see `shouldSuggestFor` for why it is derived here
+    // rather than latched when the box is entered.
+    enabled: mode === "search" && shouldSuggestFor(draft, query),
     fetchImpl,
   });
   const [cursor, setCursor] = useState(0);
@@ -347,35 +352,18 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     if (!focused) setMode("list");
   }, [focused]);
 
-  // EVERY path into search mode goes through here — there is no bare
-  // `setMode("search")` in this file, on purpose.
+  // Entering search mode remounts the TextField with `query` in it, so the draft
+  // is resynced to match. Otherwise leaving the box with text in it and arrowing
+  // back up into it would suggest against the abandoned text while the box shows
+  // something else.
   //
-  // Two things have to happen in the same batch as the mode change:
-  //
-  // 1. The draft is resynced, because entering search mode remounts the
-  //    TextField with `query` in it. Otherwise leaving the box with text in it
-  //    and arrowing back up into it would suggest against the abandoned text
-  //    while the box shows something else.
-  // 2. That same text is suppressed. Text already sitting in the box is not a
-  //    question the user just asked, so opening a list for it would pop an
-  //    unbidden dropdown on every `/` after a search — and then cost two escapes
-  //    to get back out of a box you never typed in. Typing anything new changes
-  //    the text, which clears the latch and suggests normally.
-  //
-  // `accept` here means "treat this text as already resolved", which is what the
-  // latch is for generally (`dismiss` is its other caller); it does not imply the
-  // user picked a suggestion.
-  //
-  // THIS CANNOT BE AN EFFECT, and that was measured rather than assumed. By the
-  // time an effect runs, the hook has already seen `enabled` flip true for a
-  // draft that equals `query` and has scheduled its debounced request; setting
-  // the latch afterwards changes none of that effect's dependencies, so nothing
-  // cancels the timeout and the reply still lands and still opens the list.
-  // Setting it here puts `suppressedText` in place during the very render in
-  // which `enabled` becomes true, which is the only point early enough.
+  // This is about draft CORRECTNESS only. It is deliberately not what stops a
+  // list opening over text the user did not just type — that is
+  // `shouldSuggestFor` in the `enabled` argument above, which is re-derived every
+  // render and so cannot be defeated by a path into search mode that forgets to
+  // call this.
   const enterSearch = (): void => {
     setDraft(query);
-    suggest.accept(query);
     setMode("search");
   };
 

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -8,6 +8,7 @@ import { Panel } from "./Panel";
 import { Rule } from "./Rule";
 import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
 import { useTitlePreview } from "../hooks/useTitlePreview";
+import { useTitleSuggest } from "../hooks/useTitleSuggest";
 import { PreviewPane } from "./PreviewPane";
 import { parseRelease, hintForSection } from "../../util/release";
 // The same badges the browser's rows show, from the same table the quality
@@ -26,6 +27,8 @@ import { COLOR, GUTTER, ICON, PAUSED, sourceStyle } from "../theme";
 import { downloadStateFor, type DownloadState } from "../downloadState";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
+import type { FetchImpl } from "../../util/net";
+import type { ReccClientConfig } from "../../recc/client";
 
 type Mode = "list" | "search" | "detail" | "filter";
 
@@ -199,7 +202,18 @@ function Detail({
   );
 }
 
-export function Results() {
+interface ResultsProps {
+  /**
+   * reccd's address, for title suggestions in the search box. A prop rather than
+   * a `Store` field for the reason `ForYou`'s is: a `Store` field needs matching
+   * entries in `makeStore` and `makeTestStore`, and no other pane reads this.
+   */
+  reccConfig: ReccClientConfig;
+  /** Only ever set by tests, so they never dial out. Same as `ForYou`'s. */
+  fetchImpl?: FetchImpl;
+}
+
+export function Results({ reccConfig, fetchImpl }: ResultsProps) {
   const {
     query,
     submitQuery,
@@ -265,6 +279,16 @@ export function Results() {
 
   const focused = region === "content" && isCategory(section);
   const [mode, setMode] = useState<Mode>("list");
+  // The live draft in the search box, which is what suggestions are for —
+  // `query` is the last SUBMITTED search, and suggesting against that would lag
+  // a whole search behind.
+  const [draft, setDraft] = useState(query);
+  const suggest = useTitleSuggest({
+    reccConfig,
+    query: draft,
+    enabled: mode === "search",
+    fetchImpl,
+  });
   const [cursor, setCursor] = useState(0);
   // Many releases of one title collapse to one row. ON by default, matching the
   // browser's checkbox: a browse routinely returns four uploads of every film.
@@ -322,6 +346,14 @@ export function Results() {
   useEffect(() => {
     if (!focused) setMode("list");
   }, [focused]);
+
+  // Entering search mode remounts the TextField with `query` in it, so the draft
+  // has to be reset to match. Without this, leaving the box with text in it and
+  // arrowing back up into it would suggest against the abandoned text while the
+  // box shows something else.
+  useEffect(() => {
+    if (mode === "search") setDraft(query);
+  }, [mode, query]);
 
   // The rows on screen: group headings and releases, in order. The SAME
   // groupRowPlan the browser's list renders — "which rows are there" is one
@@ -582,7 +614,15 @@ export function Results() {
 
   useInput(
     (_input, key) => {
-      if (key.escape) setMode("list");
+      if (!key.escape) return;
+      // Escape escalates: the first one puts the suggestion list away, the
+      // second leaves the box. Doing both at once would make dismissing a list
+      // cost you your place in the pane.
+      if (mode === "search" && suggest.open) {
+        suggest.dismiss();
+        return;
+      }
+      setMode("list");
     },
     { isActive: focused && (mode === "search" || mode === "filter") },
   );
@@ -711,6 +751,13 @@ export function Results() {
         editing={mode === "search"}
         placeholder={PLACEHOLDER}
         history={searchHistory}
+        suggestions={suggest.items}
+        completion={suggest.completion}
+        onChange={setDraft}
+        onComplete={(text) => {
+          setDraft(text);
+          suggest.accept(text);
+        }}
         onSubmit={onSubmit}
         onExitDown={() => setMode("list")}
         onExitLeft={() => setRegion("sidebar")}

--- a/src/ui/components/SearchBar.test.tsx
+++ b/src/ui/components/SearchBar.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { SearchBar } from "./SearchBar";
+import type { TitleSuggestion } from "../../util/titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001", title: "Kestrel", year: 2010, type: "movie", matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002", title: "Kepler", year: 2019, type: "tv", matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003", title: "Ashfall", year: 1999, type: "movie", matchedAka: "Ashfall Rising",
+};
+
+describe("SearchBar suggestions", () => {
+  it("shows nothing extra when there are no suggestions", () => {
+    const { lastFrame } = render(
+      <SearchBar width={60} value="kes" editing onSubmit={() => {}} />,
+    );
+    expect(lastFrame()).not.toContain("Kestrel");
+  });
+
+  it("lists each suggestion with its year and kind", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing
+        suggestions={[KESTREL, KEPLER]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Kestrel (2010) · film");
+    expect(frame).toContain("Kepler (2019) · show");
+  });
+
+  it("shows the aka note on a hit that matched an alternate title", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ashfall ris"
+        editing
+        suggestions={[ASHFALL_AKA]}
+        completion="Ashfall 1999"
+        onSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("Ashfall Rising");
+  });
+
+  // Suggestions belong to the box you are typing in. Leaving them under a
+  // collapsed bar would leave a stale list on screen with nothing editing it.
+  it("shows no suggestions when the bar is not being edited", () => {
+    const { lastFrame } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing={false}
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    expect(lastFrame() ?? "").not.toContain("Kestrel (2010)");
+  });
+
+  /**
+   * TAB COMPLETES ONLY WHEN THERE IS SOMETHING TO COMPLETE. The rest of the
+   * time it must still leave the field — that is what it has always done
+   * (TextField's onExitDown), and both the results pane and the splash depend
+   * on it.
+   */
+  it("completes to the top suggestion on tab", async () => {
+    const onComplete = vi.fn();
+    const onExitDown = vi.fn();
+    const { stdin } = render(
+      <SearchBar
+        width={60}
+        value="ke"
+        editing
+        suggestions={[KESTREL, KEPLER]}
+        completion="Kestrel 2010"
+        onComplete={onComplete}
+        onExitDown={onExitDown}
+        onSubmit={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\t");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onComplete).toHaveBeenCalledWith("Kestrel 2010");
+    expect(onExitDown).not.toHaveBeenCalled();
+  });
+
+  it("still leaves the field on tab with no completion available", async () => {
+    const onComplete = vi.fn();
+    const onExitDown = vi.fn();
+    const { stdin } = render(
+      <SearchBar width={60} value="ke" editing onComplete={onComplete} onExitDown={onExitDown} onSubmit={() => {}} />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\t");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onExitDown).toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  // The arrows are search history's and stay that way — a suggestion list is
+  // not worth taking a working binding away from.
+  it("leaves the up arrow to search history even with a list open", async () => {
+    const { stdin, lastFrame } = render(
+      <SearchBar
+        width={60}
+        value=""
+        editing
+        history={["Tin Rivers 2024"]}
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\u001B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("Tin Rivers 2024");
+  });
+});

--- a/src/ui/components/SearchBar.test.tsx
+++ b/src/ui/components/SearchBar.test.tsx
@@ -14,11 +14,28 @@ const ASHFALL_AKA: TitleSuggestion = {
 };
 
 describe("SearchBar suggestions", () => {
-  it("shows nothing extra when there are no suggestions", () => {
-    const { lastFrame } = render(
-      <SearchBar width={60} value="kes" editing onSubmit={() => {}} />,
+  // AN EMPTY LIST COSTS NO ROWS — the spec's promise that the layout does not
+  // move as replies arrive, and the reason the results view can budget for the
+  // bar plus exactly the rows it is showing. Asserted as a row COUNT against the
+  // one-suggestion case: the previous version asserted the frame did not contain
+  // "Kestrel" on a render that was passed no suggestions at all, so nothing could
+  // have put the string there and no bug could have failed it.
+  const rowCount = (frame: string | undefined): number => (frame ?? "").split("\n").length;
+
+  it("costs no extra rows when there are no suggestions", () => {
+    const empty = render(<SearchBar width={60} value="kes" editing suggestions={[]} onSubmit={() => {}} />);
+    const one = render(
+      <SearchBar
+        width={60}
+        value="kes"
+        editing
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
     );
-    expect(lastFrame()).not.toContain("Kestrel");
+    expect(rowCount(one.lastFrame())).toBe(rowCount(empty.lastFrame()) + 1);
+    expect(empty.lastFrame()).not.toContain("·");
   });
 
   it("lists each suggestion with its year and kind", () => {
@@ -123,6 +140,42 @@ describe("SearchBar suggestions", () => {
       />,
     );
     await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\u001B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("Tin Rivers 2024");
+  });
+  /**
+   * Completing mid-recall must end the recall. `recall()` deliberately leaves
+   * history-navigation state alone - that is what the arrows walk through with -
+   * so completing through it left `histIndex` pointing at an entry no longer in
+   * the field, and the next arrow press then moved relative to that stale index
+   * instead of starting again from the completed text.
+   *
+   * With a one-entry history the symptom is that the arrow does nothing at all,
+   * because the stale index is already the end of the list.
+   */
+  it("restarts history navigation after a tab completion", async () => {
+    const { stdin, lastFrame } = render(
+      <SearchBar
+        width={60}
+        value=""
+        editing
+        history={["Tin Rivers 2024"]}
+        suggestions={[KESTREL]}
+        completion="Kestrel 2010"
+        onSubmit={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    stdin.write("\u001B[A");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("Tin Rivers 2024");
+
+    stdin.write("\t");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lastFrame() ?? "").toContain("Kestrel 2010");
+
+    // The completion is a fresh draft, so up recalls the history entry again.
     stdin.write("\u001B[A");
     await new Promise((r) => setTimeout(r, 10));
     expect(lastFrame() ?? "").toContain("Tin Rivers 2024");

--- a/src/ui/components/SearchBar.test.tsx
+++ b/src/ui/components/SearchBar.test.tsx
@@ -35,7 +35,6 @@ describe("SearchBar suggestions", () => {
       />,
     );
     expect(rowCount(one.lastFrame())).toBe(rowCount(empty.lastFrame()) + 1);
-    expect(empty.lastFrame()).not.toContain("·");
   });
 
   it("lists each suggestion with its year and kind", () => {

--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "ink";
 import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { COLOR, ICON } from "../theme";
+import { akaNote, suggestionLabel, type TitleSuggestion } from "../../util/titleSuggest";
 
 interface SearchBarProps {
   width: number;
@@ -9,6 +10,15 @@ interface SearchBarProps {
   placeholder?: string;
   editing: boolean;
   history?: string[];
+  /**
+   * Title suggestions from reccd, already capped by the caller. Rendered only
+   * while editing — a list under a collapsed bar is a stale artefact with
+   * nothing editing it.
+   */
+  suggestions?: TitleSuggestion[];
+  /** What tab completes to, or null. */
+  completion?: string | null;
+  onComplete?: (text: string) => void;
   onSubmit: (value: string) => void;
   onChange?: (value: string) => void;
   onExitDown?: () => void;
@@ -21,34 +31,57 @@ export function SearchBar({
   placeholder = "Search torrents…",
   editing,
   history,
+  suggestions,
+  completion = null,
+  onComplete,
   onSubmit,
   onChange,
   onExitDown,
   onExitLeft,
 }: SearchBarProps) {
+  const rows = editing ? (suggestions ?? []) : [];
   return (
-    <Panel title="search" width={width} focused={editing} height={2}>
-      <Box>
-        <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
-        <Box flexGrow={1} minWidth={0}>
-          {editing ? (
-            <TextField
-              defaultValue={value}
-              placeholder={placeholder}
-              history={history}
-              width={Math.max(1, width - 6)}
-              onSubmit={onSubmit}
-              onChange={onChange}
-              onExitDown={onExitDown}
-              onExitLeft={onExitLeft}
-            />
-          ) : value ? (
-            <Text wrap="truncate-end">{value}</Text>
-          ) : (
-            <Text dimColor>{placeholder}</Text>
-          )}
+    <Box flexDirection="column">
+      <Panel title="search" width={width} focused={editing} height={2}>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            {editing ? (
+              <TextField
+                defaultValue={value}
+                placeholder={placeholder}
+                history={history}
+                completion={completion}
+                onComplete={onComplete}
+                width={Math.max(1, width - 6)}
+                onSubmit={onSubmit}
+                onChange={onChange}
+                onExitDown={onExitDown}
+                onExitLeft={onExitLeft}
+              />
+            ) : value ? (
+              <Text wrap="truncate-end">{value}</Text>
+            ) : (
+              <Text dimColor>{placeholder}</Text>
+            )}
+          </Box>
         </Box>
-      </Box>
-    </Panel>
+      </Panel>
+      {/* Rendered only when there is something to show, so an empty list costs
+          no vertical space and the layout does not jitter as replies arrive. */}
+      {rows.map((hit, i) => {
+        const aka = akaNote(hit);
+        return (
+          <Box key={hit.imdbId} paddingLeft={2}>
+            <Text dimColor wrap="truncate-end">
+              {suggestionLabel(hit)}
+              {aka ? ` · ${aka}` : ""}
+              {/* The top row is what tab takes, so it says so. */}
+              {i === 0 && completion !== null ? "   ⇥" : ""}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
   );
 }

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -156,6 +156,13 @@ export function TextField({
         // input handlers matters.
         if (completion !== null) {
           recall(completion);
+          // Completing is a new draft, not a step through history: without this,
+          // tab-completing partway through a recall left history navigation live
+          // against the index of the entry that is no longer in the field, so the
+          // next up/down jumped somewhere the user had not been. `recall` on its
+          // own deliberately preserves that state — it exists for the arrows.
+          setHistIndex(-1);
+          setDraft(completion);
           onComplete?.(completion);
           return;
         }

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -12,6 +12,14 @@ export interface TextFieldProps {
   // Previously-run values (most-recent first). When present, the up arrow
   // recalls them and the down arrow walks back toward the live draft.
   history?: string[];
+  /**
+   * What tab should complete the field to, or null for "nothing to complete".
+   * When set, tab completes instead of calling `onExitDown` — see the tab arm
+   * in `useInput` for why that swap is safe.
+   */
+  completion?: string | null;
+  /** Called after tab completed the field, with the text written into it. */
+  onComplete?: (text: string) => void;
   width?: number;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
@@ -84,6 +92,8 @@ export function TextField({
   placeholder = "",
   mask = false,
   history,
+  completion = null,
+  onComplete,
   width,
   onChange,
   onSubmit,
@@ -139,6 +149,16 @@ export function TextField({
         return;
       }
       if (key.tab) {
+        // Completion wins over leaving the field, but ONLY when there is
+        // something to complete: the rest of the time tab still exits, which is
+        // what the results pane and the splash both rely on. Both callers read
+        // the same `completion` value this does, so no ordering between Ink's
+        // input handlers matters.
+        if (completion !== null) {
+          recall(completion);
+          onComplete?.(completion);
+          return;
+        }
         onExitDown?.();
         return;
       }

--- a/src/ui/hooks/useTitleSuggest.ts
+++ b/src/ui/hooks/useTitleSuggest.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FetchImpl } from "../../util/net";
+import { fetchTitleSuggestions, type ReccClientConfig } from "../../recc/client";
+import {
+  applyReply,
+  emptySuggestState,
+  shouldQueryFor,
+  submitTextFor,
+  suppressFor,
+  topSuggestion,
+  SUGGEST_DEBOUNCE_MS,
+  SUGGEST_ROWS_TERMINAL,
+  type SuggestState,
+  type TitleSuggestion,
+} from "../../util/titleSuggest";
+
+export interface TitleSuggest {
+  /** Already capped at SUGGEST_ROWS_TERMINAL. */
+  items: TitleSuggestion[];
+  open: boolean;
+  /** What tab completes to, or null when there is nothing to complete. */
+  completion: string | null;
+  /** Escape: close the list, and do not reopen it for the current text. */
+  dismiss: () => void;
+  /** Tab completed the field — stop asking about the text now in it. */
+  accept: (text: string) => void;
+}
+
+interface Args {
+  reccConfig: ReccClientConfig;
+  /** The live draft in the field, not the submitted query. */
+  query: string;
+  /** False on a pane that is not being edited, so nothing fires off screen. */
+  enabled: boolean;
+  fetchImpl?: FetchImpl;
+  debounceMs?: number;
+}
+
+/**
+ * Title suggestions from reccd for the terminal's search box, debounced.
+ *
+ * Modelled on `useTitlePreview`, with one deliberate difference: no cache. That
+ * hook caches by a stable selection key because scrolling revisits the same
+ * rows; here every keystroke is a different query, so a cache would only grow.
+ *
+ * State lives here and NOT in `Store`: a `Store` field needs matching entries
+ * in `makeStore` (scripts/render-previews-impl.tsx) and `makeTestStore`
+ * (src/ui/testHarness.ts) or `npm run previews` and `npm run typecheck` break
+ * respectively — the right price for state other panes read, and no other pane
+ * reads this.
+ */
+export function useTitleSuggest(args: Args): TitleSuggest {
+  const { reccConfig, query, enabled, fetchImpl, debounceMs = SUGGEST_DEBOUNCE_MS } = args;
+  const [state, setState] = useState<SuggestState>(emptySuggestState);
+  // `reccConfig` is rebuilt each render by resolveReccConfig, so a fresh object
+  // every time; this pins one down that only changes when its fields do, which
+  // is what lets the effect below depend on the whole config object correctly
+  // (satisfying exhaustive-deps) without re-firing every render. This literal
+  // must track every field of `ReccClientConfig` — a field added there and not
+  // here is dropped silently, since both fields are optional and TypeScript
+  // will not flag the omission.
+  const { reccUrl, reccToken } = reccConfig;
+  const stableConfig = useMemo(() => ({ reccUrl, reccToken }), [reccUrl, reccToken]);
+  // Monotonic, and the reason a slow reply cannot overwrite a fast one. reccd
+  // answers a 2-char query in ~311ms and an 8-char one in ~71ms, so
+  // out-of-order arrival is the normal case. A ref, not state: bumping it must
+  // not itself cause a render.
+  const seq = useRef(0);
+  // The effect keys on `query`, but must read the *current* suppression latch
+  // without listing `state` as a dependency — which would re-run it on every
+  // reply and re-fire the request that produced it.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (!enabled || !stableConfig.reccUrl) return;
+    if (!shouldQueryFor(stateRef.current, query)) {
+      // Clear anything on screen for a query too short to ask about, so
+      // backspacing out of a search does not leave stale rows behind.
+      const s = ++seq.current;
+      setState((prev) => applyReply(prev, s, []));
+      return;
+    }
+    let cancelled = false;
+    const s = ++seq.current;
+    const t = setTimeout(() => {
+      void fetchTitleSuggestions(stableConfig, { q: query }, { fetchImpl }).then((res) => {
+        if (cancelled) return;
+        // Every failure renders as no suggestions. This fires per keystroke, so
+        // surfacing the reason would mean an error line per character — and the
+        // Accounts pane is where a reccd problem belongs.
+        setState((prev) => applyReply(prev, s, res.ok ? res.items : []));
+      });
+    }, debounceMs);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [enabled, stableConfig, query, fetchImpl, debounceMs]);
+
+  const dismiss = useCallback(() => {
+    setState((prev) => suppressFor(prev, query));
+  }, [query]);
+
+  const accept = useCallback((text: string) => {
+    setState((prev) => suppressFor(prev, text));
+  }, []);
+
+  // Capped here rather than in the fetch: reccd is asked for SUGGEST_LIMIT so
+  // both surfaces send it the same question, and the terminal renders fewer.
+  const items = enabled ? state.items.slice(0, SUGGEST_ROWS_TERMINAL) : [];
+  const top = topSuggestion({ ...state, items });
+  return {
+    items,
+    open: items.length > 0,
+    completion: top ? submitTextFor(top) : null,
+    dismiss,
+    accept,
+  };
+}

--- a/src/ui/hooks/useTitleSuggest.ts
+++ b/src/ui/hooks/useTitleSuggest.ts
@@ -4,6 +4,7 @@ import { fetchTitleSuggestions, type ReccClientConfig } from "../../recc/client"
 import {
   applyReply,
   emptySuggestState,
+  isSuggestOpen,
   shouldQueryFor,
   submitTextFor,
   suppressFor,
@@ -98,21 +99,30 @@ export function useTitleSuggest(args: Args): TitleSuggest {
     };
   }, [enabled, stableConfig, query, fetchImpl, debounceMs]);
 
+  // `seq.current` and not `prev.appliedSeq`: a request fired for the keystroke
+  // before this dismiss is still in flight with a HIGHER number than anything
+  // applied, and passing the applied one would let its reply reopen the list the
+  // user just closed. Escape changes no effect dependency, so the effect's
+  // `cancelled` flag never fires — this is the only guard on that path.
   const dismiss = useCallback(() => {
-    setState((prev) => suppressFor(prev, query));
+    setState((prev) => suppressFor(prev, query, seq.current));
   }, [query]);
 
   const accept = useCallback((text: string) => {
-    setState((prev) => suppressFor(prev, text));
+    setState((prev) => suppressFor(prev, text, seq.current));
   }, []);
 
   // Capped here rather than in the fetch: reccd is asked for SUGGEST_LIMIT so
   // both surfaces send it the same question, and the terminal renders fewer.
-  const items = enabled ? state.items.slice(0, SUGGEST_ROWS_TERMINAL) : [];
-  const top = topSuggestion({ ...state, items });
+  const capped: SuggestState = {
+    ...state,
+    items: enabled ? state.items.slice(0, SUGGEST_ROWS_TERMINAL) : [],
+  };
+  const items = capped.items;
+  const top = topSuggestion(capped);
   return {
     items,
-    open: items.length > 0,
+    open: isSuggestOpen(capped),
     completion: top ? submitTextFor(top) : null,
     dismiss,
     accept,

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -47,6 +47,11 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "/", label: "Edit search" },
       { keys: "↵", label: "Run search" },
       { keys: "↑", label: "Recall recent searches (while editing)" },
+      { keys: "⇥", label: "Complete to the top title suggestion (needs reccd)" },
+      {
+        keys: "esc",
+        label: "Dismiss title suggestions, then leave the box (one press, as always, when none are open)",
+      },
       { keys: "i", label: "Open on IMDb (exact match, or a title search)" },
       { keys: "f", label: "Filter list" },
       { keys: "p", label: "Toggle poster / plot preview (needs OMDb key)" },

--- a/src/ui/views/Splash.test.tsx
+++ b/src/ui/views/Splash.test.tsx
@@ -154,14 +154,17 @@ describe("Splash search suggestions", () => {
   it("still quits on escape with reccd configured and no list open", async () => {
     // Distinct from the plain "quits on escape" above: here the guard exists and
     // is asked about, but nothing has been typed so there is nothing to dismiss.
-    const { impl, urls } = suggestStub();
+    const { impl } = suggestStub();
     const quitAll = vi.fn();
     const { stdin } = renderSplash({ quitAll }, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
     await flush();
     stdin.write(ESC);
     await flush();
     expect(quitAll).toHaveBeenCalledTimes(1);
-    expect(urls).toHaveLength(0);
+    // No assertion on `urls` here: nothing was typed, so an empty list of
+    // requests is not a property any change to this code could break. The
+    // request-side negatives live in the fake-timer describe below, where the
+    // clock can be run past the debounce to make them exact.
   });
 
   it("completes on tab with a suggestion available, instead of entering the app", async () => {
@@ -271,10 +274,14 @@ describe("Splash suggestion requests", () => {
       await tick(40); // seven keystrokes, all inside one debounce window
     }
     await tick(1000);
-    // Strictly fewer requests than keystrokes, and the one that fired asks about
-    // the text finally in the box — not an intermediate prefix.
-    expect(urls.length).toBeLessThan(7);
+    // Exactly one request for the text finally in the box, not an intermediate
+    // prefix. (A `toBeLessThan(7)` used to sit above this: it passed at zero
+    // calls and said nothing that toHaveLength(1) does not say exactly.)
     expect(urls).toHaveLength(1);
-    expect(urls[0]).toContain("q=kestrel");
+    // Anchored on the trailing separator: "q=kestrel" alone is also satisfied by
+    // "q=kestrelXYZ", and both stubs in this file ignore the URL and always
+    // answer [KESTREL] — so this assertion is the only thing pinning what was
+    // actually asked.
+    expect(urls[0]).toContain("q=kestrel&");
   });
 });

--- a/src/ui/views/Splash.test.tsx
+++ b/src/ui/views/Splash.test.tsx
@@ -1,11 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { render } from "ink-testing-library";
 import { StoreContext, type Store } from "../store";
 import { Splash } from "./Splash";
+import type { FetchImpl } from "../../util/net";
+import type { ReccClientConfig } from "../../recc/client";
 
 const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
 const TAB = "\t";
 const ESC = String.fromCharCode(27);
+
+// Captured BEFORE any fake timers are installed further down this file:
+// `setImmediate` is faked too, and ink's React scheduler drains its work
+// through a MessageChannel message — a macrotask — so awaiting fake timers
+// alone never repaints the frame. Same reasoning as ForYou.test.tsx.
+const yieldToLoop = setImmediate;
 
 function storeStub(overrides: Partial<Store> = {}): Store {
   return {
@@ -23,10 +31,12 @@ function storeStub(overrides: Partial<Store> = {}): Store {
   } as unknown as Store;
 }
 
-function renderSplash(overrides: Partial<Store> = {}) {
+type SplashProps = { reccConfig?: ReccClientConfig; fetchImpl?: FetchImpl };
+
+function renderSplash(overrides: Partial<Store> = {}, props: SplashProps = {}) {
   return render(
     <StoreContext.Provider value={storeStub(overrides)}>
-      <Splash />
+      <Splash reccConfig={props.reccConfig ?? {}} fetchImpl={props.fetchImpl} />
     </StoreContext.Provider>,
   );
 }
@@ -97,5 +107,174 @@ describe("Splash", () => {
     await flush();
     expect(lastFrame()).not.toContain("stale-torbox-user");
     expect(lastFrame()).toContain("connected");
+  });
+});
+
+// reccd's replies are injected through the `fetchImpl` prop — the same escape
+// hatch ForYou uses — so nothing here dials out.
+const SUGGEST_CFG: ReccClientConfig = { reccUrl: "http://recc.invalid:4100", reccToken: "tok" };
+const KESTREL = { imdbId: "tt1", title: "Kestrel", year: 2010, type: "movie", matchedAka: null };
+
+// `fetchTitleSuggestions` validates EVERY element and fails the whole reply on
+// one bad one, which the hook then renders as an empty list — so `matchedAka` is
+// not decoration here, it is what makes the stub a valid reply.
+function suggestStub(items: unknown[] = [KESTREL]): { impl: FetchImpl; urls: string[] } {
+  const urls: string[] = [];
+  const impl = (async (url: string) => {
+    urls.push(String(url));
+    return { ok: true, status: 200, json: async () => items } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, urls };
+}
+
+describe("Splash search suggestions", () => {
+  // Escape escalates rather than quitting outright: putting a dropdown away must
+  // not be able to close the app, and escape-to-quit must survive the guard.
+  it("dismisses the suggestion list on escape rather than quitting", async () => {
+    const { impl } = suggestStub();
+    const quitAll = vi.fn();
+    const { stdin, lastFrame } = renderSplash({ quitAll }, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
+    await flush();
+    stdin.write("ke");
+    // Polls the keystroke -> debounce -> reply -> repaint chain out rather than
+    // sleeping a fixed span past it, which loses the race on a loaded machine.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("Kestrel (2010) · film"), {
+      timeout: 5000,
+    });
+
+    stdin.write(ESC);
+    await vi.waitFor(() => expect(lastFrame() ?? "").not.toContain("Kestrel (2010)"));
+    expect(quitAll).not.toHaveBeenCalled();
+
+    // The second escape, with the list gone, still quits.
+    stdin.write(ESC);
+    await vi.waitFor(() => expect(quitAll).toHaveBeenCalledTimes(1));
+  });
+
+  it("still quits on escape with reccd configured and no list open", async () => {
+    // Distinct from the plain "quits on escape" above: here the guard exists and
+    // is asked about, but nothing has been typed so there is nothing to dismiss.
+    const { impl, urls } = suggestStub();
+    const quitAll = vi.fn();
+    const { stdin } = renderSplash({ quitAll }, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
+    await flush();
+    stdin.write(ESC);
+    await flush();
+    expect(quitAll).toHaveBeenCalledTimes(1);
+    expect(urls).toHaveLength(0);
+  });
+
+  it("completes on tab with a suggestion available, instead of entering the app", async () => {
+    const { impl } = suggestStub();
+    const setView = vi.fn();
+    const setRegion = vi.fn();
+    const { stdin, lastFrame } = renderSplash(
+      { setView, setRegion },
+      { reccConfig: SUGGEST_CFG, fetchImpl: impl },
+    );
+    await flush();
+    stdin.write("ke");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("Kestrel (2010) · film"), {
+      timeout: 5000,
+    });
+
+    stdin.write(TAB);
+    // Title AND year — the whole point of canonicalising through a catalog.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("Kestrel 2010"));
+    expect(setView).not.toHaveBeenCalled();
+    expect(setRegion).not.toHaveBeenCalled();
+    // Accepting suppresses the text just taken, so the list does not reopen on it.
+    await vi.waitFor(() => expect(lastFrame() ?? "").not.toContain("Kestrel (2010) · film"));
+  });
+
+  it("still enters the app on tab with no suggestions", async () => {
+    // reccd configured, but nothing typed — tab behaves exactly as it did
+    // before suggestions existed.
+    const { impl } = suggestStub();
+    const setView = vi.fn();
+    const setRegion = vi.fn();
+    const { stdin } = renderSplash(
+      { setView, setRegion },
+      { reccConfig: SUGGEST_CFG, fetchImpl: impl },
+    );
+    await flush();
+    stdin.write(TAB);
+    await flush();
+    expect(setView).toHaveBeenCalledWith("browser");
+    expect(setRegion).toHaveBeenCalledWith("sidebar");
+  });
+
+  it("relabels the tab hint from browse to complete while a list is open", async () => {
+    const { impl } = suggestStub();
+    const { stdin, lastFrame } = renderSplash({}, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
+    await flush();
+    expect(lastFrame() ?? "").toContain("browse");
+    stdin.write("ke");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("complete"), { timeout: 5000 });
+    expect(lastFrame() ?? "").not.toContain("browse");
+  });
+});
+
+// The debounce and the `enabled` gate can only be proved EXACTLY under fake
+// time: on real timers "no request fired" after a few awaits is unbounded and
+// therefore vacuous. Fake timers stay scoped to this describe — the rest of the
+// file's `flush` is a real 20ms sleep and would never resolve under them.
+describe("Splash suggestion requests", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  // Let ink's MessageChannel-scheduled render and the fetch promise chain drain
+  // without moving the clock.
+  const settle = async (): Promise<void> => {
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve();
+      await new Promise<void>((r) => yieldToLoop(() => r()));
+    }
+  };
+  const tick = async (ms: number): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(ms);
+    await settle();
+  };
+
+  it("fires nothing at all while reccd is unconfigured", async () => {
+    const { impl, urls } = suggestStub();
+    // No reccUrl. Run the clock a full second past the 250ms debounce, so
+    // nothing can still be pending — this is what makes the negative exact.
+    const { stdin } = renderSplash({}, { reccConfig: {}, fetchImpl: impl });
+    await settle();
+    stdin.write("kestrel");
+    await tick(1000);
+    expect(urls).toHaveLength(0);
+  });
+
+  it("waits out the debounce before asking reccd anything", async () => {
+    const { impl, urls } = suggestStub();
+    const { stdin } = renderSplash({}, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
+    await settle();
+    stdin.write("ke");
+    await tick(200); // inside the 250ms window
+    expect(urls).toHaveLength(0);
+    await tick(100); // past it
+    expect(urls).toHaveLength(1);
+  });
+
+  it("collapses a burst of keystrokes into one request for the final text", async () => {
+    const { impl, urls } = suggestStub();
+    const { stdin } = renderSplash({}, { reccConfig: SUGGEST_CFG, fetchImpl: impl });
+    await settle();
+    for (const ch of "kestrel") {
+      stdin.write(ch);
+      await tick(40); // seven keystrokes, all inside one debounce window
+    }
+    await tick(1000);
+    // Strictly fewer requests than keystrokes, and the one that fired asks about
+    // the text finally in the box — not an intermediate prefix.
+    expect(urls.length).toBeLessThan(7);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain("q=kestrel");
   });
 });

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Box, Text, useInput, useStdin } from "ink";
 import { Logo } from "../components/Logo";
 import { UpdateBanner } from "../components/UpdateBanner";
@@ -7,7 +8,11 @@ import { useStore } from "../store";
 import { sourcesByGroup } from "../../sources/registry";
 import { withoutToken } from "../../web/links";
 import { getDebridProvider } from "../../integrations/debrid";
+import { useTitleSuggest } from "../hooks/useTitleSuggest";
+import { tabHintLabel } from "../../util/titleSuggest";
 import { COLOR, ICON } from "../theme";
+import type { FetchImpl } from "../../util/net";
+import type { ReccClientConfig } from "../../recc/client";
 
 const categoryLine = (adultEnabled: boolean): string =>
   sourcesByGroup(adultEnabled)
@@ -26,11 +31,22 @@ export function Splash({
   updateVersion,
   recovered,
   webStatus,
+  reccConfig,
+  fetchImpl,
 }: {
   updateVersion?: string | null;
   recovered?: boolean;
   webStatus?: SplashWebStatus | null;
-} = {}) {
+  /**
+   * reccd's address, for title suggestions under the search box. A prop rather
+   * than a `Store` field for the reason `ForYou`'s is: a `Store` field needs
+   * matching entries in `makeStore` and `makeTestStore`, and nothing else reads
+   * this.
+   */
+  reccConfig: ReccClientConfig;
+  /** Only ever set by tests, so they never dial out. Same as `ForYou`'s. */
+  fetchImpl?: FetchImpl;
+}) {
   const {
     submitQuery,
     searchHistory,
@@ -56,6 +72,11 @@ export function Splash({
   const activeUsername =
     debridStatus && debridStatus.provider === debridProvider ? debridStatus.username : undefined;
 
+  // The live draft in the search box. The splash has no submitted query of its
+  // own — enter hands one to the app — so this is the only text to suggest on.
+  const [draft, setDraft] = useState("");
+  const suggest = useTitleSuggest({ reccConfig, query: draft, enabled: true, fetchImpl });
+
   useInput(
     (input, key) => {
       // The search field is always focused on the splash, so it owns every
@@ -63,8 +84,19 @@ export function Splash({
       // like "alex" would trigger them. Tab drops into the app's sidebar menu
       // (where the shortcuts live); esc / ^c quit.
       if (key.tab) {
+        // With something to complete, tab belongs to the field: TextField reads
+        // the same `completion` value this does, so which handler Ink runs first
+        // does not matter.
+        if (suggest.completion !== null) return;
         setView("browser");
         setRegion("sidebar");
+        return;
+      }
+      // Escape escalates rather than quitting outright — putting a suggestion
+      // list away must not be able to close the app. With no list open it still
+      // quits, which is the behaviour this guard must not swallow.
+      if (key.escape && suggest.open) {
+        suggest.dismiss();
         return;
       }
       if (key.escape || (key.ctrl && input === "c")) quitAll();
@@ -131,6 +163,13 @@ export function Splash({
           editing
           placeholder="Search or paste a magnet link…"
           history={searchHistory}
+          suggestions={suggest.items}
+          completion={suggest.completion}
+          onChange={setDraft}
+          onComplete={(text) => {
+            setDraft(text);
+            suggest.accept(text);
+          }}
           onSubmit={submitQuery}
           onExitDown={() => submitQuery("")}
         />
@@ -141,7 +180,8 @@ export function Splash({
           <Text dimColor> search</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
           <Text color={COLOR.alt}>⇥</Text>
-          <Text dimColor> browse</Text>
+          {/* Tab's meaning changes while a list is open, so the hint does too. */}
+          <Text dimColor>{` ${tabHintLabel(suggest.open)}`}</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
           <Text color={COLOR.alt}>^c</Text>
           <Text dimColor> quit</Text>

--- a/src/util/titleSuggest.test.ts
+++ b/src/util/titleSuggest.test.ts
@@ -138,13 +138,13 @@ describe("shouldQueryFor", () => {
   // change handler again — without this the list would immediately reopen on
   // the text the user just picked. Escape reuses the same latch.
   it("refuses the exact text that was suppressed", () => {
-    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010", 1);
     expect(shouldQueryFor(s, "Kestrel 2010")).toBe(false);
     expect(shouldQueryFor(s, "  Kestrel 2010  ")).toBe(false);
   });
 
   it("queries again as soon as the text changes", () => {
-    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010", 1);
     expect(shouldQueryFor(s, "Kestrel 2010 1080p")).toBe(true);
   });
 });

--- a/src/util/titleSuggest.test.ts
+++ b/src/util/titleSuggest.test.ts
@@ -117,6 +117,13 @@ describe("applyReply", () => {
     expect(stale).toBe(fresh);
   });
 
+  // The abstract boundary: two applyReply calls, same seq, nothing else in play.
+  // `suppressFor`'s "discards the reply to a request that was in flight when it
+  // was called" test below exercises the SAME `<=` boundary but built the way
+  // the real code reaches it — via suppressFor's high-water mark, not a second
+  // applyReply — so it's the dismissal scenario, not a duplicate of this one.
+  // Keep both: this one pins the operator on applyReply in isolation; that one
+  // pins the actual bug the operator was fixing.
   it("discards a reply whose seq equals the one already applied", () => {
     const first = applyReply(emptySuggestState(), 3, [KEPLER]);
     expect(applyReply(first, 3, [KESTREL]).items).toEqual([KEPLER]);
@@ -213,6 +220,10 @@ describe("suppressFor", () => {
    * The previous version of this test asserted `appliedSeq` merely survived and
    * then probed with seq 3 — the one seq that was already discarded. It passed
    * against the bug.
+   *
+   * This exercises the same `<=` equality boundary as `applyReply`'s "discards
+   * a reply whose seq equals the one already applied" — see that test's
+   * comment for how the two differ.
    */
   it("discards the reply to a request that was in flight when it was called", () => {
     const some = applyReply(emptySuggestState(), 4, [KESTREL]);

--- a/src/util/titleSuggest.test.ts
+++ b/src/util/titleSuggest.test.ts
@@ -3,6 +3,7 @@ import {
   emptySuggestState,
   shouldQuery,
   shouldQueryFor,
+  shouldSuggestFor,
   applyReply,
   suppressFor,
   topSuggestion,
@@ -144,6 +145,50 @@ describe("shouldQueryFor", () => {
   it("queries again as soon as the text changes", () => {
     const s = suppressFor(emptySuggestState(), "Kestrel 2010");
     expect(shouldQueryFor(s, "Kestrel 2010 1080p")).toBe(true);
+  });
+});
+
+describe("shouldSuggestFor", () => {
+  // The whole reason this is a derived predicate rather than a latch set when the
+  // search box is entered: a latch holds only while every path into the box
+  // remembers to set it, and a path that forgets fails silently and invisibly.
+  // Everything below is a property of the two strings and nothing else, so it
+  // holds however — and whether or not — the box was entered.
+  it("refuses a draft that still equals the submitted search", () => {
+    expect(shouldSuggestFor("Kestrel 2010", "Kestrel 2010")).toBe(false);
+  });
+
+  it("allows a draft the user has actually changed", () => {
+    expect(shouldSuggestFor("Kestrel 2010 1080p", "Kestrel 2010")).toBe(true);
+    expect(shouldSuggestFor("Kestrel 201", "Kestrel 2010")).toBe(true);
+  });
+
+  it("ignores surrounding whitespace on either side", () => {
+    // Whichever side it lands on, this is the same text and must not re-ask.
+    expect(shouldSuggestFor("  Kestrel 2010  ", "Kestrel 2010")).toBe(false);
+    expect(shouldSuggestFor("Kestrel 2010", "  Kestrel 2010  ")).toBe(false);
+  });
+
+  it("refuses an empty box that has never been searched", () => {
+    // The state at mount on a fresh browse: nothing typed, nothing submitted.
+    expect(shouldSuggestFor("", "")).toBe(false);
+  });
+
+  it("allows the first thing typed into a box with no submitted search", () => {
+    expect(shouldSuggestFor("ke", "")).toBe(true);
+  });
+
+  it("allows an emptied box after a search, so the rows can be cleared", () => {
+    // The length gate downstream is what stops a request here; this predicate's
+    // job is only "has the text moved on", and it has.
+    expect(shouldSuggestFor("", "Kestrel 2010")).toBe(true);
+  });
+
+  it("is case sensitive, matching the text the box actually holds", () => {
+    // reccd's results differ by query, and "kestrel" is a different question from
+    // "Kestrel" as far as the box is concerned — so this must not fold case and
+    // silently withhold suggestions for a retyped title.
+    expect(shouldSuggestFor("kestrel 2010", "Kestrel 2010")).toBe(true);
   });
 });
 

--- a/src/util/titleSuggest.test.ts
+++ b/src/util/titleSuggest.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  emptySuggestState,
+  shouldQuery,
+  shouldQueryFor,
+  applyReply,
+  suppressFor,
+  topSuggestion,
+  suggestionLabel,
+  akaNote,
+  submitTextFor,
+  tabHintLabel,
+  SUGGEST_MIN_QUERY_LENGTH,
+  type TitleSuggestion,
+} from "./titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001",
+  title: "Kestrel",
+  year: 2010,
+  type: "movie",
+  matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002",
+  title: "Kepler",
+  year: 2019,
+  type: "tv",
+  matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003",
+  title: "Ashfall",
+  year: 1999,
+  type: "movie",
+  matchedAka: "Ashfall Rising",
+};
+
+describe("shouldQuery", () => {
+  // Must agree with reccd's SEARCH_MIN_QUERY_LENGTH exactly: a lower number
+  // fires requests guaranteed to return [], a higher one hides results reccd
+  // would have given.
+  it("matches reccd's minimum query length", () => {
+    expect(SUGGEST_MIN_QUERY_LENGTH).toBe(2);
+  });
+
+  it("refuses anything shorter than two characters after trimming", () => {
+    expect(shouldQuery("")).toBe(false);
+    expect(shouldQuery(" ")).toBe(false);
+    expect(shouldQuery("k")).toBe(false);
+    expect(shouldQuery("  k  ")).toBe(false);
+  });
+
+  it("accepts two or more characters", () => {
+    expect(shouldQuery("ke")).toBe(true);
+    expect(shouldQuery("kestrel")).toBe(true);
+    expect(shouldQuery("  ke  ")).toBe(true);
+  });
+});
+
+describe("suggestionLabel", () => {
+  // reccd's vocabulary is movie/tv; torlink says film/show everywhere else.
+  it("renders a film with its year", () => {
+    expect(suggestionLabel(KESTREL)).toBe("Kestrel (2010) · film");
+  });
+
+  it("renders a series as a show", () => {
+    expect(suggestionLabel(KEPLER)).toBe("Kepler (2019) · show");
+  });
+});
+
+describe("akaNote", () => {
+  it("is null for a primary-title hit", () => {
+    expect(akaNote(KESTREL)).toBeNull();
+  });
+
+  it("names the alternate title that caused the hit", () => {
+    expect(akaNote(ASHFALL_AKA)).toBe('also known as "Ashfall Rising"');
+  });
+});
+
+describe("submitTextFor", () => {
+  // THE YEAR IS THE POINT. Canonicalising through a catalog is only worth
+  // doing if it separates a remake from its original, and torrent release
+  // names carry the year.
+  it("includes the year", () => {
+    expect(submitTextFor(KESTREL)).toBe("Kestrel 2010");
+  });
+
+  it("uses the primary title even when the hit came via an AKA", () => {
+    expect(submitTextFor(ASHFALL_AKA)).toBe("Ashfall 1999");
+  });
+});
+
+describe("applyReply", () => {
+  it("applies a reply newer than the last one applied", () => {
+    const next = applyReply(emptySuggestState(), 1, [KESTREL]);
+    expect(next.items).toEqual([KESTREL]);
+    expect(next.appliedSeq).toBe(1);
+  });
+
+  /**
+   * MUTATION GUARD — the stale-response bug, which is real here rather than
+   * hypothetical. reccd answers q="th" in ~311ms and q="dark kni" in ~71ms
+   * (its own measured numbers), so the broad, stale reply lands AFTER the
+   * narrow fresh one and would overwrite it: the list would disagree with the
+   * input box. Debouncing does not fix this — two keystroke bursts separated
+   * by more than the debounce window both fire, and nothing orders the replies.
+   */
+  it("discards a reply older than the newest one applied", () => {
+    const fresh = applyReply(emptySuggestState(), 2, [KEPLER]);
+    const stale = applyReply(fresh, 1, [KESTREL]);
+    expect(stale.items).toEqual([KEPLER]);
+    expect(stale.appliedSeq).toBe(2);
+    expect(stale).toBe(fresh);
+  });
+
+  it("discards a reply whose seq equals the one already applied", () => {
+    const first = applyReply(emptySuggestState(), 3, [KEPLER]);
+    expect(applyReply(first, 3, [KESTREL]).items).toEqual([KEPLER]);
+  });
+
+  it("applies an empty reply, clearing what was there", () => {
+    const some = applyReply(emptySuggestState(), 1, [KESTREL]);
+    expect(applyReply(some, 2, []).items).toEqual([]);
+  });
+});
+
+describe("shouldQueryFor", () => {
+  it("defers to shouldQuery when nothing is suppressed", () => {
+    expect(shouldQueryFor(emptySuggestState(), "ke")).toBe(true);
+    expect(shouldQueryFor(emptySuggestState(), "k")).toBe(false);
+  });
+
+  // Accepting a suggestion writes its text into the box, which fires the
+  // change handler again — without this the list would immediately reopen on
+  // the text the user just picked. Escape reuses the same latch.
+  it("refuses the exact text that was suppressed", () => {
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    expect(shouldQueryFor(s, "Kestrel 2010")).toBe(false);
+    expect(shouldQueryFor(s, "  Kestrel 2010  ")).toBe(false);
+  });
+
+  it("queries again as soon as the text changes", () => {
+    const s = suppressFor(emptySuggestState(), "Kestrel 2010");
+    expect(shouldQueryFor(s, "Kestrel 2010 1080p")).toBe(true);
+  });
+});
+
+describe("suppressFor", () => {
+  it("clears the list so nothing is left on screen", () => {
+    const some = applyReply(emptySuggestState(), 1, [KESTREL, KEPLER]);
+    expect(suppressFor(some, "ke").items).toEqual([]);
+  });
+
+  // The seq must survive: a request fired before Escape is still in flight,
+  // and resetting the counter would let its reply reopen the dismissed list.
+  it("keeps the applied seq so an in-flight reply cannot reopen the list", () => {
+    const some = applyReply(emptySuggestState(), 4, [KESTREL]);
+    const dismissed = suppressFor(some, "ke");
+    expect(dismissed.appliedSeq).toBe(4);
+    expect(applyReply(dismissed, 3, [KEPLER]).items).toEqual([]);
+  });
+});
+
+describe("topSuggestion", () => {
+  it("is null with no items", () => {
+    expect(topSuggestion(emptySuggestState())).toBeNull();
+  });
+
+  it("is reccd's best-first first item", () => {
+    const s = applyReply(emptySuggestState(), 1, [KESTREL, KEPLER]);
+    expect(topSuggestion(s)).toEqual(KESTREL);
+  });
+});
+
+describe("tabHintLabel", () => {
+  it("offers completion while a list is open and browse otherwise", () => {
+    expect(tabHintLabel(true)).toBe("complete");
+    expect(tabHintLabel(false)).toBe("browse");
+  });
+});

--- a/src/util/titleSuggest.test.ts
+++ b/src/util/titleSuggest.test.ts
@@ -5,6 +5,7 @@ import {
   shouldQueryFor,
   shouldSuggestFor,
   applyReply,
+  isSuggestOpen,
   suppressFor,
   topSuggestion,
   suggestionLabel,
@@ -195,16 +196,67 @@ describe("shouldSuggestFor", () => {
 describe("suppressFor", () => {
   it("clears the list so nothing is left on screen", () => {
     const some = applyReply(emptySuggestState(), 1, [KESTREL, KEPLER]);
-    expect(suppressFor(some, "ke").items).toEqual([]);
+    expect(suppressFor(some, "ke", 1).items).toEqual([]);
   });
 
-  // The seq must survive: a request fired before Escape is still in flight,
-  // and resetting the counter would let its reply reopen the dismissed list.
-  it("keeps the applied seq so an in-flight reply cannot reopen the list", () => {
+  /**
+   * THE DISMISS-THEN-REOPEN BUG, and the reason `throughSeq` exists.
+   *
+   * The shape on all three paths (terminal Escape, browser Escape, browser
+   * blur): a reply lands and rows appear (seq 4), the user types one more
+   * character so a request numbered 5 goes out, then dismisses. The request is
+   * still in flight and 5 > 4, so before this parameter existed its reply
+   * applied and the list the user had just closed came back — costing a THIRD
+   * keypress to leave the terminal's search box, against help text promising
+   * one.
+   *
+   * The previous version of this test asserted `appliedSeq` merely survived and
+   * then probed with seq 3 — the one seq that was already discarded. It passed
+   * against the bug.
+   */
+  it("discards the reply to a request that was in flight when it was called", () => {
     const some = applyReply(emptySuggestState(), 4, [KESTREL]);
-    const dismissed = suppressFor(some, "ke");
-    expect(dismissed.appliedSeq).toBe(4);
+    const inFlight = 5; // ++seq for the keystroke after the visible reply
+    const dismissed = suppressFor(some, "kestr", inFlight);
+    expect(dismissed.appliedSeq).toBe(5);
+    expect(applyReply(dismissed, inFlight, [KEPLER]).items).toEqual([]);
+  });
+
+  it("still discards a reply older than the one already applied", () => {
+    const some = applyReply(emptySuggestState(), 4, [KESTREL]);
+    const dismissed = suppressFor(some, "ke", 4);
     expect(applyReply(dismissed, 3, [KEPLER]).items).toEqual([]);
+  });
+
+  // A stale counter must not lower the bar and let an outstanding reply back in.
+  it("never lowers the high-water mark", () => {
+    const some = applyReply(emptySuggestState(), 7, [KESTREL]);
+    const dismissed = suppressFor(some, "ke", 2);
+    expect(dismissed.appliedSeq).toBe(7);
+  });
+
+  // The latch and the seq guard are separate jobs: text the user changes must be
+  // askable again, and the next request's seq is higher still.
+  it("leaves a later request free to open the list again", () => {
+    const some = applyReply(emptySuggestState(), 4, [KESTREL]);
+    const dismissed = suppressFor(some, "kestr", 5);
+    expect(shouldQueryFor(dismissed, "kestre")).toBe(true);
+    expect(applyReply(dismissed, 6, [KEPLER]).items).toEqual([KEPLER]);
+  });
+});
+
+describe("isSuggestOpen", () => {
+  it("is false with nothing to show", () => {
+    expect(isSuggestOpen(emptySuggestState())).toBe(false);
+  });
+
+  it("is true once a reply has landed", () => {
+    expect(isSuggestOpen(applyReply(emptySuggestState(), 1, [KESTREL]))).toBe(true);
+  });
+
+  it("is false again after a dismiss", () => {
+    const some = applyReply(emptySuggestState(), 1, [KESTREL]);
+    expect(isSuggestOpen(suppressFor(some, "ke", 1))).toBe(false);
   });
 });
 

--- a/src/util/titleSuggest.ts
+++ b/src/util/titleSuggest.ts
@@ -126,11 +126,39 @@ export function applyReply(state: SuggestState, seq: number, items: TitleSuggest
  * text into the box, which fires the change handler again, and without this
  * the list would reopen on the text just picked.
  *
- * `appliedSeq` deliberately survives, so a request fired before this cannot
- * reopen the list when it answers.
+ * `throughSeq` IS THE WHOLE POINT, AND IT MUST BE THE CALLER'S CURRENT SEQ
+ * COUNTER, not `state.appliedSeq`. `suppressedText` alone does not close the
+ * list, because a request already in flight was numbered `++seq` — strictly
+ * GREATER than `appliedSeq` — so `applyReply`'s `seq <= state.appliedSeq` let
+ * its reply through and the dismissed list came back ~300ms later. Raising the
+ * high-water mark to the newest seq handed out makes every outstanding request
+ * stale by construction, so the reply is discarded whenever it lands.
+ *
+ * An earlier version of this function spread `appliedSeq` through unchanged and
+ * its doc comment claimed survival was itself the guard. It is not: survival is
+ * exactly what let the reply in.
  */
-export function suppressFor(state: SuggestState, raw: string): SuggestState {
-  return { ...state, items: [], suppressedText: raw.trim() };
+export function suppressFor(state: SuggestState, raw: string, throughSeq: number): SuggestState {
+  return {
+    ...state,
+    items: [],
+    suppressedText: raw.trim(),
+    // Math.max, not a bare assignment: the counter is monotonic so it should
+    // never go backwards, and if a caller ever passes a stale one this refuses
+    // to reopen a door rather than quietly reopening it.
+    appliedSeq: Math.max(state.appliedSeq, throughSeq),
+  };
+}
+
+/**
+ * Whether the list is on screen at all.
+ *
+ * Shared rather than `items.length > 0` in each front end: it is one expression
+ * today, but the day "open" means more than non-empty, two copies drift — and
+ * both surfaces gate keys and buttons on this answer.
+ */
+export function isSuggestOpen(state: SuggestState): boolean {
+  return state.items.length > 0;
 }
 
 export function topSuggestion(state: SuggestState): TitleSuggestion | null {

--- a/src/util/titleSuggest.ts
+++ b/src/util/titleSuggest.ts
@@ -84,6 +84,28 @@ export function shouldQueryFor(state: SuggestState, raw: string): boolean {
 }
 
 /**
+ * Whether a search box's live draft is worth suggesting on at all, given the last
+ * SUBMITTED query in the same box.
+ *
+ * False when they are the same text: the user has typed nothing new, so a list
+ * would be an unbidden dropdown over their own previous search — and one they
+ * would then need two escapes to get out of, since the first would only close it.
+ *
+ * This is deliberately DERIVED rather than latched at the moment the box is
+ * entered. A latch set on entry holds only while every path into the box
+ * remembers to set it, and a path that forgets fails silently; this is re-read on
+ * every render, so it holds however the box was entered — including at mount,
+ * where nothing runs at all.
+ *
+ * The one thing it gives up: clearing the box and retyping the previous search
+ * character-for-character yields no suggestions. That is barely reachable, and
+ * worth an invariant that cannot rot.
+ */
+export function shouldSuggestFor(draft: string, submitted: string): boolean {
+  return draft.trim() !== submitted.trim();
+}
+
+/**
  * Fold a reply into the state, ignoring it if a newer one already landed.
  *
  * THIS GUARD IS LOAD-BEARING. reccd answers a two-character query in ~311ms

--- a/src/util/titleSuggest.ts
+++ b/src/util/titleSuggest.ts
@@ -116,6 +116,12 @@ export function shouldSuggestFor(draft: string, submitted: string): boolean {
  * window both fire and nothing orders their replies.
  */
 export function applyReply(state: SuggestState, seq: number, items: TitleSuggestion[]): SuggestState {
+  // `<=`, not `<` — the equality case is not redundant, it's load-bearing.
+  // `suppressFor` sets `appliedSeq` to the seq of the request still in flight
+  // when the list is dismissed, so that request's own reply arrives with
+  // seq === appliedSeq. Equality IS the discard case for it. Tightening this
+  // to `<` would let that reply through and silently undo the dismissal fix
+  // (the list would reopen ~300ms after the user closed it).
   if (seq <= state.appliedSeq) return state;
   return { ...state, items, appliedSeq: seq };
 }

--- a/src/util/titleSuggest.ts
+++ b/src/util/titleSuggest.ts
@@ -1,0 +1,144 @@
+// Title autocomplete against reccd's `GET /search`, shared by both front ends.
+//
+// Everything here is pure and free of I/O and DOM, because both surfaces need
+// the same answers and neither one's wiring is unit-testable: `app.ts` has no
+// jsdom to run in, and the Ink tree is verified by rendering it. So the
+// decisions live here, where they can be pinned by a test.
+
+/** reccd's own vocabulary for what a title is. */
+export type TitleSuggestionType = "movie" | "tv";
+
+/**
+ * One hit from reccd's `GET /search`, narrowed to what torlink renders.
+ *
+ * reccd also returns `genres`, `rating` and `votes` (its `SearchHit extends
+ * CatalogTitle`). They are dropped at the client boundary: nothing on screen
+ * uses them, and carrying unused fields through `wire.ts` invites a future
+ * reader to assume something does.
+ */
+export interface TitleSuggestion {
+  imdbId: string;
+  title: string;
+  year: number;
+  type: TitleSuggestionType;
+  /**
+   * The alternate title that caused the hit, or null for a primary-title hit.
+   * This is what lets the UI say "you typed X, we mean Y" — the reason reccd
+   * returns it at all.
+   */
+  matchedAka: string | null;
+}
+
+/**
+ * Matches reccd's `SEARCH_MIN_QUERY_LENGTH` (`reccd/src/api/server.ts:70`)
+ * exactly. A smaller number fires requests reccd answers with `[]` and no DB
+ * round trip; a larger one hides results reccd would have given.
+ */
+export const SUGGEST_MIN_QUERY_LENGTH = 2;
+
+/** Asked for. The terminal renders 5 of these and the browser all 8. */
+export const SUGGEST_LIMIT = 8;
+
+/**
+ * reccd's own measured latency is 174–311ms for broad prefixes, so this is
+ * deliberately slower than the 150ms `useTitlePreview` uses against OMDb —
+ * at 150ms the requests would queue behind each other.
+ */
+export const SUGGEST_DEBOUNCE_MS = 250;
+
+/**
+ * Not the 10s `fetchRecommendations` uses. A suggestion arriving after ten
+ * seconds is noise: the user has finished typing and pressed Enter.
+ */
+export const SUGGEST_TIMEOUT_MS = 2500;
+
+/** Vertical space is scarce in a terminal; the browser has no such limit. */
+export const SUGGEST_ROWS_TERMINAL = 5;
+
+export interface SuggestState {
+  items: TitleSuggestion[];
+  /**
+   * The sequence number of the newest reply applied. Replies arrive out of
+   * order (see `applyReply`), and this is what makes that harmless.
+   */
+  appliedSeq: number;
+  /**
+   * Text the user has already resolved — by accepting a suggestion or by
+   * dismissing the list — for which no further request should fire.
+   * Trimmed. Null when nothing is suppressed.
+   */
+  suppressedText: string | null;
+}
+
+export function emptySuggestState(): SuggestState {
+  return { items: [], appliedSeq: 0, suppressedText: null };
+}
+
+export function shouldQuery(raw: string): boolean {
+  return raw.trim().length >= SUGGEST_MIN_QUERY_LENGTH;
+}
+
+export function shouldQueryFor(state: SuggestState, raw: string): boolean {
+  if (!shouldQuery(raw)) return false;
+  return raw.trim() !== state.suppressedText;
+}
+
+/**
+ * Fold a reply into the state, ignoring it if a newer one already landed.
+ *
+ * THIS GUARD IS LOAD-BEARING. reccd answers a two-character query in ~311ms
+ * and an eight-character one in ~71ms, so typing through a broad prefix leaves
+ * the slow, stale reply to land after the fast, fresh one. Without the
+ * sequence check the visible list would disagree with the input box, and
+ * debouncing does not help: two bursts separated by more than the debounce
+ * window both fire and nothing orders their replies.
+ */
+export function applyReply(state: SuggestState, seq: number, items: TitleSuggestion[]): SuggestState {
+  if (seq <= state.appliedSeq) return state;
+  return { ...state, items, appliedSeq: seq };
+}
+
+/**
+ * Close the list and stop asking about `raw`. Used by both accepting a
+ * suggestion and dismissing with escape — accepting writes the suggestion's
+ * text into the box, which fires the change handler again, and without this
+ * the list would reopen on the text just picked.
+ *
+ * `appliedSeq` deliberately survives, so a request fired before this cannot
+ * reopen the list when it answers.
+ */
+export function suppressFor(state: SuggestState, raw: string): SuggestState {
+  return { ...state, items: [], suppressedText: raw.trim() };
+}
+
+export function topSuggestion(state: SuggestState): TitleSuggestion | null {
+  return state.items[0] ?? null;
+}
+
+/** e.g. `Kestrel (2010) · film`. */
+export function suggestionLabel(hit: TitleSuggestion): string {
+  // reccd says movie/tv; torlink says film/show everywhere a user can read it.
+  const kind = hit.type === "tv" ? "show" : "film";
+  return `${hit.title} (${hit.year}) · ${kind}`;
+}
+
+/** The "you typed X, we mean Y" line, or null for a primary-title hit. */
+export function akaNote(hit: TitleSuggestion): string | null {
+  return hit.matchedAka === null ? null : `also known as "${hit.matchedAka}"`;
+}
+
+/**
+ * What accepting this suggestion puts in the search box.
+ *
+ * Title AND year. The year is why canonicalising through a catalog is worth
+ * doing: it separates a remake from its original, and torrent release names
+ * carry it. Note `ForYou` submits title only — see the spec's known limits.
+ */
+export function submitTextFor(hit: TitleSuggestion): string {
+  return `${hit.title} ${hit.year}`;
+}
+
+/** The splash's Tab hint, which changes meaning while a list is open. */
+export function tabHintLabel(open: boolean): string {
+  return open ? "complete" : "browse";
+}

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3127,8 +3127,16 @@ describe("GET /api/title-search", () => {
    * the reccd token or URL — if it could, the TUI's proxy would be pointless
    * and a shared link would leak the user's server.
    *
-   * Asserted against the SERIALISED body, and with a token value that appears
-   * nowhere else in the fixture, so the negative cannot quietly go vacuous.
+   * Asserted against the SERIALISED body, with a token value that appears
+   * nowhere else in the fixture and is genuinely in play in the config this
+   * request is answered from.
+   *
+   * A FORWARD-LOOKING GUARD, not a live one, and worth being honest about: on
+   * the ok branch the body is `{status:"ok", items: result.items}` from an
+   * injected stub, so no config-derived value can reach it whatever the
+   * implementation does. This is the test that would turn red if that ever
+   * changed. Its error-branch twin below is the one that covers the branch a
+   * leak could plausibly be written into today.
    */
   it("leaks neither the reccd token nor its URL", async () => {
     const res = await look(

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3046,3 +3046,176 @@ describe("POST /api/cached", () => {
     expect(res.status).toBe(401);
   });
 });
+
+
+describe("GET /api/title-search", () => {
+  const HIT = {
+    imdbId: "tt0000001",
+    title: "Kestrel",
+    year: 2010,
+    type: "movie" as const,
+    matchedAka: null,
+  };
+
+  beforeEach(() => {
+    // Both override the config file inside resolveReccConfig, so a developer
+    // with a real reccd exported would never see the not-configured path — and
+    // the "configured" tests would talk to their actual service.
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+  });
+
+  function suggestDeps(over: Partial<WebDeps> = {}): WebDeps {
+    return deps({
+      loadConfigImpl: async () => searchConfig({ reccUrl: "http://recc.local", reccToken: "t" }),
+      fetchTitleSuggestionsImpl: async () => ({ ok: true, items: [HIT] }),
+      ...over,
+    });
+  }
+
+  function look(d: WebDeps, qs = "q=kes"): Promise<WebResponse> {
+    return handleWebApi(d, "GET", "/api/title-search", new URLSearchParams(qs), AUTH, "");
+  }
+
+  // The gate is the only thing between an anonymous caller and the user's
+  // reccd: this route does not delegate to handleApi, so nothing re-checks.
+  it("rejects an unauthenticated caller when a token is set", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await handleWebApi(
+      suggestDeps({ token: "secret", fetchTitleSuggestionsImpl }),
+      "GET",
+      "/api/title-search",
+      new URLSearchParams("q=kes"),
+      undefined,
+      "",
+    );
+    expect(res.status).toBe(401);
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns reccd's hits", async () => {
+    const res = await look(suggestDeps());
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "ok", items: [HIT] });
+  });
+
+  /**
+   * 200 with its own status, NOT a 500 — the same call `/api/recommendations`
+   * and `/api/title` make. Nothing is broken: the user has no reccd, and the
+   * browser needs to be able to tell that apart from the server falling over.
+   */
+  it("answers not-configured without asking reccd", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(
+      suggestDeps({ loadConfigImpl: async () => searchConfig({}), fetchTitleSuggestionsImpl }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "not-configured" });
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("reports a reccd failure as a status, not a 500", async () => {
+    const res = await look(
+      suggestDeps({ fetchTitleSuggestionsImpl: async () => ({ ok: false, error: "couldn't reach reccd" }) }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "error", error: "couldn't reach reccd" });
+  });
+
+  /**
+   * THE WHOLE REASON THIS ROUTE EXISTS. The browser must never be able to read
+   * the reccd token or URL — if it could, the TUI's proxy would be pointless
+   * and a shared link would leak the user's server.
+   *
+   * Asserted against the SERIALISED body, and with a token value that appears
+   * nowhere else in the fixture, so the negative cannot quietly go vacuous.
+   */
+  it("leaks neither the reccd token nor its URL", async () => {
+    const res = await look(
+      suggestDeps({
+        loadConfigImpl: async () =>
+          searchConfig({ reccUrl: "http://recc.internal:4100", reccToken: "zzq-secret-9317" }),
+      }),
+    );
+    const body = JSON.stringify(res.json);
+    expect(body).not.toContain("zzq-secret-9317");
+    expect(body).not.toContain("recc.internal");
+  });
+
+  it("400s a missing q rather than asking reccd for everything", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(suggestDeps({ fetchTitleSuggestionsImpl }), "");
+    expect(res.status).toBe(400);
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  // reccd answers a short q with [] and no DB round trip; not asking at all is
+  // the same answer for free.
+  it("answers a too-short q with an empty ok, without asking reccd", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
+    const res = await look(suggestDeps({ fetchTitleSuggestionsImpl }), "q=k");
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ status: "ok", items: [] });
+    expect(fetchTitleSuggestionsImpl).not.toHaveBeenCalled();
+  });
+
+  it("forwards the query verbatim, year and all", async () => {
+    const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [] }));
+    await look(suggestDeps({ fetchTitleSuggestionsImpl }), "q=kestrel+2010");
+    expect(fetchTitleSuggestionsImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ reccUrl: "http://recc.local" }),
+      { q: "kestrel 2010", limit: 8 },
+    );
+  });
+});
+
+describe("GET /api/sources reccConfigured", () => {
+  beforeEach(() => {
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+  });
+
+  async function flag(config: Parameters<typeof searchConfig>[0]): Promise<boolean> {
+    const res = await handleWebApi(
+      deps({ loadConfigImpl: async () => searchConfig(config) }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    return (res.json as { reccConfigured: boolean }).reccConfigured;
+  }
+
+  it("is false with no reccd", async () => {
+    expect(await flag({})).toBe(false);
+  });
+
+  it("is true with a configured reccUrl", async () => {
+    expect(await flag({ reccUrl: "http://recc.local", reccToken: "t" })).toBe(true);
+  });
+
+  // resolveReccConfig, not raw config.reccUrl — the browser must agree with the
+  // TUI about whether reccd is on, and the TUI resolves it this way.
+  it("counts TORLINK_RECC_URL", async () => {
+    vi.stubEnv("TORLINK_RECC_URL", "http://recc.env");
+    expect(await flag({})).toBe(true);
+  });
+
+  it("never carries the URL or token alongside the flag", async () => {
+    const res = await handleWebApi(
+      deps({
+        loadConfigImpl: async () =>
+          searchConfig({ reccUrl: "http://recc.internal:4100", reccToken: "zzq-secret-9317" }),
+      }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    const body = JSON.stringify(res.json);
+    expect(body).not.toContain("zzq-secret-9317");
+    expect(body).not.toContain("recc.internal");
+  });
+});

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3142,6 +3142,36 @@ describe("GET /api/title-search", () => {
     expect(body).not.toContain("recc.internal");
   });
 
+  /**
+   * Same guarantee as above, but through the `!result.ok` branch, which the
+   * success-path test above cannot exercise: `{ok: true, items}` structurally
+   * cannot carry a URL or token, so that test passes with the risky branch
+   * never running. `titleSearch` forwards `result.error` into the response
+   * verbatim, so THIS is the branch a future edit could use to leak the
+   * server's address — e.g. appending `reccConfig.reccUrl` to the message for
+   * "helpful" debug context. The error text below names "the configured
+   * server", the kind of phrase such an edit would plausibly finish by
+   * interpolating the URL into — but, matching real `fetchTitleSuggestions`
+   * behaviour (a fixed sentence; see its own client tests), it does not
+   * already contain the sentinel URL or token. If it ever did get appended,
+   * this is the test that would turn red.
+   */
+  it("leaks neither the reccd token nor its URL through the error branch", async () => {
+    const res = await look(
+      suggestDeps({
+        loadConfigImpl: async () =>
+          searchConfig({ reccUrl: "http://recc.internal:4100", reccToken: "zzq-secret-9317" }),
+        fetchTitleSuggestionsImpl: async () => ({
+          ok: false,
+          error: "couldn't reach reccd's configured server",
+        }),
+      }),
+    );
+    const body = JSON.stringify(res.json);
+    expect(body).not.toContain("zzq-secret-9317");
+    expect(body).not.toContain("recc.internal");
+  });
+
   it("400s a missing q rather than asking reccd for everything", async () => {
     const fetchTitleSuggestionsImpl = vi.fn(async () => ({ ok: true as const, items: [HIT] }));
     const res = await look(suggestDeps({ fetchTitleSuggestionsImpl }), "");

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1684,9 +1684,10 @@ export async function handleWebApi(
     return checkCached(deps, bodyText);
   }
 
-  // Both past the token gate above, and both need it: neither delegates to
-  // handleApi, so this is the only check between an anonymous caller and the
-  // user's taste profile — reading it out of reccd, or writing to it.
+  // All three past the token gate above, and all three need it: none delegates
+  // to handleApi, so this is the only check between an anonymous caller and the
+  // user's taste profile or reccd's catalog — reading it, searching it, or
+  // writing to it.
   if (method === "GET" && urlPath === "/api/recommendations") {
     return recommendations(deps, query);
   }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -26,8 +26,10 @@ import {
 } from "../config/config";
 import {
   fetchRecommendations,
+  fetchTitleSuggestions,
   postEvent,
   type FetchRecommendationsResult,
+  type FetchTitleSuggestionsResult,
   type ReccClientConfig,
   type ReccEvent,
   type ReccEventType,
@@ -56,6 +58,7 @@ import { openSseChannel, type SseWrite } from "./sse";
 import type { Source, SourceGroup, SourceId, TorrentResult } from "../sources/types";
 import { addInput, type AddInputOptions, type Runtime } from "../daemon/runtime";
 import { hintForGroup, parseRelease } from "../util/release";
+import { shouldQuery, SUGGEST_LIMIT } from "../util/titleSuggest";
 import { streamCandidates } from "../util/videoFiles";
 import { toggleSavedSearches } from "../util/savedSearchList";
 import type {
@@ -77,6 +80,7 @@ import type {
   PublicRecommendations,
   PublicStreamSession,
   PublicTitleMeta,
+  PublicTitleSuggestions,
   SavedResponse,
   SourcesResponse,
   StartStreamResponse,
@@ -155,6 +159,11 @@ export interface WebDeps {
     config: ReccClientConfig,
     query: RecommendationQuery,
   ) => Promise<FetchRecommendationsResult>;
+  /** reccd's title search, for `/api/title-search`. Injected to keep tests off the network. */
+  fetchTitleSuggestionsImpl?: (
+    config: ReccClientConfig,
+    query: { q: string; limit?: number },
+  ) => Promise<FetchTitleSuggestionsResult>;
   /**
    * How `/api/recc-event` reaches reccd. Injected for the same reason, and
    * typed as returning void rather than a promise the route waits on — see the
@@ -732,6 +741,10 @@ export function sourcesResponse(config: Config, health: Map<SourceId, Health>, n
     // the browser must agree with the TUI about whether artwork is available,
     // and the TUI resolves it the same way.
     omdbConfigured: resolveOmdbApiKey(config) !== "",
+    // resolveReccConfig, not config.reccUrl, so TORLINK_RECC_URL counts — the
+    // browser must agree with the TUI about whether reccd is on, and the TUI
+    // resolves it the same way. A boolean, never the URL or the token.
+    reccConfigured: resolveReccConfig(config).reccUrl !== undefined,
     // Read only. `POST /api/preferences` is the write path; this is here so
     // fetching it costs no extra round trip on the page the browser loads first.
     preferences: toPublicQualityPrefs(config),
@@ -1426,6 +1439,56 @@ async function recommendations(deps: WebDeps, query: URLSearchParams): Promise<W
   return { status: 200, json: out };
 }
 
+/**
+ * `GET /api/title-search?q=` — reccd's catalog search, proxied.
+ *
+ * THIS ROUTE EXISTS SO THE BROWSER NEVER SEES `reccToken`. The TUI calls
+ * `fetchTitleSuggestions` directly; a page cannot, and handing it the token so
+ * it could would put the user's reccd credentials in a tab.
+ *
+ * `loadConfig()` per request, not a boot snapshot, for the same reason
+ * `recommendations` does it: a reccd URL can be pasted into the Accounts pane
+ * at any moment, and `serve --web` is a separate process from any running TUI.
+ */
+async function titleSearch(deps: WebDeps, query: URLSearchParams): Promise<WebResponse> {
+  const raw = query.get("q");
+  // Absent, not empty: a client that forgot the param is a bug worth a 400,
+  // and it matches reccd's own behaviour for a missing q.
+  if (raw === null) return { status: 400, json: { error: "missing q" } };
+
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const reccConfig = resolveReccConfig(config);
+  if (!reccConfig.reccUrl) {
+    const out: PublicTitleSuggestions = { status: "not-configured" };
+    return { status: 200, json: out };
+  }
+
+  // reccd answers a shorter query with [] and no DB round trip. Not asking is
+  // the same answer without the round trip, and it keeps the min-length rule in
+  // exactly one place (util/titleSuggest.ts) for both front ends.
+  if (!shouldQuery(raw)) {
+    const out: PublicTitleSuggestions = { status: "ok", items: [] };
+    return { status: 200, json: out };
+  }
+
+  // `fetchTitleSuggestions` never throws and bounds itself with its own
+  // timeout, so a reccd that is down or hanging costs this request that timeout
+  // and nothing else.
+  const result = await (deps.fetchTitleSuggestionsImpl ?? fetchTitleSuggestions)(reccConfig, {
+    q: raw,
+    limit: SUGGEST_LIMIT,
+  });
+  if (!result.ok) {
+    const out: PublicTitleSuggestions = { status: "error", error: result.error };
+    return { status: 200, json: out };
+  }
+  // Assigned, not re-mapped: the client already narrowed reccd's row to the
+  // fields torlink renders, and this assignment is where the compiler checks
+  // that `TitleSuggestion` and the wire type still agree.
+  const out: PublicTitleSuggestions = { status: "ok", items: result.items };
+  return { status: 200, json: out };
+}
+
 /** The event types this route will forward, as a set for the body check. */
 const RECC_EVENTS: ReadonlySet<string> = new Set<PublicReccEventType>([
   "watched",
@@ -1626,6 +1689,10 @@ export async function handleWebApi(
   // user's taste profile — reading it out of reccd, or writing to it.
   if (method === "GET" && urlPath === "/api/recommendations") {
     return recommendations(deps, query);
+  }
+
+  if (method === "GET" && urlPath === "/api/title-search") {
+    return titleSearch(deps, query);
   }
 
   if (method === "POST" && urlPath === "/api/recc-event") {

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -1265,12 +1265,17 @@ let suggestTimer: ReturnType<typeof setTimeout> | null = null;
 // out-of-order arrival is the normal case, not the edge case.
 let suggestSeq = 0;
 
+// Each row needs a stable id for `aria-activedescendant` to point at. By
+// position, because that is what the highlight is an index into.
+const suggestOptionId = (index: number): string => `suggest-option-${index}`;
+
 function renderSuggest(): void {
   suggestList.replaceChildren();
   const rows = rowPlan(suggestState);
   for (const [index, row] of rows.entries()) {
     const li = document.createElement("li");
     li.setAttribute("role", "option");
+    li.setAttribute("id", suggestOptionId(index));
     li.setAttribute("aria-selected", row.highlighted ? "true" : "false");
     // textContent, not innerHTML: a title is a string from a catalog we do not
     // control, and src/web/static has no innerHTML path anywhere by rule.
@@ -1294,7 +1299,15 @@ function renderSuggest(): void {
     });
     suggestList.append(li);
   }
+  // The two halves of "is the list on screen" — the visual one and the announced
+  // one — set side by side on purpose, so they cannot drift.
   suggestList.hidden = rows.length === 0;
+  queryInput.setAttribute("aria-expanded", rows.length === 0 ? "false" : "true");
+  const active = rows.findIndex((row) => row.highlighted);
+  // Removed rather than set to "": an empty idref is a dangling pointer, and some
+  // screen readers announce it as a lost element instead of as nothing.
+  if (active === -1) queryInput.removeAttribute("aria-activedescendant");
+  else queryInput.setAttribute("aria-activedescendant", suggestOptionId(active));
 }
 
 // Closes the list for good: the pending timer is dropped so a debounced request

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -158,7 +158,7 @@ import {
   prefsFromWire,
   type PickState,
 } from "./pickModel";
-import type { PreferencesResponse, PublicQualityPrefs } from "../wire";
+import type { PreferencesResponse, PublicQualityPrefs, PublicTitleSuggestions } from "../wire";
 import {
   emptyListState,
   isOpen as suggestOpen,
@@ -171,7 +171,6 @@ import {
   type ListState,
 } from "./suggestModel";
 import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest";
-import type { PublicTitleSuggestions } from "../wire";
 
 // The token is held in sessionStorage and sent as an Authorization header on
 // every API call. No cookie authenticates the API — but that does NOT mean there

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -1297,10 +1297,15 @@ function renderSuggest(): void {
   suggestList.hidden = rows.length === 0;
 }
 
+// Closes the list for good: the pending timer is dropped so a debounced request
+// is never sent, and `suggestSeq` is handed to the model so a request ALREADY
+// sent has its reply discarded when it lands. Both halves are needed — clearing
+// the timer alone leaves the in-flight case, which reopens the list a few
+// hundred milliseconds later with nothing focused to close it again.
 function closeSuggest(): void {
   if (suggestTimer !== null) clearTimeout(suggestTimer);
   suggestTimer = null;
-  suggestState = closedFor(suggestState, queryInput.value);
+  suggestState = closedFor(suggestState, queryInput.value, suggestSeq);
   renderSuggest();
 }
 
@@ -1310,7 +1315,7 @@ function acceptSuggest(): void {
   // Latch before searching: accepting writes text into the box, which fires the
   // input handler again, and without the latch the list would reopen on the
   // text just picked.
-  suggestState = closedFor(suggestState, plan.text);
+  suggestState = closedFor(suggestState, plan.text, suggestSeq);
   renderSuggest();
   searchForTitle(plan.text);
 }
@@ -1386,6 +1391,20 @@ queryInput.addEventListener("blur", () => closeSuggest());
 
 searchForm.addEventListener("submit", (event) => {
   event.preventDefault();
+  // Submitting settles the text, so nothing more may be suggested about it. The
+  // keydown handler above cannot do this: it returns early when the list is not
+  // open, which is exactly the fast typist's case — Enter within the 250ms
+  // debounce, before any reply has landed. Without this the request fires (or
+  // finishes) after the search has run and a dropdown opens by itself over the
+  // fresh results, and since Enter does not blur the input nothing closes it.
+  //
+  // `closeSuggest()` rather than a `lastSubmitted` variable compared through
+  // `shouldSuggestFor`: that would be a new piece of mutable state in app.ts and
+  // a decision made in the file that is not allowed to decide things, whereas
+  // this reuses the one latch every other close path already goes through and
+  // covers both sub-cases at once — timer not yet fired (cleared, no request at
+  // all) and request in flight (its reply discarded by the seq high-water mark).
+  closeSuggest();
   // No guard on an empty value: submitting a blank box is how you browse the
   // top lists, the same as pressing Enter on an empty box in the TUI.
   startSearch(queryInput.value);

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -159,6 +159,19 @@ import {
   type PickState,
 } from "./pickModel";
 import type { PreferencesResponse, PublicQualityPrefs } from "../wire";
+import {
+  emptyListState,
+  isOpen as suggestOpen,
+  withReply,
+  moveHighlight,
+  highlightAt,
+  closedFor,
+  acceptPlan,
+  rowPlan,
+  type ListState,
+} from "./suggestModel";
+import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest";
+import type { PublicTitleSuggestions } from "../wire";
 
 // The token is held in sessionStorage and sent as an Authorization header on
 // every API call. No cookie authenticates the API — but that does NOT mean there
@@ -228,6 +241,7 @@ const toTopButton = el<HTMLButtonElement>("to-top");
 
 const searchForm = el<HTMLFormElement>("search");
 const queryInput = el<HTMLInputElement>("query");
+const suggestList = el<HTMLUListElement>("suggest");
 const saveSearchButton = el<HTMLButtonElement>("save-search");
 const tabsBar = el<HTMLDivElement>("tabs");
 const sortSelect = el<HTMLSelectElement>("sort");
@@ -1239,6 +1253,137 @@ function renderPickPhase(state: PickState): void {
   else if (phase.kind === "playing") showNotice(phase.note);
   else if (phase.kind === "none") showNotice(pickNoneLine(phase.title));
 }
+
+// ---- title suggestions -------------------------------------------------
+
+// Every decision here belongs to suggestModel.ts; this block is the timer, the
+// fetch, the DOM, and the key handling. If you find yourself writing an `if`
+// that decides what to show or what to send, it goes in the model.
+let suggestState: ListState = emptyListState();
+let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+// Monotonic, and the reason a slow reply cannot overwrite a fast one — see
+// applyReply. A 2-char query costs reccd ~311ms and an 8-char one ~71ms, so
+// out-of-order arrival is the normal case, not the edge case.
+let suggestSeq = 0;
+
+function renderSuggest(): void {
+  suggestList.replaceChildren();
+  const rows = rowPlan(suggestState);
+  for (const [index, row] of rows.entries()) {
+    const li = document.createElement("li");
+    li.setAttribute("role", "option");
+    li.setAttribute("aria-selected", row.highlighted ? "true" : "false");
+    // textContent, not innerHTML: a title is a string from a catalog we do not
+    // control, and src/web/static has no innerHTML path anywhere by rule.
+    const label = document.createElement("span");
+    label.textContent = row.label;
+    li.append(label);
+    if (row.aka !== null) {
+      const aka = document.createElement("span");
+      aka.className = "aka";
+      aka.textContent = row.aka;
+      li.append(aka);
+    }
+    // mousedown, not click: click lands after the input has already blurred,
+    // and a blur that closes the list would cancel the pick.
+    li.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      // Reuse the keyboard path rather than a second accept: highlight the
+      // clicked row, then accept, so a click and an Enter cannot drift apart.
+      suggestState = highlightAt(suggestState, index);
+      acceptSuggest();
+    });
+    suggestList.append(li);
+  }
+  suggestList.hidden = rows.length === 0;
+}
+
+function closeSuggest(): void {
+  if (suggestTimer !== null) clearTimeout(suggestTimer);
+  suggestTimer = null;
+  suggestState = closedFor(suggestState, queryInput.value);
+  renderSuggest();
+}
+
+/** Run whatever the model says this keypress or click means. */
+function acceptSuggest(): void {
+  const plan = acceptPlan(suggestState, queryInput.value);
+  // Latch before searching: accepting writes text into the box, which fires the
+  // input handler again, and without the latch the list would reopen on the
+  // text just picked.
+  suggestState = closedFor(suggestState, plan.text);
+  renderSuggest();
+  searchForTitle(plan.text);
+}
+
+async function loadSuggest(raw: string, seq: number): Promise<void> {
+  try {
+    const res = await fetch(`/api/title-search?q=${encodeURIComponent(raw)}`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as PublicTitleSuggestions;
+    // Every non-ok status renders as no suggestions. This fires per keystroke,
+    // so a banner per character would be worse than silence — and the Accounts
+    // pane is where a reccd problem belongs.
+    const items = body.status === "ok" ? body.items : [];
+    suggestState = withReply(suggestState, seq, items);
+    renderSuggest();
+  } catch {
+    // A suggestion we cannot fetch is a search box that behaves exactly as it
+    // did before this feature existed. Nothing to report.
+  }
+}
+
+queryInput.addEventListener("input", () => {
+  if (suggestTimer !== null) clearTimeout(suggestTimer);
+  // The capability flag from /api/sources, so a reccd-less server never spends
+  // a request per character discovering that again.
+  if (sources?.reccConfigured !== true) return;
+  const raw = queryInput.value;
+  if (!shouldQueryFor(suggestState.suggest, raw)) {
+    suggestState = withReply(suggestState, ++suggestSeq, []);
+    renderSuggest();
+    return;
+  }
+  const seq = ++suggestSeq;
+  suggestTimer = setTimeout(() => void loadSuggest(raw, seq), SUGGEST_DEBOUNCE_MS);
+});
+
+queryInput.addEventListener("keydown", (event) => {
+  if (!suggestOpen(suggestState)) return;
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    suggestState = moveHighlight(suggestState, 1);
+    renderSuggest();
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    suggestState = moveHighlight(suggestState, -1);
+    renderSuggest();
+    return;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeSuggest();
+    return;
+  }
+  if (event.key === "Enter") {
+    // Only intercept when a row is actually highlighted; otherwise let the form
+    // submit normally with what the user typed.
+    if (suggestState.highlight < 0) {
+      closeSuggest();
+      return;
+    }
+    event.preventDefault();
+    acceptSuggest();
+  }
+});
+
+// Leaving the box closes the list — an open dropdown over a pane the user has
+// moved on from is a stuck artefact, not a suggestion.
+queryInput.addEventListener("blur", () => closeSuggest());
 
 searchForm.addEventListener("submit", (event) => {
   event.preventDefault();

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -83,7 +83,22 @@
         <form id="search" class="card">
           <label for="query">Search every source</label>
           <div class="suggest-wrap">
-            <input id="query" type="search" placeholder="a film or show — or leave blank to browse" autocomplete="off" />
+            <!-- role="combobox" and the aria-* pairing below are the ARIA 1.2
+                 combobox pattern. `aria-expanded` is not allowed on a bare
+                 searchbox, so without the explicit role a screen reader would
+                 announce neither the list appearing nor the moving highlight.
+                 `aria-controls` is static; `aria-expanded` and
+                 `aria-activedescendant` are kept in sync by renderSuggest. -->
+            <input
+              id="query"
+              type="search"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls="suggest"
+              aria-expanded="false"
+              placeholder="a film or show — or leave blank to browse"
+              autocomplete="off"
+            />
             <!-- Title suggestions from reccd, when it is configured. An overlay,
                  positioned against .suggest-wrap rather than .card, so opening
                  it never reflows the Search / save-search buttons out from

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -83,6 +83,12 @@
         <form id="search" class="card">
           <label for="query">Search every source</label>
           <input id="query" type="search" placeholder="a film or show — or leave blank to browse" autocomplete="off" />
+          <!-- Title suggestions from reccd, when it is configured. A full-width
+               row inside the card's flex layout so it sits under the input
+               rather than beside it. Empty and `hidden` until there is
+               something to show; app.ts fills it with createElement +
+               textContent, never innerHTML. -->
+          <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
           <button type="submit">Search</button>
           <button id="save-search" type="button">save search</button>
         </form>

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -82,13 +82,16 @@
       <section id="pane-search">
         <form id="search" class="card">
           <label for="query">Search every source</label>
-          <input id="query" type="search" placeholder="a film or show — or leave blank to browse" autocomplete="off" />
-          <!-- Title suggestions from reccd, when it is configured. A full-width
-               row inside the card's flex layout so it sits under the input
-               rather than beside it. Empty and `hidden` until there is
-               something to show; app.ts fills it with createElement +
-               textContent, never innerHTML. -->
-          <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
+          <div class="suggest-wrap">
+            <input id="query" type="search" placeholder="a film or show — or leave blank to browse" autocomplete="off" />
+            <!-- Title suggestions from reccd, when it is configured. An overlay,
+                 positioned against .suggest-wrap rather than .card, so opening
+                 it never reflows the Search / save-search buttons out from
+                 under the user's cursor while they are still typing. Empty and
+                 `hidden` until there is something to show; app.ts fills it with
+                 createElement + textContent, never innerHTML. -->
+            <ul id="suggest" class="suggest" role="listbox" aria-label="Title suggestions" hidden></ul>
+          </div>
           <button type="submit">Search</button>
           <button id="save-search" type="button">save search</button>
         </form>

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -103,6 +103,7 @@ const sourcesResponse = (over: Partial<SourcesResponse> = {}): SourcesResponse =
   debridProvider: null,
   debridCachedCheck: false,
   omdbConfigured: false,
+  reccConfigured: false,
   preferences: { maxResolution: null, require: [], exclude: [] },
   ...over,
 });

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1299,11 +1299,20 @@ select:focus-visible {
 .suggest-wrap {
   position: relative;
   flex: 1;
-  min-width: 0;
+  /* Was min-width: 0, which was wrong. The bare #query used to sit in this
+     flex row carrying `input { flex: 1; min-width: 12rem }` (styles.css:237),
+     and that 12rem is what makes .card wrap instead of crushing the search
+     box. The wrapper now holds that place, so it inherits that job. */
+  min-width: 12rem;
 }
 
 .suggest-wrap #query {
   width: 100%;
+  /* The generic `input` rule's min-width: 12rem would otherwise beat
+     width: 100% once the wrapper is narrower than 12rem, overflowing the
+     wrapper and leaving the overlay narrower than the input under it. The
+     wrapper enforces the 12rem floor now; the input just fills it. */
+  min-width: 0;
 }
 
 .suggest {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1289,16 +1289,37 @@ select:focus-visible {
   flex-wrap: wrap;
 }
 
-/* The search box's title suggestions. `flex: 1 0 100%` breaks it onto its own
-   row inside .card, which lays its children out as a strip of controls. */
+/* The search box's title suggestions.
+   .suggest-wrap takes over the flex growth #query used to have directly as a
+   child of .card (`flex: 1`), so the row lays out exactly as before;
+   min-width: 0 keeps a long suggestion from blowing out that row. .suggest
+   itself is positioned against this wrapper, not .card, and is an overlay
+   (position: absolute) rather than a flow row: opening it must never push
+   the Search / save-search buttons around while the user is still typing. */
+.suggest-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.suggest-wrap #query {
+  width: 100%;
+}
+
 .suggest {
-  flex: 1 0 100%;
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  background: var(--raised);
+  max-height: 16rem;
+  overflow-y: auto;
   list-style: none;
   margin: 0;
   padding: 0;
   border: 1px solid var(--line);
   border-radius: 0.5rem;
-  overflow: hidden;
 }
 
 .suggest li {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1288,3 +1288,35 @@ select:focus-visible {
   padding-top: 0.4rem;
   flex-wrap: wrap;
 }
+
+/* The search box's title suggestions. `flex: 1 0 100%` breaks it onto its own
+   row inside .card, which lays its children out as a strip of controls. */
+.suggest {
+  flex: 1 0 100%;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.suggest li {
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+}
+
+.suggest li + li {
+  border-top: 1px solid var(--line);
+}
+
+.suggest li[aria-selected="true"],
+.suggest li:hover {
+  background: var(--line);
+}
+
+.suggest .aka {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--dim);
+}

--- a/src/web/static/suggestModel.test.ts
+++ b/src/web/static/suggestModel.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  emptyListState,
+  isOpen,
+  withReply,
+  moveHighlight,
+  highlightAt,
+  closedFor,
+  acceptPlan,
+  rowPlan,
+} from "./suggestModel";
+import { shouldQueryFor, type TitleSuggestion } from "../../util/titleSuggest";
+
+const KESTREL: TitleSuggestion = {
+  imdbId: "tt0000001", title: "Kestrel", year: 2010, type: "movie", matchedAka: null,
+};
+const KEPLER: TitleSuggestion = {
+  imdbId: "tt0000002", title: "Kepler", year: 2019, type: "tv", matchedAka: null,
+};
+const ASHFALL_AKA: TitleSuggestion = {
+  imdbId: "tt0000003", title: "Ashfall", year: 1999, type: "movie", matchedAka: "Ashfall Rising",
+};
+
+const THREE = [KESTREL, KEPLER, ASHFALL_AKA];
+
+describe("isOpen", () => {
+  it("is closed with nothing to show", () => {
+    expect(isOpen(emptyListState())).toBe(false);
+  });
+
+  it("is open once there are hits", () => {
+    expect(isOpen(withReply(emptyListState(), 1, [KESTREL]))).toBe(true);
+  });
+
+  it("is closed again when a reply brings nothing", () => {
+    const open = withReply(emptyListState(), 1, [KESTREL]);
+    expect(isOpen(withReply(open, 2, []))).toBe(false);
+  });
+});
+
+describe("withReply", () => {
+  it("starts with nothing highlighted, so Enter still submits what was typed", () => {
+    expect(withReply(emptyListState(), 1, THREE).highlight).toBe(-1);
+  });
+
+  it("drops a highlight that a new, shorter reply would put out of range", () => {
+    const moved = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(moved.highlight).toBe(0);
+    expect(withReply(moved, 2, [KEPLER]).highlight).toBe(-1);
+  });
+
+  // The stale-reply guard belongs to the shared model; this proves the browser
+  // wrapper actually routes through it rather than assigning items directly.
+  it("ignores a reply older than the newest applied", () => {
+    const fresh = withReply(emptyListState(), 2, [KEPLER]);
+    expect(withReply(fresh, 1, [KESTREL]).suggest.items).toEqual([KEPLER]);
+  });
+});
+
+describe("moveHighlight", () => {
+  it("enters the list from nothing on down", () => {
+    expect(moveHighlight(withReply(emptyListState(), 1, THREE), 1).highlight).toBe(0);
+  });
+
+  it("enters at the last row from nothing on up", () => {
+    expect(moveHighlight(withReply(emptyListState(), 1, THREE), -1).highlight).toBe(2);
+  });
+
+  it("wraps past the end", () => {
+    let s = withReply(emptyListState(), 1, THREE);
+    s = moveHighlight(s, 1);
+    s = moveHighlight(s, 1);
+    s = moveHighlight(s, 1);
+    expect(s.highlight).toBe(2);
+    expect(moveHighlight(s, 1).highlight).toBe(0);
+  });
+
+  it("wraps past the start", () => {
+    const first = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(moveHighlight(first, -1).highlight).toBe(2);
+  });
+
+  it("does nothing with a closed list", () => {
+    expect(moveHighlight(emptyListState(), 1).highlight).toBe(-1);
+  });
+});
+
+describe("highlightAt", () => {
+  it("highlights the clicked row", () => {
+    const s = highlightAt(withReply(emptyListState(), 1, THREE), 2);
+    expect(s.highlight).toBe(2);
+    expect(acceptPlan(s, "ash")).toEqual({ kind: "suggestion", text: "Ashfall 1999" });
+  });
+
+  // Ignored, not clamped: the only caller is a row's own listener, so an
+  // out-of-range index means the rows changed under the click — and searching a
+  // DIFFERENT title than the one clicked is worse than doing nothing.
+  it("ignores an index the list no longer has", () => {
+    const s = withReply(emptyListState(), 1, [KESTREL]);
+    expect(highlightAt(s, 3).highlight).toBe(-1);
+    expect(highlightAt(s, -1).highlight).toBe(-1);
+  });
+});
+
+describe("acceptPlan", () => {
+  // Enter with nothing highlighted must submit what the user typed. Silently
+  // substituting a suggestion for their own words is the one thing autocomplete
+  // must never do.
+  it("submits the raw text when nothing is highlighted", () => {
+    const s = withReply(emptyListState(), 1, THREE);
+    expect(acceptPlan(s, "kes")).toEqual({ kind: "raw", text: "kes" });
+  });
+
+  it("submits the highlighted suggestion's title and year", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(acceptPlan(s, "kes")).toEqual({ kind: "suggestion", text: "Kestrel 2010" });
+  });
+
+  it("uses the primary title when the highlight matched via an AKA", () => {
+    let s = withReply(emptyListState(), 1, THREE);
+    s = moveHighlight(s, -1);
+    expect(acceptPlan(s, "ashfall ris")).toEqual({ kind: "suggestion", text: "Ashfall 1999" });
+  });
+
+  it("submits the raw text when the list is closed", () => {
+    expect(acceptPlan(emptyListState(), "kes")).toEqual({ kind: "raw", text: "kes" });
+  });
+});
+
+describe("closedFor", () => {
+  it("closes the list and clears the highlight", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    const shut = closedFor(s, "kes");
+    expect(isOpen(shut)).toBe(false);
+    expect(shut.highlight).toBe(-1);
+  });
+
+  // Escape must stick. Without the suppression latch the next debounce tick
+  // would re-fire the same query and reopen what the user just dismissed.
+  it("stops the same text being queried again", () => {
+    const shut = closedFor(withReply(emptyListState(), 1, THREE), "kes");
+    expect(shouldQueryFor(shut.suggest, "kes")).toBe(false);
+    expect(shouldQueryFor(shut.suggest, "kest")).toBe(true);
+  });
+});
+
+describe("rowPlan", () => {
+  it("is empty for a closed list", () => {
+    expect(rowPlan(emptyListState())).toEqual([]);
+  });
+
+  it("labels every row and marks the highlighted one", () => {
+    const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
+    expect(rowPlan(s)).toEqual([
+      { label: "Kestrel (2010) · film", aka: null, highlighted: true },
+      { label: "Kepler (2019) · show", aka: null, highlighted: false },
+      { label: 'Ashfall (1999) · film', aka: 'also known as "Ashfall Rising"', highlighted: false },
+    ]);
+  });
+});

--- a/src/web/static/suggestModel.test.ts
+++ b/src/web/static/suggestModel.test.ts
@@ -130,7 +130,7 @@ describe("acceptPlan", () => {
 describe("closedFor", () => {
   it("closes the list and clears the highlight", () => {
     const s = moveHighlight(withReply(emptyListState(), 1, THREE), 1);
-    const shut = closedFor(s, "kes");
+    const shut = closedFor(s, "kes", 1);
     expect(isOpen(shut)).toBe(false);
     expect(shut.highlight).toBe(-1);
   });
@@ -138,9 +138,49 @@ describe("closedFor", () => {
   // Escape must stick. Without the suppression latch the next debounce tick
   // would re-fire the same query and reopen what the user just dismissed.
   it("stops the same text being queried again", () => {
-    const shut = closedFor(withReply(emptyListState(), 1, THREE), "kes");
+    const shut = closedFor(withReply(emptyListState(), 1, THREE), "kes", 1);
     expect(shouldQueryFor(shut.suggest, "kes")).toBe(false);
     expect(shouldQueryFor(shut.suggest, "kest")).toBe(true);
+  });
+
+  /**
+   * Escape and blur, with a request still out. Rows are up from reply 1, the
+   * user types one more character (request 2), then closes the list. Reply 2
+   * arrives afterwards — app.ts's `loadSuggest` folds it in with `withReply`
+   * whatever happened in between, because a fetch already sent cannot be
+   * recalled. It must not reopen the list.
+   *
+   * The blur case is the one that cannot heal: nothing is focused, so there is
+   * no key left to press at the dropdown.
+   */
+  it("discards the reply to a request that was out when the list closed", () => {
+    const open = withReply(emptyListState(), 1, THREE);
+    const shut = closedFor(open, "kest", 2);
+    expect(isOpen(withReply(shut, 2, THREE))).toBe(false);
+  });
+
+  /**
+   * The submit path, which is the same call with a different trigger: Enter
+   * inside the debounce window means app.ts's keydown handler never runs (the
+   * list is not open yet), so the form's submit listener is what has to close
+   * it. Request 1 is in flight against the text now being searched for.
+   *
+   * app.ts's own wiring — clearing `suggestTimer` and passing `suggestSeq` in
+   * `closeSuggest()`, and calling it from the submit listener — has no test
+   * environment by design (no jsdom; see CLAUDE.md). This pins the decision it
+   * delegates here; the listener itself is verified by running `serve --web`.
+   */
+  it("discards a reply for text that has already been submitted", () => {
+    const submitted = closedFor(emptyListState(), "kestrel", 1);
+    expect(isOpen(withReply(submitted, 1, THREE))).toBe(false);
+    expect(shouldQueryFor(submitted.suggest, "kestrel")).toBe(false);
+  });
+
+  // Closing does not deafen the box: the next thing typed is a new question with
+  // a higher number, and it opens the list as usual.
+  it("lets a request made after it open the list again", () => {
+    const shut = closedFor(withReply(emptyListState(), 1, THREE), "kest", 2);
+    expect(isOpen(withReply(shut, 3, THREE))).toBe(true);
   });
 });
 

--- a/src/web/static/suggestModel.ts
+++ b/src/web/static/suggestModel.ts
@@ -2,6 +2,7 @@ import {
   akaNote,
   applyReply,
   emptySuggestState,
+  isSuggestOpen,
   submitTextFor,
   suggestionLabel,
   suppressFor,
@@ -27,7 +28,7 @@ export function emptyListState(): ListState {
 }
 
 export function isOpen(s: ListState): boolean {
-  return s.suggest.items.length > 0;
+  return isSuggestOpen(s.suggest);
 }
 
 /**
@@ -65,9 +66,16 @@ export function highlightAt(s: ListState, index: number): ListState {
   return { ...s, highlight: index };
 }
 
-/** Close the list, and stop asking about `raw` so it cannot reopen itself. */
-export function closedFor(s: ListState, raw: string): ListState {
-  return { suggest: suppressFor(s.suggest, raw), highlight: -1 };
+/**
+ * Close the list, and stop asking about `raw` so it cannot reopen itself.
+ *
+ * `throughSeq` must be the caller's live seq counter, not anything read back out
+ * of the state: a request already in flight outranks every applied reply, and
+ * without this its answer reopens the list a few hundred milliseconds after
+ * Escape, a blur, or a submit. See `suppressFor`.
+ */
+export function closedFor(s: ListState, raw: string, throughSeq: number): ListState {
+  return { suggest: suppressFor(s.suggest, raw, throughSeq), highlight: -1 };
 }
 
 /**

--- a/src/web/static/suggestModel.ts
+++ b/src/web/static/suggestModel.ts
@@ -1,0 +1,93 @@
+import {
+  akaNote,
+  applyReply,
+  emptySuggestState,
+  submitTextFor,
+  suggestionLabel,
+  suppressFor,
+  type SuggestState,
+  type TitleSuggestion,
+} from "../../util/titleSuggest";
+
+// The search box's suggestion list, as state plus transitions.
+//
+// It lives here rather than in app.ts because every function below answers
+// either "what should be on screen" or "what should be sent" — the two
+// questions app.ts is not allowed to decide, since nothing in it is reachable
+// by a test.
+
+export interface ListState {
+  suggest: SuggestState;
+  /** Index into `suggest.items`, or -1 for "nothing highlighted". */
+  highlight: number;
+}
+
+export function emptyListState(): ListState {
+  return { suggest: emptySuggestState(), highlight: -1 };
+}
+
+export function isOpen(s: ListState): boolean {
+  return s.suggest.items.length > 0;
+}
+
+/**
+ * Fold in a reply from `/api/title-search`.
+ *
+ * The highlight resets to -1 rather than being preserved: the rows have
+ * changed, so a kept index would point at a different title than the one the
+ * user was looking at — and pressing Enter would then search for something
+ * they never highlighted.
+ */
+export function withReply(s: ListState, seq: number, items: TitleSuggestion[]): ListState {
+  const suggest = applyReply(s.suggest, seq, items);
+  if (suggest === s.suggest) return s;
+  return { suggest, highlight: -1 };
+}
+
+/** Move the highlight, wrapping, and entering the list from -1. */
+export function moveHighlight(s: ListState, delta: 1 | -1): ListState {
+  const n = s.suggest.items.length;
+  if (n === 0) return s;
+  if (s.highlight === -1) return { ...s, highlight: delta === 1 ? 0 : n - 1 };
+  return { ...s, highlight: (s.highlight + delta + n) % n };
+}
+
+/**
+ * Highlight a specific row — what a click means, before it accepts.
+ *
+ * Out-of-range indices are ignored rather than clamped: the only caller is a
+ * row's own listener, so an out-of-range index means the rows changed under the
+ * click, and accepting a *different* title than the one clicked is worse than
+ * doing nothing.
+ */
+export function highlightAt(s: ListState, index: number): ListState {
+  if (index < 0 || index >= s.suggest.items.length) return s;
+  return { ...s, highlight: index };
+}
+
+/** Close the list, and stop asking about `raw` so it cannot reopen itself. */
+export function closedFor(s: ListState, raw: string): ListState {
+  return { suggest: suppressFor(s.suggest, raw), highlight: -1 };
+}
+
+/**
+ * What to search for on Enter or a click.
+ *
+ * With nothing highlighted this is the raw text, always. Substituting a
+ * suggestion for what the user actually typed is the one thing autocomplete
+ * must never do silently.
+ */
+export function acceptPlan(s: ListState, raw: string): { kind: "suggestion" | "raw"; text: string } {
+  const hit = s.highlight >= 0 ? s.suggest.items[s.highlight] : undefined;
+  if (!hit) return { kind: "raw", text: raw };
+  return { kind: "suggestion", text: submitTextFor(hit) };
+}
+
+/** One entry per row to render. Strings only — the caller sets textContent. */
+export function rowPlan(s: ListState): { label: string; aka: string | null; highlighted: boolean }[] {
+  return s.suggest.items.map((hit, i) => ({
+    label: suggestionLabel(hit),
+    aka: akaNote(hit),
+    highlighted: i === s.highlight,
+  }));
+}

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -36,6 +36,7 @@
 import type { Blocker, MediaFacts } from "../util/playability";
 import type { EpisodeRef } from "../util/episode";
 import type { FeatureId, MaxResolution } from "../util/releasePick";
+import type { TitleSuggestion } from "../util/titleSuggest";
 
 /**
  * One in-flight (or paused / queued / failed) download.
@@ -388,6 +389,20 @@ export interface SourcesResponse {
    */
   omdbConfigured: boolean;
   /**
+   * Whether reccd is configured (file or `TORLINK_RECC_URL`), which is what
+   * makes title autocomplete available.
+   *
+   * A capability flag, never the URL or the token — the same contract as
+   * `debridConfigured` and `omdbConfigured`, and here for the same reason:
+   * this is the one payload the browser fetches before it can render anything.
+   *
+   * WHAT IT SAVES. Without it, a reccd-less server has every keystroke in the
+   * search box fire `/api/title-search` purely to be told
+   * `{status: "not-configured"}` — a request per character to learn a fact
+   * that is true for the whole session.
+   */
+  reccConfigured: boolean;
+  /**
    * The stored viewing preference — quality-picker state the TUI has always
    * had. It rides on this response rather than getting its own `GET` route for
    * the same reason `debridConfigured` and `omdbConfigured` do: this is the one
@@ -536,6 +551,26 @@ export interface PublicRecommendation {
  */
 export type PublicRecommendations =
   | { status: "ok"; items: PublicRecommendation[] }
+  | { status: "not-configured" }
+  | { status: "error"; error: string };
+
+/**
+ * The body of `GET /api/title-search?q=`.
+ *
+ * THE SAME THREE-WAY SHAPE AS `PublicRecommendations` AND `PublicTitleMeta`,
+ * deliberately: "the server has no reccd" is a thing the UI must be able to
+ * say, not a failure, and a fourth bespoke encoding of that idea would be
+ * drift.
+ *
+ * `"error"` carries reccd's own message so the browser and the TUI could show
+ * the same sentence — but the browser deliberately does not. This fires per
+ * keystroke, and an error banner per character is worse than no suggestions,
+ * so the browser renders every non-`"ok"` status as an empty list. The field
+ * is here because throwing the reason away at the wire would make a broken
+ * reccd indistinguishable from a working one with no matches.
+ */
+export type PublicTitleSuggestions =
+  | { status: "ok"; items: TitleSuggestion[] }
   | { status: "not-configured" }
   | { status: "error"; error: string };
 


### PR DESCRIPTION
Both search boxes were blind. Misremember a spelling or a year and the torrent search
returned nothing, without saying why — the recovery was to leave torlink, look the title up
elsewhere, and come back.

reccd already had the catalog that answers this: `GET /search`, a prefix and word-prefix
lookup over IMDb's ~1.5M-title catalog. torlink talked to reccd for recommendations, events
and profile, but not for search. Now, when reccd is configured, **both** front ends suggest
titles as you type, and picking one puts the canonical title *and its year* into the search —
which is what separates a remake from its original.

Ships in both surfaces, per `CLAUDE.md`.

| | Terminal | Browser |
| --- | --- | --- |
| Rows | up to 5 under the box | a floating overlay under the input |
| Take one | `⇥` completes to the top hit | `↓`/`↑` highlight (wraps), `Enter`, or click |
| Dismiss | `esc` | `esc`, or blur |
| Arrows | unchanged — still search history | move the highlight |

`↑`/`↓` keep meaning search history in the terminal. A navigable list would have overloaded
three working bindings to gain reaching row 3 instead of row 1; tab-to-top-hit collides with
nothing. The browser has free arrows, so it gets the full list — the sanctioned kind of
asymmetry.

## How it's wired

- `src/util/titleSuggest.ts` — **new**, shared and pure. The min-length gate, the labels,
  what a pick submits, and the stale-reply guard. Both front ends and the server route
  import it; nothing was copied.
- The terminal calls reccd directly. The browser **cannot** — `reccToken` must never reach a
  tab — so `GET /api/title-search` proxies it, mirroring `/api/recommendations` including
  `loadConfig()` per request and a 200-with-status for "no reccd" rather than a 500.
- `/api/sources` gains `reccConfigured`, so a reccd-less server spends **zero** requests per
  keystroke discovering that again. Verified live: 7 keystrokes, 0 requests.
- 250ms debounce (reccd's own measured latency is 174–311ms for broad prefixes, so the 150ms
  `useTitlePreview` uses would queue), 2.5s timeout, and **every failure renders as silence** —
  an error banner per keystroke is worse than no suggestions.

## Two deviations from the plan, both deliberate

**`footerHints` is not updated, though `HELP_GROUPS` is.** Two key meanings changed — `⇥`
completes when a list is open, and `esc` escalates (first press closes the list, second leaves
the box; one press as always when nothing is open). `CLAUDE.md` says a new key goes in both
halves of `keymap.ts`, and this knowingly does one. `footerHints(region, section, …)` has no
parameter that can express "the search box has suggestions open", and its `tab` entry is the
shared `SWITCH` hint every pane reuses; threading an editing-mode parameter through for one
conditional label is disproportionate, and that footer is already not mode-aware — while you
type a search it advertises `d`, `r` and `v`, none of which apply. The splash's own hint row
*is* mode-aware and does switch between "browse" and "complete".

**The browser's list is an absolute overlay, not the planned in-flow row.** The planned
`flex: 1 0 100%` reflowed the Search / save-search buttons down a row every time the list
opened, moving click targets mid-keystroke. Caught by running it. The plan document was
corrected to match in `b6fc681`, so spec and code agree.

## Known limits, documented in the README rather than left to be discovered

- **Suggestions are titles, not releases.** reccd's catalog holds films and shows —
  `parseBasicsLine` drops `tvEpisode` — so you're offered `Harrowgate`, never
  `Harrowgate S03`. Narrow to a season once results are in.
- **No typo tolerance.** Matching is on the start of any word, so `tin riv` finds
  `Tin Rivers` but `tin rivrs` finds nothing.
- With reccd unconfigured, both boxes behave exactly as before.

## Verification

`npm test`, `npm run typecheck`, `npm run lint`, `npm run build` all clean; one known
pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx` left alone.

`app.ts` has no test environment by design, so the browser wiring was verified by running it
against a stub reccd: suggestion rendering, arrow wrap at both ends, escape staying shut,
click-accept, the "also known as" row resolving to the **primary** title, one request per
debounce window, and zero requests when unconfigured.

Three bugs were found by review or by running the thing, not by the test suite:

- **An in-flight reply reopened a dismissed list.** `suppressFor` left `appliedSeq` untouched
  while `applyReply` gated only on the sequence number, so a request already out carried a
  higher seq and applied anyway. Worst path: press Enter within 250ms of your last keystroke
  and a dropdown opened by itself over your fresh results, and never self-healed. Fixed in the
  shared module so both surfaces inherit the guard.
- **Deleting `|| v === "tv"` left the whole suite green**, and the failure was total rather than
  partial — the type guard is all-or-nothing, so one TV hit rejected the entire array and films
  stopped suggesting too.
- **The terminal's height budget ignored the suggestion rows**, costing the results panel up to
  5 rows and its bottom border while a list was open.

## One bisect hazard

`8f83940` alone fails `npm run typecheck` — two test-only call sites missed a new required
argument, and vitest does not typecheck. Fixed at `d5b83fb`, disclosed in that commit message.
The tip is clean; interactive rebase was unavailable in this environment.

## Follow-ups, deliberately not in scope

- `ForYou` submits a pick's title without its year (`ForYou.tsx:119`), so it and autocomplete
  now differ. Left alone rather than changing a shipped path here.
- `docs/superpowers/notes/2026-07-31-reccd-search-wishlist.md` records what reccd could add —
  a `type` filter, artwork, typo tolerance, season info — and three things reccd must **not**
  change without telling us, chiefly that `matchedAka` has to stay an explicit `null`: torlink's
  guard is all-or-nothing, so omitting the key would reject every primary-title hit and kill the
  feature silently.
- Pre-existing real film titles in `src/util/release.test.ts` and some historical docs predate
  this branch and want their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
