### PR TITLE
Make the browser's play flow findable, legible and abortable

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,11 @@ the active stream; press **`x`** to stop.
 
 In the browser, torlnk resolves the torrent — through the active debrid provider if you have one
 connected, otherwise straight from the swarm — picks the video file (or asks, if there are several), and
-opens a player page. Before it builds a player at all it asks the server what the file actually *is* —
+opens a player page. While it resolves, the button you pressed says so and a line in the corner of the
+window counts up — `Caching on Real-Debrid… 42% · 12s`, the same words the terminal uses — because a
+torrent your provider has never seen genuinely takes minutes. That line carries a **Cancel** that stops
+the session, the browser's answer to the terminal's `esc`. When there are several files to choose from,
+the question opens over the page rather than at the top of it, so it finds you wherever you had scrolled. Before it builds a player at all it asks the server what the file actually *is* —
 container and codecs, read with `ffprobe` where you have it and from the release name where you don't. So
 what happens next is decided up front, and you find out immediately rather than watching a black rectangle
 give up after twelve seconds:

--- a/docs/superpowers/plans/2026-07-31-web-stream-flow-parity.md
+++ b/docs/superpowers/plans/2026-07-31-web-stream-flow-parity.md
@@ -1,0 +1,1676 @@
+# Web Stream Flow Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the browser's play flow findable, legible and abortable — a modal `<dialog>` picker that opens in the viewport, a busy state on every Play button, a viewport-anchored progress pill, and a Cancel that actually stops the session.
+
+**Architecture:** The terminal (`src/ui/App.tsx`) already does all three; the browser is behind on each. Decisions go into pure modules (`src/util/prepareLine.ts`, `src/web/static/streamBusy.ts`, `src/web/static/streamFlow.ts`) where tests can reach them, and `app.ts` stays DOM wiring. The waiting line moves *down* into `src/util` so both front ends share one string.
+
+**Tech Stack:** TypeScript, vitest, Ink (TUI), hand-rolled DOM (`src/web/static`, bundled by tsup with `platform: "browser"`).
+
+**Spec:** `docs/superpowers/specs/2026-07-31-web-stream-flow-parity-design.md`
+
+## Global Constraints
+
+- **No `innerHTML` / `insertAdjacentHTML` / `document.write` / `outerHTML` anywhere in `src/web/static/`.** Every node is `createElement` + `textContent`. Filenames come from whoever uploaded the torrent.
+- **`src/web` must not import from `src/ui`**, and `src/util` must import from neither. Lint enforces this.
+- **`src/util/prepareLine.ts` must import nothing at all** — it is pulled into a browser bundle. `npm run build` is the only check that `src/web/static/` reaches no `node:*`.
+- **Never introduce a real film or show title** into a test, fixture, doc comment or user-facing copy. Use only: `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`.
+- **Conventional Commits.** Each task ends in one commit.
+- **Before saying done:** `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) — leave it.
+- The cancel notice string is exactly `"Stream cancelled."` — the terminal's own (`src/ui/App.tsx:1251`).
+
+---
+
+### Task 1: The shared waiting line
+
+The terminal builds this string inline at `src/ui/App.tsx:2386-2393`. It moves down to `src/util` so the browser can use the same one; writing it a second time in `src/web` would be the fifth recorded copy-then-drift bug in this repo.
+
+**Files:**
+- Create: `src/util/prepareLine.ts`
+- Create: `src/util/prepareLine.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PrepareFacts` (interface), `prepareLine(facts: PrepareFacts): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/prepareLine.test.ts`. The first three assertions are the *exact* strings the TUI renders today, minus its `  (esc cancels)` suffix — that is what makes Task 2 provably behaviour-preserving.
+
+```ts
+import { describe, expect, it } from "vitest";
+import { prepareLine } from "./prepareLine";
+
+describe("prepareLine", () => {
+  // The three strings src/ui/App.tsx:2386-2393 built inline before this module
+  // existed. They are asserted verbatim so Task 2's swap cannot change what the
+  // terminal renders.
+  it("says who is caching and how far along, for a debrid resolve", () => {
+    expect(
+      prepareLine({
+        source: "rd",
+        phase: "caching",
+        providerLabel: "Real-Debrid",
+        label: "Harrowgate.S03.1080p.WEB-DL",
+        pct: 42,
+        elapsedSec: 12,
+      }),
+    ).toBe("Caching on Real-Debrid… 42% · 12s");
+  });
+
+  it("names the release while looking for peers, where there is no percent to give", () => {
+    expect(
+      prepareLine({
+        source: "torrent",
+        phase: "caching",
+        label: "Kestrel.2010.1080p.BluRay.x264",
+        pct: 0,
+        elapsedSec: 3,
+      }),
+    ).toBe("Finding peers… Kestrel.2010.1080p.BluRay.x264 · 3s");
+  });
+
+  it("says only how long it has been fetching a link, which has no percent either", () => {
+    expect(
+      prepareLine({
+        source: "rd",
+        phase: "fetching",
+        providerLabel: "TorBox",
+        label: "Ashfall.1999.1080p",
+        pct: 0,
+        elapsedSec: 7,
+      }),
+    ).toBe("Fetching link… 7s");
+  });
+
+  it("falls back to a generic provider name rather than rendering 'undefined'", () => {
+    const line = prepareLine({
+      source: "rd",
+      phase: "caching",
+      label: "Ashfall.1999.1080p",
+      pct: 5,
+      elapsedSec: 1,
+    });
+    expect(line).toBe("Caching on debrid… 5% · 1s");
+    expect(line).not.toContain("undefined");
+    expect(line).not.toContain("null");
+  });
+
+  // Floors rather than rounds, for the reason dashboard.ts gives: rounding 99.6
+  // up to 100 on something still working reads as a stuck UI.
+  it("clamps and floors a nonsense percent instead of rendering it", () => {
+    const at = (pct: number): string =>
+      prepareLine({ source: "rd", phase: "caching", providerLabel: "RD", label: "n", pct, elapsedSec: 0 });
+    expect(at(140)).toContain("100%");
+    expect(at(-3)).toContain("0%");
+    expect(at(Number.NaN)).toContain("0%");
+    expect(at(99.7)).toContain("99%");
+  });
+
+  it("clamps a nonsense elapsed time the same way", () => {
+    const at = (elapsedSec: number): string =>
+      prepareLine({ source: "torrent", phase: "caching", label: "n", pct: 0, elapsedSec });
+    expect(at(-1)).toContain("· 0s");
+    expect(at(Number.NaN)).toContain("· 0s");
+    expect(at(12.9)).toContain("· 12s");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run src/util/prepareLine.test.ts`
+Expected: FAIL — `Failed to resolve import "./prepareLine"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/prepareLine.ts`:
+
+```ts
+// What a user waiting for a stream to resolve reads, for both front ends.
+//
+// This lived inline in src/ui/App.tsx's render (a three-armed ternary in a
+// <Spinner label>) until the browser needed the same line. It moved down here
+// rather than being written a second time: this codebase records four bugs
+// caused by copy-then-drift — a byte formatter, an uploadSpeed field, a
+// progress unit, an API path table — and a waiting line the two front ends
+// disagree about is the same bug in a place the user is staring at for minutes.
+//
+// IMPORTS NOTHING, and must keep importing nothing: it is pulled into
+// src/web/static's browser bundle (platform: "browser" in tsup.web.config.ts),
+// where a transitive `node:*` fails the build. That is also why it is its own
+// module rather than a function in a larger util.
+//
+// The affordance is NOT part of the line. The terminal appends
+// "  (esc cancels)" and the browser puts a Cancel button next to it — a
+// keybinding hint is CLAUDE.md's "a surface can't express it", and it is the
+// only thing about this line that differs between the two.
+
+export interface PrepareFacts {
+  /**
+   * Which network is resolving this. Spelled "rd" rather than "debrid" because
+   * these field names are the TUI's `preparing` state verbatim, so its call
+   * site is a spread and cannot silently mismatch. The browser's wire form is
+   * `PublicStreamSession.backend`, which spells the same thing "debrid" — the
+   * one mapping between them lives in streamFlow.ts's pollDecision.
+   */
+  source: "rd" | "torrent";
+  /** Ignored when `source` is "torrent", which has no link-fetch step. */
+  phase: "caching" | "fetching";
+  /** Only meaningful when caching on debrid. Absent falls back to "debrid". */
+  providerLabel?: string | null;
+  /** The release name, already shortened by the caller. */
+  label: string;
+  /** Integer percent, 0-100. Clamped here rather than by callers. */
+  pct: number;
+  elapsedSec: number;
+}
+
+/**
+ * The waiting line, without any affordance appended.
+ *
+ * The elapsed seconds are load-bearing, not decoration: a Real-Debrid cache
+ * sits at one percent for minutes at a time, and a number that moves is the
+ * whole difference between "working" and "hung".
+ */
+export function prepareLine(facts: PrepareFacts): string {
+  const secs = `${whole(facts.elapsedSec, 0)}s`;
+  if (facts.source === "torrent") return `Finding peers… ${facts.label} · ${secs}`;
+  if (facts.phase === "fetching") return `Fetching link… ${secs}`;
+  const who = facts.providerLabel ?? "debrid";
+  return `Caching on ${who}… ${whole(facts.pct, 100)}% · ${secs}`;
+}
+
+// Defended against a backend reporting something outside its documented range,
+// and against a NaN — `Math.floor(NaN)` is NaN, which would render the word
+// "NaN" at the user. Floors rather than rounds: see dashboard.ts's same rule.
+function whole(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(max, Math.floor(value)));
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx vitest run src/util/prepareLine.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/prepareLine.ts src/util/prepareLine.test.ts
+git commit -m "feat(util): share the stream-preparing line between both front ends"
+```
+
+---
+
+### Task 2: The terminal consumes it
+
+Behaviour-preserving by construction — Task 1 asserts the three strings verbatim.
+
+**Files:**
+- Modify: `src/ui/App.tsx:2386-2393`
+
+**Interfaces:**
+- Consumes: `prepareLine` from Task 1.
+- Produces: nothing new.
+
+- [ ] **Step 1: Check the current render, so the swap is provably like-for-like**
+
+Run: `sed -n 2384,2396p src/ui/App.tsx`
+
+You should see a `<Spinner label={…}>` with a three-armed ternary. Confirm the `preparing` state's fields (`src/ui/App.tsx:320-330`) are `label`, `phase`, `pct`, `source`, `providerLabel?` — they match `PrepareFacts` exactly, which is why the call below is a spread.
+
+- [ ] **Step 2: Add the import**
+
+Add to the `src/util` imports near the top of `src/ui/App.tsx` (match the surrounding import style; find the existing block with `grep -n 'from "../util/' src/ui/App.tsx | head -3`):
+
+```tsx
+import { prepareLine } from "../util/prepareLine";
+```
+
+- [ ] **Step 3: Replace the inline ternary**
+
+Replace the whole `<Spinner label={…} />` element at `src/ui/App.tsx:2386-2394` with:
+
+```tsx
+            <Spinner
+              // The line itself is shared with the browser (src/util/prepareLine.ts)
+              // so the two front ends cannot drift on what a waiting user reads.
+              // The key hint is appended here and only here: the browser has a
+              // Cancel button in its place.
+              label={`${prepareLine({ ...preparing, elapsedSec: prepElapsed })}  (esc cancels)`}
+            />
+```
+
+- [ ] **Step 4: Verify the terminal still typechecks and its tests pass**
+
+Run: `npx tsc --noEmit -p tsconfig.json && npx vitest run src/ui`
+Expected: PASS. If `tsc` complains that `preparing` has extra fields, that is a spread supplying more than `PrepareFacts` declares — allowed for a spread of a variable (excess-property checks apply only to object literals). If it complains about a *missing* field, the `preparing` state shape has changed since this plan was written: pass the fields explicitly instead of spreading.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/App.tsx
+git commit -m "refactor(ui): build the preparing line from the shared helper"
+```
+
+---
+
+### Task 3: `pollDecision` speaks the shared line
+
+**Files:**
+- Modify: `src/web/static/streamFlow.ts` (`pollDecision`, and delete `resolvePercent`)
+- Modify: `src/web/static/streamFlow.test.ts` (the `pollDecision` describe block, `src/web/static/streamFlow.test.ts:256-306`)
+
+**Interfaces:**
+- Consumes: `prepareLine` from Task 1.
+- Produces: `pollDecision(session: PublicStreamSession, elapsedMs: number, name: string, providerLabel?: string | null): PollDecision` — one new trailing optional parameter. `PollDecision` itself is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/web/static/streamFlow.test.ts`, replace the three tests named `"shows the percent the session reports, so it doesn't look hung"`, `"clamps a nonsense percent rather than rendering it"` and `"clips a very long name for the notice"` with these. Note the `session` helper defaults to `backend: "torrent"` (`src/web/static/streamFlow.test.ts:32`), so a debrid case must say so.
+
+```ts
+  it("names the provider and the percent for a debrid resolve", () => {
+    const d = pollDecision(
+      session({ state: "resolving", backend: "debrid", progress: 42 }),
+      12_000,
+      "Harrowgate.S03.1080p.WEB-DL",
+      "Real-Debrid",
+    );
+    expect(d.kind).toBe("poll");
+    if (d.kind !== "poll") return;
+    expect(d.label).toBe("Caching on Real-Debrid… 42% · 12s");
+    expect(d.delayMs).toBe(POLL_MS);
+  });
+
+  it("names the release, not a percent, while finding peers in a swarm", () => {
+    const d = pollDecision(
+      session({ state: "resolving", backend: "torrent", progress: 42 }),
+      3_000,
+      "Kestrel.2010.1080p.BluRay.x264",
+    );
+    expect(d.kind).toBe("poll");
+    if (d.kind !== "poll") return;
+    expect(d.label).toBe("Finding peers… Kestrel.2010.1080p.BluRay.x264 · 3s");
+  });
+
+  // The elapsed seconds are what tell a user that a resolve sitting at one
+  // percent for minutes is working rather than hung. Deleting them is the
+  // mutation this guards.
+  it("counts the seconds up, so a stalled percent still shows movement", () => {
+    const at = (ms: number): string => {
+      const d = pollDecision(session({ state: "resolving", backend: "debrid", progress: 7 }), ms, "n", "RD");
+      return d.kind === "poll" ? d.label : "";
+    };
+    expect(at(0)).toContain("· 0s");
+    expect(at(1_000)).toContain("· 1s");
+    expect(at(65_400)).toContain("· 65s");
+  });
+
+  it("clamps a nonsense percent rather than rendering it", () => {
+    const at = (progress: number): string => {
+      const d = pollDecision(session({ state: "resolving", backend: "debrid", progress }), 0, "n", "RD");
+      return d.kind === "poll" ? d.label : "";
+    };
+    expect(at(140)).toContain("100%");
+    expect(at(-3)).toContain("0%");
+    expect(at(Number.NaN)).toContain("0%");
+    expect(at(99.7)).toContain("99%");
+  });
+
+  // Asserts the TRUNCATED name is present, not merely that some "…" is: every
+  // line prepareLine produces contains an ellipsis of its own ("Finding peers…"),
+  // so `toContain("…")` would pass while the name went unclipped. That is the
+  // vacuous-assertion trap CLAUDE.md records.
+  it("clips a very long name for the waiting line", () => {
+    const long = "x".repeat(300);
+    const d = pollDecision(session({ state: "resolving", backend: "torrent" }), 0, long);
+    expect(d.kind).toBe("poll");
+    if (d.kind !== "poll") return;
+    expect(d.label).not.toContain(long);
+    expect(d.label).toContain(`${"x".repeat(79)}…`);
+  });
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `npx vitest run src/web/static/streamFlow.test.ts -t pollDecision`
+Expected: FAIL — the labels read `Preparing "…" — 42%`, not the new strings.
+
+- [ ] **Step 3: Implement**
+
+In `src/web/static/streamFlow.ts`, add the import beside the existing `../../util/*` imports:
+
+```ts
+// The sixth value import out of this directory, and the same argument as the
+// other five: what a waiting user reads is a decision both front ends make, so
+// it is shared rather than written twice. See src/util/prepareLine.ts.
+import { prepareLine } from "../../util/prepareLine";
+```
+
+Replace `pollDecision`'s signature and its `poll` return with:
+
+```ts
+export function pollDecision(
+  session: PublicStreamSession,
+  elapsedMs: number,
+  name: string,
+  providerLabel?: string | null,
+): PollDecision {
+  if (session.state !== "resolving") return { kind: "settled" };
+  const label = shortName(name);
+  if (elapsedMs >= RESOLVE_TIMEOUT_MS) {
+    return {
+      kind: "timeout",
+      message: `Gave up waiting for “${label}” to be ready. It may still be caching — try again in a few minutes.`,
+    };
+  }
+  return {
+    kind: "poll",
+    delayMs: POLL_MS,
+    // `phase: "caching"` unconditionally: the wire has one `resolving` state
+    // and no way to distinguish the provider's link-fetch step from its cache,
+    // so the browser never renders prepareLine's "Fetching link…" arm. The TUI
+    // does, from its own richer local state. Reporting a percent of 0 as
+    // "Caching… 0%" is honest for that moment; inventing a phase would not be.
+    label: prepareLine({
+      source: session.backend === "debrid" ? "rd" : "torrent",
+      phase: "caching",
+      providerLabel,
+      label,
+      pct: session.progress,
+      elapsedSec: elapsedMs / 1000,
+    }),
+  };
+}
+```
+
+Then **delete** the now-unused `resolvePercent` function and its comment block at the bottom of `src/web/static/streamFlow.ts` — `prepareLine` owns the clamp now. Verify nothing else calls it:
+
+```bash
+grep -rn "resolvePercent" src/
+```
+
+Expected: no hits after the deletion.
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `npx vitest run src/web/static/streamFlow.test.ts && npx tsc --noEmit -p tsconfig.json`
+Expected: PASS. The `runPlay` test at `src/web/static/streamFlow.test.ts:575` (`"keeps polling while the session is resolving, and shows the percent"`) may also assert on the old label — if it fails, update its expectation to the new string; do not weaken it to a substring match.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/streamFlow.ts src/web/static/streamFlow.test.ts
+git commit -m "feat(web): report a resolve with the terminal's own waiting line"
+```
+
+---
+
+### Task 4: `runPlay` gains an abort signal and a progress channel
+
+Two changes to one contract, so one task: the third positional parameter becomes an options bag (it was `wanted?`, and there are now three things to pass), and progress gets its own effect so the pill and the notice line stop competing for `fx.notice`.
+
+**Files:**
+- Modify: `src/web/static/streamFlow.ts` (`PlayEffects`, `runPlay`)
+- Modify: `src/web/static/streamFlow.test.ts` (the `harness` helper at `src/web/static/streamFlow.test.ts:448-489`, every `runPlay(row(), fx, wanted)` call site, plus new abort tests)
+
+**Interfaces:**
+- Consumes: `pollDecision` from Task 3.
+- Produces:
+  - `PlayEffects.start(row: DashRow, confirmed: boolean, signal?: AbortSignal): Promise<StartResult>`
+  - `PlayEffects.poll(sessionId: string, signal?: AbortSignal): Promise<PublicStreamSession | null>`
+  - `PlayEffects.sleep(ms: number, signal?: AbortSignal): Promise<void>`
+  - `PlayEffects.progress(line: string | null): void` — **required**, so forgetting it cannot leave a pill on screen forever
+  - `PlayOptions { wanted?: EpisodeRef | null; providerLabel?: string | null; signal?: AbortSignal }`
+  - `runPlay(row: DashRow, fx: PlayEffects, opts?: PlayOptions): Promise<void>`
+  - `CANCELLED_NOTICE = "Stream cancelled."`
+
+- [ ] **Step 1: Write the failing tests**
+
+First update the `harness` helper in `src/web/static/streamFlow.test.ts` (at `:448`) to record the two new effects — add to `calls`:
+
+```ts
+    progress: [] as (string | null)[],
+    slept: [] as { ms: number; aborts: boolean }[],
+```
+
+and to `fx`:
+
+```ts
+    progress: (line) => calls.progress.push(line),
+```
+
+and replace its `sleep` with one that records whether it was handed a signal:
+
+```ts
+    sleep: async (ms, signal) => {
+      calls.slept.push({ ms, aborts: signal !== undefined });
+      clock += ms;
+    },
+```
+
+Then add this block at the end of `describe("runPlay", …)`:
+
+```ts
+  describe("cancelling", () => {
+    // A resolve can run for ten minutes. Before this there was no way out of
+    // one but reloading the page, which orphaned the session either way.
+    it("does not start anything at all when already aborted", async () => {
+      const ac = new AbortController();
+      ac.abort();
+      const { fx, calls } = harness({ start: async () => started({ files: [file("movie.mp4", 0)] }) });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.starts).toEqual([]);
+      expect(calls.opened).toEqual([]);
+      expect(calls.notices).toEqual(["Stream cancelled."]);
+    });
+
+    // THE RACE THAT MATTERS. An abort landing after the POST succeeded but
+    // before the first poll must still DELETE the session — otherwise
+    // cancelling at the worst possible moment leaks the exact resource that
+    // cancelling exists to release, and the torrent runs until the idle reaper.
+    it("stops the session when the abort lands after it was started", async () => {
+      const ac = new AbortController();
+      const { fx, calls } = harness({
+        start: async () => {
+          ac.abort();
+          return started({ state: "resolving", progress: 0 });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.stopped).toEqual(["s1"]);
+      expect(calls.notices).toContain("Stream cancelled.");
+      expect(calls.polls).toBe(0);
+      expect(calls.opened).toEqual([]);
+    });
+
+    it("stops polling and releases the session when cancelled mid-resolve", async () => {
+      const ac = new AbortController();
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async () => started({ state: "resolving", progress: 10 }),
+        poll: async () => {
+          polls++;
+          if (polls === 2) ac.abort();
+          return session({ state: "resolving", progress: 10 + polls });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(polls).toBe(2);
+      expect(calls.stopped).toEqual(["s1"]);
+      expect(calls.notices).toContain("Stream cancelled.");
+    });
+
+    it("hands the signal to start, poll and sleep, so an in-flight fetch dies too", async () => {
+      const ac = new AbortController();
+      const seen: { start?: boolean; poll?: boolean } = {};
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async (_row, _confirmed, signal) => {
+          seen.start = signal === ac.signal;
+          return started({ state: "resolving", progress: 0 });
+        },
+        poll: async (_id, signal) => {
+          seen.poll = signal === ac.signal;
+          polls++;
+          return polls === 1 ? session({ state: "resolving" }) : session({ files: [file("movie.mp4", 0)] });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(seen.start).toBe(true);
+      expect(seen.poll).toBe(true);
+      expect(calls.slept.every((s) => s.aborts)).toBe(true);
+    });
+  });
+
+  describe("progress", () => {
+    it("reports the waiting line on its own channel, not as a notice", async () => {
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async () => started({ state: "resolving", backend: "debrid", progress: 40 }),
+        poll: async () => {
+          polls++;
+          return polls === 1
+            ? session({ state: "resolving", backend: "debrid", progress: 60 })
+            : session({ files: [file("movie.mp4", 0)] });
+        },
+      });
+      await runPlay(row(), fx, { providerLabel: "Real-Debrid" });
+      expect(calls.progress[0]).toBe("Caching on Real-Debrid… 40% · 0s");
+      expect(calls.notices).toEqual([]);
+    });
+
+    // The pill must come down however the flow ends, or it sits over the page
+    // for good. Asserted for a success, a failure and a cancel.
+    it("clears the waiting line however the flow ends", async () => {
+      const ok = harness({ start: async () => started({ files: [file("movie.mp4", 0)] }) });
+      await runPlay(row(), ok.fx);
+      expect(ok.calls.progress.at(-1)).toBeNull();
+
+      const bad = harness({ start: async () => started({ state: "error", error: "no peers" }) });
+      await runPlay(row(), bad.fx);
+      expect(bad.calls.progress.at(-1)).toBeNull();
+
+      const ac = new AbortController();
+      ac.abort();
+      const off = harness();
+      await runPlay(row(), off.fx, { signal: ac.signal });
+      expect(off.calls.progress.at(-1)).toBeNull();
+    });
+  });
+```
+
+Finally, update the existing `wanted` call sites to the options bag. Find them:
+
+```bash
+grep -n "runPlay(row(), fx, " src/web/static/streamFlow.test.ts
+```
+
+Each `runPlay(row(), fx, someWanted)` becomes `runPlay(row(), fx, { wanted: someWanted })`.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `npx vitest run src/web/static/streamFlow.test.ts`
+Expected: FAIL — `progress` is not a property of `PlayEffects`, and `runPlay`'s third argument is not an object.
+
+- [ ] **Step 3: Implement**
+
+In `src/web/static/streamFlow.ts`, add to `PlayEffects` (and change the three existing members' signatures):
+
+```ts
+  /** POST /api/stream. `confirmed` is only ever true after a human said so. */
+  start(row: DashRow, confirmed: boolean, signal?: AbortSignal): Promise<StartResult>;
+  /** GET /api/stream/:sid, or null when it can't be read. */
+  poll(sessionId: string, signal?: AbortSignal): Promise<PublicStreamSession | null>;
+  /**
+   * The waiting line, or null to take it down.
+   *
+   * A SEPARATE CHANNEL FROM `notice`, deliberately. `notice` is a transient
+   * line that hides itself after a few seconds; this one has to persist for as
+   * long as the resolve does, which can be minutes, and it has a Cancel button
+   * attached. Sharing one effect meant the progress label re-firing every
+   * second stamped over any real message the user needed to read.
+   *
+   * REQUIRED, not optional: an implementation that forgets it would leave a
+   * pill fixed over the page for good.
+   */
+  progress(line: string | null): void;
+  sleep(ms: number, signal?: AbortSignal): Promise<void>;
+```
+
+Add above `runPlay`:
+
+```ts
+/**
+ * The one wording for a cancelled stream, shared with the TUI's own
+ * `cancelPreparing` (src/ui/App.tsx:1251) by being the same string.
+ */
+export const CANCELLED_NOTICE = "Stream cancelled.";
+
+/**
+ * The three things `runPlay` needs that are DATA rather than effects.
+ *
+ * An options bag rather than three positional parameters: `wanted` was the
+ * third argument and the other two would make a call site read
+ * `runPlay(row, fx, null, "Real-Debrid", signal)`, where transposing two
+ * arguments typechecks and silently plays the wrong episode.
+ */
+export interface PlayOptions {
+  /** A Continue-watching row's own suggested episode. See wantedEpisodeFor. */
+  wanted?: EpisodeRef | null;
+  /** Who is caching, for the waiting line. Absent renders "debrid". */
+  providerLabel?: string | null;
+  /**
+   * Cancels the flow. Threaded into `start`, `poll` and `sleep` rather than
+   * merely checked between them, so a cancel kills an in-flight fetch instead
+   * of waiting it out — and, crucially, a session that HAD started is stopped
+   * on the way out (see the abort tests).
+   */
+  signal?: AbortSignal;
+}
+```
+
+Rewrite `runPlay`:
+
+```ts
+export async function runPlay(
+  row: DashRow,
+  fx: PlayEffects,
+  opts: PlayOptions = {},
+): Promise<void> {
+  const { wanted, providerLabel, signal } = opts;
+
+  // Every exit from here down goes through one of these two, so the waiting
+  // line cannot be left up by a path someone forgot about.
+  const done = (): void => fx.progress(null);
+  const cancel = (sessionId: string | null): void => {
+    if (sessionId) fx.stop(sessionId);
+    done();
+    fx.notice(CANCELLED_NOTICE);
+  };
+
+  if (signal?.aborted) {
+    cancel(null);
+    return;
+  }
+
+  let start = await fx.start(row, false, signal);
+
+  if (start.kind === "confirm") {
+    if (!fx.confirm(confirmFallbackMessage(start.reason, row.name))) {
+      done();
+      fx.notice("Playback cancelled — nothing was streamed.");
+      return;
+    }
+    start = await fx.start(row, true, signal);
+    // A second 409 means the server didn't accept the confirmation. Do not loop
+    // asking: one prompt per click.
+    if (start.kind === "confirm") {
+      done();
+      fx.notice("Couldn't start that stream.");
+      return;
+    }
+  }
+  if (start.kind !== "started") {
+    done();
+    if (start.kind === "failed") fx.onUnresolved?.();
+    return;
+  }
+
+  const { sessionId, capability } = start;
+  // From here on a session EXISTS, so every early return owes it a stop —
+  // including an abort. This is the leak the "abort lands after it was
+  // started" test guards.
+  if (signal?.aborted) {
+    cancel(sessionId);
+    return;
+  }
+
+  let session = start.session;
+  const began = fx.now();
+  for (;;) {
+    const decision = pollDecision(session, fx.now() - began, row.name, providerLabel);
+    if (decision.kind === "settled") break;
+    if (decision.kind === "timeout") {
+      done();
+      fx.notice(decision.message);
+      fx.stop(sessionId);
+      return;
+    }
+    fx.progress(decision.label);
+    await fx.sleep(decision.delayMs, signal);
+    if (signal?.aborted) {
+      cancel(sessionId);
+      return;
+    }
+    const next = await fx.poll(sessionId, signal);
+    if (!next) {
+      // An aborted fetch also lands here, and must not be reported as a
+      // transport failure — the user asked for this.
+      if (signal?.aborted) {
+        cancel(sessionId);
+        return;
+      }
+      // The session is gone or unreadable. Not stopped here: a DELETE we can't
+      // read the answer to adds nothing, and the id may not exist at all.
+      done();
+      fx.notice("Lost track of that stream — try again.");
+      return;
+    }
+    session = next;
+  }
+
+  done();
+
+  const outcome = streamOutcome(session, wanted);
+  if (outcome.kind === "error") {
+    // Already worded for a human by the core, which reuses the TUI's strings.
+    fx.notice(outcome.message);
+    fx.stop(sessionId);
+    return;
+  }
+  if (outcome.kind === "empty") {
+    fx.notice("There is nothing playable in that torrent.");
+    fx.stop(sessionId);
+    return;
+  }
+  if (outcome.kind === "single") {
+    fx.open(playerPath(sessionId, outcome.file, capability));
+    return;
+  }
+  fx.choose(sessionId, capability, row.name, outcome.files, outcome.preselect);
+}
+```
+
+Also update `runPlay`'s doc comment: replace the paragraph beginning "`wanted` is data, not an effect" with one describing `PlayOptions` and adding a third numbered rule:
+
+```
+ * 3. A CANCEL RELEASES THE SESSION. Every exit after `start` succeeded stops
+ *    the session, an abort included — a cancel that leaked the torrent would
+ *    be worse than no cancel, because the user believes they stopped it.
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `npx vitest run src/web/static/streamFlow.test.ts && npx tsc --noEmit -p tsconfig.json`
+Expected: PASS. `tsc` will now flag `app.ts`'s `runPlay` call (it passes `wanted` positionally and has no `progress`) — that is Task 7's job. If you want a green tree at this commit, apply the two-line stopgap in Step 5.
+
+- [ ] **Step 5: Keep `app.ts` compiling, then commit**
+
+`app.ts` must typecheck at every commit. Apply the minimal stopgap in `src/web/static/app.ts`'s `play()`: add `progress: showNotice` beside `notice: showNotice` in the effects object (temporary — Task 7 replaces it with the pill), and change the trailing `}, wanted);` to `}, { wanted });`.
+
+```bash
+npx tsc --noEmit -p tsconfig.json && npx vitest run src/web/static/
+git add src/web/static/streamFlow.ts src/web/static/streamFlow.test.ts src/web/static/app.ts
+git commit -m "feat(web): let a resolve be cancelled, and report progress on its own channel"
+```
+
+---
+
+### Task 5: Derived busy state
+
+**Files:**
+- Create: `src/web/static/streamBusy.ts`
+- Create: `src/web/static/streamBusy.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `FlowState`, `ControlState`, `BUSY_LABEL`, `controlState(flow: FlowState, key: string, idleLabel: string): ControlState`, `isBusy(flow: FlowState): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web/static/streamBusy.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { BUSY_LABEL, controlState, isBusy, type FlowState } from "./streamBusy";
+
+const idle: FlowState = { prepare: null, picking: null };
+const preparing: FlowState = { prepare: { key: "abc", title: "Harrowgate.S03.1080p.WEB-DL" }, picking: null };
+const picking: FlowState = { prepare: null, picking: "Kestrel" };
+
+describe("controlState", () => {
+  it("leaves every control alone when nothing is in flight", () => {
+    expect(controlState(idle, "abc", "play")).toEqual({ disabled: false, busy: false, label: "play" });
+    expect(controlState(idle, "Kestrel", "Play next")).toEqual({
+      disabled: false,
+      busy: false,
+      label: "Play next",
+    });
+  });
+
+  it("marks the control that started the flow as busy", () => {
+    expect(controlState(preparing, "abc", "play")).toEqual({
+      disabled: true,
+      busy: true,
+      label: BUSY_LABEL,
+    });
+  });
+
+  // The point of the whole module. A Play button that stays enabled while a
+  // prepare runs, and silently does nothing when pressed, is what taught users
+  // to hammer it — one prepare at a time is the terminal's rule
+  // (src/ui/App.tsx:1317) and this is it, rendered.
+  it("disables every OTHER control rather than letting it no-op silently", () => {
+    expect(controlState(preparing, "def", "play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "play",
+    });
+    expect(controlState(preparing, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "Play",
+    });
+  });
+
+  it("treats a pick search exactly as it treats a prepare", () => {
+    expect(controlState(picking, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: true,
+      label: BUSY_LABEL,
+    });
+    expect(controlState(picking, "abc", "play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "play",
+    });
+  });
+
+  // A pick hands off to a prepare, so both can be set for one tick. The row
+  // actually resolving is the more specific truth and wins; without this the
+  // title's button would claim to be busy while the row's did the work.
+  it("prefers the prepare when a pick has already handed off to one", () => {
+    const both: FlowState = { prepare: { key: "abc", title: "Kestrel" }, picking: "Kestrel" };
+    expect(controlState(both, "abc", "play").busy).toBe(true);
+    expect(controlState(both, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "Play",
+    });
+  });
+
+  // Info hashes and titles are two namespaces and are never compared across.
+  // A key from the wrong one simply never matches, which lands it in the
+  // disabled branch — the correct answer for it anyway.
+  it("never mistakes a title for an info hash", () => {
+    expect(controlState(preparing, "Harrowgate.S03.1080p.WEB-DL", "Play").busy).toBe(false);
+  });
+});
+
+describe("isBusy", () => {
+  it("is the one-at-a-time gate the terminal has and the browser did not", () => {
+    expect(isBusy(idle)).toBe(false);
+    expect(isBusy(preparing)).toBe(true);
+    expect(isBusy(picking)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run src/web/static/streamBusy.test.ts`
+Expected: FAIL — `Failed to resolve import "./streamBusy"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/web/static/streamBusy.ts`:
+
+```ts
+// Whether a Play control is busy, disabled, or neither — and the one gate that
+// stops a second stream starting while the first is still resolving.
+//
+// Pure, and here rather than in app.ts for the reason every model in this
+// directory is: there is no jsdom in this repo, so a conditional that lives in
+// app.ts is a conditional no test can reach. "If you are writing a conditional
+// in app.ts that decides what to show, it belongs in a pure module" — CLAUDE.md,
+// and this has been caught in review twice.
+//
+// DERIVED, NEVER STORED ON THE ELEMENT. The queue's rows are rebuilt four times
+// a second by the SSE tick, so a `disabled` set once on click is gone by the
+// next frame. app.ts re-applies this over the live DOM after every render.
+
+export interface FlowState {
+  /**
+   * The row a prepare is running for, or null. `key` is the info hash — the
+   * same `DashRow.id` that `runPlay` was handed, so the two cannot disagree
+   * about which row is busy.
+   */
+  prepare: { key: string; title: string } | null;
+  /**
+   * The title a pickController search is running for, or null. A TITLE, not a
+   * hash: a one-click Play on a recommendation has no torrent yet, which is
+   * exactly what it is off finding.
+   */
+  picking: string | null;
+}
+
+export interface ControlState {
+  disabled: boolean;
+  /** Render `aria-busy` and a spinner. Exactly one control can be busy. */
+  busy: boolean;
+  label: string;
+}
+
+/** What the control that started the flow says while it waits. */
+export const BUSY_LABEL = "preparing…";
+
+/**
+ * What one Play control should look like right now.
+ *
+ * The rule is the terminal's, made visible: ONE prepare or pick at a time
+ * (`if (preparing || streamFiles || activeStream) return` — src/ui/App.tsx:1317
+ * and :1445). The browser had the same rule per-row and silently returned when
+ * it fired, so a button stayed lit and did nothing when pressed — which is how
+ * a user learns to press it repeatedly, starting nothing each time. So every
+ * control that is not the busy one is DISABLED, not merely ineligible.
+ *
+ * `idleLabel` is passed in rather than assumed because the six Play controls do
+ * not share one word: "play", "Play", "Play next". Nothing here decides copy.
+ */
+export function controlState(flow: FlowState, key: string, idleLabel: string): ControlState {
+  // The prepare wins when both are set: a pick that has found its release and
+  // handed off is now a prepare, and the row doing the work is the truer answer
+  // than the title that asked for it.
+  const active = flow.prepare?.key ?? flow.picking;
+  if (active === null || active === undefined) {
+    return { disabled: false, busy: false, label: idleLabel };
+  }
+  // Two namespaces (info hashes, titles) and no comparison across them: a key
+  // from the other one never matches, and disabled is the right answer for it.
+  if (active === key) return { disabled: true, busy: true, label: BUSY_LABEL };
+  return { disabled: true, busy: false, label: idleLabel };
+}
+
+/**
+ * Whether a new play or pick may start at all.
+ *
+ * The browser's guard was `playing.has(row.id)` — per-row, so two different
+ * rows could resolve at once, each polling a session for up to ten minutes,
+ * with one shared progress line between them reporting whichever wrote last.
+ */
+export function isBusy(flow: FlowState): boolean {
+  return flow.prepare !== null || flow.picking !== null;
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx vitest run src/web/static/streamBusy.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/streamBusy.ts src/web/static/streamBusy.test.ts
+git commit -m "feat(web): derive the Play buttons' busy state from one flow state"
+```
+
+---
+
+### Task 6: The picker becomes a modal `<dialog>`
+
+**Files:**
+- Modify: `src/web/static/index.html:63-79` (move `#picker` out of `<main>`, make it a `<dialog>`)
+- Modify: `src/web/static/styles.css:370-372` (`.picker`), plus a `::backdrop`
+- Modify: `src/web/static/app.ts` (`picker` element type, `showPicker`, `hidePicker`, the Cancel handler)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: nothing new; `showPicker`'s signature is unchanged.
+
+- [ ] **Step 1: Move the markup and make it a dialog**
+
+In `src/web/static/index.html`, **delete** the `#picker` block (currently the first child of `<main id="app">`, `src/web/static/index.html:63-79`) and re-insert it **immediately after** `<p id="notice" …></p>` and **before** `<main id="app" hidden>`, as:
+
+```html
+    <!-- The stream file picker. Shown only when a session resolves to more than
+         one playable file; every child below the heading is built by app.js with
+         createElement, because the filenames come out of a torrent.
+
+         A MODAL <dialog>, and OUTSIDE <main id="app">, both deliberately:
+
+         - Modal because it used to be an inline card at the top of the document.
+           Press play on a season pack 500px down a browse and the question
+           appeared off screen, with nothing where the user was looking to say
+           anything had happened. showModal() centres it in the viewport, takes
+           focus, and closes on Escape.
+         - Outside #app because #app carries `hidden` until the page loads, and a
+           <dialog> inside a display:none subtree does not render at all. Its old
+           position was justified by sitting above both panes so neither list's
+           re-render could replace it (the queue's happens four times a second);
+           a top-level sibling keeps that and adds nothing to it. -->
+    <dialog id="picker" class="card picker">
+      <p id="picker-title" class="picker-title"></p>
+      <ul id="picker-files" class="picker-files"></ul>
+      <div class="picker-actions">
+        <!-- The terminal picker's "s" key, as a button: title order or
+             largest-first. Its label is set by app.js from the current mode. -->
+        <button id="picker-sort" type="button"></button>
+        <button id="picker-cancel" type="button">Cancel</button>
+      </div>
+    </dialog>
+```
+
+Note there is no `hidden` attribute: a `<dialog>` is closed until opened.
+
+- [ ] **Step 2: Fix the CSS, which would otherwise leave the closed dialog on screen**
+
+In `src/web/static/styles.css`, replace the `.picker` rule (`src/web/static/styles.css:370-372`):
+
+```css
+/* The stream file picker. Overrides .card's row layout — it is a heading above a
+   list, not a form — in the same way .fallback does on the player page.
+   
+   SCOPED TO [open], and this is load-bearing rather than tidy: a bare
+   `.picker { display: block }` overrides the UA's own
+   `dialog:not([open]) { display: none }` and leaves the closed picker visible
+   at the top of the page for good. */
+.picker[open] {
+  display: block;
+}
+
+/* A dialog carries a UA border, padding and `margin: auto`; .card supplies the
+   first two and centring is what we want from the third, so only the border is
+   reset. max-height keeps a 40-episode pack scrollable inside the dialog rather
+   than taller than the viewport, which would put Cancel off screen — the exact
+   problem this change exists to fix. */
+.picker {
+  border: 1px solid var(--line);
+  max-height: min(80vh, 40rem);
+  max-width: min(46rem, calc(100vw - 2rem));
+  overflow-y: auto;
+}
+
+/* Dim rather than black: the list behind is context — which release this is a
+   pack of — not something to hide. */
+.picker::backdrop {
+  background: rgb(0 0 0 / 55%);
+}
+```
+
+- [ ] **Step 3: Wire it in `app.ts`**
+
+In `src/web/static/app.ts`:
+
+1. Change the element type at `src/web/static/app.ts:209`:
+
+```ts
+const picker = el<HTMLDialogElement>("picker");
+```
+
+2. Replace `hidePicker` (`src/web/static/app.ts:674-679`):
+
+```ts
+// Closes the picker WITHOUT stopping its session — the caller is handing that
+// session to the player. Clearing `pickerSession` before `close()` is what tells
+// the `close` listener below to leave it alone, so the two ways out of a picker
+// (chose a file / walked away) stay distinguishable with no extra flag.
+function hidePicker(): void {
+  pickerSession = null;
+  if (picker.open) picker.close();
+}
+```
+
+3. Replace the `pickerCancel` handler (`src/web/static/app.ts:786-790`) with a Cancel that just closes, plus the `close` listener that does the actual releasing:
+
+```ts
+pickerCancel.addEventListener("click", () => picker.close());
+
+// EVERY way out of the picker lands here — the Cancel button, Escape, and
+// `hidePicker`. Escape is the reason this is a `close` listener rather than more
+// work in the click handler: a <dialog> closes on Escape natively, bypassing any
+// button handler, and the session it was offering has a torrent attached. Left
+// running it would sit there until the idle reaper collected it.
+//
+// `pickerSession` being null means a file was chosen and the session now belongs
+// to the player (hidePicker cleared it first, on purpose) — nothing to release.
+picker.addEventListener("close", () => {
+  const sessionId = pickerSession;
+  pickerSession = null;
+  drawPicker = null;
+  pickerFiles.replaceChildren();
+  if (sessionId) stopSession(sessionId);
+});
+```
+
+4. In `showPicker`, replace `picker.hidden = false;` (`src/web/static/app.ts:769`) with the modal open, and add the orphan fix at the top of the function. Replace the opening lines of `showPicker` (`src/web/static/app.ts:711-712`) with:
+
+```ts
+  // A session already on offer here is one nobody is going to answer now, and it
+  // has a torrent attached. Releasing it is a fix for a leak that predates the
+  // modal: the old code overwrote `pickerSession` and left the previous session
+  // running until the idle reaper. Guarded on inequality so a redraw of the same
+  // session can never stop the session it is redrawing.
+  if (pickerSession !== null && pickerSession !== sessionId) stopSession(pickerSession);
+  pickerSession = sessionId;
+  pickerTitle.textContent = `Which file from “${shortName(name)}”?`;
+```
+
+and replace `picker.hidden = false;` with:
+
+```ts
+  // showModal(), not show(): the backdrop and the focus trap are the point. It
+  // throws if the dialog is already open, which a second choose() can do.
+  if (!picker.open) picker.showModal();
+```
+
+5. Rewrite the stale comment above `showPicker` (`src/web/static/app.ts:684-692`). Replace the paragraph beginning "`infoHash` is a PARAMETER" with:
+
+```
+// `infoHash` is a PARAMETER, not a module-level variable read when a file is
+// chosen, and it stays one. The hazard it was written against — a second play()
+// opening a picker for a different torrent while this one is open, so that
+// choosing a file from the FIRST records its filename as watched against the
+// SECOND torrent's favourite — is now unreachable twice over: the picker is a
+// modal, and `isBusy` refuses a second play while one is in flight at all (the
+// terminal's own one-at-a-time rule, src/ui/App.tsx:1445). Closing over the hash
+// at the call site costs nothing and remains the correct shape, so the belt stays
+// on with the braces.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+npx tsc --noEmit -p tsconfig.json && npm run lint && npm run build
+grep -n "picker.hidden" src/web/static/app.ts
+```
+
+Expected: typecheck, lint and build all pass; the `grep` returns **no hits** (any remaining `picker.hidden` would silently do nothing on a `<dialog>`).
+
+- [ ] **Step 5: Verify by running it — this is wiring, which no unit test here reaches**
+
+```bash
+npm run dev -- serve --web
+```
+
+In the browser: search for a show, press **play** on a season pack while scrolled well down the page. Confirm all five:
+1. The picker appears centred in the viewport over a dimmed backdrop, wherever you were scrolled.
+2. Keyboard focus is inside it (the "next" row, if one is badged).
+3. **Escape** closes it, and the queue does not gain a stuck session.
+4. **Cancel** closes it likewise.
+5. Choosing a file opens the player.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/index.html src/web/static/styles.css src/web/static/app.ts
+git commit -m "fix(web): open the file picker as a modal, in the viewport
+
+Press play on a season pack 500px down a browse and the 'which episode?'
+question appeared at the top of the document, off screen, with nothing
+where the user was looking to say anything had happened.
+
+Also releases a session the picker was offering when a second picker
+replaces it — a leak that predates the modal — and on Escape, which
+closes a <dialog> natively and bypassed the Cancel handler."
+```
+
+---
+
+### Task 7: The progress pill, with Cancel
+
+**Files:**
+- Modify: `src/web/static/index.html` (the pill, beside `#notice`)
+- Modify: `src/web/static/styles.css` (`.prepare`)
+- Modify: `src/web/static/app.ts` (`flow` state, `showPrepare`/`hidePrepare`, `play()`'s effects, the Cancel wiring)
+
+**Interfaces:**
+- Consumes: `PlayOptions`, `CANCELLED_NOTICE`, `PlayEffects.progress` (Task 4); `prepareLine` indirectly via `pollDecision` (Task 3); `FlowState`/`isBusy` (Task 5).
+- Produces: module-level `flow: FlowState`, `prepareAbort: AbortController | null`, `setFlowPrepare(prepare: FlowState["prepare"]): void`.
+
+- [ ] **Step 1: Add the markup**
+
+In `src/web/static/index.html`, immediately after the `</dialog>` from Task 6:
+
+```html
+    <!-- The waiting line for a resolving stream, anchored to the viewport.
+         Resolving a torrent Real-Debrid has never seen genuinely takes minutes,
+         and the only progress report used to be #notice — a paragraph above
+         <main> that scrolls away, so a user 500px down a browse saw nothing at
+         all and pressed play again. Bottom LEFT because .to-top already owns
+         bottom right.
+
+         aria-live is OFF on purpose. The line changes every second (the elapsed
+         count moves even when the percent does not), so a live region would talk
+         over a screen-reader user continuously for minutes. #notice keeps the
+         milestones worth announcing: started, cancelled, failed. -->
+    <div id="prepare" class="prepare" role="status" aria-live="off" hidden>
+      <span id="prepare-line" class="prepare-line"></span>
+      <button id="prepare-cancel" type="button">Cancel</button>
+    </div>
+```
+
+- [ ] **Step 2: Style it**
+
+Append to `src/web/static/styles.css`:
+
+```css
+/* The resolving-stream pill. Fixed bottom left; .to-top is bottom right at
+   z-index 4, and sharing a corner would overlap them. */
+.prepare {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: min(30rem, calc(100vw - 7rem));
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  background: var(--raised);
+  font-size: 0.75rem;
+}
+
+.prepare-line {
+  color: var(--dim);
+  overflow-wrap: anywhere;
+  /* The elapsed seconds and the percent both tick; without this the whole line
+     jitters sideways once a second. */
+  font-variant-numeric: tabular-nums;
+}
+
+.prepare button {
+  flex-shrink: 0;
+}
+
+/* On a phone the pill and .to-top would sit side by side in 375px. Full width
+   above it instead. */
+@media (max-width: 30rem) {
+  .prepare {
+    left: 1rem;
+    right: 1rem;
+    bottom: 3.5rem;
+    max-width: none;
+  }
+}
+```
+
+- [ ] **Step 3: Wire it in `app.ts`**
+
+Add the element handles beside the other `el<…>` calls near `src/web/static/app.ts:207`:
+
+```ts
+const prepare = el<HTMLDivElement>("prepare");
+const prepareLineText = el<HTMLSpanElement>("prepare-line");
+const prepareCancel = el<HTMLButtonElement>("prepare-cancel");
+```
+
+Add the imports: `import { controlState, isBusy, type FlowState } from "./streamBusy";` (`controlState` is used in Task 8), and add `CANCELLED_NOTICE` to the existing `./streamFlow` import list.
+
+Replace the `playing` set (`src/web/static/app.ts:555-559`) with the flow state:
+
+```ts
+// What the one in-flight play or pick is, if any. ONE, not a set: the terminal
+// allows one prepare or pick at a time (src/ui/App.tsx:1317, :1445) and the
+// browser's per-row set let two rows resolve at once, each polling for up to ten
+// minutes, sharing one progress line that reported whichever wrote last.
+//
+// Every Play button on the page is repainted from this (paintPlayBusy), so the
+// rule is visible rather than enforced by a silent early return — a lit button
+// that does nothing when pressed is what taught people to press it repeatedly.
+const flow: FlowState = { prepare: null, picking: null };
+
+// Cancels the in-flight prepare. Held here so the pill's Cancel button can reach
+// it; runPlay threads the signal into its fetches and its sleep, and stops the
+// session on the way out.
+let prepareAbort: AbortController | null = null;
+```
+
+Add the pill's own functions near `showNotice`:
+
+```ts
+// The waiting line, or null to take it down. runPlay's `progress` effect —
+// separate from `notice` because this one persists for the length of a resolve
+// (minutes) and carries a Cancel, while a notice hides itself after seconds.
+function showPrepare(line: string | null): void {
+  if (line === null) {
+    prepare.hidden = true;
+    prepareLineText.textContent = "";
+    return;
+  }
+  prepareLineText.textContent = line;
+  prepare.hidden = false;
+}
+
+prepareCancel.addEventListener("click", () => {
+  // Feedback on the press itself: aborting kills an in-flight fetch, but the
+  // sleep between polls can still be most of a second, and a Cancel that looks
+  // inert gets pressed again.
+  prepareCancel.disabled = true;
+  prepareAbort?.abort();
+});
+```
+
+Rewrite `play()` (`src/web/static/app.ts:821-848`) — the guard, the flow bookkeeping and the new options:
+
+```ts
+async function play(
+  row: DashRow,
+  onUnresolved?: () => void,
+  next?: EpisodeRef | null,
+): Promise<void> {
+  // One at a time, and the buttons say so (paintPlayBusy), so this early return
+  // is now a backstop rather than the whole mechanism.
+  if (isBusy(flow)) return;
+  const wanted = wantedEpisodeFor(row.name, savedState.continueWatching, next);
+  const ac = new AbortController();
+  prepareAbort = ac;
+  prepareCancel.disabled = false;
+  flow.prepare = { key: row.id, title: row.name };
+  paintPlayBusy();
+  try {
+    await runPlay(
+      row,
+      {
+        start: startSession,
+        poll: pollSession,
+        stop: stopSession,
+        confirm: (message) => confirm(message),
+        notice: showNotice,
+        progress: showPrepare,
+        // Closes over THIS row's hash, not a module-level variable — see
+        // showPicker's comment for why that distinction is load-bearing.
+        choose: (sessionId, capability, name, files, preselect) =>
+          showPicker(row.id, sessionId, capability, name, files, preselect),
+        open: (path) => openPlayer(path),
+        sleep,
+        now: () => Date.now(),
+        onUnresolved,
+      },
+      {
+        wanted,
+        // The provider's display name for the waiting line, from the same
+        // DEBRID_LABELS table the add button uses (searchModel.ts) — not a
+        // second one written here.
+        providerLabel: sources?.debridProvider ? debridProviderLabel(sources.debridProvider) : null,
+        signal: ac.signal,
+      },
+    );
+  } finally {
+    prepareAbort = null;
+    flow.prepare = null;
+    // runPlay clears the pill itself on every exit; this is belt and braces for
+    // a throw, which would skip it.
+    showPrepare(null);
+    paintPlayBusy();
+  }
+}
+```
+
+Add `debridProviderLabel` to the existing `./searchModel` import list. Verify it is exported there:
+
+```bash
+grep -n "export function debridProviderLabel" src/web/static/searchModel.ts
+```
+
+`paintPlayBusy` is Task 8's; for this commit add the stub so the tree compiles, and Task 8 fills it in:
+
+```ts
+// Repaints every Play control from `flow`. Task 8 fills this in; a no-op here
+// keeps this commit's tree green.
+function paintPlayBusy(): void {}
+```
+
+- [ ] **Step 4: Verify it compiles and nothing regressed**
+
+```bash
+npx tsc --noEmit -p tsconfig.json && npm run lint && npm run build && npm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Verify by running it**
+
+```bash
+npm run dev -- serve --web
+```
+
+Press play on something that has to resolve, scrolled well down the page. Confirm:
+1. The pill appears bottom left with a line like `Caching on Real-Debrid… 12% · 4s` (or `Finding peers… <name> · 4s` with no provider connected), and the **seconds tick up**.
+2. It is visible wherever you scroll.
+3. **Cancel** takes the pill down and shows `Stream cancelled.` in the notice line.
+4. After a cancel, the queue has no session left resolving — check the terminal's log output for the session being stopped.
+5. On a narrow window (< 30rem) the pill sits above the back-to-top button rather than overlapping it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/index.html src/web/static/styles.css src/web/static/app.ts
+git commit -m "feat(web): show resolve progress where the user is, and let them cancel it
+
+A resolve can run for minutes and reported progress only into #notice, a
+paragraph above <main> that scrolls away — so a user reading nothing
+pressed play again. The line is now a viewport-anchored pill carrying the
+terminal's own wording and elapsed count, plus the Cancel the browser
+never had."
+```
+
+---
+
+### Task 8: Paint the busy state on all six Play buttons
+
+**Files:**
+- Modify: `src/web/static/app.ts` — `paintPlayBusy`, a `tagPlayKey` helper, and the six button sites: `:468` (queue row), `:1646` (search result), `:3034` (library row), `:3075` (continue-watching resume), `:2674` (For You `Play`), `:3100` (`Play next`)
+
+**Interfaces:**
+- Consumes: `controlState`, `BUSY_LABEL` (Task 5); `flow`, `paintPlayBusy` stub (Task 7).
+- Produces: `tagPlayKey(button: HTMLButtonElement, key: string, idleLabel: string): void`.
+
+- [ ] **Step 1: Add the helper and the paint pass**
+
+In `src/web/static/app.ts`, replace the `paintPlayBusy` stub from Task 7 with:
+
+```ts
+// Stamps a Play control with the identity `flow` will match it against, and the
+// word it says when idle.
+//
+// A SEPARATE ATTRIBUTE FROM tagControl's `data-row-key`, and that is not
+// duplication. `data-row-key` is resultFocus's identity — for a search result it
+// is the GROUP key (one row per title, several releases inside), not the info
+// hash `play()` was handed. Matching busy state on it would mark the wrong
+// control the moment a title has more than one release.
+//
+// `data-idle-label` is stamped because the paint overwrites `textContent`: once
+// a button reads "preparing…", the word it should return to is no longer
+// anywhere in the DOM.
+function tagPlayKey(button: HTMLButtonElement, key: string, idleLabel: string): void {
+  button.dataset.playKey = key;
+  button.dataset.idleLabel = idleLabel;
+}
+
+// Repaints every Play control on the page from `flow`.
+//
+// DERIVED ON EVERY RENDER, never set once on click: the queue's rows are rebuilt
+// four times a second by the SSE tick, and a `disabled` set in a click handler is
+// gone by the next frame. That is the bug this whole pass exists to close — the
+// button that was pressed looked untouched, so it got pressed again.
+function paintPlayBusy(): void {
+  for (const button of document.querySelectorAll<HTMLButtonElement>("[data-play-key]")) {
+    const key = button.dataset.playKey ?? "";
+    const state = controlState(flow, key, button.dataset.idleLabel ?? button.textContent ?? "play");
+    button.disabled = state.disabled;
+    button.textContent = state.label;
+    // A boolean attribute, so it is removed rather than set to "false":
+    // aria-busy="false" is technically correct but noisier to read in devtools
+    // and is what the rest of this file does with aria-current.
+    if (state.busy) button.setAttribute("aria-busy", "true");
+    else button.removeAttribute("aria-busy");
+  }
+}
+```
+
+- [ ] **Step 2: Tag all six sites**
+
+Each site gets one `tagPlayKey` call. The key must be **exactly** what `flow` will hold — the info hash for the four `play()` paths, the title for the two `pickController` paths.
+
+At `src/web/static/app.ts:468-471` (queue row), after `tagControl(playButton, row.id, "play")`:
+
+```ts
+    tagPlayKey(playButton, row.id, "play");
+```
+
+At `src/web/static/app.ts:1646-1649` (search result) — `rowForPlay(result).id` is `result.infoHash` (`searchModel.ts:411`):
+
+```ts
+  tagPlayKey(playButton, result.infoHash, "play");
+```
+
+At `src/web/static/app.ts:3034-3036` (library row) — the row plays `dashRowForPlay(f.id, f.name)`:
+
+```ts
+  tagPlayKey(playButton, f.id, "play");
+```
+
+At `src/web/static/app.ts:3075-3077` (continue-watching resume) — `playContinueWatching` plays `dashRowForPlay(item.infoHash, item.rawName)` (`src/web/static/app.ts:2970`), so the key is the **info hash**, not the title:
+
+```ts
+  tagPlayKey(playButton, item.infoHash, "play");
+```
+
+At `src/web/static/app.ts:2672-2677` (For You `Play`, inside `paintReccPlay`) — this one goes through `pickController.start(item.title, …)`, so the key is the title:
+
+```ts
+  tagPlayKey(playButton, item.title, "Play");
+```
+
+At `src/web/static/app.ts:3098-3106` (`Play next`) — also `pickController.start(item.title, …)`:
+
+```ts
+    tagPlayKey(playNext, item.title, "Play next");
+```
+
+Two of those six — For You `Play` and `Play next` — had **no guard of any kind** before this: they call `pickController.start` directly, which the `playing` set never covered.
+
+- [ ] **Step 3: Repaint after every render, and drive `flow.picking`**
+
+Find where the panes render and add a `paintPlayBusy()` call after each list is replaced. The paint must run after *any* `replaceChildren` that can produce a Play control:
+
+```bash
+grep -n "replaceChildren" src/web/static/app.ts | cut -c1-110
+```
+
+For each render function that builds rows containing a Play button — the queue/dashboard render, `renderResults`, the library render, the continue-watching render, and `paintReccPlay`'s own caller — add `paintPlayBusy();` as the last statement.
+
+Then wire `flow.picking` from the pick controller's phase. In `renderPickPhase` (`src/web/static/app.ts:1259-1266`), add the flow bookkeeping:
+
+```ts
+function renderPickPhase(state: PickState): void {
+  const { phase } = state;
+  // The one-click Play's search is a flow too, and while it runs no other Play
+  // button should look pressable — same rule as a prepare. Only "searching"
+  // counts: by "playing" the controller has handed off to play(), which owns
+  // `flow.prepare` from there.
+  flow.picking = phase.kind === "searching" ? phase.title : null;
+  paintPlayBusy();
+  if (phase.kind === "searching") showNotice(pickSearchingLine(phase.title));
+  else if (phase.kind === "playing") showNotice(phase.note);
+  else if (phase.kind === "none") showNotice(pickNoneLine(phase.title));
+}
+```
+
+Guard `pickController.start`'s two call sites with the same one-at-a-time rule. At `src/web/static/app.ts:2676` and `:3106`, wrap the handler bodies:
+
+```ts
+  playButton.addEventListener("click", () => {
+    if (isBusy(flow)) return;
+    pickController.start(item.title, { kind: "film" });
+  });
+```
+
+```ts
+    playNext.addEventListener("click", () => {
+      if (isBusy(flow)) return;
+      pickController.start(item.title, intent, () => void playContinueWatching(item));
+    });
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+npx tsc --noEmit -p tsconfig.json && npm run lint && npm run build && npm test
+grep -c "tagPlayKey(" src/web/static/app.ts
+```
+
+Expected: all green, and the `grep -c` reports **7** (one definition plus six call sites).
+
+- [ ] **Step 5: Verify by running it — the part no unit test reaches**
+
+```bash
+npm run dev -- serve --web
+```
+
+Confirm each:
+1. Press **play** on a queue row: that button reads `preparing…` and is disabled; **every other** Play button on the page is disabled too.
+2. Wait through several SSE ticks (the queue repaints four times a second) and confirm the busy state **persists** — this is the regression the derive-on-render rule exists to prevent.
+3. When it finishes (or you Cancel), every button returns to `play` / `Play` / `Play next` — check all three words came back correctly, since the paint overwrites `textContent`.
+4. On the **For You** tab, press `Play` on a film: it reads `preparing…` through the search and the resolve that follows.
+5. Press `Play next` on a Continue-watching row and confirm the same.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/app.ts
+git commit -m "feat(web): show every Play button's busy state, derived on render
+
+Pressing play changed nothing on screen, so the natural response was to
+press it again. Queue rows rebuild four times a second, so the state is
+derived from the flow on every render rather than set on click. Two of
+the six Play buttons — For You and Play next — had no guard at all."
+```
+
+---
+
+### Task 9: Docs, and the whole-tree check
+
+**Files:**
+- Modify: `README.md:225-239` (the browser's "can't do yet" list) and `README.md:279` (the browser play paragraph)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Check what the README now gets wrong**
+
+Run: `sed -n 225,240p README.md; sed -n 278,282p README.md`
+
+The "What the browser can't do yet" list must not claim anything this change fixed. The play paragraph at `README.md:279` says torlnk "picks the video file (or asks, if there are several)" — still true, but it should now say where it asks and that the wait is cancellable.
+
+- [ ] **Step 2: Update the play paragraph**
+
+In `README.md`, replace the sentence "In the browser, torlnk resolves the torrent — through the active debrid provider if you have one connected, otherwise straight from the swarm — picks the video file (or asks, if there are several), and opens a player page." with:
+
+```markdown
+In the browser, torlnk resolves the torrent — through the active debrid provider if you have one
+connected, otherwise straight from the swarm — picks the video file (or asks, if there are several), and
+opens a player page. While it resolves, the button you pressed says so and a line in the corner of the
+window counts up — `Caching on Real-Debrid… 42% · 12s`, the same words the terminal uses — because a
+torrent your provider has never seen genuinely takes minutes. That line carries a **Cancel** that stops
+the session, the browser's answer to the terminal's `esc`. When there are several files to choose from,
+the question opens over the page rather than at the top of it, so it finds you wherever you had scrolled.
+```
+
+- [ ] **Step 3: Check the limitations list is still true**
+
+Read `README.md:225-239`. None of its three bullets — no restarting a stopped seed, no subtitles or scrubber, no settings page — is affected by this change, so **leave them**. Confirm rather than assume:
+
+```bash
+grep -nE "can't|cannot|no way to" README.md | sed -n 1,25p | cut -c1-120
+```
+
+If any line claims the browser cannot cancel a stream or that the picker appears at the top of the page, fix it. If none does, this step is a no-op — say so in the commit body rather than inventing an edit.
+
+- [ ] **Step 4: Run the full gate**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+```
+
+Expected: all pass. Exactly one lint warning is expected and pre-existing (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`); any second warning is yours.
+
+Then confirm nothing was missed across the tree:
+
+```bash
+grep -rn "resolvePercent" src/                     # expect: no hits (Task 3 deleted it)
+grep -rn "picker.hidden" src/                      # expect: no hits (Task 6)
+grep -rn "playing\.\(has\|add\|delete\)" src/web/  # expect: no hits (Task 7 replaced the set)
+grep -rn "innerHTML\|insertAdjacentHTML" src/web/static/  # expect: no hits, ever
+```
+
+- [ ] **Step 5: Verify both front ends run**
+
+The TUI was modified (Task 2), so it gets run too — not just its tests:
+
+```bash
+npm run dev
+```
+
+Press `v` on a result and confirm the preparing line still reads `Caching on …% · Ns  (esc cancels)` or `Finding peers… <name> · Ns  (esc cancels)`, and that `esc` still cancels.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: describe the browser's resolve progress and its cancel"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of the spec maps to a task: §1 modal `<dialog>` → Task 6 (including all three UA-behaviour traps and the orphan-session fix); §2 the pill and `src/util/prepareLine.ts` → Tasks 1, 2, 3, 7 (the `aria-live="off"` decision is in Task 7's markup comment); §3 abort through `runPlay` → Task 4, with the start-then-abort race as its own named test; §4 derived busy state and one-at-a-time → Tasks 5 and 8, all six button sites enumerated with their keys; "deliberately not changing" → the `window.confirm` is untouched by every task above, and belongs in the PR body; Files table → Tasks 1-9 cover every row.
+
+**Two corrections to the spec, made here rather than left to be discovered:**
+
+1. **`PrepareFacts` needs `phase`, not just a backend.** The terminal has a third arm — `Fetching link… 12s` (`src/ui/App.tsx:2392`) — which the spec's four-field shape could not express. The field names now mirror the TUI's `preparing` state exactly so its call site is a spread. The browser never renders that arm (the wire has one `resolving` state), which Task 3 documents at the call site.
+2. **The busy paint cannot reuse `tagControl`'s `data-row-key`.** On a search result that attribute holds the *group* key for `resultFocus`, not the info hash `play()` receives — so matching on it would mark the wrong control as soon as a title has two releases. Task 8 introduces `data-play-key` instead.
+
+**Placeholder scan.** No TBDs; every code step carries the actual code, every verification step the actual command and its expected output. Task 9 Step 3 is conditional by design ("if none does, this step is a no-op — say so rather than inventing an edit") because whether the README currently over-claims is a fact to check, not to guess.
+
+**Type consistency.** `prepareLine`/`PrepareFacts` (T1) are consumed unchanged by T2 and T3. `pollDecision`'s fourth parameter (T3) is supplied by `runPlay` from `PlayOptions.providerLabel` (T4), which `app.ts` fills from `debridProviderLabel` (T7). `PlayEffects.progress` (T4) is implemented as `showPrepare` (T7). `FlowState`/`controlState`/`isBusy`/`BUSY_LABEL` (T5) are consumed by `paintPlayBusy` and `play()` (T7, T8) with the same names throughout. `CANCELLED_NOTICE` is defined once (T4) and asserted by string in T4's tests. `paintPlayBusy` is deliberately stubbed in T7 and filled in T8, noted at both ends so the tree compiles at every commit.

--- a/docs/superpowers/specs/2026-07-31-web-stream-flow-parity-design.md
+++ b/docs/superpowers/specs/2026-07-31-web-stream-flow-parity-design.md
@@ -1,0 +1,220 @@
+# The browser's play flow: make the picker findable, the wait legible, and the wait abortable
+
+## The complaint
+
+Press Play on a season pack in the browser UI while scrolled 500px down a browse, and:
+
+1. The "which episode?" picker opens **at the top of the document**, off screen. Nothing on
+   screen says anything happened.
+2. There is no busy state on the button that was pressed, so the natural response is to press
+   it again — and again.
+3. During the wait — which for a Real-Debrid torrent it has never seen is genuinely
+   *minutes* — the only progress indicator is `#notice`, a non-sticky `<p>` above `<main>`,
+   also off screen.
+
+## The diagnosis: this is parity, not a new feature
+
+`src/ui` already solves all three. The browser is three things behind the terminal, and every
+symptom above falls out of exactly one of them:
+
+| | Terminal (`src/ui/App.tsx`) | Browser today |
+| --- | --- | --- |
+| One prepare/pick at a time | `if (preparing \|\| streamFiles \|\| activeStream) return` — global (`:1317`, `:1445`) | per-`row.id` only (`app.ts:826`), and it **silently returns** |
+| Progress while resolving | persistent line, elapsed seconds, per-source wording (`:2384-2391`) | `#notice`, non-sticky, above `<main>` |
+| Abort | Escape → `AbortController`; all other keys swallowed (`:2201-2203`) | none — polls to a 10-minute timeout, escapable only by reloading |
+
+This framing decides the CLAUDE.md question. Nothing here needs the "one surface only"
+exemption except the *mechanism* for abort — `(esc cancels)` in a terminal versus a Cancel
+button in a browser — which is the named "a surface can't express it" case. The feature itself
+lands in both, because it is already in one.
+
+No wire changes are required. `PublicStreamSession.backend` is already `"debrid" | "torrent"`
+(`src/web/wire.ts:161`) and `app.ts` already holds `debridProvider` from `/api/sources`.
+
+## What is being built
+
+### 1. The picker becomes a modal `<dialog>`
+
+`#picker` today is a `.card` at the top of `<main id="app">` with `display: block`, toggled by
+`.hidden`. It becomes `<dialog id="picker">`, opened with `showModal()`.
+
+`showModal()` centres it in the viewport, so where the user is scrolled stops mattering; it
+takes focus and Escape for free; and the backdrop makes it unmistakably the thing to answer.
+
+**It moves out of `<main id="app">`** to sit as a sibling of `#notice`. `#app` carries `hidden`
+(= `display: none`) until the page loads, and a `<dialog>` inside a `display: none` subtree
+will not render at all. Its original placement rationale — "above both panes, so neither
+list's re-render replaces it" — is preserved by being a top-level sibling instead.
+
+Three traps, each of which silently breaks a `<dialog>` and so is called out here rather than
+discovered in review:
+
+- **`.picker { display: block }` overrides the UA's `dialog:not([open]) { display: none }`**,
+  which would leave the closed dialog permanently visible. Scope the rule to `.picker[open]`.
+- **Escape closes a `<dialog>` natively and bypasses the `#picker-cancel` click handler** —
+  which is where `stopSession` lives, so an Escape would orphan a live session with a torrent
+  attached. A `close` listener stops `pickerSession` if it is still set. The
+  file-was-chosen path already clears `pickerSession` *before* navigating, so the two cases
+  stay distinguishable with no new flag.
+- **Drop `hidden` entirely** in favour of `.open` / `showModal()` / `close()`. Mixing the two
+  is its own footgun.
+
+`showPicker`'s comment at `app.ts:685-692` argues the picker is inline *because* a second Play
+can open a second picker for a different torrent while the first is open. Adopting the
+terminal's global one-at-a-time rule (§4) makes that scenario unreachable, so the comment is
+**rewritten to say that**, not left as a stale hazard analysis. The load-bearing part of it —
+that `infoHash` is a parameter closed over at the call site rather than a module-level
+variable — is unchanged and still correct; it costs nothing and remains the right shape.
+
+**A pre-existing leak is fixed on the way.** Today a second `fx.choose` overwrites
+`pickerSession` without stopping the previous session, which then runs until the idle reaper
+collects it. `showPicker` gains: if `pickerSession` is set and is not this session, stop it.
+
+### 2. A viewport-anchored progress pill, with Cancel
+
+A new fixed element, bottom-**left** (`.to-top` already owns bottom-right at `z-index: 4`;
+sharing a corner would overlap them). It shows the terminal's own wording:
+
+```
+Caching on Real-Debrid… 42% · 12s          [Cancel]
+Finding peers… Harrowgate.S03.1080p · 12s  [Cancel]
+```
+
+The line is built by a new **`src/util/prepareLine.ts`**, consumed by *both* front ends. The
+terminal builds this string inline at `App.tsx:2388-2391`; writing it a second time in
+`src/web` would be the fifth recorded copy-then-drift bug in this codebase, so it moves down
+rather than being copied — the same move `resultSort.ts`, `resultFilter.ts`,
+`favouriteList.ts` and `savedSearchList.ts` already made.
+
+```ts
+export interface PrepareFacts {
+  backend: "debrid" | "torrent";
+  /** Only meaningful for backend === "debrid"; falls back to "debrid". */
+  providerLabel?: string | null;
+  /** The release name. Shortened by the caller's own shortName. */
+  label: string;
+  /** Integer percent, 0-100. Ignored for backend === "torrent". */
+  pct: number;
+  elapsedSec: number;
+}
+export function prepareLine(facts: PrepareFacts): string;
+```
+
+Each surface appends its own affordance: the terminal `  (esc cancels)`, the browser nothing
+(it has a button). That split is the CLAUDE.md exemption, and it is the *only* thing that
+differs between them.
+
+`streamFlow.ts`'s `pollDecision` produces this label instead of its current
+`Preparing "X" — 42%`, so there is exactly one decision site for what the waiting user reads.
+It already receives `elapsedMs`; it gains the provider label as a parameter.
+
+**Accessibility, decided rather than defaulted:** the pill is `role="status"` with
+**`aria-live="off"`**. The string changes every second (elapsed seconds move even when the
+percent does not), and a live region would talk over the user continuously for minutes.
+`#notice` keeps the announceable milestones — started, cancelled, failed, "nothing playable".
+
+### 3. Cancel, threaded through `runPlay`
+
+`runPlay` takes an `AbortSignal`. It is not enough to check a flag between polls:
+
+- it is passed to `fx.start` and `fx.poll`, so an in-flight fetch dies rather than being
+  waited out;
+- `fx.sleep(ms, signal)` becomes abortable, so a cancel does not wait out the remaining
+  `POLL_MS`;
+- the loop checks `signal.aborted` at its top.
+
+On abort: `fx.stop(sessionId)` if a session had started, then the notice
+`"Stream cancelled."` — the terminal's exact string (`App.tsx:1251`).
+
+**The race that gets its own test:** an abort arriving *after* the `POST /api/stream` succeeded
+but before the first poll must still `DELETE` the session. Otherwise cancelling at the worst
+moment leaks exactly the resource cancel exists to release.
+
+### 4. Busy state, derived on render, one prepare at a time
+
+Queue rows are rebuilt four times a second by the SSE tick, so busy state can never be set
+once on click — it must be **derived at render time** from flow state. New pure module
+**`src/web/static/streamBusy.ts`**:
+
+```ts
+export interface FlowState {
+  /** The row a prepare is running for, or null. */
+  prepare: { key: string; title: string } | null;
+  /** The title a pickController search is running for, or null. */
+  picking: string | null;
+}
+export interface ControlState { disabled: boolean; busy: boolean; label: string }
+export function controlState(flow: FlowState, key: string): ControlState;
+```
+
+- The control whose `key` matches the in-flight one: `busy: true`, `disabled: true`, label
+  `"preparing…"`.
+- **Every other Play control: `disabled: true`.** This is the honest rendering of
+  one-at-a-time. An enabled button that silently no-ops is precisely the bug being fixed.
+- Nothing in flight: all enabled, label unchanged.
+
+`key` comes from two namespaces — an info hash for the four `play()` sites, a title for the two
+`pickController` sites — and that is deliberately harmless: the rule is "the matching control is
+busy, every other one is disabled", so a key from the wrong namespace simply never matches and
+falls into the disabled branch, which is the correct answer for it anyway. No cross-namespace
+comparison is ever made, and no synthetic combined key is invented.
+
+`tagControl` (`app.ts:391`) already stamps `data-row-key` and `data-control`, so the paint is
+one pass over `[data-control="play"]` re-applied after every render — not a flag threaded
+through six render sites.
+
+Six Play buttons exist and all six are covered. Two of them have **no guard whatever today**
+because they go through `pickController`, not `play()`:
+
+| Site | Path | Today |
+| --- | --- | --- |
+| `app.ts:470` queue row | `play()` | tagged, guarded per-row |
+| `app.ts:1648` search result | `play()` | tagged, guarded per-row |
+| `app.ts:3036` library row | `play()` | untagged, guarded per-row |
+| `app.ts:3080` continue-watching resume | `play()` | untagged, guarded per-row |
+| `app.ts:2676` For You `Play` | `pickController.start` | **untagged, unguarded** |
+| `app.ts:3100` `Play next` | `pickController.start` | **untagged, unguarded** |
+
+The four untagged sites gain `tagControl`. `pickController`'s existing `PickPhase`
+(`pickModel.ts:64`) already distinguishes `searching`; `FlowState.picking` is read from it,
+so the two flows share one busy surface instead of two competing ones.
+
+## Deliberately not changing
+
+**The `window.confirm` for the Real-Debrid fallback stays native.** `streamFlow.ts:375` and
+`app.ts:804-806` argue synchronous-and-unmissable on purpose, for a consent decision whose
+consequence — your IP address in a public swarm — cannot be taken back. Making it a styled
+in-page modal makes it dismissable by reflex. This is stated in the PR body so it reads as a
+decision rather than an oversight.
+
+**`#notice` keeps its current role and styling** for everything that is not stream progress.
+Only the resolving-progress line moves to the pill.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `src/util/prepareLine.ts` | **new** — the shared waiting line |
+| `src/util/prepareLine.test.ts` | **new** |
+| `src/web/static/streamBusy.ts` | **new** — derived control state |
+| `src/web/static/streamBusy.test.ts` | **new** |
+| `src/web/static/streamFlow.ts` | `AbortSignal` through `runPlay`; `pollDecision` emits `prepareLine` |
+| `src/web/static/streamFlow.test.ts` | updated for the new `PlayEffects` shape; new abort tests incl. the start-then-abort race |
+| `src/web/static/app.ts` | `<dialog>` wiring, the pill, `tagControl` on four sites, busy paint, orphan-session fix |
+| `src/web/static/index.html` | `#picker` → `<dialog>`, moved out of `#app`; the pill element |
+| `src/web/static/styles.css` | `.picker[open]`, the pill, backdrop |
+| `src/ui/App.tsx` | consume `prepareLine` instead of building it inline |
+| `README.md` | the web UI's own limitations list — check "no way to cancel" is no longer true |
+
+## Verification
+
+`npm test`, `npm run typecheck`, `npm run lint`, `npm run build` — the last being the only
+check that `src/web/static/` pulled in no `node:*` (`src/util/prepareLine.ts` must import
+nothing; that is why it is its own module and not part of a larger util).
+
+Wiring is not reachable by unit test — there is no jsdom here, deliberately — so it is
+verified by running it: `npm run dev -- serve --web`, then pressing Play on a season pack
+while scrolled down, and cancelling a resolve mid-percent.
+
+Because the terminal's `App.tsx` is touched, the TUI's own prepare line is verified by running
+`npm run dev` and starting a stream, not only by its tests.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -68,6 +68,7 @@ import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { readClipboard, writeClipboard } from "../util/clipboard";
 import { openFolder } from "../util/openFolder";
 import { openUrl } from "../util/openUrl";
+import { prepareLine } from "../util/prepareLine";
 import { cleanText, formatBytes, truncate } from "../util/format";
 import { isCategory, parseSection } from "./store";
 import {
@@ -2384,13 +2385,11 @@ export function App({
         {preparing ? (
           <Box>
             <Spinner
-              label={
-                preparing.source === "torrent"
-                  ? `Finding peers… ${preparing.label} · ${prepElapsed}s  (esc cancels)`
-                  : preparing.phase === "caching"
-                    ? `Caching on ${preparing.providerLabel ?? "debrid"}… ${preparing.pct}% · ${prepElapsed}s  (esc cancels)`
-                    : `Fetching link… ${prepElapsed}s  (esc cancels)`
-              }
+              // The line itself is shared with the browser
+              // (src/util/prepareLine.ts) so the two front ends cannot drift on
+              // what a waiting user reads. The key hint is appended here and
+              // only here: the browser has a Cancel button in its place.
+              label={`${prepareLine({ ...preparing, elapsedSec: prepElapsed })}  (esc cancels)`}
             />
           </Box>
         ) : null}

--- a/src/util/prepareLine.test.ts
+++ b/src/util/prepareLine.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { prepareLine } from "./prepareLine";
+
+describe("prepareLine", () => {
+  // The three strings src/ui/App.tsx:2386-2393 built inline before this module
+  // existed. They are asserted verbatim so the terminal's swap over to this
+  // helper cannot change a word of what it renders.
+  it("says who is caching and how far along, for a debrid resolve", () => {
+    expect(
+      prepareLine({
+        source: "rd",
+        phase: "caching",
+        providerLabel: "Real-Debrid",
+        label: "Harrowgate.S03.1080p.WEB-DL",
+        pct: 42,
+        elapsedSec: 12,
+      }),
+    ).toBe("Caching on Real-Debrid… 42% · 12s");
+  });
+
+  it("names the release while looking for peers, where there is no percent to give", () => {
+    expect(
+      prepareLine({
+        source: "torrent",
+        phase: "caching",
+        label: "Kestrel.2010.1080p.BluRay.x264",
+        pct: 0,
+        elapsedSec: 3,
+      }),
+    ).toBe("Finding peers… Kestrel.2010.1080p.BluRay.x264 · 3s");
+  });
+
+  it("says only how long it has been fetching a link, which has no percent either", () => {
+    expect(
+      prepareLine({
+        source: "rd",
+        phase: "fetching",
+        providerLabel: "TorBox",
+        label: "Ashfall.1999.1080p",
+        pct: 0,
+        elapsedSec: 7,
+      }),
+    ).toBe("Fetching link… 7s");
+  });
+
+  it("falls back to a generic provider name rather than rendering 'undefined'", () => {
+    const line = prepareLine({
+      source: "rd",
+      phase: "caching",
+      label: "Ashfall.1999.1080p",
+      pct: 5,
+      elapsedSec: 1,
+    });
+    expect(line).toBe("Caching on debrid… 5% · 1s");
+    expect(line).not.toContain("undefined");
+    expect(line).not.toContain("null");
+  });
+
+  // Floors rather than rounds, for the reason dashboard.ts gives: rounding 99.6
+  // up to 100 on something still working reads as a stuck UI.
+  it("clamps and floors a nonsense percent instead of rendering it", () => {
+    const at = (pct: number): string =>
+      prepareLine({
+        source: "rd",
+        phase: "caching",
+        providerLabel: "RD",
+        label: "n",
+        pct,
+        elapsedSec: 0,
+      });
+    expect(at(140)).toContain("100%");
+    expect(at(-3)).toContain("0%");
+    expect(at(Number.NaN)).toContain("0%");
+    expect(at(99.7)).toContain("99%");
+  });
+
+  it("clamps a nonsense elapsed time the same way", () => {
+    const at = (elapsedSec: number): string =>
+      prepareLine({ source: "torrent", phase: "caching", label: "n", pct: 0, elapsedSec });
+    expect(at(-1)).toContain("· 0s");
+    expect(at(Number.NaN)).toContain("· 0s");
+    expect(at(12.9)).toContain("· 12s");
+  });
+});

--- a/src/util/prepareLine.ts
+++ b/src/util/prepareLine.ts
@@ -1,0 +1,66 @@
+// What a user waiting for a stream to resolve reads, for both front ends.
+//
+// This lived inline in src/ui/App.tsx's render (a three-armed ternary in a
+// <Spinner label>) until the browser needed the same line. It moved down here
+// rather than being written a second time: this codebase records four bugs
+// caused by copy-then-drift — a byte formatter, an uploadSpeed field, a
+// progress unit, an API path table — and a waiting line the two front ends
+// disagree about is the same bug in a place the user is staring at for minutes.
+//
+// IMPORTS NOTHING, and must keep importing nothing: it is pulled into
+// src/web/static's browser bundle (platform: "browser" in tsup.web.config.ts),
+// where a transitive `node:*` fails the build. That is also why it is its own
+// module rather than a function in a larger util.
+//
+// The affordance is NOT part of the line. The terminal appends
+// "  (esc cancels)" and the browser puts a Cancel button next to it — a
+// keybinding hint is CLAUDE.md's "a surface can't express it", and it is the
+// only thing about this line that differs between the two.
+
+export interface PrepareFacts {
+  /**
+   * Which network is resolving this. Spelled "rd" rather than "debrid" because
+   * these field names are the TUI's `preparing` state verbatim, so its call
+   * site is a spread and cannot silently mismatch. The browser's wire form is
+   * `PublicStreamSession.backend`, which spells the same thing "debrid" — the
+   * one mapping between them lives in streamFlow.ts's pollDecision.
+   */
+  source: "rd" | "torrent";
+  /** Ignored when `source` is "torrent", which has no link-fetch step. */
+  phase: "caching" | "fetching";
+  /** Only meaningful when caching on debrid. Absent falls back to "debrid". */
+  providerLabel?: string | null;
+  /** The release name, already shortened by the caller. */
+  label: string;
+  /** Integer percent, 0-100. Clamped here rather than by callers. */
+  pct: number;
+  elapsedSec: number;
+}
+
+/**
+ * The waiting line, without any affordance appended.
+ *
+ * The elapsed seconds are load-bearing, not decoration: a Real-Debrid cache
+ * sits at one percent for minutes at a time, and a number that moves is the
+ * whole difference between "working" and "hung".
+ */
+export function prepareLine(facts: PrepareFacts): string {
+  const secs = `${whole(facts.elapsedSec)}s`;
+  if (facts.source === "torrent") return `Finding peers… ${facts.label} · ${secs}`;
+  if (facts.phase === "fetching") return `Fetching link… ${secs}`;
+  const who = facts.providerLabel ?? "debrid";
+  return `Caching on ${who}… ${Math.min(100, whole(facts.pct))}% · ${secs}`;
+}
+
+// Defended against a backend reporting something outside its documented range,
+// and against a NaN — `Math.floor(NaN)` is NaN, which would render the word
+// "NaN" at the user. Floors rather than rounds: see dashboard.ts's same rule.
+//
+// No upper bound here, because only one of the two callers has one: a percent
+// caps at 100, an elapsed count does not. The cap is applied at the one call
+// site that needs it rather than passed in, so nothing has to encode "no
+// ceiling" as a magic number.
+function whole(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}

--- a/src/web/static/abortableSleep.test.ts
+++ b/src/web/static/abortableSleep.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { abortableSleep } from "./abortableSleep";
+
+describe("abortableSleep", () => {
+  it("resolves after the delay when nothing aborts", async () => {
+    const began = Date.now();
+    await abortableSleep(20);
+    expect(Date.now() - began).toBeGreaterThanOrEqual(15);
+  });
+
+  it("works with no signal at all", async () => {
+    await expect(abortableSleep(1)).resolves.toBeUndefined();
+  });
+
+  // The whole reason this exists. A sleep that ran its full POLL_MS would leave
+  // Cancel looking inert for the rest of the second.
+  it("gives up as soon as the signal aborts, long before the delay", async () => {
+    const ac = new AbortController();
+    const began = Date.now();
+    const waited = abortableSleep(5_000, ac.signal);
+    ac.abort();
+    await waited;
+    expect(Date.now() - began).toBeLessThan(200);
+  });
+
+  // A cancel can land between two polls, so the next sleep starts life aborted.
+  it("returns immediately when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const began = Date.now();
+    await abortableSleep(5_000, ac.signal);
+    expect(Date.now() - began).toBeLessThan(200);
+  });
+
+  it("resolves, never rejects — the caller's next line is an abort check", async () => {
+    const ac = new AbortController();
+    const waited = abortableSleep(5_000, ac.signal);
+    ac.abort();
+    await expect(waited).resolves.toBeUndefined();
+  });
+
+  // Left attached, the listener keeps this closure and its timer reachable for as
+  // long as the signal is — for a long-lived controller, until the tab closes.
+  it("removes its abort listener once the delay has elapsed", async () => {
+    const ac = new AbortController();
+    let removed = 0;
+    const realRemove = ac.signal.removeEventListener.bind(ac.signal);
+    ac.signal.removeEventListener = (...args: Parameters<typeof realRemove>) => {
+      removed++;
+      return realRemove(...args);
+    };
+    await abortableSleep(5, ac.signal);
+    expect(removed).toBe(1);
+  });
+
+  // The abort path relies on `{ once: true }` rather than an explicit removal, so
+  // this pins that the listener really is gone: a second abort must not fire it.
+  it("does not fire its listener twice when the signal aborts repeatedly", async () => {
+    const ac = new AbortController();
+    let resolutions = 0;
+    const waited = abortableSleep(5_000, ac.signal).then(() => resolutions++);
+    ac.abort();
+    ac.abort();
+    await waited;
+    expect(resolutions).toBe(1);
+  });
+});

--- a/src/web/static/abortableSleep.ts
+++ b/src/web/static/abortableSleep.ts
@@ -1,0 +1,42 @@
+// A sleep that gives up early when a signal aborts.
+//
+// Small enough to look like it belongs inline in app.ts, and it did for one
+// commit — but it has two ways to be wrong that no amount of reading catches
+// (never resolving on abort; leaving its listener attached), and app.ts is
+// unreachable by any test in this repo. So it lives here, where a test can hold
+// it to both. CLAUDE.md's rule about decisions living in pure modules, applied to
+// a utility whose failure modes are a hang and a leak.
+
+/**
+ * Resolve after `ms`, or as soon as `signal` aborts — whichever comes first.
+ *
+ * RESOLVES ON ABORT, never rejects. The only caller is `runPlay`'s polling loop,
+ * whose very next line is an abort check; rejecting would mean a try/catch there
+ * to reach the same branch, and an unhandled rejection if anyone forgot it.
+ *
+ * Without the early resolve, pressing Cancel mid-poll leaves the button looking
+ * inert for the rest of the second — long enough to be pressed again, which is
+ * the habit the whole change is trying to break.
+ */
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    // Already aborted is not an edge case: the signal is per-play and a cancel
+    // can land between two polls, so the next sleep starts life aborted.
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    // The listener is removed on BOTH paths. Left attached, it keeps this closure
+    // — and so the timer — reachable for as long as the signal itself is, which
+    // for a long-lived controller means until the tab closes.
+    function onAbort(): void {
+      clearTimeout(timer);
+      resolve();
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -674,7 +674,11 @@ let drawPicker: (() => void) | null = null;
 // reachable by a test.
 const sleep = abortableSleep;
 
-async function startSession(row: DashRow, confirmed: boolean): Promise<StartResult> {
+async function startSession(
+  row: DashRow,
+  confirmed: boolean,
+  signal?: AbortSignal,
+): Promise<StartResult> {
   let res: Response;
   try {
     res = await fetch("/api/stream", {
@@ -689,8 +693,17 @@ async function startSession(row: DashRow, confirmed: boolean): Promise<StartResu
         name: row.name,
         ...(confirmed ? { confirm: true } : {}),
       }),
+      // So Cancel kills the request rather than waiting it out. Resolving a
+      // torrent can hold this POST open for a while.
+      signal,
     });
   } catch {
+    // AN ABORT LANDS HERE TOO, and it is not a dead server. Saying so would
+    // blame the backend for something the user just asked for, and — worse —
+    // setConn("lost") repaints the whole header as disconnected. runPlay checks
+    // `signal.aborted` immediately after this returns and reports the cancel
+    // itself, so this stays silent and lets it.
+    if (signal?.aborted) return { kind: "failed" };
     showNotice("Play failed — the server is not responding.");
     setConn("lost");
     return { kind: "failed" };
@@ -732,10 +745,17 @@ async function startSession(row: DashRow, confirmed: boolean): Promise<StartResu
   };
 }
 
-async function pollSession(sessionId: string): Promise<PublicStreamSession | null> {
+// Null on anything unreadable, an abort included — runPlay's `if (!next)` branch
+// checks `signal.aborted` before reporting a lost session, so a cancel mid-poll
+// is not mistaken for one.
+async function pollSession(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<PublicStreamSession | null> {
   try {
     const res = await fetch(`/api/stream/${encodeURIComponent(sessionId)}`, {
       headers: authHeaders(),
+      signal,
     });
     if (!res.ok) return null;
     const body = (await res.json()) as unknown;
@@ -953,7 +973,19 @@ async function play(
   prepareAbort = ac;
   prepareCancel.disabled = false;
   flow.prepare = { key: row.id, title: row.name };
+  // Read BEFORE the paint: paintPlayBusy is about to disable this control, and
+  // disabling the focused element drops focus to <body> — where captureRowFocus
+  // finds nothing, so focusTargetAfterRender has nothing to restore and the list
+  // stays unreachable by keyboard for the whole prepare. That is the exact
+  // failure resultFocus.ts was written for.
+  const pressedWasFocused = document.activeElement instanceof HTMLElement &&
+    document.activeElement.dataset["playKey"] === row.id;
   paintPlayBusy();
+  // Focus follows the user's next action, which is now Cancel — the browser's
+  // stand-in for the terminal's `esc`. Only when they were driving from the
+  // keyboard: a mouse user has no focus ring to lose and would be surprised to
+  // find Enter now cancelling their stream.
+  if (pressedWasFocused) prepareCancel.focus();
   try {
     await runPlay(
       row,

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -833,6 +833,13 @@ async function play(
       stop: stopSession,
       confirm: (message) => confirm(message),
       notice: showNotice,
+      // TEMPORARY: the next commit gives this its own viewport-anchored pill,
+      // which is the whole point of splitting it from `notice`. Pointing it at
+      // the notice line for one commit keeps this file compiling without
+      // pretending the split has landed.
+      progress: (line) => {
+        if (line !== null) showNotice(line);
+      },
       // Closes over THIS row's hash, not a module-level variable — see
       // showPicker's comment for why that distinction is load-bearing.
       choose: (sessionId, capability, name, files, preselect) =>
@@ -841,7 +848,7 @@ async function play(
       sleep,
       now: () => Date.now(),
       onUnresolved,
-    }, wanted);
+    }, { wanted });
   } finally {
     playing.delete(row.id);
   }

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -14,6 +14,8 @@ import {
   type DashRow,
   type StatusPayload,
 } from "./dashboard";
+import { abortableSleep } from "./abortableSleep";
+import { isBusy, type FlowState } from "./streamBusy";
 import {
   fileLabel,
   isPlayable,
@@ -39,6 +41,7 @@ import {
   dashRowForPlay,
   debridAddedNotice,
   debridAddLabel,
+  debridProviderLabel,
   emptyView,
   defaultExpandedKeys,
   groupCountLabel,
@@ -212,6 +215,12 @@ const pickerFiles = el<HTMLUListElement>("picker-files");
 const pickerCancel = el<HTMLButtonElement>("picker-cancel");
 const pickerSort = el<HTMLButtonElement>("picker-sort");
 
+// The resolving-stream pill. Named `prepareBox` rather than `prepare` so it
+// cannot be confused with `prepareLine`, the shared helper that writes into it.
+const prepareBox = el<HTMLDivElement>("prepare");
+const prepareText = el<HTMLSpanElement>("prepare-line");
+const prepareCancel = el<HTMLButtonElement>("prepare-cancel");
+
 const prefsBlock = el<HTMLDetailsElement>("prefs");
 const prefsResSelect = el<HTMLSelectElement>("pref-res");
 const prefsFeaturesBox = el<HTMLDivElement>("pref-features");
@@ -340,6 +349,36 @@ function showNotice(message: string): void {
     notice.hidden = true;
   }, NOTICE_MS);
 }
+
+// The waiting line, or null to take it down. This is runPlay's `progress` effect
+// — separate from `notice` because this one persists for the length of a resolve
+// (minutes) and carries a Cancel, while a notice hides itself after seconds.
+//
+// The line itself is prepareLine's (src/util/prepareLine.ts, via pollDecision):
+// nothing here decides what a waiting user reads.
+function showPrepare(line: string | null): void {
+  if (line === null) {
+    prepareBox.hidden = true;
+    prepareText.textContent = "";
+    return;
+  }
+  prepareText.textContent = line;
+  prepareBox.hidden = false;
+}
+
+// Repaints every Play control from `flow`. Filled in by the next commit, which
+// tags the six Play buttons it reads; a no-op here keeps this one green rather
+// than half-wiring the paint and the tags together.
+function paintPlayBusy(): void {}
+
+prepareCancel.addEventListener("click", () => {
+  // Feedback on the press itself. Aborting kills an in-flight fetch, but there
+  // is still a round trip before the pill comes down, and a Cancel that looks
+  // inert for a second gets pressed again — which is the habit this whole change
+  // is about. Re-enabled by play()'s next call, not here.
+  prepareCancel.disabled = true;
+  prepareAbort?.abort();
+});
 
 // Every action the row buttons can take. Downloads and seeds expose different
 // sets; `delete` also removes the files, which is why it is offered only where
@@ -552,11 +591,21 @@ async function control(id: string, action: string): Promise<void> {
 // Everything below to the next banner is the Play flow. The decisions live in
 // streamFlow.ts; what is here is fetch, timers and DOM.
 
-// Rows with a Play already in flight. Starting a session takes a round trip and
-// then up to minutes of polling, and the row's buttons are rebuilt four times a
-// second by the SSE tick — so without this a second tap starts a second session
-// (a second swarm, a second Real-Debrid job) for the same torrent.
-const playing = new Set<string>();
+// What the one in-flight play or pick is, if any. ONE, not a set: the terminal
+// allows one prepare or pick at a time (src/ui/App.tsx's
+// `if (preparing || streamFiles || activeStream) return`) and the browser's
+// per-row set let two rows resolve at once, each polling a session for up to ten
+// minutes, sharing one progress line that reported whichever wrote last.
+//
+// Every Play button on the page is repainted from this (paintPlayBusy), so the
+// rule is visible rather than enforced by a silent early return — a lit button
+// that does nothing when pressed is what taught people to press it repeatedly.
+const flow: FlowState = { prepare: null, picking: null };
+
+// Cancels the in-flight prepare. Held here so the pill's Cancel button can reach
+// it; runPlay threads the signal into its fetches and its sleep, and stops the
+// session on the way out.
+let prepareAbort: AbortController | null = null;
 
 // The session the picker is currently offering. Held so Cancel can stop it: the
 // session is live by then, with a torrent attached, and closing the picker
@@ -574,7 +623,11 @@ let pickerSession: string | null = null;
 let pickerMode: StreamFileSort = "name";
 let drawPicker: (() => void) | null = null;
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+// runPlay's `sleep` effect. The abort handling is in abortableSleep.ts rather
+// than here because it has two failure modes reading cannot catch — never
+// resolving, and leaving its listener attached — and nothing in app.ts is
+// reachable by a test.
+const sleep = abortableSleep;
 
 async function startSession(row: DashRow, confirmed: boolean): Promise<StartResult> {
   let res: Response;
@@ -847,34 +900,52 @@ async function play(
   onUnresolved?: () => void,
   next?: EpisodeRef | null,
 ): Promise<void> {
-  if (playing.has(row.id)) return;
-  playing.add(row.id);
+  // One at a time, and the buttons say so (paintPlayBusy), so this early return
+  // is now a backstop rather than the whole mechanism.
+  if (isBusy(flow)) return;
   const wanted = wantedEpisodeFor(row.name, savedState.continueWatching, next);
+  const ac = new AbortController();
+  prepareAbort = ac;
+  prepareCancel.disabled = false;
+  flow.prepare = { key: row.id, title: row.name };
+  paintPlayBusy();
   try {
-    await runPlay(row, {
-      start: startSession,
-      poll: pollSession,
-      stop: stopSession,
-      confirm: (message) => confirm(message),
-      notice: showNotice,
-      // TEMPORARY: the next commit gives this its own viewport-anchored pill,
-      // which is the whole point of splitting it from `notice`. Pointing it at
-      // the notice line for one commit keeps this file compiling without
-      // pretending the split has landed.
-      progress: (line) => {
-        if (line !== null) showNotice(line);
+    await runPlay(
+      row,
+      {
+        start: startSession,
+        poll: pollSession,
+        stop: stopSession,
+        confirm: (message) => confirm(message),
+        notice: showNotice,
+        progress: showPrepare,
+        // Closes over THIS row's hash, not a module-level variable — see
+        // showPicker's comment for why that distinction is load-bearing.
+        choose: (sessionId, capability, name, files, preselect) =>
+          showPicker(row.id, sessionId, capability, name, files, preselect),
+        open: (path) => openPlayer(path),
+        sleep,
+        now: () => Date.now(),
+        onUnresolved,
       },
-      // Closes over THIS row's hash, not a module-level variable — see
-      // showPicker's comment for why that distinction is load-bearing.
-      choose: (sessionId, capability, name, files, preselect) =>
-        showPicker(row.id, sessionId, capability, name, files, preselect),
-      open: (path) => openPlayer(path),
-      sleep,
-      now: () => Date.now(),
-      onUnresolved,
-    }, { wanted });
+      {
+        wanted,
+        // The provider's display name for the waiting line, from the same
+        // DEBRID_LABELS table the add button reads (searchModel.ts) — not a
+        // second one written here.
+        providerLabel: sources?.debridProvider
+          ? debridProviderLabel(sources.debridProvider)
+          : null,
+        signal: ac.signal,
+      },
+    );
   } finally {
-    playing.delete(row.id);
+    prepareAbort = null;
+    flow.prepare = null;
+    // runPlay takes the pill down itself on every exit; this is belt and braces
+    // for a throw, which would skip it.
+    showPrepare(null);
+    paintPlayBusy();
   }
 }
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -206,7 +206,7 @@ const rowsList = el<HTMLUListElement>("rows");
 const emptyNote = el<HTMLParagraphElement>("empty");
 const notice = el<HTMLParagraphElement>("notice");
 const conn = el<HTMLSpanElement>("conn");
-const picker = el<HTMLDivElement>("picker");
+const picker = el<HTMLDialogElement>("picker");
 const pickerTitle = el<HTMLParagraphElement>("picker-title");
 const pickerFiles = el<HTMLUListElement>("picker-files");
 const pickerCancel = el<HTMLButtonElement>("picker-cancel");
@@ -671,25 +671,29 @@ function openPlayer(path: string): void {
   location.assign(path);
 }
 
+// Closes the picker WITHOUT stopping its session — the caller is handing that
+// session to the player. Clearing `pickerSession` before `close()` is what tells
+// the `close` listener below to leave it alone, so the two ways out of a picker
+// (chose a file / walked away) stay distinguishable with no extra flag. The rest
+// of the teardown lives in that listener, because Escape reaches it and does not
+// reach here.
 function hidePicker(): void {
   pickerSession = null;
-  drawPicker = null;
-  picker.hidden = true;
-  pickerFiles.replaceChildren();
+  if (picker.open) picker.close();
 }
 
 // Same createElement/textContent rule as renderRow, and for a stronger reason:
 // these strings are filenames from inside a stranger's torrent.
 //
 // `infoHash` is a PARAMETER, not a module-level variable read when a file is
-// chosen. The picker is an inline card, not a modal (index.html's `.picker` is
-// `display: block`), so the results list stays clickable while it is open —
-// clicking play on a different row opens a second picker for a different
-// torrent. A module-level "current picker hash" would be overwritten by that
-// second play(), and choosing a file from the FIRST picker would then record
-// its filename as watched against the SECOND torrent's favourite. Closing over
-// the hash at the call site (see play()) makes that impossible: each picker's
-// callbacks carry the hash they were opened with, for good.
+// chosen, and it stays one. The hazard it was written against — a second play()
+// opening a picker for a different torrent while this one is open, so that
+// choosing a file from the FIRST records its filename as watched against the
+// SECOND torrent's favourite — is now unreachable twice over: the picker is a
+// modal, and isBusy refuses a second play while one is in flight at all (the
+// terminal's own one-at-a-time rule, src/ui/App.tsx). Closing over the hash at
+// the call site costs nothing and remains the correct shape, so the belt stays on
+// with the braces.
 //
 // `preselect` is streamOutcome's decision (streamFlow.ts), never one made here:
 // which file is the next episode is shared with the TUI's picker, and app.ts is
@@ -708,6 +712,12 @@ function showPicker(
   files: PublicStreamFile[],
   preselect: number | null,
 ): void {
+  // A session already on offer here is one nobody is going to answer now, and it
+  // has a torrent attached. Releasing it fixes a leak that predates the modal:
+  // the old code overwrote `pickerSession` and left the previous session running
+  // until the idle reaper. Guarded on inequality so a redraw of the same session
+  // can never stop the session it is redrawing.
+  if (pickerSession !== null && pickerSession !== sessionId) stopSession(pickerSession);
   pickerSession = sessionId;
   pickerTitle.textContent = `Which file from “${shortName(name)}”?`;
 
@@ -766,7 +776,9 @@ function showPicker(
     }
   };
 
-  picker.hidden = false;
+  // showModal(), not show(): the backdrop and the focus trap are the point. It
+  // throws if the dialog is already open, which a second choose() can do.
+  if (!picker.open) picker.showModal();
   // Only a re-sort has a file to keep; opening the picker follows the preselect.
   drawPicker = () => draw(focusedPickerFile(files));
   draw();
@@ -783,9 +795,21 @@ function focusedPickerFile(files: PublicStreamFile[]): number | null {
   return found >= 0 ? found : null;
 }
 
-pickerCancel.addEventListener("click", () => {
+pickerCancel.addEventListener("click", () => picker.close());
+
+// EVERY way out of the picker lands here — the Cancel button, Escape, and
+// hidePicker(). Escape is the reason this is a `close` listener rather than more
+// work in the click handler: a <dialog> closes on Escape natively, bypassing any
+// button handler, and the session it was offering has a torrent attached. Left
+// running, it would sit there until the idle reaper collected it.
+//
+// `pickerSession` being null means a file was chosen and the session now belongs
+// to the player (hidePicker cleared it first, on purpose) — nothing to release.
+picker.addEventListener("close", () => {
   const sessionId = pickerSession;
-  hidePicker();
+  pickerSession = null;
+  drawPicker = null;
+  pickerFiles.replaceChildren();
   if (sessionId) stopSession(sessionId);
 });
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -15,7 +15,7 @@ import {
   type StatusPayload,
 } from "./dashboard";
 import { abortableSleep } from "./abortableSleep";
-import { isBusy, type FlowState } from "./streamBusy";
+import { controlState, isBusy, type FlowState } from "./streamBusy";
 import {
   fileLabel,
   isPlayable,
@@ -366,10 +366,50 @@ function showPrepare(line: string | null): void {
   prepareBox.hidden = false;
 }
 
-// Repaints every Play control from `flow`. Filled in by the next commit, which
-// tags the six Play buttons it reads; a no-op here keeps this one green rather
-// than half-wiring the paint and the tags together.
-function paintPlayBusy(): void {}
+// Stamps a Play control with the identity `flow` will match it against, and the
+// word it says when idle.
+//
+// A SEPARATE ATTRIBUTE FROM tagControl's `data-row-key`, and that is not
+// duplication. `data-row-key` is resultFocus's identity — for a search result it
+// is the GROUP key (one row per title, several releases nested inside), not the
+// info hash `play()` is handed. Matching busy state on it would mark the wrong
+// control the moment a title has more than one release.
+//
+// `data-idle-label` is stamped because the paint overwrites `textContent`: once a
+// button reads "preparing…", the word it should return to is no longer anywhere
+// in the DOM to read back.
+function tagPlayKey(button: HTMLButtonElement, key: string, idleLabel: string): void {
+  button.dataset.playKey = key;
+  button.dataset.idleLabel = idleLabel;
+}
+
+// Repaints every Play control on the page from `flow`.
+//
+// DERIVED ON EVERY RENDER, never set once on click: the queue's rows are rebuilt
+// four times a second by the SSE tick, so a `disabled` set in a click handler is
+// gone by the next frame. That is the bug this pass exists to close — the button
+// that was pressed looked untouched, so it got pressed again.
+//
+// Which control looks how is controlState's decision (streamBusy.ts), not one
+// made here: all this does is assign the three values it hands back.
+function paintPlayBusy(): void {
+  for (const button of document.querySelectorAll<HTMLButtonElement>("[data-play-key]")) {
+    const state = controlState(
+      flow,
+      button.dataset.playKey ?? "",
+      // The stamped label, falling back to whatever the button currently says —
+      // which is only wrong for a control that was somehow never tagged, and is
+      // still better than blanking it.
+      button.dataset.idleLabel ?? button.textContent ?? "play",
+    );
+    button.disabled = state.disabled;
+    button.textContent = state.label;
+    // A boolean attribute, so it is removed rather than set to "false" — the same
+    // thing this file already does with aria-current on the picker's next row.
+    if (state.busy) button.setAttribute("aria-busy", "true");
+    else button.removeAttribute("aria-busy");
+  }
+}
 
 prepareCancel.addEventListener("click", () => {
   // Feedback on the press itself. Aborting kills an in-flight fetch, but there
@@ -507,6 +547,7 @@ function renderRow(row: DashRow): HTMLLIElement {
     playButton.className = "play";
     playButton.textContent = "play";
     tagControl(playButton, row.id, "play");
+    tagPlayKey(playButton, row.id, "play");
     playButton.addEventListener("click", () => void play(row));
     actions.append(playButton);
   }
@@ -541,6 +582,10 @@ function render(): void {
     focusBefore,
     rows.map((r) => r.id),
   );
+  // The buttons that were just rebuilt know nothing about a play in flight. This
+  // list is replaced four times a second, so this is the call that makes a busy
+  // state survive longer than 250ms.
+  paintPlayBusy();
   // The queue tab carries its own count so a search that added something shows
   // it without switching panes — otherwise "did that work?" needs a click.
   queueCount.textContent = rows.length > 0 ? String(rows.length) : "";
@@ -1363,6 +1408,12 @@ const pickController = createPickController<PublicSearchResult>({
 // the controller.
 function renderPickPhase(state: PickState): void {
   const phase = state.phase;
+  // The one-click Play's search is a flow too, and while it runs no other Play
+  // button should look pressable — the same rule as a prepare. Only "searching"
+  // counts: by "playing" the controller has handed off to play(), which owns
+  // `flow.prepare` from that point on.
+  flow.picking = phase.kind === "searching" ? phase.title : null;
+  paintPlayBusy();
   if (phase.kind === "searching") showNotice(pickSearchingLine(phase.title));
   else if (phase.kind === "playing") showNotice(phase.note);
   else if (phase.kind === "none") showNotice(pickNoneLine(phase.title));
@@ -1748,6 +1799,10 @@ function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivEleme
   playButton.className = "play";
   playButton.textContent = "play";
   tagControl(playButton, rowKey, "play");
+  // `result.infoHash`, NOT `rowKey`: rowKey is the group key (this row may nest
+  // several releases of one title), while play() is handed rowForPlay(result),
+  // whose id is the hash. See tagPlayKey for why the two identities are separate.
+  tagPlayKey(playButton, result.infoHash, "play");
   playButton.addEventListener("click", () => void play(rowForPlay(result)));
   actions.append(playButton);
 
@@ -2202,6 +2257,8 @@ function renderResults(): void {
   );
   applyRovingTabIndex(rowKeys, selectedRowKey);
   restoreRowFocus(resultsList, focusBefore, rowKeys);
+  // Freshly built rows, so freshly built Play buttons: re-apply the flow.
+  paintPlayBusy();
 
   const status = searchStatus(searchView, shown.length);
   searchStatusLine.textContent = status.text;
@@ -2776,8 +2833,19 @@ function paintReccPlay(
   playButton.type = "button";
   playButton.className = "play recc-play";
   playButton.textContent = "Play";
-  playButton.addEventListener("click", () => pickController.start(item.title, { kind: "film" }));
+  // The TITLE, not a hash: this button goes through pickController, which is off
+  // to find a release for a film that has no torrent picked yet.
+  tagPlayKey(playButton, item.title, "Play");
+  playButton.addEventListener("click", () => {
+    // One flow at a time, exactly as play() does. This button had NO guard of any
+    // kind before — pickController is not covered by play()'s.
+    if (isBusy(flow)) return;
+    pickController.start(item.title, { kind: "film" });
+  });
   actions.prepend(playButton);
+  // A recc card repaints on its own (paintReccPlay is called per render), so the
+  // freshly built button needs the current flow applied to it.
+  paintPlayBusy();
 }
 
 /** Post one rating to reccd and, for the three that are verdicts, drop the pick. */
@@ -2921,6 +2989,7 @@ function renderPick(item: PublicRecommendation, filter: ReccType): HTMLLIElement
 function renderRecc(state: ReccState): void {
   const items = reccItems(state);
   reccList.replaceChildren(...items.map((item) => renderPick(item, state.filters.type)));
+  paintPlayBusy();
 
   const status = reccStatus(state);
   reccStatusLine.textContent = status.text;
@@ -3135,6 +3204,9 @@ function renderLibraryRow(f: PublicFavourite): HTMLLIElement {
   playButton.type = "button";
   playButton.className = "play";
   playButton.textContent = "play";
+  // `f.id` is the info hash dashRowForPlay builds the row's id from, so this is
+  // the same key `flow.prepare` will hold.
+  tagPlayKey(playButton, f.id, "play");
   playButton.addEventListener("click", () => void play(dashRowForPlay(f.id, f.name)));
   actions.append(playButton);
 
@@ -3176,6 +3248,11 @@ function renderContinueRow(item: PublicStreamHistoryItem): HTMLLIElement {
   playButton.type = "button";
   playButton.className = "play";
   playButton.textContent = "play";
+  // The INFO HASH, not the title: playContinueWatching resumes the remembered
+  // torrent via dashRowForPlay(item.infoHash, …), so that is the key flow holds.
+  // The "Play next" button below is the one keyed by title — it goes looking for
+  // a fresh release instead.
+  tagPlayKey(playButton, item.infoHash, "play");
   playButton.addEventListener("click", () => void playContinueWatching(item));
   actions.append(playButton);
 
@@ -3201,12 +3278,18 @@ function renderContinueRow(item: PublicStreamHistoryItem): HTMLLIElement {
     playNext.type = "button";
     playNext.className = "play";
     playNext.textContent = "Play next";
+    // Keyed by TITLE, unlike the resume button above: this one goes through
+    // pickController to find a fresh release for the next episode.
+    tagPlayKey(playNext, item.title, "Play next");
     // onNone falls back to the same "remembered torrent" resume the plain
     // play button above uses — a fresh pick found nothing, not a reason to
     // strand the row with no action at all.
-    playNext.addEventListener("click", () =>
-      pickController.start(item.title, intent, () => void playContinueWatching(item)),
-    );
+    playNext.addEventListener("click", () => {
+      // As with the For You card: pickController is not covered by play()'s
+      // guard, so this button had none at all before.
+      if (isBusy(flow)) return;
+      pickController.start(item.title, intent, () => void playContinueWatching(item));
+    });
     actions.prepend(playNext);
   }
 
@@ -3224,6 +3307,8 @@ function renderSaved(): void {
   continueRows.replaceChildren(...savedState.continueWatching.map(renderContinueRow));
   savedSearchesRows.replaceChildren(...savedState.savedSearches.map(renderSavedSearchRow));
   libraryRows.replaceChildren(...savedState.library.map(renderLibraryRow));
+  // Continue-watching and library rows both carry Play buttons.
+  paintPlayBusy();
 
   const cw = continueWatchingStatus(savedState);
   continueStatusLine.textContent = cw.text;

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -88,6 +88,22 @@
       </div>
     </dialog>
 
+    <!-- The waiting line for a resolving stream, anchored to the viewport.
+         Resolving a torrent Real-Debrid has never seen genuinely takes minutes,
+         and the only progress report used to be #notice — a paragraph above
+         <main> that scrolls away, so a user 500px down a browse saw nothing at
+         all and pressed play again. Bottom LEFT because .to-top already owns
+         bottom right.
+
+         aria-live is OFF on purpose. The line changes every second (the elapsed
+         count moves even when the percent does not), so a live region would talk
+         over a screen-reader user continuously for minutes. #notice keeps the
+         milestones worth announcing: started, cancelled, failed. -->
+    <div id="prepare" class="prepare" role="status" aria-live="off" hidden>
+      <span id="prepare-line" class="prepare-line"></span>
+      <button id="prepare-cancel" type="button">Cancel</button>
+    </div>
+
     <main id="app" hidden>
       <!-- ---- search ------------------------------------------------------ -->
       <section id="pane-search">

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -60,24 +60,35 @@
 
     <p id="notice" class="notice" hidden></p>
 
-    <main id="app" hidden>
-      <!-- The stream file picker. Shown only when a session resolves to more
-           than one playable file; every child below the heading is built by
-           app.js with createElement, because the filenames come out of a
-           torrent. It sits above both panes because Play is offered on a search
-           result and on a queue row, and it is replaced wholesale by neither
-           list's re-render (the queue's happens four times a second). -->
-      <div id="picker" class="card picker" hidden>
-        <p id="picker-title" class="picker-title"></p>
-        <ul id="picker-files" class="picker-files"></ul>
-        <div class="picker-actions">
-          <!-- The terminal picker's "s" key, as a button: title order or
-               largest-first. Its label is set by app.js from the current mode. -->
-          <button id="picker-sort" type="button"></button>
-          <button id="picker-cancel" type="button">Cancel</button>
-        </div>
-      </div>
+    <!-- The stream file picker. Shown only when a session resolves to more than
+         one playable file; every child below the heading is built by app.js with
+         createElement, because the filenames come out of a torrent.
 
+         A MODAL <dialog>, and OUTSIDE <main id="app">, both deliberately:
+
+         - Modal because it used to be an inline card at the top of the document.
+           Press play on a season pack 500px down a browse and the question
+           appeared off screen, with nothing where the user was looking to say
+           anything had happened at all. showModal() centres it in the viewport,
+           takes focus, and closes on Escape.
+         - Outside #app because #app carries `hidden` until the page loads, and a
+           <dialog> inside a display:none subtree does not render at all. Its old
+           position was justified by sitting above both panes so that neither
+           list's re-render could replace it (the queue's happens four times a
+           second); a top-level sibling keeps that property and adds nothing to
+           it. -->
+    <dialog id="picker" class="card picker">
+      <p id="picker-title" class="picker-title"></p>
+      <ul id="picker-files" class="picker-files"></ul>
+      <div class="picker-actions">
+        <!-- The terminal picker's "s" key, as a button: title order or
+             largest-first. Its label is set by app.js from the current mode. -->
+        <button id="picker-sort" type="button"></button>
+        <button id="picker-cancel" type="button">Cancel</button>
+      </div>
+    </dialog>
+
+    <main id="app" hidden>
       <!-- ---- search ------------------------------------------------------ -->
       <section id="pane-search">
         <form id="search" class="card">

--- a/src/web/static/streamBusy.test.ts
+++ b/src/web/static/streamBusy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { BUSY_LABEL, controlState, isBusy, type FlowState } from "./streamBusy";
+
+const idle: FlowState = { prepare: null, picking: null };
+const preparing: FlowState = {
+  prepare: { key: "abc", title: "Harrowgate.S03.1080p.WEB-DL" },
+  picking: null,
+};
+const picking: FlowState = { prepare: null, picking: "Kestrel" };
+
+describe("controlState", () => {
+  it("leaves every control alone when nothing is in flight", () => {
+    expect(controlState(idle, "abc", "play")).toEqual({
+      disabled: false,
+      busy: false,
+      label: "play",
+    });
+    expect(controlState(idle, "Kestrel", "Play next")).toEqual({
+      disabled: false,
+      busy: false,
+      label: "Play next",
+    });
+  });
+
+  it("marks the control that started the flow as busy", () => {
+    expect(controlState(preparing, "abc", "play")).toEqual({
+      disabled: true,
+      busy: true,
+      label: BUSY_LABEL,
+    });
+  });
+
+  // The point of the whole module. A Play button that stays enabled while a
+  // prepare runs, and silently does nothing when pressed, is what taught users
+  // to hammer it — one prepare at a time is the terminal's rule
+  // (src/ui/App.tsx's `if (preparing || streamFiles || activeStream) return`)
+  // and this is that rule, rendered.
+  it("disables every OTHER control rather than letting it no-op silently", () => {
+    expect(controlState(preparing, "def", "play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "play",
+    });
+    expect(controlState(preparing, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "Play",
+    });
+  });
+
+  it("treats a pick search exactly as it treats a prepare", () => {
+    expect(controlState(picking, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: true,
+      label: BUSY_LABEL,
+    });
+    expect(controlState(picking, "abc", "play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "play",
+    });
+  });
+
+  // A pick hands off to a prepare, so both can be set for one tick. The row
+  // actually resolving is the more specific truth and wins; without this the
+  // title's button would claim to be busy while the row's did the work.
+  it("prefers the prepare when a pick has already handed off to one", () => {
+    const both: FlowState = { prepare: { key: "abc", title: "Kestrel" }, picking: "Kestrel" };
+    expect(controlState(both, "abc", "play").busy).toBe(true);
+    expect(controlState(both, "Kestrel", "Play")).toEqual({
+      disabled: true,
+      busy: false,
+      label: "Play",
+    });
+  });
+
+  // Info hashes and titles are two namespaces and are never compared across.
+  // A key from the wrong one simply never matches, which lands it in the
+  // disabled branch — the correct answer for it anyway.
+  it("never mistakes a title for an info hash", () => {
+    expect(controlState(preparing, "Harrowgate.S03.1080p.WEB-DL", "Play").busy).toBe(false);
+  });
+});
+
+describe("isBusy", () => {
+  it("is the one-at-a-time gate the terminal has and the browser did not", () => {
+    expect(isBusy(idle)).toBe(false);
+    expect(isBusy(preparing)).toBe(true);
+    expect(isBusy(picking)).toBe(true);
+  });
+});

--- a/src/web/static/streamBusy.ts
+++ b/src/web/static/streamBusy.ts
@@ -1,0 +1,77 @@
+// Whether a Play control is busy, disabled, or neither — and the one gate that
+// stops a second stream starting while the first is still resolving.
+//
+// Pure, and here rather than in app.ts for the reason every model in this
+// directory is: there is no jsdom in this repo, so a conditional that lives in
+// app.ts is a conditional no test can reach. "If you are writing a conditional
+// in app.ts that decides what to show, it belongs in a pure module" — CLAUDE.md,
+// and this has been caught in review twice.
+//
+// DERIVED, NEVER STORED ON THE ELEMENT. The queue's rows are rebuilt four times a
+// second by the SSE tick, so a `disabled` set once in a click handler is gone by
+// the next frame — which is precisely the bug this closes. app.ts re-applies this
+// over the live DOM after every render.
+
+export interface FlowState {
+  /**
+   * The row a prepare is running for, or null. `key` is the info hash — the same
+   * `DashRow.id` that `runPlay` was handed, so the two cannot disagree about
+   * which row is busy.
+   */
+  prepare: { key: string; title: string } | null;
+  /**
+   * The title a pickController search is running for, or null. A TITLE, not a
+   * hash: a one-click Play on a recommendation has no torrent yet, which is
+   * exactly what it is off finding.
+   */
+  picking: string | null;
+}
+
+export interface ControlState {
+  disabled: boolean;
+  /** Render `aria-busy` on this one. At most one control can be busy. */
+  busy: boolean;
+  label: string;
+}
+
+/** What the control that started the flow says while it waits. */
+export const BUSY_LABEL = "preparing…";
+
+/**
+ * What one Play control should look like right now.
+ *
+ * The rule is the terminal's, made visible: ONE prepare or pick at a time
+ * (`if (preparing || streamFiles || activeStream) return`, src/ui/App.tsx). The
+ * browser had the same rule per-row and SILENTLY RETURNED when it fired, so a
+ * button stayed lit and did nothing when pressed — which is how a user learns to
+ * press it repeatedly, starting nothing each time. So every control that is not
+ * the busy one is DISABLED, not merely ineligible.
+ *
+ * `idleLabel` is passed in rather than assumed because the six Play controls do
+ * not share one word: "play", "Play", "Play next". Nothing here decides copy.
+ */
+export function controlState(flow: FlowState, key: string, idleLabel: string): ControlState {
+  // The prepare wins when both are set: a pick that has found its release and
+  // handed off is now a prepare, and the row doing the work is a truer answer
+  // than the title that asked for it.
+  const active = flow.prepare?.key ?? flow.picking;
+  if (active === null || active === undefined) {
+    return { disabled: false, busy: false, label: idleLabel };
+  }
+  // Two namespaces (info hashes, titles) and no comparison across them: a key
+  // from the other one never matches, and disabled is the right answer for it
+  // anyway, since nothing may start while this flow runs.
+  if (active === key) return { disabled: true, busy: true, label: BUSY_LABEL };
+  return { disabled: true, busy: false, label: idleLabel };
+}
+
+/**
+ * Whether a new play or pick may start at all.
+ *
+ * The browser's guard was `playing.has(row.id)` — per-row, so two different rows
+ * could resolve at once, each polling a session for up to ten minutes, sharing
+ * one progress line that reported whichever wrote last.
+ */
+export function isBusy(flow: FlowState): boolean {
+  return flow.prepare !== null || flow.picking !== null;
+}

--- a/src/web/static/streamFlow.test.ts
+++ b/src/web/static/streamFlow.test.ts
@@ -501,6 +501,8 @@ function harness(over: Partial<PlayEffects> = {}) {
       preselect: number | null;
     }[],
     polls: 0,
+    progress: [] as (string | null)[],
+    slept: [] as { ms: number; aborts: boolean }[],
   };
   let clock = 0;
   const fx: PlayEffects = {
@@ -518,10 +520,14 @@ function harness(over: Partial<PlayEffects> = {}) {
       return false;
     },
     notice: (message) => calls.notices.push(message),
+    progress: (line) => calls.progress.push(line),
     choose: (sessionId, capability, _name, files, preselect) =>
       calls.chosen.push({ sessionId, capability, files, preselect }),
     open: (path) => calls.opened.push(path),
-    sleep: async (ms) => {
+    // Records whether it was handed the signal: a sleep that ignores one makes a
+    // cancel wait out the remaining POLL_MS before anything happens.
+    sleep: async (ms, signal) => {
+      calls.slept.push({ ms, aborts: signal !== undefined });
       clock += ms;
     },
     now: () => clock,
@@ -632,9 +638,11 @@ describe("runPlay", () => {
         return states[i++] ?? null;
       },
     });
-    await runPlay(row(), fx);
+    await runPlay(row(), fx, { providerLabel: "Real-Debrid" });
     expect(calls.polls).toBe(3);
-    expect(calls.notices.some((n) => n.includes("55%"))).toBe(true);
+    // On the progress channel, not the notice line: the percent re-fires every
+    // second and would stamp over any real message the user needed to read.
+    expect(calls.progress.some((n) => n?.includes("55%"))).toBe(true);
     expect(calls.opened).toEqual(["/play/s1/0?k=cap&n=movie.mp4"]);
   });
 
@@ -681,7 +689,7 @@ describe("runPlay", () => {
           files: [file("Harrowgate.S03E04.mkv", 0), file("Harrowgate.S03E05.mkv", 1)],
         }),
     });
-    await runPlay(row(), fx, { season: 3, episode: 5 });
+    await runPlay(row(), fx, { wanted: { season: 3, episode: 5 } });
     expect(calls.chosen[0]!.preselect).toBe(1);
   });
 
@@ -781,6 +789,135 @@ describe("runPlay", () => {
     it("is optional — runPlay does not require it", async () => {
       const { fx } = harness();
       await expect(runPlay(row(), fx)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("cancelling", () => {
+    // A resolve can run for ten minutes. Before this there was no way out of one
+    // but reloading the page, which orphaned the session either way.
+    it("does not start anything at all when already aborted", async () => {
+      const ac = new AbortController();
+      ac.abort();
+      const { fx, calls } = harness({
+        start: async () => started({ files: [file("movie.mp4", 0)] }),
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.starts).toEqual([]);
+      expect(calls.opened).toEqual([]);
+      expect(calls.notices).toEqual(["Stream cancelled."]);
+    });
+
+    // THE RACE THAT MATTERS. An abort landing after the POST succeeded but
+    // before the first poll must still DELETE the session — otherwise
+    // cancelling at the worst possible moment leaks the exact resource that
+    // cancelling exists to release, and the torrent runs until the idle reaper.
+    it("stops the session when the abort lands after it was started", async () => {
+      const ac = new AbortController();
+      const { fx, calls } = harness({
+        start: async () => {
+          ac.abort();
+          return started({ state: "resolving", progress: 0 });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.stopped).toEqual(["s1"]);
+      expect(calls.notices).toContain("Stream cancelled.");
+      expect(calls.polls).toBe(0);
+      expect(calls.opened).toEqual([]);
+    });
+
+    it("stops polling and releases the session when cancelled mid-resolve", async () => {
+      const ac = new AbortController();
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async () => started({ state: "resolving", progress: 10 }),
+        poll: async () => {
+          polls++;
+          if (polls === 2) ac.abort();
+          return session({ state: "resolving", progress: 10 + polls });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(polls).toBe(2);
+      expect(calls.stopped).toEqual(["s1"]);
+      expect(calls.notices).toContain("Stream cancelled.");
+    });
+
+    it("hands the signal to start, poll and sleep, so an in-flight fetch dies too", async () => {
+      const ac = new AbortController();
+      const seen: { start?: boolean; poll?: boolean } = {};
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async (_row, _confirmed, signal) => {
+          seen.start = signal === ac.signal;
+          return started({ state: "resolving", progress: 0 });
+        },
+        poll: async (_id, signal) => {
+          seen.poll = signal === ac.signal;
+          polls++;
+          return polls === 1
+            ? session({ state: "resolving" })
+            : session({ files: [file("movie.mp4", 0)] });
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(seen.start).toBe(true);
+      expect(seen.poll).toBe(true);
+      expect(calls.slept.every((s) => s.aborts)).toBe(true);
+    });
+
+    // An aborted fetch reads as an unreadable session, which has its own,
+    // wrong, message: "Lost track of that stream — try again." tells a user who
+    // just pressed Cancel that something went wrong.
+    it("reports a cancel as a cancel, not as a lost session", async () => {
+      const ac = new AbortController();
+      const { fx, calls } = harness({
+        start: async () => started({ state: "resolving", progress: 10 }),
+        poll: async () => {
+          ac.abort();
+          return null;
+        },
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.notices).toContain("Stream cancelled.");
+      expect(calls.notices).not.toContain("Lost track of that stream — try again.");
+      expect(calls.stopped).toEqual(["s1"]);
+    });
+  });
+
+  describe("progress", () => {
+    it("reports the waiting line on its own channel, not as a notice", async () => {
+      let polls = 0;
+      const { fx, calls } = harness({
+        start: async () => started({ state: "resolving", backend: "debrid", progress: 40 }),
+        poll: async () => {
+          polls++;
+          return polls === 1
+            ? session({ state: "resolving", backend: "debrid", progress: 60 })
+            : session({ files: [file("movie.mp4", 0)] });
+        },
+      });
+      await runPlay(row(), fx, { providerLabel: "Real-Debrid" });
+      expect(calls.progress[0]).toBe("Caching on Real-Debrid… 40% · 0s");
+      expect(calls.notices).toEqual([]);
+    });
+
+    // The pill must come down however the flow ends, or it sits over the page
+    // for good. Asserted for a success, a failure and a cancel.
+    it("clears the waiting line however the flow ends", async () => {
+      const ok = harness({ start: async () => started({ files: [file("movie.mp4", 0)] }) });
+      await runPlay(row(), ok.fx);
+      expect(ok.calls.progress.at(-1)).toBeNull();
+
+      const bad = harness({ start: async () => started({ state: "error", error: "no peers" }) });
+      await runPlay(row(), bad.fx);
+      expect(bad.calls.progress.at(-1)).toBeNull();
+
+      const ac = new AbortController();
+      ac.abort();
+      const off = harness();
+      await runPlay(row(), off.fx, { signal: ac.signal });
+      expect(off.calls.progress.at(-1)).toBeNull();
     });
   });
 });

--- a/src/web/static/streamFlow.test.ts
+++ b/src/web/static/streamFlow.test.ts
@@ -843,6 +843,46 @@ describe("runPlay", () => {
       expect(calls.notices).toContain("Stream cancelled.");
     });
 
+    // An aborted POST comes back as `failed` — the fetch threw and the caller
+    // cannot tell a cancel from a dead server. Checked BEFORE the failed branch,
+    // or a cancel exits with no "Stream cancelled." and fires onUnresolved, whose
+    // Continue-watching binding launches a fallback SEARCH. Pressing Cancel would
+    // start a search.
+    it("reports a cancel during the initial POST as a cancel, and fires no fallback", async () => {
+      const ac = new AbortController();
+      let fallbacks = 0;
+      const { fx, calls } = harness({
+        start: async () => {
+          ac.abort();
+          return { kind: "failed" };
+        },
+        onUnresolved: () => fallbacks++,
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.notices).toEqual(["Stream cancelled."]);
+      expect(fallbacks).toBe(0);
+      expect(calls.stopped).toEqual([]);
+    });
+
+    // Same rule on the second POST, the one after a human accepted the
+    // torrent-confirm prompt.
+    it("reports a cancel during the confirmed retry as a cancel", async () => {
+      const ac = new AbortController();
+      let fallbacks = 0;
+      const { fx, calls } = harness({
+        start: async (_row, confirmed) => {
+          if (!confirmed) return { kind: "confirm", reason: "no premium" };
+          ac.abort();
+          return { kind: "failed" };
+        },
+        confirm: () => true,
+        onUnresolved: () => fallbacks++,
+      });
+      await runPlay(row(), fx, { signal: ac.signal });
+      expect(calls.notices).toEqual(["Stream cancelled."]);
+      expect(fallbacks).toBe(0);
+    });
+
     it("hands the signal to start, poll and sleep, so an in-flight fetch dies too", async () => {
       const ac = new AbortController();
       const seen: { start?: boolean; poll?: boolean } = {};

--- a/src/web/static/streamFlow.test.ts
+++ b/src/web/static/streamFlow.test.ts
@@ -263,18 +263,56 @@ describe("pollDecision", () => {
     }
   });
 
-  it("shows the percent the session reports, so it doesn't look hung", () => {
-    const d = pollDecision(session({ state: "resolving", progress: 42 }), 0, "A Release");
+  it("names the provider and the percent for a debrid resolve", () => {
+    const d = pollDecision(
+      session({ state: "resolving", backend: "debrid", progress: 42 }),
+      12_000,
+      "Harrowgate.S03.1080p.WEB-DL",
+      "Real-Debrid",
+    );
     expect(d.kind).toBe("poll");
     if (d.kind !== "poll") return;
-    expect(d.label).toContain("42%");
-    expect(d.label).toContain("A Release");
+    expect(d.label).toBe("Caching on Real-Debrid… 42% · 12s");
     expect(d.delayMs).toBe(POLL_MS);
+  });
+
+  it("names the release, not a percent, while finding peers in a swarm", () => {
+    const d = pollDecision(
+      session({ state: "resolving", backend: "torrent", progress: 42 }),
+      3_000,
+      "Kestrel.2010.1080p.BluRay.x264",
+    );
+    expect(d.kind).toBe("poll");
+    if (d.kind !== "poll") return;
+    expect(d.label).toBe("Finding peers… Kestrel.2010.1080p.BluRay.x264 · 3s");
+  });
+
+  // The elapsed seconds are what tell a user that a resolve sitting at one
+  // percent for minutes is working rather than hung. Deleting them is the
+  // mutation this guards.
+  it("counts the seconds up, so a stalled percent still shows movement", () => {
+    const at = (ms: number): string => {
+      const d = pollDecision(
+        session({ state: "resolving", backend: "debrid", progress: 7 }),
+        ms,
+        "n",
+        "RD",
+      );
+      return d.kind === "poll" ? d.label : "";
+    };
+    expect(at(0)).toContain("· 0s");
+    expect(at(1_000)).toContain("· 1s");
+    expect(at(65_400)).toContain("· 65s");
   });
 
   it("clamps a nonsense percent rather than rendering it", () => {
     const at = (progress: number): string => {
-      const d = pollDecision(session({ state: "resolving", progress }), 0, "n");
+      const d = pollDecision(
+        session({ state: "resolving", backend: "debrid", progress }),
+        0,
+        "n",
+        "RD",
+      );
       return d.kind === "poll" ? d.label : "";
     };
     expect(at(140)).toContain("100%");
@@ -295,13 +333,17 @@ describe("pollDecision", () => {
     expect(d.message).toContain("A Release");
   });
 
-  it("clips a very long name for the notice", () => {
+  // Asserts the TRUNCATED name is present, not merely that some "…" is: every
+  // line prepareLine produces contains an ellipsis of its own ("Finding peers…"),
+  // so `toContain("…")` would pass while the name went unclipped. That is the
+  // vacuous-assertion trap CLAUDE.md records.
+  it("clips a very long name for the waiting line", () => {
     const long = "x".repeat(300);
-    const d = pollDecision(session({ state: "resolving" }), 0, long);
+    const d = pollDecision(session({ state: "resolving", backend: "torrent" }), 0, long);
     expect(d.kind).toBe("poll");
     if (d.kind !== "poll") return;
     expect(d.label).not.toContain(long);
-    expect(d.label).toContain("…");
+    expect(d.label).toContain(`${"x".repeat(79)}…`);
   });
 });
 
@@ -572,15 +614,19 @@ describe("runPlay", () => {
   // MUTATION GUARD #5. Real-Debrid caching reports a percent for minutes; a loop
   // that stopped at the first tick would strand a session that was about to be
   // ready and leave the user watching a frozen number.
+  // `backend: "debrid"` throughout, because a percent is only a thing a debrid
+  // resolve HAS: a swarm reports no cache progress, so its line names the release
+  // and counts seconds instead. Asserting "55%" against a torrent session would
+  // be asserting something the UI is right not to say.
   it("keeps polling while the session is resolving, and shows the percent", async () => {
     const states: PublicStreamSession[] = [
-      session({ state: "resolving", progress: 10 }),
-      session({ state: "resolving", progress: 55 }),
+      session({ state: "resolving", backend: "debrid", progress: 10 }),
+      session({ state: "resolving", backend: "debrid", progress: 55 }),
       session({ state: "ready", files: [file("movie.mp4", 0)] }),
     ];
     let i = 0;
     const { fx, calls } = harness({
-      start: async () => started({ state: "resolving", progress: 0 }),
+      start: async () => started({ state: "resolving", backend: "debrid", progress: 0 }),
       poll: async () => {
         calls.polls++;
         return states[i++] ?? null;

--- a/src/web/static/streamFlow.ts
+++ b/src/web/static/streamFlow.ts
@@ -418,16 +418,36 @@ export type StartResult =
  * choice). So the effects are parameters and the flow is testable end to end.
  */
 export interface PlayEffects {
-  /** POST /api/stream. `confirmed` is only ever true after a human said so. */
-  start(row: DashRow, confirmed: boolean): Promise<StartResult>;
+  /**
+   * POST /api/stream. `confirmed` is only ever true after a human said so.
+   *
+   * `signal` is `PlayOptions.signal`, passed down so a cancel kills the request
+   * in flight rather than waiting for it. An implementation that aborts must
+   * NOT report that as a transport failure — the user asked for it. See the
+   * abort check immediately after this is called in `runPlay`.
+   */
+  start(row: DashRow, confirmed: boolean, signal?: AbortSignal): Promise<StartResult>;
   /** GET /api/stream/:sid, or null when it can't be read. */
-  poll(sessionId: string): Promise<PublicStreamSession | null>;
+  poll(sessionId: string, signal?: AbortSignal): Promise<PublicStreamSession | null>;
   /** DELETE /api/stream/:sid, best effort. */
   stop(sessionId: string): void;
   /** A blocking yes/no. window.confirm in the browser. */
   confirm(message: string): boolean;
   /** Transient message in the dashboard's notice line. */
   notice(message: string): void;
+  /**
+   * The waiting line, or null to take it down.
+   *
+   * A SEPARATE CHANNEL FROM `notice`, deliberately. `notice` is a transient line
+   * that hides itself after a few seconds; this one has to persist for as long
+   * as the resolve does, which can be minutes, and it has a Cancel button
+   * attached. Sharing one effect meant the progress label re-firing every second
+   * stamped over any real message the user needed to read.
+   *
+   * REQUIRED, not optional: an implementation that forgot it would leave a pill
+   * fixed over the page for good.
+   */
+  progress(line: string | null): void;
   /**
    * Show the file picker. Ownership of the session passes to it.
    *
@@ -443,7 +463,12 @@ export interface PlayEffects {
   ): void;
   /** Go to a player URL. Ownership of the session passes to the player. */
   open(path: string): void;
-  sleep(ms: number): Promise<void>;
+  /**
+   * Wait. Takes the signal so a cancel does not have to wait out the remaining
+   * `POLL_MS` before anything visible happens — a Cancel button that looks
+   * inert for most of a second gets pressed again.
+   */
+  sleep(ms: number, signal?: AbortSignal): Promise<void>;
   now(): number;
   /**
    * Called when `start` could not start a session at all — `start.kind ===
@@ -465,6 +490,42 @@ export interface PlayEffects {
 }
 
 /**
+ * The one wording for a cancelled stream, shared with the TUI's own
+ * `cancelPreparing` (src/ui/App.tsx) by being the same string.
+ */
+export const CANCELLED_NOTICE = "Stream cancelled.";
+
+/**
+ * The three things `runPlay` needs that are DATA rather than effects.
+ *
+ * An options bag rather than three positional parameters: `wanted` was the third
+ * argument, and the other two would make a call site read
+ * `runPlay(row, fx, null, "Real-Debrid", signal)` — where transposing two
+ * arguments typechecks and silently plays the wrong episode. This is not
+ * hypothetical: the test that pins the preselection passed
+ * `{ season: 3, episode: 5 }` positionally, which is structurally exactly what a
+ * bag of options is not.
+ */
+export interface PlayOptions {
+  /**
+   * A Continue-watching row's own suggested episode, passed straight through to
+   * `streamOutcome`. Every other caller — a search result, a queue row — has no
+   * such row and passes nothing. (Named `wanted` rather than `next` only because
+   * the polling loop already has a `next`.)
+   */
+  wanted?: EpisodeRef | null;
+  /** Who is caching, for the waiting line. Absent renders "debrid". */
+  providerLabel?: string | null;
+  /**
+   * Cancels the flow. Threaded into `start`, `poll` and `sleep` rather than
+   * merely checked between them, so a cancel kills an in-flight fetch instead of
+   * waiting it out — and, crucially, a session that HAD started is stopped on
+   * the way out. See rule 3 below.
+   */
+  signal?: AbortSignal;
+}
+
+/**
  * Press Play on one row: start a session, wait for it, open something.
  *
  * The two rules this function exists to hold:
@@ -475,60 +536,103 @@ export interface PlayEffects {
  * 2. A `resolving` session is POLLED until it settles or the deadline passes.
  *    Real-Debrid caching sits mid-percent for minutes, and a loop that gave up
  *    early would strand a session that was about to be ready.
+ * 3. A CANCEL RELEASES THE SESSION. Every exit after `start` succeeded stops the
+ *    session, an abort included — a cancel that leaked the torrent would be
+ *    worse than no cancel at all, because the user believes they stopped it.
  *
- * `wanted` is data, not an effect, which is why it is a parameter rather than
- * another member of `PlayEffects`: it is the Continue-watching row's own `next`,
- * passed straight through to `streamOutcome`. Every other caller — a search
- * result, a queue row — has no such row and passes nothing. (Named `wanted`
- * rather than `next` only because the polling loop below already has a `next`.)
+ * Everything in `PlayOptions` is DATA rather than an effect, which is why it is
+ * a parameter and not more members of `PlayEffects`. See that interface.
  */
 export async function runPlay(
   row: DashRow,
   fx: PlayEffects,
-  wanted?: EpisodeRef | null,
+  opts: PlayOptions = {},
 ): Promise<void> {
-  let start = await fx.start(row, false);
+  const { wanted, providerLabel, signal } = opts;
+
+  // Every exit from here down goes through one of these two, so the waiting line
+  // cannot be left up by a path someone forgot about.
+  const done = (): void => fx.progress(null);
+  const cancel = (sessionId: string | null): void => {
+    if (sessionId) fx.stop(sessionId);
+    done();
+    fx.notice(CANCELLED_NOTICE);
+  };
+
+  if (signal?.aborted) {
+    cancel(null);
+    return;
+  }
+
+  let start = await fx.start(row, false, signal);
 
   if (start.kind === "confirm") {
     if (!fx.confirm(confirmFallbackMessage(start.reason, row.name))) {
+      done();
       fx.notice("Playback cancelled — nothing was streamed.");
       return;
     }
-    start = await fx.start(row, true);
+    start = await fx.start(row, true, signal);
     // A second 409 means the server didn't accept the confirmation. Do not loop
     // asking: one prompt per click.
     if (start.kind === "confirm") {
+      done();
       fx.notice("Couldn't start that stream.");
       return;
     }
   }
   if (start.kind !== "started") {
+    done();
     if (start.kind === "failed") fx.onUnresolved?.();
     return;
   }
 
   const { sessionId, capability } = start;
+  // From here on a session EXISTS, so every early return owes it a stop — an
+  // abort included. This is the leak the "abort lands after it was started" test
+  // guards: cancelling at the worst possible moment must not be the one path
+  // that keeps a torrent running.
+  if (signal?.aborted) {
+    cancel(sessionId);
+    return;
+  }
+
   let session = start.session;
   const began = fx.now();
   for (;;) {
-    const decision = pollDecision(session, fx.now() - began, row.name);
+    const decision = pollDecision(session, fx.now() - began, row.name, providerLabel);
     if (decision.kind === "settled") break;
     if (decision.kind === "timeout") {
+      done();
       fx.notice(decision.message);
       fx.stop(sessionId);
       return;
     }
-    fx.notice(decision.label);
-    await fx.sleep(decision.delayMs);
-    const next = await fx.poll(sessionId);
+    fx.progress(decision.label);
+    await fx.sleep(decision.delayMs, signal);
+    if (signal?.aborted) {
+      cancel(sessionId);
+      return;
+    }
+    const next = await fx.poll(sessionId, signal);
     if (!next) {
+      // An aborted fetch also lands here, and must not be reported as a
+      // transport failure: "Lost track of that stream" tells a user who just
+      // pressed Cancel that something went wrong.
+      if (signal?.aborted) {
+        cancel(sessionId);
+        return;
+      }
       // The session is gone or unreadable. Not stopped here: a DELETE we can't
       // read the answer to adds nothing, and the id may not exist at all.
+      done();
       fx.notice("Lost track of that stream — try again.");
       return;
     }
     session = next;
   }
+
+  done();
 
   const outcome = streamOutcome(session, wanted);
   if (outcome.kind === "error") {

--- a/src/web/static/streamFlow.ts
+++ b/src/web/static/streamFlow.ts
@@ -42,6 +42,11 @@ import { nextEpisodeIndex } from "../../util/nextEpisodeFile";
 // than being copied. `release.ts` was already in this bundle via nextEpisodeFile.
 import { historyKeyFor } from "../../util/streamHistoryKey";
 import { parseRelease } from "../../util/release";
+// The sixth value import out of this directory, and the same argument as the
+// other five: what a waiting user reads is a decision both front ends make, so
+// it is shared rather than written twice. It lived inline in src/ui/App.tsx's
+// render until this file needed it. See src/util/prepareLine.ts.
+import { prepareLine } from "../../util/prepareLine";
 import type { EpisodeRef } from "../../util/episode";
 import type { PublicStreamFile, PublicStreamHistoryItem, PublicStreamSession } from "../wire";
 import { formatBytes, shortName, type DashRow } from "./dashboard";
@@ -333,6 +338,7 @@ export function pollDecision(
   session: PublicStreamSession,
   elapsedMs: number,
   name: string,
+  providerLabel?: string | null,
 ): PollDecision {
   if (session.state !== "resolving") return { kind: "settled" };
   const label = shortName(name);
@@ -345,18 +351,24 @@ export function pollDecision(
   return {
     kind: "poll",
     delayMs: POLL_MS,
-    label: `Preparing “${label}” — ${resolvePercent(session)}%`,
+    // `phase: "caching"` unconditionally: the wire has one `resolving` state and
+    // no way to distinguish the provider's link-fetch step from its cache, so
+    // the browser never renders prepareLine's "Fetching link…" arm. The TUI
+    // does, from its own richer local state. Reporting a percent of 0 as
+    // "Caching… 0%" is honest for that moment; inventing a phase would not be.
+    //
+    // The clamp on `progress` lives in prepareLine, which is why there is no
+    // longer a `resolvePercent` here — one guard, shared with the terminal,
+    // rather than two that can disagree about what 99.7% rounds to.
+    label: prepareLine({
+      source: session.backend === "debrid" ? "rd" : "torrent",
+      phase: "caching",
+      providerLabel,
+      label,
+      pct: session.progress,
+      elapsedSec: elapsedMs / 1000,
+    }),
   };
-}
-
-// The session's own percent, defended against a backend that reports something
-// outside the documented 0–100 integer range. Same floor-don't-round rule as
-// dashboard.ts: rounding 99.6 up to 100 on something that is still working
-// reads as a stuck UI.
-function resolvePercent(session: PublicStreamSession): number {
-  const pct = session.progress;
-  if (!Number.isFinite(pct)) return 0;
-  return Math.max(0, Math.min(100, Math.floor(pct)));
 }
 
 /**

--- a/src/web/static/streamFlow.ts
+++ b/src/web/static/streamFlow.ts
@@ -564,7 +564,23 @@ export async function runPlay(
     return;
   }
 
+  // Every `await fx.start(...)` is followed by this, and it has to come BEFORE
+  // the confirm/failed branches below. An aborted POST throws inside the effect,
+  // which reports it as `failed` — indistinguishable from a dead server. Left to
+  // fall through, a cancel would exit with no "Stream cancelled." at all AND
+  // fire `onUnresolved`, whose Continue-watching binding launches a fallback
+  // search: pressing Cancel would start a search.
+  //
+  // Stops the session when one came back regardless, since an abort that landed
+  // just after the POST succeeded still owes it a stop.
+  const abortedAfterStart = (result: StartResult): boolean => {
+    if (!signal?.aborted) return false;
+    cancel(result.kind === "started" ? result.sessionId : null);
+    return true;
+  };
+
   let start = await fx.start(row, false, signal);
+  if (abortedAfterStart(start)) return;
 
   if (start.kind === "confirm") {
     if (!fx.confirm(confirmFallbackMessage(start.reason, row.name))) {
@@ -573,6 +589,7 @@ export async function runPlay(
       return;
     }
     start = await fx.start(row, true, signal);
+    if (abortedAfterStart(start)) return;
     // A second 409 means the server didn't accept the confirmation. Do not loop
     // asking: one prompt per click.
     if (start.kind === "confirm") {
@@ -588,15 +605,6 @@ export async function runPlay(
   }
 
   const { sessionId, capability } = start;
-  // From here on a session EXISTS, so every early return owes it a stop — an
-  // abort included. This is the leak the "abort lands after it was started" test
-  // guards: cancelling at the worst possible moment must not be the one path
-  // that keeps a torrent running.
-  if (signal?.aborted) {
-    cancel(sessionId);
-    return;
-  }
-
   let session = start.session;
   const began = fx.now();
   for (;;) {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -366,9 +366,47 @@ button:hover {
 }
 
 /* The stream file picker. Overrides .card's row layout — it is a heading above
-   a list, not a form — in the same way .fallback does on the player page. */
-.picker {
+   a list, not a form — in the same way .fallback does on the player page.
+
+   SCOPED TO [open], and that is load-bearing rather than tidy: a bare
+   `.picker { display: block }` overrides the UA's own
+   `dialog:not([open]) { display: none }` and leaves the closed picker sitting
+   visible at the top of the page for good. */
+.picker[open] {
   display: block;
+}
+
+/* And the closed case stated explicitly, because scoping the rule above is not
+   on its own enough: this element is also a `.card`, which sets
+   `display: flex` — and THAT overrides the UA's `dialog:not([open])` rule just
+   as surely. Measured, not theorised: the closed dialog rendered 72px tall at
+   the top of the page until this rule existed. Written against the element
+   rather than against `.card` so it holds however the class list changes. */
+.picker:not([open]) {
+  display: none;
+}
+
+/* A dialog carries a UA border, padding and `margin: auto`; .card supplies the
+   first two, and the third has to be restored — `.card`'s own
+   `margin-bottom: 1.5rem` beats the UA's `auto` on that one edge, which leaves
+   the vertical centring lopsided: measured at 392px above and 24px below in a
+   639px viewport, i.e. sitting near the bottom rather than in the middle.
+
+   max-height keeps a forty-episode pack scrollable INSIDE the dialog rather than
+   taller than the viewport — which would put Cancel off screen, the very problem
+   this whole change exists to fix. */
+.picker {
+  margin: auto;
+  border: 1px solid var(--line);
+  max-height: min(80vh, 40rem);
+  max-width: min(46rem, calc(100vw - 2rem));
+  overflow-y: auto;
+}
+
+/* Dim rather than opaque: the list behind is context — which release this is a
+   pack of — not something to hide. */
+.picker::backdrop {
+  background: rgb(0 0 0 / 55%);
 }
 
 .picker-title {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1407,3 +1407,49 @@ select:focus-visible {
   font-size: 0.75rem;
   color: var(--dim);
 }
+
+/* The resolving-stream pill. Fixed bottom left; .to-top is bottom right at
+   z-index 4, and sharing a corner would overlap them.
+
+   Deliberately not a .card, even though it looks like one: this element is
+   `hidden` between resolves, and the global [hidden] rule at the top of this
+   file exists precisely because .card's `display: flex` used to defeat it. Its
+   own layout keeps it out of that argument entirely. */
+.prepare {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: min(30rem, calc(100vw - 7rem));
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.5rem;
+  background: var(--raised);
+  font-size: 0.75rem;
+}
+
+.prepare-line {
+  color: var(--dim);
+  overflow-wrap: anywhere;
+  /* The elapsed seconds and the percent both tick; without this the whole line
+     jitters sideways once a second. */
+  font-variant-numeric: tabular-nums;
+}
+
+.prepare button {
+  flex-shrink: 0;
+}
+
+/* On a phone the pill and .to-top would sit side by side in 375px. Full width
+   above it instead. */
+@media (max-width: 30rem) {
+  .prepare {
+    left: 1rem;
+    right: 1rem;
+    bottom: 3.5rem;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## The report

> on the webui, when clicking the play button on a season pack, the 'pick which episode' is at the top of the page, whereas you might be scrolled 500px down and never see it. plus there are no spinners whilst it loads so it encourages people to keep hammering the play button

All three symptoms turned out to be **one thing**: the browser is behind the terminal in three
specific places. So this ships as parity, not as new invention.

| | Terminal (`src/ui/App.tsx`) | Browser, before |
| --- | --- | --- |
| One prepare/pick at a time | `if (preparing \|\| streamFiles \|\| activeStream) return` — global | per-`row.id`, and it **silently returned** |
| Progress while resolving | persistent line, elapsed seconds, per-source wording | `#notice`, a non-sticky `<p>` above `<main>` |
| Abort | `esc` → `AbortController`, other keys swallowed | none — polled to a 10-minute timeout |

## What's in it

**The picker is a modal `<dialog>`.** `showModal()` centres it in the viewport, so where you are
scrolled stops mattering; it takes focus and Escape for free. It moved out of `<main id="app">`
because `#app` carries `hidden` until load and a `<dialog>` in a `display: none` subtree does not
render at all.

**Every Play button shows its state, derived on render.** The pressed control reads `preparing…`
with `aria-busy`; every other one is disabled. That is the honest rendering of one-at-a-time — a lit
button that silently no-ops is what teaches people to press it again. Derived on every render because
queue rows are rebuilt four times a second, so a `disabled` set in a click handler is gone within
250ms. **Two of the six Play buttons had no guard of any kind before** (For You's `Play` and
`Play next` go through `pickController`, which `play()`'s guard never covered).

**A viewport-anchored pill, with the Cancel the browser never had.** `Caching on Real-Debrid… 42% ·
12s`, or `Finding peers… <release> · 12s` — the terminal's own wording, now shared rather than
written twice.

## Both front ends, and the one exemption

`src/util/prepareLine.ts` is new and **both** front ends use it; `src/ui/App.tsx` stops building that
string inline. Writing it a second time in `src/web` would have been the fifth recorded
copy-then-drift bug in this repo.

The only asymmetry is the affordance: the terminal appends `  (esc cancels)`, the browser puts a
Cancel button next to it. That is CLAUDE.md's *"a surface can't express it"* exemption — the terminal
has no button and the browser has no keybindings. Nothing else here differs between them.

## Two bugs found in review, not by a test

**The cancel did not abort the fetches.** `PlayEffects.start`/`poll` grew a `signal` parameter but
`app.ts`'s implementations never took one — TypeScript is silent about a 2-param function passed
where 3 are declared, and the test only proved the *harness* offers the signal. The comment asserted
behaviour the code did not have.

Wiring it exposed the worse half: an aborted POST throws, the effect reports `failed`, and the abort
check sat **after** that branch. So a cancel during the initial request exited with no
`Stream cancelled.` **and fired `onUnresolved`** — whose Continue-watching binding launches a
fallback search. *Pressing Cancel would have started a search.* Two tests pin it now.

**Disabling the pressed button dropped keyboard focus to `<body>`**, where `captureRowFocus` finds
nothing to restore — the exact failure `resultFocus.ts` was written for, which would have left the
list unreachable by keyboard for the whole prepare. Focus now moves to the pill's Cancel, and only
for users actually driving from the keyboard.

## Two CSS traps that only running it would find

- The **closed** dialog rendered 72px tall at the top of the page. Scoping `.picker` to `[open]` is
  not enough — it is also a `.card`, whose `display: flex` overrides the UA's
  `dialog:not([open])` rule just as surely. Hence an explicit `:not([open])` rule.
- It opened **low, not centred** (392px above, 24px below in a 639px viewport) because `.card`'s
  `margin-bottom` beats the UA's `margin: auto` on that one edge.

## Deliberate non-changes

**The Real-Debrid fallback prompt stays a native `window.confirm`.** Synchronous and unmissable are
the right properties for a consent decision whose consequence — your IP in a public swarm — cannot be
taken back. A styled in-page modal is dismissable by reflex. This is a decision, not an oversight.

**The "what the browser can't do yet" list needed no edit** — none of its three bullets was about
cancelling or about where the picker opens. Verified rather than assumed.

## Known exposure, pre-existing

If a search source held an SSE connection open forever with neither `done` nor an error,
`flow.picking` would stay set and the Play buttons would stay disabled until reload. `searchOnce`
resolves on `done` **and** on transport errors, so it settles in practice; the hang itself predates
this change, which raises its cost from "the pane looks busy" to "the buttons are disabled". Happy to
put a ceiling on it in a follow-up if you'd rather.

## Verification

`npm test` (2372 passing, 145 files), `npm run typecheck`, `npm run lint` (only the one known
pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx`), `npm run build`.

New tests: `prepareLine` (6 — the three old terminal strings asserted **verbatim**, so the TUI swap is
provably like-for-like), `streamBusy` (7), `abortableSleep` (7), plus 9 new `runPlay` tests covering
the abort races and the progress channel.

Wiring is not reachable by a unit test — there is no jsdom here, deliberately — so it was checked by
running `serve --web` in a real browser: closed dialog is `display: none`; open dialog fully inside
the viewport at scrollY 800 with focus inside it; the backdrop paints; the pill sits 16px from the
bottom-left without overlapping `.to-top`; and `paintPlayBusy` provably runs per-render (a
hand-corrupted button was reset by the next render).

**Not verified, and worth a human minute:** pressing Play on a real torrent — the busy state across a
real multi-second prepare, and Cancel stopping a live session. Both are unit-tested, but the live path
would have spent a Real-Debrid account, so I left it. Escape-closing the dialog is also unverified:
synthetic keypresses never reached the page under automation (the `close` teardown itself is
confirmed).

Design and plan: `docs/superpowers/specs/2026-07-31-web-stream-flow-parity-design.md`,
`docs/superpowers/plans/2026-07-31-web-stream-flow-parity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
