### PR TITLE
Make the browser's play flow lead somewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,24 @@ give up after twelve seconds:
   playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android you also get
   a direct VLC link.
 
+#### The player page knows what else is in the torrent
+
+Play an episode out of a season pack and the page you land on lists the rest of it: **up next** first, then
+every episode in the torrent, headed by season when there is more than one. Each is a link to the same
+page for that file, so the next episode is one click — you never go back to the search, and you never
+reopen the picker. This is the browser catching up to the terminal, whose picker has always stayed open
+after launching a player so the next episode is one keypress away.
+
+There is also **Download rest of season .m3u**, which is one playlist containing this episode and every
+later one in order — hand it to VLC once and it runs the rest of the season unattended.
+
+Above the filename is a breadcrumb back to the show, and the header's **back to results** goes back to the
+search you ran rather than to an empty box: the dashboard now keeps its query and category in its own URL,
+so a full page load — which is what the browser's Back button does here, because the player is a separate
+page — restores what you were looking at. That also means a search is a link you can bookmark or send to
+another device. Only the query and the tab; a stream is per-session and dies with it, so nothing in that
+URL claims to resume one.
+
 That check is also why the card is honest about *which* part is the problem. An `.mp4` that turns out to be
 carrying HEVC used to look playable right up until it wasn't; now it's caught before anything loads.
 

--- a/src/core/streamSession.ts
+++ b/src/core/streamSession.ts
@@ -19,6 +19,13 @@ export interface StreamSession {
   backend: StreamBackend;
   // Which debrid service served it, when `backend` is "debrid".
   provider?: DebridProviderId;
+  // The torrent this session is of. Kept because it is the key every store in
+  // the app is written under — `markWatched` and `recordPlayedFile` both take
+  // it — and the player page, which is a separate document that knows only its
+  // own URL, has to be able to say "this episode was opened" without it.
+  // NOT part of `PublicStreamSession`: `toPublicSession` picks fields, and a
+  // polled session body has no use for it.
+  infoHash: string;
   name: string;
   state: StreamSessionState;
   // Upstream URLs: a Real-Debrid link, or a localhost WebTorrent URL. These stay
@@ -130,6 +137,7 @@ export class StreamSessionRegistry {
       backendHandle: null,
       backend: viaDebrid ? "debrid" : "torrent",
       ...(viaDebrid && input.route.kind === "debrid" ? { provider: input.route.provider } : {}),
+      infoHash: input.infoHash,
       name: input.name,
       state: "resolving",
       files: [],

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -274,6 +274,7 @@ describe("toPublicSession", () => {
       capability: CAPABILITY,
       backendHandle: null,
       backend: "torrent",
+      infoHash: "f".repeat(40),
       name: "Some Release",
       state: "ready",
       files: [

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -186,6 +186,7 @@ import {
 import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest";
 import { authHeadersFor, readStoredToken, storeToken } from "./token";
 import { routeFromSearch, urlForRoute, type RouteState } from "./route";
+import { rememberReturn } from "./returnTo";
 
 const EMPTY_TEXT = "Nothing in the queue.";
 const NOTICE_MS = 4000;
@@ -766,14 +767,22 @@ function stopSession(sessionId: string): void {
 // Navigate this tab, rather than window.open(): by the time a session is ready
 // the click that started it is seconds or minutes old, so the popup has lost its
 // user activation and every browser blocks it — and on a phone there is nowhere
-// useful for a second tab to go anyway. The player page carries a "back to
-// queue" link.
+// useful for a second tab to go anyway. The player page carries a link back
+// here.
+//
+// THE NOTE IS WHY THAT LINK WORKS. The player page cannot tell where it came
+// from: it sets `no-referrer` deliberately, because its URL carries a stream
+// capability in `?k=` and a Referer would hand that to anything it links at. So
+// this side writes down where it is going *from*, into sessionStorage, which is
+// per tab — and this is the same tab, because of the `location.assign` below.
+// See returnTo.ts.
 //
 // The session is deliberately NOT stopped here. It is what the player is about
 // to fetch. Nothing in this tab outlives the navigation, so a session whose
 // player tab is simply closed is cleaned up by the registry's idle reaping —
 // the player page cannot DELETE it itself, having a capability but no token.
 function openPlayer(path: string): void {
+  rememberReturn(`${location.pathname}${location.search}`);
   location.assign(path);
 }
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -184,16 +184,8 @@ import {
   type ListState,
 } from "./suggestModel";
 import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest";
-
-// The token is held in sessionStorage and sent as an Authorization header on
-// every API call. No cookie authenticates the API — but that does NOT mean there
-// is no CSRF vector, which is what this comment used to claim: the usual way to
-// run the dashboard is with no token at all, and then there is no credential to
-// forge in the first place. A cross-origin page's POST would simply have been
-// authorized. The server rejects state-changing requests whose Origin /
-// Sec-Fetch-Site say cross-site (daemon/auth.ts, isCrossSiteRequest); this
-// page's own fetches are same-origin and unaffected.
-const TOKEN_KEY = "torlnk.token";
+import { authHeadersFor, readStoredToken, storeToken } from "./token";
+import { routeFromSearch, urlForRoute, type RouteState } from "./route";
 
 const EMPTY_TEXT = "Nothing in the queue.";
 const NOTICE_MS = 4000;
@@ -282,26 +274,15 @@ const previewSub = el<HTMLParagraphElement>("preview-sub");
 const previewBody = el<HTMLParagraphElement>("preview-body");
 const previewImdb = el<HTMLAnchorElement>("preview-imdb");
 
-// sessionStorage throws, rather than returning null, when storage is blocked
-// (Safari private mode, a hardened profile). Losing the remembered token is a
-// re-prompt; letting it throw here would leave the page dead before it renders.
-function readStoredToken(): string {
-  try {
-    return sessionStorage.getItem(TOKEN_KEY) ?? "";
-  } catch {
-    return "";
-  }
-}
-
-function storeToken(value: string): void {
-  try {
-    sessionStorage.setItem(TOKEN_KEY, value);
-  } catch {
-    /* not remembering the token is survivable; failing the unlock is not */
-  }
-}
-
+// readStoredToken/storeToken moved to ./token.ts when the player page became a
+// second reader of the same sessionStorage slot — moved down rather than copied,
+// as always.
 let token = readStoredToken();
+
+// What this URL says the user was doing, read BEFORE the token strip below —
+// which rewrites the address bar and, if it ran first, would be reading the
+// route out of a URL it had already replaced. `openApp` applies it.
+const bootRoute = routeFromSearch(location.search);
 
 // A magic link (`…/#k=<token>`) hands this page a working token so the user
 // never types one. Adopted into the same sessionStorage slot the unlock form
@@ -315,7 +296,12 @@ if (linkToken) {
   token = linkToken;
   storeToken(token);
   try {
-    history.replaceState(null, "", location.pathname + location.search);
+    // `urlForRoute`, not `location.pathname + location.search`, which is what
+    // this used to be: the search string now carries the route, and rebuilding
+    // it from `bootRoute` is what keeps the strip from being order-dependent.
+    // The fragment is not an input to that function, so the token cannot come
+    // back out of it.
+    history.replaceState(null, "", urlForRoute(location.pathname, bootRoute));
   } catch {
     // Same defence, and the same reason, as readStoredToken/storeToken above:
     // an opaque origin (a sandboxed iframe without allow-same-origin) breaks
@@ -332,7 +318,7 @@ let noticeTimer: ReturnType<typeof setTimeout> | null = null;
 let reprobing = false;
 
 function authHeaders(): Record<string, string> {
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return authHeadersFor(token);
 }
 
 function setConn(state: "connecting" | "live" | "lost"): void {
@@ -1177,6 +1163,39 @@ let seededExpansion = false;
 // rows that are not rendered.
 let currentRows: GroupRow<PublicSearchResult>[] = [];
 
+/**
+ * Put what the user is doing into the address bar.
+ *
+ * WHY THIS PAGE HAS A URL NOW. The player at `/play/:sid/:idx` is a separate
+ * document, so leaving it — by its back link or by the browser's Back button —
+ * is a full page load of `/`. With nothing in the URL that booted to
+ * `emptyView()`: an empty box and no results, having discarded the search that
+ * got the user there. Finish an episode, want the next one, start again.
+ *
+ * `index.html` used to carry a comment refusing a router outright, because "a
+ * URL that could be bookmarked mid-search would promise a restored search it
+ * cannot deliver (the stream is not replayable)". That is true of STREAMS and
+ * route.ts keeps it true — no session id and no `?k=` goes in here, ever. It is
+ * not true of searches: a query and a tab replay by definition, and within
+ * `cachedSearch`'s five minutes they replay out of memory.
+ *
+ * `replaceState`, NOT `pushState`. Switching tabs is not a history entry the
+ * user asked for, and the one entry that matters — `/` → `/play/…` — has to be
+ * crossable in a single press of Back. Pushing here would bury it under one
+ * entry per keystroke-driven search.
+ *
+ * Wrapped for the reason the token strip above is: the History API throws on an
+ * opaque origin, and a tidy address bar is not worth a dead page.
+ */
+function syncUrl(): void {
+  const state: RouteState = { view, query: searchView.query, group: searchView.group };
+  try {
+    history.replaceState(null, "", urlForRoute(location.pathname, state));
+  } catch {
+    /* an opaque origin has no History API; the app is unaffected */
+  }
+}
+
 function showView(next: ViewName): void {
   view = next;
   paneSearch.hidden = next !== "search";
@@ -1195,6 +1214,7 @@ function showView(next: ViewName): void {
   // while this pane sat hidden must be here when the user opens it, and the
   // response is two small arrays.
   if (next === "saved") void loadSaved();
+  syncUrl();
 }
 
 viewSearchTab.addEventListener("click", () => showView("search"));
@@ -1329,6 +1349,9 @@ function startSearch(raw: string): void {
   cachedHashes = new Set();
   paintSearchHint();
   renderResults();
+  // After searchView.query is set, so the address bar names the search actually
+  // running rather than the one before it.
+  syncUrl();
 
   const source = new EventSource(searchUrl(query, searchView.group, token));
   searchStream = source;
@@ -3436,6 +3459,12 @@ function openApp(payload: StatusPayload): void {
   app.hidden = false;
   viewsNav.hidden = false;
   prefsBlock.hidden = false;
+  // The URL's tab, before the first render, so the strip and the state agree
+  // from the outset. The QUERY is run at the end of this function, once the
+  // panes exist and `loadSaved` has been kicked off — running it here would
+  // paint results into a `hidden` #app.
+  view = bootRoute.view;
+  searchView = { ...searchView, group: bootRoute.group };
   showView(view);
   renderTabs();
   layoutSelect.value = layout;
@@ -3463,6 +3492,17 @@ function openApp(payload: StatusPayload): void {
   // "favourite" and the first click removes it.
   void loadSaved();
   queryInput.focus();
+  // The search the URL asked for — last, and only when there is one.
+  //
+  // This is what makes coming back from the player work: the player page is a
+  // separate document, so Back is a full page load, and the query the user ran
+  // has to come from somewhere. It comes from here. A blank query is left alone
+  // rather than run as a browse: an empty `/` must not fan out to 23 trackers
+  // because someone opened the dashboard.
+  if (bootRoute.query.trim()) {
+    queryInput.value = bootRoute.query;
+    startSearch(bootRoute.query);
+  }
 }
 
 function connect(): void {

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -10,10 +10,18 @@
   <body>
     <header id="page-header">
       <h1>torlnk</h1>
-      <!-- Search / For You / Saved / Queue. Buttons rather than links or a
-           router: it is one page with four panes, and a URL that could be
-           bookmarked mid-search would promise a restored search it cannot
-           deliver (the stream is not replayable).
+      <!-- Search / For You / Saved / Queue. Buttons rather than links: it is one
+           page with four panes, and there is no route to navigate to.
+
+           There IS now URL state (route.ts writes ?q= &group= &view= with
+           replaceState), which this comment used to rule out on the grounds
+           that a bookmarked URL "would promise a restored search it cannot
+           deliver (the stream is not replayable)". That is right about STREAMS,
+           and still holds: no session id and no ?k= is ever written here, so
+           nothing in this URL promises to resume a dead session. It was wrong
+           about SEARCHES — a query and a tab replay by definition — and the
+           cost of pretending otherwise was that leaving the player page, which
+           is a separate document, dropped the user on an empty search box.
 
            Saved holds both of the TUI's lists — saved searches (saved search
            queries) and the library (favourited torrents) — in one pane rather

--- a/src/web/static/player.html
+++ b/src/web/static/player.html
@@ -12,15 +12,30 @@
   <body>
     <header>
       <h1>torlnk</h1>
-      <a class="back" href="/">back to queue</a>
+      <!--
+        The href is the FALLBACK, not the behaviour. player.js intercepts the
+        click and goes back one history entry when there is a same-origin one to
+        go back to, which lands on the search that got you here — the dashboard
+        keeps its query in its own URL for exactly this. The href covers the
+        cases where there is no such entry: a player URL that was bookmarked, or
+        opened in a new tab, or pasted onto a phone.
+
+        It used to say "back to queue" and land on the search pane, which was
+        simply untrue.
+      -->
+      <a id="back" class="back" href="/">← back to results</a>
     </header>
 
     <!-- Everything below is filled in by player.js from the page's own URL.
          Nothing is templated server-side: this file ships as static bytes. -->
+    <p id="breadcrumb" class="breadcrumb" hidden></p>
     <p id="file-name" class="file-name"></p>
     <div id="stage" class="stage"></div>
     <div id="actions" class="actions"></div>
     <p id="notice" class="notice" hidden></p>
+    <!-- The rest of the torrent: what is up next, and everything else in it.
+         Empty for a single-file session, so a film looks exactly as it did. -->
+    <div id="episodes" class="episodes" hidden></div>
 
     <script type="module" src="/player.js"></script>
   </body>

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -24,6 +24,7 @@ import {
   interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  restPlaylistPath,
   routeFailure,
   streamPath,
   vlcLinks,
@@ -443,6 +444,16 @@ function renderEpisodes(body: StreamFilesResponse, target: PlayerTarget): void {
   // page exists to offer, and it must not depend on scrolling past sixty rows.
   if (view.next) {
     nodes.push(listHeading("up next"), episodeRow(view.next));
+    // Only when there IS something after this one — a playlist of one file is
+    // the button that is already at the top of the page. Appended rather than
+    // built with the others because it depends on `.files`, which lands after
+    // the first paint.
+    actions.append(
+      linkButton(
+        "Download rest of season .m3u",
+        absoluteUrl(location.origin, restPlaylistPath(target)),
+      ),
+    );
   }
   nodes.push(listHeading(view.next ? "all episodes" : "everything in this torrent"));
   for (const row of view.rows) {

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -34,6 +34,7 @@ import {
 import { mountHls } from "./hlsMount";
 import { upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
+import { backTarget, readReturn } from "./returnTo";
 import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
 
 const el = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
@@ -473,25 +474,26 @@ function link(text: string, href: string): HTMLAnchorElement {
 }
 
 /**
- * Back means "the page I came from", when there is one.
+ * Back means "the page I came from", when this tab knows where that was.
  *
- * The `href` in the markup is the fallback and stays working: a bookmarked
- * player URL, or one opened in a new tab, has no history entry to return to, and
- * `history.back()` there would either do nothing or leave the site. The referrer
- * check is what distinguishes the two — same-origin means the dashboard sent us
- * here, and the dashboard now keeps its query in its own URL, so going back one
- * entry restores the search rather than reloading an empty one.
+ * `backTarget` (returnTo.ts) decides; this is the two DOM effects of its two
+ * answers. Note what it is NOT keyed on: `document.referrer` is always empty
+ * here, because `player.html` sets `no-referrer` so this page's `?k=` never
+ * leaks into a Referer — a back link built on the referrer would silently never
+ * fire, which is exactly what happened on the first attempt.
+ *
+ * The href is also rewritten up front rather than only on click, so that
+ * middle-click, "open in new tab" and the status bar all agree with what a
+ * plain click does.
  */
-backLink.addEventListener("click", (event) => {
-  let sameOrigin = false;
-  try {
-    sameOrigin = document.referrer !== "" && new URL(document.referrer).origin === location.origin;
-  } catch {
-    sameOrigin = false; // a malformed referrer is not a page we can go back to
-  }
-  if (!sameOrigin || history.length <= 1) return; // let the href do its job
-  event.preventDefault();
-  history.back();
-});
+const back = backTarget(readReturn(), history.length, backLink.getAttribute("href") ?? "/");
+if (back.kind === "href") {
+  backLink.href = back.href;
+} else {
+  backLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    history.back();
+  });
+}
 
 void render();

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -19,6 +19,7 @@ import {
   chooseSource,
   detectPlatform,
   fallbackMessage,
+  filesPath,
   infoPath,
   interruptedNotice,
   parsePlayerLocation,
@@ -30,14 +31,19 @@ import {
   type PlayerTarget,
 } from "./playerModel";
 import { mountHls } from "./hlsMount";
-import type { StreamInfoResponse } from "../wire";
+import { upNextView, type EpisodeRow } from "./upNext";
+import { authHeadersFor, readStoredToken } from "./token";
+import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
 
 const el = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
 
+const backLink = el<HTMLAnchorElement>("back");
+const breadcrumb = el<HTMLParagraphElement>("breadcrumb");
 const nameLabel = el<HTMLParagraphElement>("file-name");
 const stage = el<HTMLDivElement>("stage");
 const actions = el<HTMLDivElement>("actions");
 const notice = el<HTMLParagraphElement>("notice");
+const episodes = el<HTMLDivElement>("episodes");
 const NOTICE_MS = 4000;
 
 let noticeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -280,6 +286,21 @@ async function render(): Promise<void> {
   }
   actions.replaceChildren(...controls);
 
+  // The rest of the torrent, and the bookkeeping — BEFORE the playability
+  // question below, and never gated on its answer. The whole reported failure
+  // is the flow where the browser CANNOT play the file: the user downloads the
+  // .m3u, watches it in VLC, comes back, and wants the next episode. Putting
+  // this after an early `return` would remove it from exactly that case.
+  //
+  // Not awaited: `.files` is a small JSON read and the playability probe behind
+  // `.info` can take seconds, so they run together and whichever lands first
+  // paints. Nothing below depends on this.
+  void fetchFiles(target).then((body) => {
+    if (!body) return; // offline, a 401, an older server — the page still plays
+    recordPlayed(body, target);
+    renderEpisodes(body, target);
+  });
+
   // Ask the server what this file actually is before creating any element. This
   // is what removes the twelve-second black rectangle: a container or codec the
   // browser refuses is now known up front rather than discovered by a decode
@@ -320,5 +341,146 @@ async function fetchInfo(target: PlayerTarget): Promise<StreamInfoResponse | nul
     return null;
   }
 }
+
+/** Fetch `.files`, or null. Null on any failure, for the reason `fetchInfo` is. */
+async function fetchFiles(target: PlayerTarget): Promise<StreamFilesResponse | null> {
+  try {
+    const res = await fetch(absoluteUrl(location.origin, filesPath(target)));
+    if (!res.ok) return null;
+    return (await res.json()) as StreamFilesResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tell the server this file was opened, so Continue-watching keeps advancing.
+ *
+ * THE SAME CALL THE PICKER MAKES, deliberately. `app.ts` fires this before
+ * navigating here, which was the only writer while the picker was the only way
+ * to reach a player page. Jumping episode to episode from the list below never
+ * touches the picker, so without this the high-water mark would freeze at
+ * whichever episode you happened to pick — and the saved pane would keep
+ * offering an episode you watched an hour ago.
+ *
+ * One mechanism, two call sites, one route. `recordPlayedFile`
+ * (`src/core/streamHistory.ts`) is a high-water mark that returns the same array
+ * reference when nothing moved, so recording twice costs nothing and the
+ * picker's call stays as the fallback for when this one cannot be made.
+ *
+ * BEST-EFFORT, and silent. `/api/library` needs the bearer token, which this
+ * page reads from sessionStorage: `openPlayer` navigates the same tab, so it is
+ * simply there for the ordinary flow. A cold-opened player URL — a bookmark, a
+ * link handed to a phone — has no token and does not record, which is the right
+ * answer for someone else's link anyway. Nothing here is worth interrupting
+ * playback to report.
+ */
+function recordPlayed(body: StreamFilesResponse, target: PlayerTarget): void {
+  const filename = body.files.find((f) => f.index === target.index)?.filename;
+  if (!filename) return;
+  const request: LibraryRequest = {
+    infoHash: body.infoHash,
+    name: body.name,
+    action: "watched",
+    filename,
+  };
+  void fetch("/api/library", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeadersFor(readStoredToken()) },
+    body: JSON.stringify(request),
+  }).catch(() => {});
+}
+
+/** One heading in the episode list. A `<p>`, not an `<h*>`: it labels a run of rows. */
+function listHeading(text: string): HTMLParagraphElement {
+  const p = document.createElement("p");
+  p.className = "episodes-heading";
+  p.textContent = text;
+  return p;
+}
+
+/**
+ * One row: a link to the same page for a different file.
+ *
+ * `textContent`, as everywhere on this page — a filename comes out of a torrent,
+ * i.e. from whoever uploaded it. The `href` is a property assignment built by
+ * `playerPath`, not markup.
+ */
+function episodeRow(row: EpisodeRow): HTMLAnchorElement {
+  const a = document.createElement("a");
+  a.className = row.current ? "episode-row is-current" : "episode-row";
+  a.href = row.href;
+  a.textContent = row.label;
+  a.title = row.file.filename;
+  if (row.current) {
+    // The page you are already on. Announced rather than merely styled, so the
+    // list reads the same to a screen reader as it looks.
+    a.setAttribute("aria-current", "true");
+  }
+  return a;
+}
+
+/**
+ * The rest of the torrent, under the player.
+ *
+ * Hidden entirely for a single-file session, so a film looks exactly as it did
+ * before this existed.
+ */
+function renderEpisodes(body: StreamFilesResponse, target: PlayerTarget): void {
+  const view = upNextView(body, target.sid, target.index, target.capability);
+
+  breadcrumb.replaceChildren(link(view.breadcrumb.label, view.breadcrumb.href));
+  breadcrumb.hidden = false;
+
+  if (view.rows.length === 0) {
+    episodes.replaceChildren();
+    episodes.hidden = true;
+    return;
+  }
+
+  const nodes: HTMLElement[] = [];
+  // "Up next" sits ABOVE the full list on purpose: it is the one action this
+  // page exists to offer, and it must not depend on scrolling past sixty rows.
+  if (view.next) {
+    nodes.push(listHeading("up next"), episodeRow(view.next));
+  }
+  nodes.push(listHeading(view.next ? "all episodes" : "everything in this torrent"));
+  for (const row of view.rows) {
+    if (row.heading) nodes.push(listHeading(row.heading));
+    nodes.push(episodeRow(row));
+  }
+  episodes.replaceChildren(...nodes);
+  episodes.hidden = false;
+}
+
+/** A plain anchor. Same rule as everything else here: textContent, href as a property. */
+function link(text: string, href: string): HTMLAnchorElement {
+  const a = document.createElement("a");
+  a.textContent = text;
+  a.href = href;
+  return a;
+}
+
+/**
+ * Back means "the page I came from", when there is one.
+ *
+ * The `href` in the markup is the fallback and stays working: a bookmarked
+ * player URL, or one opened in a new tab, has no history entry to return to, and
+ * `history.back()` there would either do nothing or leave the site. The referrer
+ * check is what distinguishes the two — same-origin means the dashboard sent us
+ * here, and the dashboard now keeps its query in its own URL, so going back one
+ * entry restores the search rather than reloading an empty one.
+ */
+backLink.addEventListener("click", (event) => {
+  let sameOrigin = false;
+  try {
+    sameOrigin = document.referrer !== "" && new URL(document.referrer).origin === location.origin;
+  } catch {
+    sameOrigin = false; // a malformed referrer is not a page we can go back to
+  }
+  if (!sameOrigin || history.length <= 1) return; // let the href do its job
+  event.preventDefault();
+  history.back();
+});
 
 void render();

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -32,7 +32,7 @@ import {
   type PlayerTarget,
 } from "./playerModel";
 import { mountHls } from "./hlsMount";
-import { upNextView, type EpisodeRow } from "./upNext";
+import { breadcrumbFor, upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
 import { backTarget, readReturn } from "./returnTo";
 import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
@@ -262,6 +262,11 @@ async function render(): Promise<void> {
   nameLabel.title = target.filename;
   document.title = target.filename ? `${target.filename} — torlnk` : "torlnk";
 
+  // From the URL, before any fetch — so there is a way back even if every
+  // request below fails. Upgraded to the session's release name if `.files`
+  // lands. Skipped for an unnamed link, where there is nothing to parse.
+  if (target.filename) renderBreadcrumb(target.filename);
+
   const stream = absoluteUrl(location.origin, streamPath(target));
   const playlist = absoluteUrl(location.origin, playlistPath(target));
 
@@ -428,11 +433,33 @@ function episodeRow(row: EpisodeRow): HTMLAnchorElement {
  * Hidden entirely for a single-file session, so a film looks exactly as it did
  * before this existed.
  */
+/**
+ * The way back to the show.
+ *
+ * Rendered from whatever name is available, and rendered EARLY. The first call
+ * uses `?n=`, the filename in the page's own URL, so the breadcrumb is on screen
+ * before any request has been made — and, crucially, still on screen when
+ * `.files` fails. That is the case where it matters most: a session the registry
+ * has reaped leaves a page that can neither play nor list anything, and the
+ * breadcrumb is then the only way out that does not involve the address bar. An
+ * earlier version rendered it inside `renderEpisodes`, which meant it vanished
+ * in exactly that situation.
+ *
+ * The second call, once `.files` lands, upgrades it to the session's release
+ * name — "Harrowgate.S03.1080p.WEB-DL" names the show more reliably than one
+ * episode's filename does, and for a file inside a folder it may be the only
+ * thing that names it at all.
+ */
+function renderBreadcrumb(name: string): void {
+  const crumb = breadcrumbFor(name);
+  breadcrumb.replaceChildren(link(crumb.label, crumb.href));
+  breadcrumb.hidden = false;
+}
+
 function renderEpisodes(body: StreamFilesResponse, target: PlayerTarget): void {
   const view = upNextView(body, target.sid, target.index, target.capability);
 
-  breadcrumb.replaceChildren(link(view.breadcrumb.label, view.breadcrumb.href));
-  breadcrumb.hidden = false;
+  renderBreadcrumb(body.name);
 
   if (view.rows.length === 0) {
     episodes.replaceChildren();

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -5,6 +5,7 @@ import {
   detectPlatform,
   extensionOf,
   fallbackMessage,
+  filesPath,
   infoPath,
   interruptedNotice,
   parsePlayerLocation,
@@ -118,6 +119,20 @@ describe("infoPath", () => {
 
   it("omits the query entirely when there is no capability", () => {
     expect(infoPath(target({ capability: "" }))).toBe("/stream/sid-1/0.info");
+  });
+});
+
+describe("filesPath", () => {
+  it("is the stream handle plus .files, carrying the capability", () => {
+    expect(filesPath(target())).toBe("/stream/sid-1/0.files?k=cap-1");
+  });
+
+  it("encodes a session id with a slash in it", () => {
+    expect(filesPath(target({ sid: "a/b" }))).toBe("/stream/a%2Fb/0.files?k=cap-1");
+  });
+
+  it("omits the query entirely when there is no capability", () => {
+    expect(filesPath(target({ capability: "" }))).toBe("/stream/sid-1/0.files");
   });
 });
 

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -10,6 +10,7 @@ import {
   interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  restPlaylistPath,
   routeFailure,
   streamPath,
   vlcLinks,
@@ -119,6 +120,18 @@ describe("infoPath", () => {
 
   it("omits the query entirely when there is no capability", () => {
     expect(infoPath(target({ capability: "" }))).toBe("/stream/sid-1/0.info");
+  });
+});
+
+describe("restPlaylistPath", () => {
+  it("appends to the capability's query string", () => {
+    expect(restPlaylistPath(target())).toBe("/stream/sid-1/0.m3u?k=cap-1&rest=1");
+  });
+
+  it("starts a query string when there is no capability", () => {
+    // A tokenless loopback server puts no ?k= on the URL, and "?k=&rest=1"
+    // would be a capability the server reads as empty.
+    expect(restPlaylistPath(target({ capability: "" }))).toBe("/stream/sid-1/0.m3u?rest=1");
   });
 });
 

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -92,6 +92,24 @@ export function playlistPath(target: PlayerTarget): string {
   return repPath(target, ".m3u");
 }
 
+/**
+ * The `.m3u` for this file AND every later one — the rest of the season in one
+ * playlist, so VLC runs on without coming back here between episodes.
+ *
+ * A parameter on the playlist rather than a fifth representation, mirroring the
+ * server: `?rest=1` reuses the same guards, the same origin check and the same
+ * "no filename in the body" rule, and a route of its own would be a second
+ * place to forget one of them.
+ *
+ * Built by appending rather than through `repPath`, because the separator
+ * depends on whether a capability put a `?` there first. A tokenless loopback
+ * server has no capability on the URL and would otherwise get `?k=&rest=1`.
+ */
+export function restPlaylistPath(target: PlayerTarget): string {
+  const base = playlistPath(target);
+  return `${base}${base.includes("?") ? "&" : "?"}rest=1`;
+}
+
 /** Resolve one of the paths above against the page's own origin. */
 export function absoluteUrl(origin: string, path: string): string {
   return `${origin.replace(/\/+$/, "")}${path}`;

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -66,21 +66,30 @@ export function parsePlayerLocation(pathname: string, search: string): PlayerTar
 }
 
 /**
- * The stream handle path for a target: `/stream/:sid/:idx?k=…`.
+ * One representation of the stream handle: `/stream/:sid/:idx<suffix>?k=…`.
+ *
+ * Written once and shared by the four public builders below, which are the same
+ * address four times over — `splitRepresentation` on the server treats them as
+ * one route with one set of guards, and it would be odd for the client to spell
+ * the address four times and risk them drifting apart.
  *
  * Mirrors `streamHandle` in ../routes.ts — the same encodeURIComponent, for the
- * same reason. A session id with a slash in it must not become a different
- * path here than the one the server will parse.
+ * same reason. A session id with a slash in it must not become a different path
+ * here than the one the server will parse.
  */
-export function streamPath(target: PlayerTarget): string {
-  const base = `/stream/${encodeURIComponent(target.sid)}/${target.index}`;
+function repPath(target: PlayerTarget, suffix: string): string {
+  const base = `/stream/${encodeURIComponent(target.sid)}/${target.index}${suffix}`;
   return target.capability ? `${base}?k=${encodeURIComponent(target.capability)}` : base;
+}
+
+/** The media itself: `/stream/:sid/:idx?k=…`. */
+export function streamPath(target: PlayerTarget): string {
+  return repPath(target, "");
 }
 
 /** The `.m3u` path for a target. Same address, playlist representation. */
 export function playlistPath(target: PlayerTarget): string {
-  const base = `/stream/${encodeURIComponent(target.sid)}/${target.index}.m3u`;
-  return target.capability ? `${base}?k=${encodeURIComponent(target.capability)}` : base;
+  return repPath(target, ".m3u");
 }
 
 /** Resolve one of the paths above against the page's own origin. */
@@ -95,8 +104,19 @@ export { extensionOf };
 
 /** The `.info` path for a target. Same address, facts representation. */
 export function infoPath(target: PlayerTarget): string {
-  const base = `/stream/${encodeURIComponent(target.sid)}/${target.index}.info`;
-  return target.capability ? `${base}?k=${encodeURIComponent(target.capability)}` : base;
+  return repPath(target, ".info");
+}
+
+/**
+ * The `.files` path for a target. Same address, session-listing representation.
+ *
+ * Capability-carrying like the other three, and for the reason the page exists
+ * at all: this document may be a phone that was handed a link, so it holds the
+ * session capability and not the server's bearer token, and `/api/stream/:sid`
+ * is closed to it.
+ */
+export function filesPath(target: PlayerTarget): string {
+  return repPath(target, ".files");
 }
 
 /**

--- a/src/web/static/returnTo.test.ts
+++ b/src/web/static/returnTo.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { backTarget } from "./returnTo";
+
+const HOME = "/";
+
+describe("backTarget", () => {
+  it("goes back one entry when the dashboard sent us here", () => {
+    expect(backTarget("/?q=harrowgate&group=TV", 2, HOME)).toEqual({ kind: "back" });
+  });
+
+  /**
+   * A player URL opened cold — a bookmark, a link pasted onto a phone — in a tab
+   * that has browsed elsewhere. `history.length > 1` is true there too, so going
+   * back on that alone would leave the site. The note is what distinguishes them.
+   */
+  it("navigates when there is no note, however long the history is", () => {
+    expect(backTarget("", 9, HOME)).toEqual({ kind: "href", href: HOME });
+  });
+
+  it("navigates when this is the only entry in the tab", () => {
+    expect(backTarget("/?q=kepler", 1, HOME)).toEqual({ kind: "href", href: "/?q=kepler" });
+  });
+
+  it("prefers the remembered search over the bare fallback", () => {
+    // Someone who bookmarked a player page still gets the search that led to it,
+    // when this tab happens to know it.
+    expect(backTarget("/?q=kepler&group=TV", 1, HOME)).toEqual({
+      kind: "href",
+      href: "/?q=kepler&group=TV",
+    });
+  });
+});
+
+/**
+ * sessionStorage is user-writable and survives upgrades, and this value ends up
+ * in `location`. Every one of these must fall back rather than be followed.
+ */
+describe("backTarget — a hostile note", () => {
+  it.each([
+    ["a protocol-relative URL", "//evil.example/"],
+    ["an absolute URL", "https://evil.example/"],
+    ["a javascript: URL", "javascript:alert(1)"],
+    ["a data: URL", "data:text/html,<script>1</script>"],
+    ["a relative path with no leading slash", "evil.example"],
+    ["another page on this origin", "/play/abc/0?k=leak"],
+    ["a path that only starts like the dashboard", "/admin?q=x"],
+    ["empty", ""],
+    ["whitespace", "   "],
+  ])("refuses %s", (_why, value) => {
+    expect(backTarget(value, 5, HOME)).toEqual({ kind: "href", href: HOME });
+  });
+
+  it("refuses a hostile note even when it would only be used for history.back", () => {
+    // The `back` branch does not navigate to the value — but accepting it here
+    // would mean a crafted note decides whether Back leaves the app, so the
+    // validation gates both branches rather than just the one that reads it.
+    expect(backTarget("//evil.example/", 5, HOME)).toEqual({ kind: "href", href: HOME });
+  });
+});

--- a/src/web/static/returnTo.ts
+++ b/src/web/static/returnTo.ts
@@ -1,0 +1,88 @@
+/**
+ * Where the player page's back link goes.
+ *
+ * WHY IT IS NOT `document.referrer`. That was the first attempt and it cannot
+ * work here: `player.html` sets `<meta name="referrer" content="no-referrer">`
+ * on purpose, because this page's URL carries a stream capability in `?k=` and a
+ * `Referer` would hand it to whatever a link on the page points at. So the
+ * referrer is *always* empty, and a back link keyed on it would silently never
+ * fire. The security header is right; the heuristic was wrong.
+ *
+ * So the dashboard leaves a note instead. `openPlayer` writes the URL it is
+ * navigating away from into sessionStorage before it calls `location.assign`;
+ * the player page reads it. sessionStorage is per TAB and `openPlayer` navigates
+ * the same tab, so the note is there for exactly the journeys that made it and
+ * absent for every other way of arriving — a bookmark, a link pasted onto a
+ * phone, a fresh tab.
+ *
+ * That note is also better than a bare `history.back()`, because it says WHERE
+ * as well as WHETHER: a player URL opened cold in a tab with unrelated history
+ * would have `history.length > 1` and going back would leave the site entirely.
+ *
+ * The value is a same-origin path this app wrote, and it is used only as a
+ * `href`/`history.back()` target — but sessionStorage is user-writable, so
+ * {@link backTarget} validates it rather than trusting it.
+ */
+const RETURN_KEY = "torlnk.returnTo";
+
+/** Remember where we are, just before navigating to the player. */
+export function rememberReturn(url: string): void {
+  try {
+    sessionStorage.setItem(RETURN_KEY, url);
+  } catch {
+    /* storage blocked; the back link falls back to "/" */
+  }
+}
+
+/** The remembered dashboard URL, or "". */
+export function readReturn(): string {
+  try {
+    return sessionStorage.getItem(RETURN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export type BackTarget =
+  /** Go back one entry — the dashboard is sitting there with its state intact. */
+  | { kind: "back" }
+  /** Navigate. Restores the search from the URL, at the cost of re-running it. */
+  | { kind: "href"; href: string };
+
+/**
+ * What the back link should do.
+ *
+ * `back` whenever the dashboard is the previous entry, because that is strictly
+ * better than navigating to the same URL: the browser may restore the page from
+ * bfcache with its results still on screen, and even when it does not, one entry
+ * back is what a user pressing Back expects to match.
+ *
+ * `href` otherwise, and the remembered URL is preferred over the markup's bare
+ * `/` — someone who bookmarked a player page still gets the search that
+ * originally led to it, if this tab happens to know it.
+ *
+ * VALIDATED, not trusted. `stored` comes from sessionStorage, which is
+ * user-writable and survives upgrades, and it ends up in `location`. Only a
+ * root-relative path is accepted: `//evil.example` and `javascript:…` are both
+ * rejected, and so is anything that is not this app's own dashboard.
+ */
+export function backTarget(stored: string, historyLength: number, fallback: string): BackTarget {
+  const safe = isDashboardPath(stored) ? stored : "";
+  // history.length counts this entry, so >1 means there is something behind us.
+  // Paired with the note, which is what says that something is the dashboard.
+  if (safe && historyLength > 1) return { kind: "back" };
+  return { kind: "href", href: safe || fallback };
+}
+
+/**
+ * A path on this app's dashboard: `/`, optionally with a query.
+ *
+ * Deliberately strict. A leading `//` is a protocol-relative URL to another
+ * host, which is the classic open-redirect shape, and anything with a scheme is
+ * refused outright rather than parsed and inspected.
+ */
+function isDashboardPath(value: string): boolean {
+  if (!value.startsWith("/") || value.startsWith("//")) return false;
+  const path = value.split("?")[0];
+  return path === "/" || path === "";
+}

--- a/src/web/static/route.test.ts
+++ b/src/web/static/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ROUTE,
+  routeFromSearch,
+  searchForRoute,
+  urlForRoute,
+  type RouteState,
+} from "./route";
+import { ALL_TAB } from "./searchModel";
+
+describe("routeFromSearch", () => {
+  it("reads the query, the tab and the view", () => {
+    expect(routeFromSearch("?q=harrowgate&group=TV&view=search")).toEqual({
+      view: "search",
+      query: "harrowgate",
+      group: "TV",
+    });
+  });
+
+  it("works with or without the leading question mark", () => {
+    expect(routeFromSearch("q=kepler")).toEqual({ ...DEFAULT_ROUTE, query: "kepler" });
+    expect(routeFromSearch("?q=kepler")).toEqual({ ...DEFAULT_ROUTE, query: "kepler" });
+  });
+
+  it("is the default route for an empty search string", () => {
+    expect(routeFromSearch("")).toEqual(DEFAULT_ROUTE);
+    expect(routeFromSearch("?")).toEqual(DEFAULT_ROUTE);
+  });
+
+  /**
+   * The URL bar is user-writable and survives upgrades, so every field is
+   * PARSED rather than cast — the same rule `parseLayout`/`parseGrouping` apply
+   * to localStorage. A hand-edited `view=admin` must land on the search pane,
+   * not on `undefined.hidden = false`.
+   */
+  it("falls back rather than throwing on a view it does not know", () => {
+    expect(routeFromSearch("?view=admin").view).toBe("search");
+    expect(routeFromSearch("?view=").view).toBe("search");
+  });
+
+  /**
+   * An unknown group is NOT validated against the source list here — that list
+   * arrives from `GET /api/sources` after boot, and this module is pure. It is
+   * passed through as a string and the tab strip simply never matches it, which
+   * renders as the All tab. Validating it here would need a second copy of the
+   * server's `SOURCE_GROUPS`, which is the copy-then-drift this codebase keeps
+   * paying for.
+   */
+  it("passes an unrecognised group through as a string", () => {
+    expect(routeFromSearch("?group=Nonsense").group).toBe("Nonsense");
+  });
+
+  it("decodes a query with spaces and punctuation", () => {
+    expect(routeFromSearch("?q=tin%20rivers").query).toBe("tin rivers");
+    expect(routeFromSearch("?q=tin+rivers").query).toBe("tin rivers");
+  });
+
+  it("ignores anything else already in the query string", () => {
+    expect(routeFromSearch("?q=kepler&utm_source=x")).toEqual({
+      ...DEFAULT_ROUTE,
+      query: "kepler",
+    });
+  });
+});
+
+describe("searchForRoute", () => {
+  it("is empty for the default route, so a fresh page keeps a clean URL", () => {
+    expect(searchForRoute(DEFAULT_ROUTE)).toBe("");
+  });
+
+  it("omits the group when it is the All tab", () => {
+    expect(searchForRoute({ view: "search", query: "kepler", group: ALL_TAB })).toBe("?q=kepler");
+  });
+
+  it("omits the view when it is the search pane", () => {
+    expect(searchForRoute({ view: "search", query: "kepler", group: "TV" })).toBe(
+      "?q=kepler&group=TV",
+    );
+  });
+
+  it("writes the view when it is not the search pane", () => {
+    expect(searchForRoute({ view: "saved", query: "", group: ALL_TAB })).toBe("?view=saved");
+  });
+
+  /**
+   * A blank query is a real state — it is browse mode, the empty query every
+   * source maps to its own top/latest endpoint — but it is also the default, so
+   * it is not worth a `q=` in the URL when nothing else distinguishes it.
+   */
+  it("omits a blank query", () => {
+    expect(searchForRoute({ view: "queue", query: "", group: ALL_TAB })).toBe("?view=queue");
+    expect(searchForRoute({ view: "search", query: "   ", group: "TV" })).toBe("?group=TV");
+  });
+
+  it("round-trips every field", () => {
+    const state: RouteState = { view: "recc", query: "tin rivers", group: "Movies" };
+    expect(routeFromSearch(searchForRoute(state))).toEqual(state);
+  });
+
+  it("round-trips a query that needs encoding", () => {
+    const state: RouteState = { view: "search", query: "a&b=c d", group: ALL_TAB };
+    expect(searchForRoute(state)).not.toContain("&b=c");
+    expect(routeFromSearch(searchForRoute(state))).toEqual(state);
+  });
+});
+
+/**
+ * The magic-link interaction, which is where this most plausibly breaks.
+ *
+ * `app.ts` reads `#k=<token>` at boot and then `replaceState`s to strip it. That
+ * strip used to hardcode `location.pathname + location.search`, which was
+ * harmless when the search string was always empty and is not now: the route has
+ * to survive the strip, and the token must not survive into history. Composing
+ * the replacement URL here — from the route, out of reach of the fragment —
+ * is what makes the ordering impossible to get wrong at the call site.
+ */
+describe("urlForRoute", () => {
+  it("keeps the route on the path", () => {
+    expect(urlForRoute("/", { view: "search", query: "harrowgate", group: "TV" })).toBe(
+      "/?q=harrowgate&group=TV",
+    );
+  });
+
+  /**
+   * The fragment is not an input, and that is the guarantee: whatever `#k=`
+   * held cannot reach a URL this function returns, because it never sees it.
+   */
+  it("cannot carry a token into the URL it produces", () => {
+    const out = urlForRoute("/", routeFromSearch("?q=kepler"));
+    expect(out).not.toContain("#");
+    expect(out).toBe("/?q=kepler");
+  });
+
+  it("leaves a bare path bare when there is no route to keep", () => {
+    expect(urlForRoute("/", DEFAULT_ROUTE)).toBe("/");
+  });
+
+  /**
+   * The search string is rewritten FROM THE ROUTE, never preserved from what
+   * happened to be in the address bar. The route is the whole of what this
+   * page's URL means, so a stray parameter someone pasted in does not survive.
+   */
+  it("drops a parameter that is not part of the route", () => {
+    expect(urlForRoute("/", routeFromSearch("?q=kepler&utm_source=x"))).toBe("/?q=kepler");
+  });
+});

--- a/src/web/static/route.ts
+++ b/src/web/static/route.ts
@@ -1,0 +1,111 @@
+/**
+ * What the dashboard's own URL means: which pane you are on, and what you
+ * searched for.
+ *
+ * WHY THIS EXISTS. The player at `/play/:sid/:idx` is a separate document, so
+ * leaving it — by the back link or by the browser's Back button — is a full page
+ * load of `/`. With no state in the URL that boots to `emptyView()`: an empty
+ * box and no results, having thrown away the search that got you there. Finish
+ * an episode, want the next one, and the app makes you start again.
+ *
+ * The terminal has never had that failure. Its panes are `display` toggles on a
+ * tree that is never unmounted (`src/ui/App.tsx`), so results survive playing
+ * something. This is the browser catching up, and the URL is the only place a
+ * separate document can leave a note for the one that replaces it.
+ *
+ * WHAT IS DELIBERATELY NOT IN HERE. No session id, no `?k=`, no `/play` state.
+ * `index.html` used to carry a comment rejecting a router outright, on the
+ * grounds that a bookmarked URL "would promise a restored search it cannot
+ * deliver (the stream is not replayable)". That is right about STREAMS and this
+ * module keeps it true: a stream capability is minted per session and dies with
+ * it, so putting one in a bookmarkable URL would promise exactly the thing that
+ * cannot be kept. It is wrong about SEARCHES — a query and a tab are replayable
+ * by definition, `cachedSearch` (`src/sources/cache.ts`) even serves an
+ * immediate return from memory — and that is the whole of what goes in the URL.
+ *
+ * Pure, and tested. `app.ts` is DOM wiring only (CLAUDE.md), and "what does this
+ * URL mean" is a decision.
+ */
+import { ALL_TAB } from "./searchModel";
+
+/** The four panes, mirroring `ViewName` in app.ts. */
+const VIEWS = ["search", "recc", "saved", "queue"] as const;
+
+export type RouteView = (typeof VIEWS)[number];
+
+export interface RouteState {
+  view: RouteView;
+  /** The search box's contents. Blank is a real state: it is browse mode. */
+  query: string;
+  /** `ALL_TAB` or one of the server's group names, matching `SearchView.group`. */
+  group: string;
+}
+
+/**
+ * A fresh page: the search pane, nothing typed, every source.
+ *
+ * Search opens first for the reason app.ts gives — this is a torrent finder, and
+ * a queue monitor is what it looks like when it opens on the queue.
+ */
+export const DEFAULT_ROUTE: RouteState = { view: "search", query: "", group: ALL_TAB };
+
+function isView(value: string): value is RouteView {
+  return (VIEWS as readonly string[]).includes(value);
+}
+
+/**
+ * `?q=…&group=…&view=…` → a route.
+ *
+ * PARSED, NOT CAST, for the reason `parseLayout` and `parseGrouping` are: the
+ * address bar is user-writable and survives upgrades, so `view=admin` has to
+ * land on the search pane rather than on `undefined.hidden = false`.
+ *
+ * The GROUP is passed through as an arbitrary string rather than validated. The
+ * real list arrives from `GET /api/sources` after boot and depends on the user's
+ * config — whether adult sources are enabled changes it — so validating here
+ * would need a second copy of the server's `SOURCE_GROUPS`, which is the
+ * copy-then-drift this codebase has four recorded bugs from. An unrecognised
+ * group simply matches no tab, which renders as All.
+ */
+export function routeFromSearch(search: string): RouteState {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  const rawView = params.get("view") ?? "";
+  const group = params.get("group") ?? "";
+  return {
+    view: isView(rawView) ? rawView : DEFAULT_ROUTE.view,
+    query: params.get("q") ?? "",
+    group: group || DEFAULT_ROUTE.group,
+  };
+}
+
+/**
+ * A route → the `?…` to put in the address bar, or `""` for the default.
+ *
+ * Every field that is at its default is OMITTED, so a user who has done nothing
+ * sees a clean `/` rather than `/?q=&group=All&view=search`. The parse above is
+ * the inverse of that: an absent parameter means the default, so the round trip
+ * holds.
+ */
+export function searchForRoute(state: RouteState): string {
+  const params = new URLSearchParams();
+  if (state.query.trim()) params.set("q", state.query);
+  if (state.group && state.group !== ALL_TAB) params.set("group", state.group);
+  if (state.view !== DEFAULT_ROUTE.view) params.set("view", state.view);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+/**
+ * The full URL for a route on a given path — what `replaceState` is handed.
+ *
+ * It exists as its own function because of the magic link. `app.ts` reads
+ * `#k=<token>` from the fragment at boot and then replaces state to strip it;
+ * that call used to hardcode `location.pathname + location.search`, which was
+ * harmless while the search string was always empty and is not now. The route
+ * has to survive the strip and the token must not survive into history, and
+ * composing the replacement here — where the fragment is not even an input —
+ * is what makes those impossible to do in the wrong order.
+ */
+export function urlForRoute(pathname: string, state: RouteState): string {
+  return `${pathname}${searchForRoute(state)}`;
+}

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1153,6 +1153,24 @@ select:focus-visible {
   color: var(--accent);
 }
 
+/* The way back to the show, above the filename it belongs to. Quiet: it is an
+   escape hatch for when there is no history to go back through, not a thing to
+   look at while the episode plays. */
+.breadcrumb {
+  margin: 0 0 0.25rem;
+  font-size: 0.8rem;
+  color: var(--dim);
+}
+
+.breadcrumb a {
+  color: var(--dim);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  color: var(--accent);
+}
+
 .file-name {
   margin: 0 0 1rem;
   overflow-wrap: anywhere;
@@ -1199,6 +1217,51 @@ select:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+/* The rest of the torrent. Borrows the picker's vocabulary deliberately — this
+   is the same list of the same files, and it should not look like a new idea
+   just because it is on a different page. */
+.episodes {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.episodes-heading {
+  margin: 0.9rem 0 0.35rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+
+.episodes-heading:first-child {
+  margin-top: 0;
+}
+
+.episode-row {
+  display: block;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  color: inherit;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.episode-row:hover {
+  border-color: var(--line);
+  background: var(--raised);
+}
+
+/* The file this page is already for. Dimmed rather than hidden: it is the
+   anchor that tells you where in the season you are, so removing it would make
+   the list harder to read, but it is not somewhere to click. */
+.episode-row.is-current {
+  color: var(--dim);
+  background: var(--sunken);
 }
 
 /* An <a> that has to sit next to a <button> and be indistinguishable from it.

--- a/src/web/static/token.ts
+++ b/src/web/static/token.ts
@@ -1,0 +1,50 @@
+/**
+ * The bearer token, as the two pages of this bundle share it.
+ *
+ * The token is held in sessionStorage and sent as an Authorization header on
+ * every API call. No cookie authenticates the API — but that does NOT mean there
+ * is no CSRF vector, which is what this comment used to claim in app.ts: the
+ * usual way to run the dashboard is with no token at all, and then there is no
+ * credential to forge in the first place. A cross-origin page's POST would
+ * simply have been authorized. The server rejects state-changing requests whose
+ * Origin / Sec-Fetch-Site say cross-site (`daemon/auth.ts`,
+ * `isCrossSiteRequest`); this page's own fetches are same-origin and unaffected.
+ *
+ * WHY IT LEFT app.ts. The player page is a separate document, and it now records
+ * the episode it opened so Continue-watching keeps advancing when you jump
+ * episode to episode without going back. That is a `POST /api/library`, which
+ * needs the same token. `openPlayer` navigates the SAME TAB (`app.ts`), and
+ * sessionStorage is per tab, so the token is simply there — but only if both
+ * pages read the same key, which is exactly the copy-then-drift this codebase
+ * has four recorded bugs from. Moved down rather than copied.
+ */
+const TOKEN_KEY = "torlnk.token";
+
+/**
+ * The stored token, or "".
+ *
+ * sessionStorage THROWS, rather than returning null, when storage is blocked
+ * (Safari private mode, a hardened profile). Losing the remembered token is a
+ * re-prompt on the dashboard and a skipped bookkeeping call on the player page;
+ * letting it throw here would leave either page dead before it rendered.
+ */
+export function readStoredToken(): string {
+  try {
+    return sessionStorage.getItem(TOKEN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function storeToken(value: string): void {
+  try {
+    sessionStorage.setItem(TOKEN_KEY, value);
+  } catch {
+    /* not remembering the token is survivable; failing the unlock is not */
+  }
+}
+
+/** The Authorization header for a token, or nothing when there is none. */
+export function authHeadersFor(token: string): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/src/web/static/upNext.test.ts
+++ b/src/web/static/upNext.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { upNextView } from "./upNext";
+import type { PublicStreamFile, StreamFilesResponse } from "../wire";
+
+const SID = "sid-1";
+const CAP = "cap-1";
+
+function file(index: number, filename: string, bytes = 1024 ** 3): PublicStreamFile {
+  return { filename, bytes, index, handle: `/stream/${SID}/${index}` };
+}
+
+/** A season pack whose files arrive in the order the torrent happened to name them. */
+const HARROWGATE: StreamFilesResponse = {
+  name: "Harrowgate.S03.1080p.WEB-DL",
+  infoHash: "a".repeat(40),
+  files: [
+    file(0, "Harrowgate.S03E03.1080p.WEB-DL.mkv"),
+    file(1, "Harrowgate.S03E01.1080p.WEB-DL.mkv"),
+    file(3, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
+  ],
+};
+
+/** Two seasons in one torrent — the case a flat list would render as a wall. */
+const KEPLER: StreamFilesResponse = {
+  name: "Kepler.S01-S02.1080p.WEB-DL",
+  infoHash: "a".repeat(40),
+  files: [
+    file(0, "Kepler.S01E01.1080p.WEB-DL.mkv"),
+    file(1, "Kepler.S01E02.1080p.WEB-DL.mkv"),
+    file(2, "Kepler.S02E01.1080p.WEB-DL.mkv"),
+    file(3, "Kepler.S02E02.1080p.WEB-DL.mkv"),
+  ],
+};
+
+const KESTREL: StreamFilesResponse = {
+  name: "Kestrel.2010.1080p.BluRay.x264",
+  infoHash: "a".repeat(40),
+  files: [file(0, "Kestrel.2010.1080p.BluRay.x264.mkv")],
+};
+
+describe("upNextView — the list", () => {
+  it("orders the files the way the picker does, not the way the torrent did", () => {
+    const view = upNextView(HARROWGATE, SID, 0, CAP);
+    expect(view.rows.map((r) => r.file.filename)).toEqual([
+      "Harrowgate.S03E01.1080p.WEB-DL.mkv",
+      "Harrowgate.S03E02.1080p.WEB-DL.mkv",
+      "Harrowgate.S03E03.1080p.WEB-DL.mkv",
+    ]);
+  });
+
+  it("keeps each file's SESSION index, not its position in the list", () => {
+    // The .files response has already dropped a .nfo, so these are 1, 3, 0 —
+    // and a row that used its list position would play a different episode.
+    expect(upNextView(HARROWGATE, SID, 0, CAP).rows.map((r) => r.file.index)).toEqual([1, 3, 0]);
+  });
+
+  it("links each row at the player page for that file", () => {
+    const [first] = upNextView(HARROWGATE, SID, 0, CAP).rows;
+    // playerPath's URL, not a second spelling of it — the `:sid` encoding is
+    // written in three places already and they have to agree.
+    expect(first?.href).toBe(`/play/${SID}/1?k=${CAP}&n=Harrowgate.S03E01.1080p.WEB-DL.mkv`);
+  });
+
+  it("marks exactly the file the page is for", () => {
+    const view = upNextView(HARROWGATE, SID, 3, CAP);
+    expect(view.rows.filter((r) => r.current).map((r) => r.file.index)).toEqual([3]);
+  });
+
+  it("labels rows the way the picker labels them", () => {
+    const [first] = upNextView(HARROWGATE, SID, 0, CAP).rows;
+    // fileLabel's format, not a second one: the picker and this page have to
+    // read identically or they look like different lists of different things.
+    expect(first?.label).toBe("Harrowgate.S03E01.1080p.WEB-DL.mkv · 1.00 GB");
+  });
+
+  /**
+   * A film has nothing to list, and an "all episodes" heading over one row that
+   * is the row you are already on is noise. Empty rows means "render nothing".
+   */
+  it("has no rows for a single-file session", () => {
+    const view = upNextView(KESTREL, SID, 0, CAP);
+    expect(view.rows).toEqual([]);
+    expect(view.next).toBeNull();
+  });
+
+  it("survives an index that names no file in the list", () => {
+    // A hand-edited URL, or a `.nfo` index that the video filter removed.
+    const view = upNextView(HARROWGATE, SID, 99, CAP);
+    expect(view.rows.some((r) => r.current)).toBe(false);
+    expect(view.next).toBeNull();
+  });
+});
+
+describe("upNextView — season headings", () => {
+  /**
+   * THE TEST THAT PINS THE DECISION. A flat list and a season-grouped list are
+   * indistinguishable on a single-season pack, so without a multi-season case
+   * the suite would pass whichever was built.
+   */
+  it("heads each season exactly once, at its first episode", () => {
+    const rows = upNextView(KEPLER, SID, 0, CAP).rows;
+    expect(rows.map((r) => r.heading)).toEqual(["Season 1", null, "Season 2", null]);
+  });
+
+  it("puts no heading on a pack that is all one season", () => {
+    expect(upNextView(HARROWGATE, SID, 0, CAP).rows.map((r) => r.heading)).toEqual([
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("puts no heading on files that name no season at all", () => {
+    const parts: StreamFilesResponse = {
+      name: "Kestrel.2010.1080p.BluRay.x264",
+      infoHash: "a".repeat(40),
+      files: [file(0, "Kestrel.part1.mkv"), file(1, "Kestrel.part2.mkv")],
+    };
+    expect(upNextView(parts, SID, 0, CAP).rows.map((r) => r.heading)).toEqual([null, null]);
+  });
+});
+
+describe("upNextView — what is next", () => {
+  /**
+   * "The next file after this one, in the order shown." Not "the next unwatched
+   * episode": the user has just played the current file, which is a fact this
+   * page has and a picker opening cold does not, so there is nothing to infer.
+   */
+  it("is the row after the current one in display order", () => {
+    // Session index 1 is E01, which sorts first — so next is E02, index 3.
+    expect(upNextView(HARROWGATE, SID, 1, CAP).next?.file.index).toBe(3);
+  });
+
+  it("crosses a season boundary", () => {
+    expect(upNextView(KEPLER, SID, 1, CAP).next?.file.filename).toBe(
+      "Kepler.S02E01.1080p.WEB-DL.mkv",
+    );
+  });
+
+  it("is null on the last episode", () => {
+    // Session index 0 is E03, which sorts last.
+    expect(upNextView(HARROWGATE, SID, 0, CAP).next).toBeNull();
+  });
+
+  it("is one of the rows, not a copy of one", () => {
+    const view = upNextView(HARROWGATE, SID, 1, CAP);
+    expect(view.rows).toContain(view.next);
+  });
+});
+
+describe("upNextView — the breadcrumb", () => {
+  it("names the show and links to a search for it", () => {
+    const crumb = upNextView(HARROWGATE, SID, 0, CAP).breadcrumb;
+    expect(crumb?.label).toBe("Harrowgate");
+    expect(crumb?.href).toBe("/?q=Harrowgate&group=TV");
+  });
+
+  it("sends a film to the Movies tab", () => {
+    const crumb = upNextView(KESTREL, SID, 0, CAP).breadcrumb;
+    expect(crumb?.label).toBe("Kestrel");
+    expect(crumb?.href).toBe("/?q=Kestrel&group=Movies");
+  });
+
+  /**
+   * The breadcrumb is the escape hatch that works with no history to go back
+   * through — a bookmarked player URL, a link opened in a new tab. It must
+   * never be the only thing missing in exactly that case, so an unparseable
+   * release name falls back to the dashboard rather than to nothing.
+   */
+  it("falls back to the dashboard when the name parses to nothing", () => {
+    const odd: StreamFilesResponse = {
+      name: "   ",
+      infoHash: "a".repeat(40),
+      files: [file(0, "a.mkv"), file(1, "b.mkv")],
+    };
+    const crumb = upNextView(odd, SID, 0, CAP).breadcrumb;
+    expect(crumb?.href).toBe("/");
+    expect(crumb?.label).toBe("torlnk");
+  });
+
+  it("encodes a title that needs it", () => {
+    const two: StreamFilesResponse = {
+      name: "Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP",
+      infoHash: "a".repeat(40),
+      files: [file(0, "Tin.Rivers.2024.2160p.mkv")],
+    };
+    expect(upNextView(two, SID, 0, CAP).breadcrumb?.href).toBe("/?q=Tin+Rivers&group=Movies");
+  });
+});

--- a/src/web/static/upNext.test.ts
+++ b/src/web/static/upNext.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { upNextView } from "./upNext";
+import { breadcrumbFor, upNextView } from "./upNext";
 import type { PublicStreamFile, StreamFilesResponse } from "../wire";
 
 const SID = "sid-1";
@@ -176,6 +176,39 @@ describe("upNextView — the breadcrumb", () => {
     const crumb = upNextView(odd, SID, 0, CAP).breadcrumb;
     expect(crumb?.href).toBe("/");
     expect(crumb?.label).toBe("torlnk");
+  });
+
+  /**
+   * The player page renders the breadcrumb from `?n=` before it fetches
+   * anything, so that a session the registry has already reaped — which cannot
+   * play, cannot list its files, and cannot say why — still offers a way out.
+   * A breadcrumb that only worked off the `.files` response would be missing in
+   * exactly that case.
+   */
+  it("works from one episode's filename, not just the session name", () => {
+    expect(breadcrumbFor("Harrowgate.S03E02.1080p.WEB-DL.mkv")).toEqual({
+      label: "Harrowgate",
+      href: "/?q=Harrowgate&group=TV",
+    });
+    expect(breadcrumbFor("Kestrel.2010.1080p.BluRay.x264.mkv")).toEqual({
+      label: "Kestrel",
+      href: "/?q=Kestrel&group=Movies",
+    });
+  });
+
+  it("falls back to the dashboard for a filename that parses to nothing", () => {
+    expect(breadcrumbFor("").href).toBe("/");
+    expect(breadcrumbFor("   ").href).toBe("/");
+  });
+
+  /**
+   * A bare filename with no year and no episode still yields a search, on the
+   * All tab. It is a poor query, and it is deliberately not special-cased:
+   * "is this title meaningful?" has no rule that would not also throw away
+   * one-word titles like Kestrel and Ashfall.
+   */
+  it("searches for a bare name rather than giving up on it", () => {
+    expect(breadcrumbFor("video.mkv")).toEqual({ label: "video", href: "/?q=video" });
   });
 
   it("encodes a title that needs it", () => {

--- a/src/web/static/upNext.ts
+++ b/src/web/static/upNext.ts
@@ -73,7 +73,14 @@ export interface UpNextView {
 const HOME: Breadcrumb = { label: "torlnk", href: "/" };
 
 /**
- * Where the breadcrumb points.
+ * Where the breadcrumb points, for any name that describes this session.
+ *
+ * Exported separately from {@link upNextView} because the player page renders it
+ * TWICE: once from `?n=` before any request, so there is a way back even when
+ * every fetch below fails, and again from the session's release name once
+ * `.files` lands. The first of those is the one that matters — a session the
+ * registry has reaped leaves a page that can neither play nor list anything, and
+ * a breadcrumb that only appeared on success would be missing exactly then.
  *
  * A SEARCH, not a restored session: the session behind this player page is
  * ephemeral and its capability dies with it, so the honest destination is the
@@ -85,7 +92,7 @@ const HOME: Breadcrumb = { label: "torlnk", href: "/" };
  * "series" from a season or episode number, so a pack is a series and a bare
  * title with a year is a film — the same judgement every other surface makes.
  */
-function breadcrumbFor(name: string): Breadcrumb {
+export function breadcrumbFor(name: string): Breadcrumb {
   const parsed = parseRelease(name);
   if (!parsed) return HOME;
   const group = parsed.type === "series" ? "TV" : parsed.type === "movie" ? "Movies" : "";

--- a/src/web/static/upNext.ts
+++ b/src/web/static/upNext.ts
@@ -1,0 +1,153 @@
+/**
+ * What else the player page can offer: the rest of the torrent, what to play
+ * next, and the way back to the show.
+ *
+ * WHY THE PAGE NEEDS ANY OF THIS. `/play/:sid/:idx` is a separate document that
+ * knows one file. Finish an episode and the only affordance is Back, which
+ * before this change was a full page load onto an empty search box. The terminal
+ * has never had that problem — `playFromPicker` (`src/ui/App.tsx`) keeps the
+ * picker open on purpose, "so the user can go straight to the next episode" —
+ * and this is the browser catching up rather than a new idea.
+ *
+ * A PURE MODULE, tested, because `app.ts` and `player.ts` are DOM wiring only
+ * (CLAUDE.md): "what to show" and "what to send" are decisions and they live
+ * here. `player.ts` turns the rows below into elements and does nothing else
+ * with them.
+ */
+import { parseRelease } from "../../util/release";
+import { sortStreamFiles } from "../../util/streamFileSort";
+import { fileLabel, playerPath } from "./streamFlow";
+import { searchForRoute, DEFAULT_ROUTE } from "./route";
+import type { PublicStreamFile, StreamFilesResponse } from "../wire";
+
+export interface EpisodeRow {
+  file: PublicStreamFile;
+  /** `fileLabel`'s line, so this list and the picker read identically. */
+  label: string;
+  /** `/play/:sid/:idx?k=…&n=…` — the same page, a different file. */
+  href: string;
+  /** True for the one file this player page is for. */
+  current: boolean;
+  /**
+   * A season heading to print ABOVE this row, or null.
+   *
+   * On the row rather than in a separate tree because the list is flat and the
+   * heading is a property of where a row sits in it: a caller renders rows in
+   * order and emits a heading whenever one is present, which is one loop and no
+   * nesting. A tree would be a second shape to keep in step with the ordering.
+   */
+  heading: string | null;
+}
+
+export interface Breadcrumb {
+  label: string;
+  href: string;
+}
+
+export interface UpNextView {
+  /**
+   * Every playable file, in the picker's display order, headings folded in.
+   *
+   * EMPTY for a single-file session. A film has nothing to list, and an "all
+   * episodes" heading over the one row you are already on is noise.
+   */
+  rows: EpisodeRow[];
+  /**
+   * The row after the current one, or null when there isn't one.
+   *
+   * "The next file in the order shown" — NOT `nextEpisodeIndex`'s "the next
+   * unwatched episode". That function answers a different question: which row a
+   * picker opening cold should land on, given only a high-water mark. Here the
+   * user has just played the current file, which is a fact this page holds and
+   * a cold picker does not, so there is nothing left to infer and no history to
+   * consult. Reusing it would be a reuse in name only, and it would get the
+   * rewatch case wrong — going back to E02 and asking for the next thing must
+   * offer E03, not the E06 the high-water mark points at.
+   */
+  next: EpisodeRow | null;
+  /** The show or film this session is, and a search that finds it. Never null. */
+  breadcrumb: Breadcrumb;
+}
+
+/** The dashboard, for when a release name tells us nothing to search for. */
+const HOME: Breadcrumb = { label: "torlnk", href: "/" };
+
+/**
+ * Where the breadcrumb points.
+ *
+ * A SEARCH, not a restored session: the session behind this player page is
+ * ephemeral and its capability dies with it, so the honest destination is the
+ * query that found the thing. `searchForRoute` composes it, so this link and the
+ * URL the dashboard writes for itself cannot spell the same state differently.
+ *
+ * The tab is picked from what the name parses as, because landing on All when
+ * the user was on TV shows loses the filter they chose. `parseRelease` decides
+ * "series" from a season or episode number, so a pack is a series and a bare
+ * title with a year is a film — the same judgement every other surface makes.
+ */
+function breadcrumbFor(name: string): Breadcrumb {
+  const parsed = parseRelease(name);
+  if (!parsed) return HOME;
+  const group = parsed.type === "series" ? "TV" : parsed.type === "movie" ? "Movies" : "";
+  const href = searchForRoute({
+    ...DEFAULT_ROUTE,
+    query: parsed.title,
+    group: group || DEFAULT_ROUTE.group,
+  });
+  return href ? { label: parsed.title, href: `/${href}` } : HOME;
+}
+
+/** The season a file's own name commits to, or null. Season packs name none. */
+function seasonOf(filename: string): number | null {
+  const parsed = parseRelease(filename);
+  return parsed?.season ?? null;
+}
+
+/**
+ * The whole of what the player page renders below its own file.
+ *
+ * `index` is the SESSION index from the page's URL, which is why the rows carry
+ * `file.index` rather than their position: `.files` has already dropped the
+ * `.nfo`s, so the two differ, and a link built from a list position plays a
+ * different episode than the one clicked. An index naming no file in the list —
+ * a hand-edited URL, or the index of a file the video filter removed — is an
+ * ordinary answer: nothing is marked current and nothing is next.
+ */
+export function upNextView(
+  body: StreamFilesResponse,
+  sessionId: string,
+  index: number,
+  capability: string,
+): UpNextView {
+  const breadcrumb = breadcrumbFor(body.name);
+  if (body.files.length < 2) return { rows: [], next: null, breadcrumb };
+
+  // "name", the picker's default: a season pack listed in whatever order the
+  // torrent named its files is the bug `sortStreamFiles` was extracted to fix,
+  // and the two lists must not disagree about episode order.
+  const sorted = sortStreamFiles(body.files, "name");
+  const seasons = sorted.map((f) => seasonOf(f.filename));
+  // Headings only when they DISTINGUISH something. Multi-season packs exist and
+  // sixty ungrouped rows is a wall, but a lone "Season 3" over a list that is
+  // entirely season 3 says nothing the page has not already said — and a
+  // torrent that numbers nothing at all must stay a plain list.
+  const multiSeason = new Set(seasons.filter((s) => s !== null)).size > 1;
+  let lastSeason: number | null = null;
+  const rows: EpisodeRow[] = sorted.map((file, at) => {
+    const season = seasons[at] ?? null;
+    const heading = multiSeason && season !== null && season !== lastSeason
+      ? `Season ${season}`
+      : null;
+    if (season !== null) lastSeason = season;
+    return {
+      file,
+      label: fileLabel(file),
+      href: playerPath(sessionId, file, capability),
+      current: file.index === index,
+      heading,
+    };
+  });
+
+  const at = rows.findIndex((row) => row.current);
+  return { rows, next: at >= 0 ? (rows[at + 1] ?? null) : null, breadcrumb };
+}

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -872,6 +872,10 @@ describe("splitRepresentation", () => {
     expect(splitRepresentation("/stream/a/0.info")).toEqual({ path: "/stream/a/0", rep: "info" });
   });
 
+  it("splits a .files off", () => {
+    expect(splitRepresentation("/stream/a/0.files")).toEqual({ path: "/stream/a/0", rep: "files" });
+  });
+
   it("does not treat a near-miss suffix as a representation", () => {
     expect(splitRepresentation("/stream/a/0.information")).toEqual({
       path: "/stream/a/0.information",
@@ -879,6 +883,16 @@ describe("splitRepresentation", () => {
     });
     expect(splitRepresentation("/stream/a/0.INFO")).toEqual({
       path: "/stream/a/0.INFO",
+      rep: "media",
+    });
+    expect(splitRepresentation("/stream/a/0.FILES")).toEqual({
+      path: "/stream/a/0.FILES",
+      rep: "media",
+    });
+    // A real filename, not a representation: `.files` is matched on the whole
+    // suffix, and "profiles" merely ends in the same five letters.
+    expect(splitRepresentation("/stream/a/0.profiles")).toEqual({
+      path: "/stream/a/0.profiles",
       rep: "media",
     });
   });
@@ -1160,6 +1174,124 @@ describe("GET /stream/:sid/:idx.info", () => {
     const { base, capability, id } = await infoSession();
     const res = await fetch(`${base}/stream/${id}/0.m3u?k=${capability}`);
     expect(res.headers.get("content-type")).toContain("audio/x-mpegurl");
+  });
+});
+
+describe("GET /stream/:sid/:idx.files", () => {
+  const PACK = "Harrowgate.S03.1080p.WEB-DL";
+  const EPISODES: StreamFile[] = [
+    { url: "https://cdn.example/3", filename: "Harrowgate.S03E03.1080p.WEB-DL.mkv", bytes: 300 },
+    { url: "https://cdn.example/1", filename: "Harrowgate.S03E01.1080p.WEB-DL.mkv", bytes: 100 },
+    { url: "https://cdn.example/nfo", filename: "Harrowgate.S03/readme.nfo", bytes: 1 },
+    { url: "https://cdn.example/2", filename: "Harrowgate.S03E02.1080p.WEB-DL.mkv", bytes: 200 },
+  ];
+
+  async function packSession(
+    over: { files?: StreamFile[]; name?: string; token?: string } = {},
+  ): Promise<{ base: string; capability: string; id: string }> {
+    const reg = registry({
+      idFactory: () => "sid-files",
+      capabilityFactory: () => "cap-files",
+      resolveDebridImpl: async () => over.files ?? EPISODES,
+    });
+    const s = await reg.start({
+      infoHash: "1".repeat(40),
+      magnet: "magnet:?xt=urn:btih:" + "1".repeat(40),
+      name: over.name ?? PACK,
+      route: { kind: "debrid", provider: "realdebrid" },
+      debridToken: "rd-token",
+    });
+    expect(s.state).toBe("ready");
+    const base = await start(reg, over.token ? { token: over.token } : {});
+    return { base, capability: "cap-files", id: "sid-files" };
+  }
+
+  it("401s without the capability", async () => {
+    const { base, id } = await packSession();
+    const res = await fetch(`${base}/stream/${id}/0.files`);
+    expect(res.status).toBe(401);
+  });
+
+  it("401s for the wrong capability", async () => {
+    const { base, id } = await packSession();
+    const res = await fetch(`${base}/stream/${id}/0.files?k=not-the-capability`);
+    expect(res.status).toBe(401);
+  });
+
+  /**
+   * The capability is the ONLY key to this representation. `?k=` deliberately
+   * satisfies no `/api/*` route, and the converse has to hold too: the server's
+   * bearer token is not a substitute for a session's own capability, or the
+   * "one guard" this handler funnels everything through would have a second
+   * door beside it.
+   */
+  it("is not reachable with the server's bearer token in place of ?k=", async () => {
+    const { base, id, capability } = await packSession({ token: "server-token" });
+    const res = await fetch(`${base}/stream/${id}/0.files`, {
+      headers: { Authorization: "Bearer server-token" },
+    });
+    expect(res.status).toBe(401);
+    // And the capability still opens it on the same tokened server: two
+    // separate doors, not both shut.
+    expect((await fetch(`${base}/stream/${id}/0.files?k=${capability}`)).status).toBe(200);
+  });
+
+  it("404s for an unknown session", async () => {
+    const { base, capability } = await packSession();
+    const res = await fetch(`${base}/stream/nope/0.files?k=${capability}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for an index past the end of the file list", async () => {
+    const { base, capability, id } = await packSession();
+    const res = await fetch(`${base}/stream/${id}/99.files?k=${capability}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("lists the session's video files with their session indexes", async () => {
+    const { base, capability, id } = await packSession();
+    const res = await fetch(`${base}/stream/${id}/0.files?k=${capability}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe(PACK);
+    // Session order is preserved — the DISPLAY order is the page's business,
+    // and it applies the same sortStreamFiles the picker does.
+    expect(body.files.map((f: { filename: string }) => f.filename)).toEqual([
+      "Harrowgate.S03E03.1080p.WEB-DL.mkv",
+      "Harrowgate.S03E01.1080p.WEB-DL.mkv",
+      "Harrowgate.S03E02.1080p.WEB-DL.mkv",
+    ]);
+    // The .nfo is dropped, so the indexes are NOT 0,1,2 — they still address
+    // the session, which is the whole point of sending them.
+    expect(body.files.map((f: { index: number }) => f.index)).toEqual([0, 1, 3]);
+    expect(body.files[0].handle).toBe(`/stream/${id}/0`);
+  });
+
+  it("never includes the upstream URL", async () => {
+    const { base, capability, id } = await packSession();
+    const text = await (await fetch(`${base}/stream/${id}/0.files?k=${capability}`)).text();
+    expect(text).not.toContain("cdn.example");
+  });
+
+  it("never logs the capability", async () => {
+    const { base, capability, id } = await packSession();
+    await fetch(`${base}/stream/${id}/0.files?k=${capability}`);
+    expect(logs.join("\n")).not.toContain("cap-files");
+  });
+
+  it("rejects a method other than GET or HEAD", async () => {
+    const { base, capability, id } = await packSession();
+    const res = await fetch(`${base}/stream/${id}/0.files?k=${capability}`, { method: "POST" });
+    expect(res.status).toBe(405);
+  });
+
+  it("falls back to every file when nothing looks like video", async () => {
+    const { base, capability, id } = await packSession({
+      files: [{ url: "https://cdn.example/a", filename: "disc.bin", bytes: 9 }],
+    });
+    const body = await (await fetch(`${base}/stream/${id}/0.files?k=${capability}`)).json();
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].filename).toBe("disc.bin");
   });
 });
 

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1293,6 +1293,66 @@ describe("GET /stream/:sid/:idx.files", () => {
     expect(body.files).toHaveLength(1);
     expect(body.files[0].filename).toBe("disc.bin");
   });
+
+  /**
+   * `?rest=1` on the EXISTING playlist branch, not a new route: same path
+   * grammar, same guards, same absent filenames in the body. VLC gets one file
+   * per line and plays the rest of the season unattended.
+   */
+  describe("?rest=1", () => {
+    it("lists this file and every later one, in display order", async () => {
+      const { base, capability, id } = await packSession();
+      const res = await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`);
+      expect(res.status).toBe(200);
+      const lines = (await res.text()).trim().split("\n");
+      // Session index 1 is E01, which sorts first — so all three, in E01, E02,
+      // E03 order, which is session indexes 1, 3, 0.
+      expect(lines).toEqual([
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/1?k=${capability}`,
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/3?k=${capability}`,
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/0?k=${capability}`,
+      ]);
+    });
+
+    it("is just this file when it is the last one", async () => {
+      const { base, capability, id } = await packSession();
+      // Session index 0 is E03, which sorts last.
+      const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
+      expect(text.trim().split("\n")).toHaveLength(1);
+    });
+
+    it("skips the non-video files the picker skips", async () => {
+      const { base, capability, id } = await packSession();
+      const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`)).text();
+      // The .nfo is session index 2 and must not be handed to a media player.
+      expect(text).not.toContain(`/stream/${id}/2?`);
+    });
+
+    it("still contains no filename at all", async () => {
+      const { base, capability, id } = await packSession();
+      const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`)).text();
+      // The whole point of the plain-URL body: another application parses this
+      // file, and nothing in it comes from a release name.
+      expect(text).not.toContain("Harrowgate");
+      expect(text).not.toContain("#EXTINF");
+    });
+
+    it("is unchanged without the parameter", async () => {
+      const { base, capability, id } = await packSession();
+      const text = await (await fetch(`${base}/stream/${id}/1.m3u?k=${capability}`)).text();
+      expect(text.trim().split("\n")).toHaveLength(1);
+    });
+
+    /**
+     * The value is read as a presence flag, but `rest=0` reading as "yes" would
+     * be a trap for anyone building the URL by hand.
+     */
+    it("treats rest=0 as off", async () => {
+      const { base, capability, id } = await packSession();
+      const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=0&k=${capability}`)).text();
+      expect(text.trim().split("\n")).toHaveLength(1);
+    });
+  });
 });
 
 describe("requestOrigin", () => {

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -20,13 +20,14 @@
 import http from "node:http";
 import https from "node:https";
 import { isAuthorized } from "../daemon/auth";
-import { streamHandle } from "./routes";
+import { streamHandle, toPublicSession } from "./routes";
 import { probeUrl } from "../core/probe";
 import { blockersFor, classifyFromName, extensionOf, type MediaFacts } from "../util/playability";
 import type { ProbeCache } from "../core/probeCache";
 import type { HlsVerdictCache } from "../core/hlsVerdictCache";
 import type { StreamSession, StreamSessionRegistry } from "../core/streamSession";
-import type { StreamInfoResponse } from "./wire";
+import { streamCandidates } from "../util/videoFiles";
+import type { StreamFilesResponse, StreamInfoResponse } from "./wire";
 import {
   HTTP_AND_HTTPS,
   HTTP_ONLY,
@@ -135,24 +136,26 @@ export function parseStreamPath(urlPath: string): { sid: string; index: number }
 
 const PLAYLIST_SUFFIX = ".m3u";
 const INFO_SUFFIX = ".info";
+const FILES_SUFFIX = ".files";
 
 /** Which representation of the stream handle a path is asking for. */
-export type StreamRep = "media" | "playlist" | "info";
+export type StreamRep = "media" | "playlist" | "info" | "files";
 
 /**
- * Split a trailing `.m3u` or `.info` off a stream path.
+ * Split a trailing `.m3u`, `.info` or `.files` off a stream path.
  *
- * Both are *representations* of the handle, not second resources, so neither is
- * a second route: stripping the suffix here means the session lookup, the
+ * All are *representations* of the handle, not second resources, so none is a
+ * second route: stripping the suffix here means the session lookup, the
  * capability check, the readiness check and the bounds check below are literally
- * the same code for all three. A `.m3u` that skipped the capability would hand
- * out a playable URL to anyone who guessed a session id, and a `.info` that
- * skipped it would hand out a filename and codec list; the only durable way to
- * stop both is for there to be one guard, not three.
+ * the same code for all four. A `.m3u` that skipped the capability would hand
+ * out a playable URL to anyone who guessed a session id, a `.info` that skipped
+ * it would hand out a filename and codec list, and a `.files` that skipped it
+ * would hand out every filename in the torrent; the only durable way to stop
+ * all three is for there to be one guard, not four.
  *
- * Matched with `endsWith` on an exact lowercase suffix, so `.m3u8`, `.INFO` and
- * `.information` are all just filenames — a near-miss must fall through to the
- * media branch rather than be helpfully interpreted.
+ * Matched with `endsWith` on an exact lowercase suffix, so `.m3u8`, `.INFO`,
+ * `.information` and `.profiles` are all just filenames — a near-miss must fall
+ * through to the media branch rather than be helpfully interpreted.
  */
 export function splitRepresentation(urlPath: string): { path: string; rep: StreamRep } {
   if (urlPath.endsWith(PLAYLIST_SUFFIX)) {
@@ -160,6 +163,9 @@ export function splitRepresentation(urlPath: string): { path: string; rep: Strea
   }
   if (urlPath.endsWith(INFO_SUFFIX)) {
     return { path: urlPath.slice(0, -INFO_SUFFIX.length), rep: "info" };
+  }
+  if (urlPath.endsWith(FILES_SUFFIX)) {
+    return { path: urlPath.slice(0, -FILES_SUFFIX.length), rep: "files" };
   }
   return { path: urlPath, rep: "media" };
 }
@@ -337,6 +343,31 @@ export async function handleStreamRequest(
   if (!file) {
     writeJson(res, 404, { error: "unknown file" });
     return 404;
+  }
+
+  // The `.files`: what else is in this session, so the player page can offer
+  // the next episode instead of being a dead end. Same position as `.info` and
+  // the playlist — after every guard, before the backend split — because the
+  // answer is about the session, not about who is serving its bytes.
+  //
+  // `toPublicSession` does the mapping, not a local loop: it is the one place
+  // that swaps a file's upstream URL (a Real-Debrid credential, or an
+  // unreachable localhost address) for a `/stream/:sid/:idx` handle, and it
+  // builds by picking fields so a field added to `StreamSession` later stays
+  // private by default. A second mapping here would inherit neither property.
+  //
+  // `streamCandidates` filters to the video files — the same rule the picker
+  // uses, so the two lists cannot disagree about what is in a torrent — and it
+  // falls back to every file when nothing looks like video, because a release
+  // that ships one unrecognised container is still worth handing to VLC.
+  if (rep === "files") {
+    const body: StreamFilesResponse = {
+      name: session.name,
+      infoHash: session.infoHash,
+      files: streamCandidates(toPublicSession(session).files),
+    };
+    writeJson(res, 200, body);
+    return 200;
   }
 
   // The `.info`: what this file is, and how the player page should try to play

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -27,6 +27,7 @@ import type { ProbeCache } from "../core/probeCache";
 import type { HlsVerdictCache } from "../core/hlsVerdictCache";
 import type { StreamSession, StreamSessionRegistry } from "../core/streamSession";
 import { streamCandidates } from "../util/videoFiles";
+import { sortStreamFiles } from "../util/streamFileSort";
 import type { StreamFilesResponse, StreamInfoResponse } from "./wire";
 import {
   HTTP_AND_HTTPS,
@@ -168,6 +169,28 @@ export function splitRepresentation(urlPath: string): { path: string; rep: Strea
     return { path: urlPath.slice(0, -FILES_SUFFIX.length), rep: "files" };
   }
   return { path: urlPath, rep: "media" };
+}
+
+/**
+ * The session indexes for `?rest=1`: this file, then every later one.
+ *
+ * "Later" is in DISPLAY order, not session order — the two differ whenever a
+ * torrent names its files in some order of its own, which is most of them, and
+ * a playlist in session order would run E08 then E02. `sortStreamFiles` is the
+ * ordering the picker and the player page's episode list already use, so all
+ * three agree about what "the rest of the season" means.
+ *
+ * Returns just `[index]` when the file is not among the candidates — a `.nfo`
+ * addressed directly, say. That is the pre-`rest` behaviour, which is the right
+ * answer for a file that is not part of any run.
+ */
+function restOfSession(session: StreamSession, index: number): number[] {
+  const ordered = sortStreamFiles(
+    streamCandidates(session.files.map((file, at) => ({ ...file, at }))),
+    "name",
+  );
+  const from = ordered.findIndex((file) => file.at === index);
+  return from >= 0 ? ordered.slice(from).map((file) => file.at) : [index];
 }
 
 const PLAY_BASE = "/play";
@@ -473,12 +496,29 @@ export async function handleStreamRequest(
     // session, so nothing a client put in the URL is reflected into the body.
     // The capability is re-encoded from the value that just passed the auth
     // check — omit it and the playlist is a 401 in whatever player opens it.
-    const url = `${origin}${streamHandle(parsed.sid, parsed.index)}?k=${encodeURIComponent(k!)}`;
-    // One bare URL, no #EXTM3U and no #EXTINF title. Every player accepts the
+    const handleUrl = (index: number): string =>
+      `${origin}${streamHandle(parsed.sid, index)}?k=${encodeURIComponent(k!)}`;
+
+    // `?rest=1` — this file and every later one, so a season plays unattended
+    // rather than one download per episode. A PARAMETER on the existing
+    // representation rather than a route of its own: the guards above, the
+    // origin check, and the body rule below all apply unchanged, and a second
+    // playlist route would be a second place to forget one of them.
+    //
+    // Order is `sortStreamFiles`, the module the picker and the player page's
+    // episode list already share — a playlist that ran E08, E02, E03 would be
+    // the same bug that helper was extracted to fix — and `streamCandidates`
+    // drops the `.nfo`s, because handing a text file to a media player is how a
+    // playlist stalls halfway through a season.
+    const wantsRest = (query.get("rest") ?? "") === "1";
+    const indexes = wantsRest ? restOfSession(session, parsed.index) : [parsed.index];
+
+    // Bare URLs, no #EXTM3U and no #EXTINF title. Every player accepts the
     // simplest form, and the alternative would mean interpolating a torrent's
     // filename — attacker-controlled text — into a file another application
-    // parses. Nothing in this body is derived from the media at all.
-    const body = `${url}\n`;
+    // parses. Nothing in this body is derived from the media at all, and adding
+    // a second entry does not change that.
+    const body = `${indexes.map(handleUrl).join("\n")}\n`;
     res.writeHead(200, {
       // The content type is what makes the browser hand the file to the OS
       // instead of rendering it. text/plain and octet-stream both end with the

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -132,6 +132,48 @@ export interface StreamInfoResponse {
 }
 
 /**
+ * `GET /stream/:sid/:idx.files?k=…` — everything else in this session.
+ *
+ * Capability-authenticated for the same reason `.info` is: the player page is a
+ * separate document that knows only what its own URL tells it, and it may be a
+ * phone that was handed a link, so it holds the session capability and not the
+ * server's bearer token.
+ *
+ * WHY THE PLAYER PAGE NEEDS THIS AT ALL. Without it the page knows about one
+ * file, so finishing an episode means going Back — which, before this, threw
+ * the whole search away. The terminal never had that problem: its picker stays
+ * open after launching a player (`src/ui/App.tsx`, `playFromPicker`) precisely
+ * so the next episode is one keypress. This is the browser catching up.
+ *
+ * `files` REUSES `PublicStreamFile` rather than declaring a parallel shape, and
+ * is produced by `toPublicSession` — so it inherits that function's guarantee
+ * that the upstream URL (a debrid credential, or a useless localhost address)
+ * is replaced by a `/stream/:sid/:idx` handle. A second mapping here would be
+ * the fifth copy-then-drift bug in this codebase's ledger.
+ *
+ * It carries only the video candidates (`streamCandidates`), and it is in
+ * SESSION ORDER — `index` addresses the session, so the two cannot be conflated.
+ * Display order is the page's business and it applies the same
+ * `sortStreamFiles` the picker does.
+ */
+export interface StreamFilesResponse {
+  /** The session's release name, e.g. `Harrowgate.S03.1080p.WEB-DL`. */
+  name: string;
+  /**
+   * The torrent this session is of.
+   *
+   * Here so the player page can record the episode it opened — `POST
+   * /api/library {action:"watched"}` is keyed by info hash, and a page that
+   * knows only its own URL has no other way to learn it. Not a disclosure: an
+   * info hash is a torrent's public name, the search results the user clicked
+   * through already carried it, and whoever holds this session's capability can
+   * already stream every byte of the thing it identifies.
+   */
+  infoHash: string;
+  files: PublicStreamFile[];
+}
+
+/**
  * A live stream session as a browser is allowed to see it. The body of
  * `GET /api/stream/:sid`, and the `session` field of the start response.
  *


### PR DESCRIPTION
Finish an episode in the browser and the only way on was Back — which is a full
page load of `/`, onto an empty search box. The search that got you there is
gone, the season pack is gone, and picking the next episode means starting over.

The terminal has never had that problem. `playFromPicker` (`src/ui/App.tsx`)
keeps the picker open on purpose — the comment says "so the user can go straight
to the next episode" — the cursor auto-advances to the next unwatched file, and
`Results` is never unmounted. **So this is parity work, not a new feature.**

## What it does

**1. The player page knows what else is in the torrent.**

`GET /stream/:sid/:idx.files` — a fourth representation of the stream handle
alongside `.m3u` and `.info`, *inside the same guard funnel*, so it inherits the
session lookup, the constant-time capability check, the readiness check and the
bounds check rather than getting its own set. Capability-authenticated for the
reason `.info` is: this page may be a phone that was handed a link, so it holds
the session capability and not the bearer token.

The page renders **up next**, then every episode in the torrent — headed by
season only when there is more than one, because a lone "Season 3" over a list
that is entirely season 3 distinguishes nothing. Each row links to the same page
for that file, so the next episode is one click and the picker never reopens.

**2. Back returns you to your search.**

The dashboard keeps `?q=` `&group=` `&view=` in its own URL via `replaceState`
(`route.ts`). `index.html` carried a comment explicitly rejecting a router,
because a bookmarked URL "would promise a restored search it cannot deliver (the
stream is not replayable)". That is right about **streams** and this change keeps
it true — no session id and no `?k=` is ever written there. It was wrong about
**searches**. The comment is rewritten rather than quietly contradicted.

**3. The back link said "back to queue" and landed on search.** It now says what
it does and goes back one entry when the dashboard is behind it.

**4. `?rest=1`** on the existing playlist — this file and every later one, one
bare URL per line, so VLC runs the rest of the season unattended.

## Two things only running it could have caught

- **The back link could never have worked as first written.** `player.html` sets
  `no-referrer` deliberately, because the URL carries a stream capability in
  `?k=` and a `Referer` would hand it to anything the page links at — so
  `document.referrer` is *always* empty here and a referrer-keyed link silently
  never fires. The dashboard leaves a note in sessionStorage instead, which says
  *where* as well as *whether*: a bookmarked player URL in a tab with unrelated
  history no longer risks a `history.back()` that leaves the site. The note is
  validated, not trusted — sessionStorage is user-writable and the value reaches
  `location`.
- **Continue-watching would have frozen.** The picker was the only thing
  recording plays, and jumping episode to episode never touches it. The player
  page now fires the same `POST /api/library`, so one mechanism has two call
  sites rather than two mechanisms. `recordPlayedFile` is a high-water mark that
  returns the same array reference when nothing moved, so double-recording is
  free and the picker's call stays as the fallback.

Also fixed in review: the breadcrumb was drawn inside `renderEpisodes`, so it was
missing in the one case where it is the only way out — a reaped session, whose
page can neither play, nor list its files, nor say why.

## No terminal-UI change, and why

CLAUDE.md makes a one-surface feature the default-prohibited outcome, so: the
terminal already has all three properties. Its picker stays open on the next
unwatched file, `✓` marks what you have played, and `esc` returns to results that
were never unmounted. Under "a surface can't express it" — the terminal has no
URL, no separate document and no Back button, so parts 2 and 3 have no analogue
there, and part 1 is the browser catching up to `src/ui/App.tsx:1408`.

## Verification

`npm test` (2538), `npm run typecheck`, `npm run lint` (one documented
pre-existing warning) and `npm run build` all clean.

Walked live against a real 10-episode season pack:

- search → `/?q=…&group=TV` → play → pick E03 → episode list, up next, breadcrumb
- one click E03 → E04, "up next" advanced, current row moved
- the results row went **"up to E04" → "up to E05"** from player-page jumps
  alone, and the picker then preselected **E05 · NEXT** — that is the
  bookkeeping above working end to end
- Back → the restored search, right tab, results present
- a cold player URL in a fresh tab → back falls back to the href, breadcrumb
  reaches the show
- **VLC ran the `?rest=1` playlist headless through all ten items in order**,
  each demuxed as `mp4`, all ten indexes seen in the server log

Fixtures use the CLAUDE.md cast (`Harrowgate.S03`, `Kepler`, `Kestrel`), with a
multi-season `Kepler` case added specifically because a flat list and a
season-grouped list both pass a single-season test — without it the suite would
not be testing the grouping decision at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
