### PR TITLE
Make the player page's hand-off to a real player work, and say what it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,10 @@ give up after twelve seconds:
   while it's on, these releases fall through to the next line too.
 - **Anything left over** — a release streamed from the swarm, or one the provider won't transcode — gets a
   card naming the part your browser can't handle, plus a **Download .m3u** button: your OS hands that tiny
-  playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android you also get
-  a direct VLC link.
+  playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android there's also
+  a direct **Open in VLC** button, because those apps register a URL scheme a web page can link to.
+  Desktop VLC registers none — not on macOS, Windows or Linux — so there's no button to offer there, and
+  the `.m3u` is the route that works. It also doesn't assume VLC is what you watch things in.
 
 #### The player page knows what else is in the torrent
 
@@ -320,7 +322,11 @@ reopen the picker. This is the browser catching up to the terminal, whose picker
 after launching a player so the next episode is one keypress away.
 
 There is also **Download rest of season .m3u**, which is one playlist containing this episode and every
-later one in order — hand it to VLC once and it runs the rest of the season unattended.
+later one *of the same season* — hand it to VLC once and it runs the rest of the season unattended.
+Bonus features and extras are left out, so a gag reel can't interrupt episode four, and every entry is
+titled, so a thirteen-episode playlist reads as episodes rather than as thirteen identical URLs. Open a
+bonus feature instead and the button says **Download the rest as .m3u**, because there's no season there
+to be the rest of.
 
 Above the filename is a breadcrumb back to the show, and the header's **back to results** goes back to the
 search you ran rather than to an empty box: the dashboard now keeps its query and category in its own URL,

--- a/docs/superpowers/plans/2026-08-01-web-player-handoff.md
+++ b/docs/superpowers/plans/2026-08-01-web-player-handoff.md
@@ -1,0 +1,1146 @@
+# Player Page Hand-Off Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the four ways out of the browser player — copy the URL, open VLC, download a `.m3u`, download the rest of the season — actually work and say what they do.
+
+**Architecture:** Two new pure modules in `src/util/` (`playlistTitle.ts`, `restPlaylist.ts`) that the server's `.m3u` route and the browser's player page both consume, so the rule for "which files, and what they are called" has one implementation. One cherry-pick. Two small edits to existing decision modules (`playerModel.ts`, `upNext.ts`). `player.ts` and `stream.ts` gain no new conditionals of their own.
+
+**Tech Stack:** TypeScript, Node 20+, vitest, tsup (browser bundle for `src/web/static/`), Ink/React (untouched here).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-web-player-handoff-design.md`
+
+## Global Constraints
+
+- **Never name a real film or show** in a test, fixture, doc comment, example or user-facing copy. Reuse the repo's cast: `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`.
+- **`src/util/` must stay browser-safe**: no `node:*` import may appear in `playlistTitle.ts` or `restPlaylist.ts`, or in anything they reach. `npm run build` is the enforcement, not grep.
+- **No `innerHTML` / `insertAdjacentHTML` / `document.write` / `outerHTML`** anywhere in `src/web/static/`. Every node is `createElement` + `textContent`.
+- **`src/web` must not import from `src/ui`**; `src/core` must not import from either. Share by moving helpers down into `src/util/`.
+- **Decisions live in pure modules**, never in `app.ts` or `player.ts`. A conditional that decides what to show or what to send belongs in a tested module.
+- Conventional Commits. Commit messages end with:
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`
+- Before declaring done: `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) is expected — leave it.
+- Branch: `worktree-enumerated-dazzling-scott`, based on `main` at `3891cd8`. Do not `cd` out of this worktree.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| Create `src/util/playlistTitle.ts` | One filename → one `#EXTINF` title. Sanitising and derivation, nothing else. |
+| Create `src/util/playlistTitle.test.ts` | Its tests. |
+| Create `src/util/restPlaylist.ts` | Which session indexes a "rest" playlist contains, and which kind it is. |
+| Create `src/util/restPlaylist.test.ts` | Its tests. |
+| Create `src/web/static/copyText.ts` + `.test.ts` | Arrives via cherry-pick. Clipboard routes. |
+| Modify `src/web/stream.ts` | The `.m3u` body: `#EXTM3U`, `#EXTINF` per entry, indexes from `restPlaylist`. Delete the local `restOfSession`. |
+| Modify `src/web/stream.test.ts` | Body assertions now read URL lines, not the whole body. Two policy tests rewritten. |
+| Modify `src/web/static/playerModel.ts` | `vlcLinks` offers nothing on macOS. `interruptedNotice` stops naming VLC. |
+| Modify `src/web/static/upNext.ts` | `UpNextView.restLabel` — the button's text, or null. |
+| Modify `src/web/static/player.ts` | Renders `restLabel`. Wiring only. Plus the cherry-pick's copy wiring. |
+| Modify `README.md` | The desktop VLC paragraph, and the rest-of-season definition. |
+
+---
+
+### Task 1: The copy button copies on an insecure origin
+
+Cherry-pick, not a rewrite: this work exists and is already tested.
+
+**Files:**
+- Create (by cherry-pick): `src/web/static/copyText.ts`, `src/web/static/copyText.test.ts`
+- Modify (by cherry-pick): `src/web/static/player.ts`, `src/web/static/styles.css`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `copyText(text, ports): CopyOutcome | Promise<CopyOutcome>`, `copyNotice(outcome): string`, `clipboardPorts(): CopyPorts`, `type CopyOutcome = "copied" | "manual"` — all from `src/web/static/copyText.ts`. Task 6 edits the same region of `player.ts`, so this task must land first.
+
+- [ ] **Step 1: Confirm the commit is the one intended, and that it is only the copy fix**
+
+```bash
+git log --oneline -2 copy-stream-url-on-insecure-origins
+# aeb28b8 docs: design for subtitle support        <- DO NOT take this one
+# 2e6ba39 fix(web): copy the stream URL on an insecure origin
+git show --stat 2e6ba39
+```
+
+Expected: `2e6ba39` touches exactly `src/web/static/copyText.ts`, `src/web/static/copyText.test.ts`, `src/web/static/player.ts`, `src/web/static/styles.css`. If it touches anything else, stop and report.
+
+- [ ] **Step 2: Cherry-pick it**
+
+```bash
+git cherry-pick 2e6ba39
+```
+
+Expected: clean. If it conflicts in `player.ts`, resolve by keeping *both* sides' intent — the incoming `copyText` call replaces the old `navigator.clipboard` block inside the `"Copy stream URL"` button, and everything else in the file stays.
+
+- [ ] **Step 3: Run its tests**
+
+Run: `npx vitest run src/web/static/copyText.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Verify the old dead-end message is gone**
+
+Run: `grep -rn "needs a secure context" src/`
+Expected: no matches. If one remains, the cherry-pick's `player.ts` hunk did not apply — fix `player.ts` so the button calls `copyText(stream, clipboardPorts())` and reports through `copyNotice`, and reveals the manual field on `"manual"`.
+
+- [ ] **Step 5: Full suite, then stop**
+
+Run: `npm test`
+Expected: PASS. The cherry-pick is already committed by `git cherry-pick`; nothing to commit here.
+
+---
+
+### Task 2: No dead VLC button on the desktop
+
+**Files:**
+- Modify: `src/web/static/playerModel.ts` — `vlcLinks` (~line 221), `interruptedNotice` (~line 325)
+- Test: `src/web/static/playerModel.test.ts` — the `vlcLinks` describe block (~line 224)
+
+**Interfaces:**
+- Consumes: `type Platform = "ios" | "android" | "macos" | "other"` and `ExternalLink` from `playerModel.ts`, both unchanged.
+- Produces: `vlcLinks(absolute: string, platform: Platform): ExternalLink[]` — same signature, now `[]` for `"macos"`. `detectPlatform` is unchanged and still returns `"macos"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/web/static/playerModel.test.ts`, **replace** the existing `it("offers the x-callback scheme on iOS and macOS", …)` with these two, and **replace** the existing `it("offers nothing on other platforms", …)` with the third:
+
+```ts
+  it("offers the x-callback scheme on iOS", () => {
+    expect(vlcLinks(url, "ios")).toEqual([
+      {
+        id: "vlc-callback",
+        label: "Open in VLC",
+        href: `vlc-x-callback://x-callback-url/stream?url=${encodeURIComponent(url)}`,
+      },
+    ]);
+  });
+
+  /**
+   * macOS was given the iOS app's scheme, and the click was a silent no-op.
+   * Verified against a real install: VLC.app's Info.plist registers http, https,
+   * ftp, mms, mmsh, rtsp, udp, rtp, rtmp*, sftp and smb — no `vlc://` and no
+   * `vlc-x-callback://`. There is nothing for a page to link to, so the desktop
+   * gets the `.m3u`, which works, and no button that does nothing.
+   */
+  it("offers nothing on desktop, macOS included", () => {
+    for (const platform of ["macos", "other"] as const) {
+      expect(vlcLinks(url, platform)).toEqual([]);
+    }
+  });
+
+  // The platform is still detected; only what we offer it changed.
+  it("still recognises a Mac", () => {
+    expect(detectPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe("macos");
+  });
+```
+
+Then add, in the file's `interruptedNotice` describe block (or a new one at the end of the file if there is none):
+
+```ts
+describe("interruptedNotice", () => {
+  // Desktop has no VLC button any more, so naming one is naming a control that
+  // is not on screen.
+  it.each(["stall", "error"] as const)("names no button the desktop lacks (%s)", (reason) => {
+    expect(interruptedNotice(reason)).not.toContain("VLC");
+    expect(interruptedNotice(reason)).toContain(".m3u");
+  });
+});
+```
+
+Make sure `interruptedNotice` and `detectPlatform` are in the file's import list from `./playerModel`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/web/static/playerModel.test.ts`
+Expected: FAIL — `vlcLinks(url, "macos")` returns the callback link, and `interruptedNotice` contains "VLC".
+
+- [ ] **Step 3: Make macOS offer nothing**
+
+In `src/web/static/playerModel.ts`, change `vlcLinks` and its doc comment:
+
+```ts
+/**
+ * The "open in VLC" links that can actually work on this platform.
+ *
+ * Empty on every desktop — Windows, Linux and macOS — and that is the point:
+ * none of them registers a VLC URL scheme, so a button there is a button that
+ * does nothing. macOS was in the iOS branch and was exactly that bug: VLC.app's
+ * Info.plist registers http, https, ftp, mms, mmsh, rtsp, udp, rtp, rtmp*, sftp
+ * and smb, and `vlc-x-callback://` belongs to the iOS app alone, so the click
+ * went nowhere with nothing on screen to say why. Desktop gets the `.m3u`
+ * download, which does work, and is not told to use VLC — it may not be what
+ * they play video in.
+ */
+export function vlcLinks(absolute: string, platform: Platform): ExternalLink[] {
+  if (platform === "ios") {
+    return [
+      {
+        id: "vlc-callback",
+        label: "Open in VLC",
+        href: `vlc-x-callback://x-callback-url/stream?url=${encodeURIComponent(absolute)}`,
+      },
+    ];
+  }
+  if (platform === "android") {
+    const href = androidIntent(absolute);
+    return href ? [{ id: "vlc-intent", label: "Open in VLC", href }] : [];
+  }
+  return [];
+}
+```
+
+- [ ] **Step 4: Stop telling desktop users to open VLC**
+
+Replace the two return strings in `interruptedNotice`:
+
+```ts
+export function interruptedNotice(reason: FallbackReason): string {
+  if (reason === "stall") {
+    return "Playback stopped — no more of the stream arrived. Download the .m3u and carry on watching there.";
+  }
+  return "Playback stopped partway through — the stream failed upstream. Download the .m3u and carry on watching there.";
+}
+```
+
+Also update that function's doc comment, whose last paragraph says both branches "point at the `.m3u` and VLC, because those buttons are still on screen" — only the `.m3u` is, on a desktop.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run src/web/static/playerModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/playerModel.ts src/web/static/playerModel.test.ts
+git commit -m "$(printf 'fix(web): stop offering macOS a VLC scheme it has never registered\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: `playlistTitle` — what an entry is called
+
+**Files:**
+- Create: `src/util/playlistTitle.ts`
+- Test: `src/util/playlistTitle.test.ts`
+
+**Interfaces:**
+- Consumes: `parseRelease(name: string): ParsedRelease | null` from `src/util/release.ts`. Verified behaviour, relied on below: `Kepler (2019) - S02E04 - … .mkv` → `{title: "Kepler", season: 2, episode: 4}`; `Harrowgate.S03/Bonus_Gag_Reel_1.mkv` → `{title: "Harrowgate", season: 3, episode: undefined}`; `Kestrel.2010….mkv` → `{title: "Kestrel", year: 2010}`.
+- Produces: `playlistTitle(filename: string): string` — never empty, never contains CR, LF or a control character, at most 120 characters. Used by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/playlistTitle.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { playlistTitle } from "./playlistTitle";
+
+describe("playlistTitle", () => {
+  it("names an episode by its show and tag, without the release junk", () => {
+    expect(playlistTitle("Harrowgate.S03E01.1080p.WEB-DL.mkv")).toBe("Harrowgate S03E01");
+  });
+
+  /**
+   * The Sonarr/Plex shape, which is the one that actually carries an episode
+   * name. The spaced dash is what marks it as a name rather than release junk.
+   */
+  it("keeps a spaced-dash episode name", () => {
+    expect(
+      playlistTitle("Kepler (2019) - S02E04 - Ashfall Rising (1080p BluRay x265 GROUP).mkv"),
+    ).toBe("Kepler S02E04 · Ashfall Rising");
+  });
+
+  it("does not mistake dot-delimited junk for an episode name", () => {
+    const title = playlistTitle("Kepler.S02E04.1080p.WEB-DL.mkv");
+    expect(title).toBe("Kepler S02E04");
+    expect(title).not.toContain("1080p");
+  });
+
+  it("carries a multi-episode tag whole", () => {
+    expect(playlistTitle("Harrowgate.S03E01E02.1080p.WEB-DL.mkv")).toBe("Harrowgate S03E01E02");
+  });
+
+  it("names a film by title and year", () => {
+    expect(playlistTitle("Kestrel.2010.1080p.BluRay.x264.mkv")).toBe("Kestrel 2010");
+  });
+
+  it("names a season pack that commits to no episode by its title", () => {
+    expect(playlistTitle("Harrowgate.S03.1080p.WEB-DL.mkv")).toBe("Harrowgate");
+  });
+
+  /**
+   * The case that started this: a bonus feature in a season pack. The directory
+   * is dropped — a playlist row reading "Harrowgate.S03/" tells you nothing —
+   * and the underscores become spaces.
+   */
+  it("reads a bonus feature as its own name, without the directory", () => {
+    const title = playlistTitle("Harrowgate.S03/Bonus_Gag_Reel_1.mkv");
+    expect(title).toBe("Bonus Gag Reel 1");
+    expect(title).not.toContain("/");
+  });
+
+  /**
+   * THE SECURITY CASE. A filename comes from whoever made the torrent, and this
+   * string is written into a file another application parses line by line. A
+   * newline would let it ADD AN ENTRY pointing anywhere it liked.
+   */
+  it("strips every character that could add or forge a line", () => {
+    const title = playlistTitle("evil\r\nhttp://attacker.example/x\nmore.mkv");
+    expect(title).not.toContain("\n");
+    expect(title).not.toContain("\r");
+    expect(title).not.toContain("attacker.example/x\n");
+  });
+
+  it("cannot pose as a playlist directive", () => {
+    expect(playlistTitle("#EXTINF:-1,nope.mkv").startsWith("#")).toBe(false);
+  });
+
+  it("strips control characters", () => {
+    expect(playlistTitle("a\u0007b\u009fc.mkv")).toBe("abc");
+  });
+
+  it("caps the length", () => {
+    expect(playlistTitle(`${"a".repeat(300)}.mkv`).length).toBe(120);
+  });
+
+  it("keeps commas, which #EXTINF allows after the first one", () => {
+    expect(playlistTitle("Kepler (2019) - S02E04 - Ashfall, Rising.mkv")).toBe(
+      "Kepler S02E04 · Ashfall, Rising",
+    );
+  });
+
+  it("never returns an empty title", () => {
+    for (const name of ["", ".mkv", "###", "\u0000\u0001"]) {
+      expect(playlistTitle(name)).toBe("stream");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/util/playlistTitle.test.ts`
+Expected: FAIL — `Cannot find module './playlistTitle'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/playlistTitle.ts`:
+
+```ts
+/**
+ * What one entry in a `.m3u` is called.
+ *
+ * WHY THIS IS A MODULE AND NOT A TEMPLATE STRING. The `.m3u` route deliberately
+ * wrote bare URLs for a long time, on the grounds that an `#EXTINF` title means
+ * interpolating a filename — which comes from whoever made the torrent — into a
+ * file another application parses. That objection is right, and this is the
+ * answer to it rather than a decision to ignore it:
+ *
+ * - **A newline is the real hazard.** A playlist is parsed line by line, so a
+ *   filename carrying `\n` followed by a URL would ADD AN ENTRY pointing
+ *   wherever its author chose. CR, LF and every C0/C1 control character go.
+ * - A leading `#` is removed, so a title cannot pose as a directive.
+ * - The result is capped, because a title is a label and not a payload.
+ * - Commas STAY. `#EXTINF`'s duration separator is the *first* comma on the
+ *   line and the title is everything after it, so "Ashfall, Rising" is both
+ *   safe and correct.
+ *
+ * It lives in `src/util/` because the server builds the playlist body and
+ * `parseRelease` already lives here. Browser-safe: no `node:*`, directly or
+ * transitively — `npm run build` is the enforcement.
+ */
+import { parseRelease } from "./release";
+
+/** `#EXTINF` is one line; a label longer than this is not helping anyone. */
+const MAX = 120;
+
+/** C0 and C1, which covers CR, LF, NUL and every terminal escape. */
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/g;
+
+/**
+ * `S03E01`, and `S03E01E02` for a double bill. Case-insensitive because
+ * releases write it every way, and normalised to upper case on the way out so a
+ * playlist does not mix `s03e01` and `S03E02` rows.
+ */
+const TAG = /S(\d{1,2})E\d{1,3}(?:E\d{1,3})*/i;
+
+/**
+ * An episode name follows the tag only when a SPACED dash introduced it — the
+ * shape Sonarr and Plex write. Dot-delimited text after a tag is release junk
+ * (`.1080p.WEB-DL`), and guessing otherwise puts "1080p WEB DL" in front of the
+ * user as a title.
+ */
+const SPACED_DASH = /^\s+[-–—]\s+/;
+
+/** Where an episode name ends: the bracketed quality group that follows it. */
+const BRACKET = /\s+[([].*$/;
+
+export function playlistTitle(filename: string): string {
+  const base = basename(filename);
+  const tag = TAG.exec(base);
+  if (tag) {
+    const show = parseRelease(base)?.title ?? "";
+    const label = [show, tag[0].toUpperCase()].filter(Boolean).join(" ");
+    const name = episodeName(base.slice(tag.index + tag[0].length));
+    return clamp(sanitise(name ? `${label} · ${name}` : label)) || fallback(base);
+  }
+  const parsed = parseRelease(base);
+  const named = parsed ? [parsed.title, parsed.year].filter(Boolean).join(" ") : "";
+  return clamp(sanitise(named || spaced(base))) || fallback(base);
+}
+
+/** The filename alone, no directory and no extension. */
+function basename(filename: string): string {
+  const leaf = filename.split(/[/\\]/).pop() ?? "";
+  return leaf.replace(/\.[^.]{1,10}$/, "");
+}
+
+/** The episode name after a tag, or "" when the shape says there isn't one. */
+function episodeName(rest: string): string {
+  if (!SPACED_DASH.test(rest)) return "";
+  return rest.replace(SPACED_DASH, "").replace(BRACKET, "").trim();
+}
+
+/** A dotted or underscored name as words: `Bonus_Gag_Reel_1` → `Bonus Gag Reel 1`. */
+function spaced(base: string): string {
+  return base.replace(/[._]+/g, " ");
+}
+
+/**
+ * Everything that must not reach the file. Note the order: controls go first,
+ * so a `#` hidden behind a stripped character cannot end up leading the line.
+ */
+function sanitise(text: string): string {
+  return text.replace(CONTROL, "").replace(/\s+/g, " ").trim().replace(/^#+\s*/, "").trim();
+}
+
+function clamp(text: string): string {
+  return text.length > MAX ? text.slice(0, MAX).trim() : text;
+}
+
+/**
+ * The last resort. `#EXTINF:-1,` with nothing after the comma is worse than no
+ * title at all, so this never returns "".
+ */
+function fallback(base: string): string {
+  return clamp(sanitise(spaced(base))) || "stream";
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run src/util/playlistTitle.test.ts`
+Expected: PASS. If the multi-episode or bonus case fails, fix the implementation to match the test — the test is the spec. Do not weaken an assertion to make it pass; if you believe a test is wrong, stop and report which and why.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/playlistTitle.ts src/util/playlistTitle.test.ts
+git commit -m "$(printf 'feat(util): derive a safe .m3u entry title from a filename\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 4: `restPlaylist` — which files "the rest" means
+
+**Files:**
+- Create: `src/util/restPlaylist.ts`
+- Test: `src/util/restPlaylist.test.ts`
+
+**Interfaces:**
+- Consumes: `sortStreamFiles(files, "name")` from `src/util/streamFileSort.ts`; `streamCandidates(files)` and `type SizedFile` from `src/util/videoFiles.ts`; `parseRelease` from `src/util/release.ts`; `type EpisodeRef` from `src/util/episode.ts`.
+- Produces, all from `src/util/restPlaylist.ts`, used by Tasks 5 and 6:
+
+```ts
+export type RestKind = "season" | "everything";
+export interface RestPlaylist {
+  kind: RestKind;
+  indexes: number[];
+}
+export interface IndexedFile extends SizedFile {
+  index: number;
+}
+export function restPlaylist<T extends IndexedFile>(
+  files: readonly T[],
+  index: number,
+): RestPlaylist;
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/restPlaylist.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { restPlaylist, type IndexedFile } from "./restPlaylist";
+
+function file(index: number, filename: string, bytes = 1024 ** 3): IndexedFile {
+  return { index, filename, bytes };
+}
+
+/**
+ * A season pack shaped like the one that prompted this: episodes named out of
+ * order, a bonus feature that names the season but no episode, and a `.nfo` the
+ * picker already drops.
+ */
+const PACK: IndexedFile[] = [
+  file(0, "Harrowgate.S03E03.1080p.WEB-DL.mkv"),
+  file(1, "Harrowgate.S03E01.1080p.WEB-DL.mkv"),
+  file(2, "Harrowgate.S03/readme.nfo"),
+  file(3, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
+  file(4, "Harrowgate.S03/Bonus_Gag_Reel_1.mkv"),
+];
+
+describe("restPlaylist", () => {
+  it("from an episode, plays the rest of that season", () => {
+    expect(restPlaylist(PACK, 1)).toEqual({ kind: "season", indexes: [1, 3, 0] });
+  });
+
+  /**
+   * THE BUG. Started from an episode, the old rule was "every later file in
+   * name order", which swept the bonus feature into the season playlist.
+   */
+  it("leaves out a bonus feature that names no episode", () => {
+    expect(restPlaylist(PACK, 1).indexes).not.toContain(4);
+  });
+
+  it("leaves out the non-video files the picker leaves out", () => {
+    expect(restPlaylist(PACK, 1).indexes).not.toContain(2);
+  });
+
+  it("is one entry from the last episode of a season", () => {
+    // Session index 0 is E03, which sorts last of the three episodes.
+    expect(restPlaylist(PACK, 0)).toEqual({ kind: "season", indexes: [0] });
+  });
+
+  /**
+   * From a bonus feature there is no season to be the rest of, so the meaning
+   * falls back to "everything from here" — and the caller labels it that way.
+   */
+  it("from a bonus feature, takes everything from there on", () => {
+    const out = restPlaylist(PACK, 4);
+    expect(out.kind).toBe("everything");
+    expect(out.indexes[0]).toBe(4);
+    expect(out.indexes).toContain(1);
+  });
+
+  it("stops at the season boundary in a multi-season pack", () => {
+    const two: IndexedFile[] = [
+      file(0, "Kepler.S01E01.1080p.WEB-DL.mkv"),
+      file(1, "Kepler.S01E02.1080p.WEB-DL.mkv"),
+      file(2, "Kepler.S02E01.1080p.WEB-DL.mkv"),
+    ];
+    expect(restPlaylist(two, 0)).toEqual({ kind: "season", indexes: [0, 1] });
+  });
+
+  it("is a single entry for a film", () => {
+    const film = [file(0, "Kestrel.2010.1080p.BluRay.x264.mkv")];
+    expect(restPlaylist(film, 0)).toEqual({ kind: "everything", indexes: [0] });
+  });
+
+  /**
+   * A season pack file that names a season but no episode is not an episode, so
+   * there is no season to continue — the same branch a bonus feature takes.
+   */
+  it("treats a file naming a season but no episode as everything", () => {
+    const pack = [
+      file(0, "Harrowgate.S03.1080p.WEB-DL.mkv"),
+      file(1, "Harrowgate.S03.extras.mkv"),
+    ];
+    expect(restPlaylist(pack, 0).kind).toBe("everything");
+  });
+
+  it("falls back to just that index when it names no candidate", () => {
+    expect(restPlaylist(PACK, 99)).toEqual({ kind: "everything", indexes: [99] });
+    // The .nfo is not a candidate, so asking for it is the same case.
+    expect(restPlaylist(PACK, 2)).toEqual({ kind: "everything", indexes: [2] });
+  });
+
+  /**
+   * RECORDED CHOICE, not an oversight: an extra that poses as an episode stays
+   * in. Deduplicating by episode number would drop it — and would equally drop
+   * `S03E02.Part2` next to `S03E02.Part1`, which loses half an episode to tidy
+   * up a duplicate. Including one extra is the cheaper mistake.
+   */
+  it("keeps an extra that names an episode of its own", () => {
+    const posing: IndexedFile[] = [
+      file(0, "Harrowgate.S03E01.1080p.WEB-DL.mkv"),
+      file(1, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
+      file(2, "Harrowgate.S03E02.Deleted.Scenes.mkv"),
+    ];
+    expect(restPlaylist(posing, 0).indexes).toEqual([0, 1, 2]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/util/restPlaylist.test.ts`
+Expected: FAIL — `Cannot find module './restPlaylist'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/restPlaylist.ts`:
+
+```ts
+/**
+ * Which files a "play on from here" playlist contains — the rule, shared.
+ *
+ * WHY IT IS HERE AND NOT IN `src/web/stream.ts`, where it started. Two surfaces
+ * need the same answer: the server picks the files that go in the `.m3u`, and
+ * the player page decides what the button is called and whether to show it at
+ * all. Two implementations of one rule is the copy-then-drift bug this codebase
+ * has recorded four times, so the rule is in one place and both call it.
+ *
+ * WHAT WAS WRONG WITH THE OLD RULE. "This file and every later one in name
+ * order" is only accidentally right. Started from a bonus feature it yields
+ * every remaining extra and then the whole season, under a button that says
+ * "rest of season"; started from an episode it happens to be correct only while
+ * the extras sort clear of the episodes, and a torrent naming one
+ * `Show.S03E02.Deleted.Scenes` breaks that.
+ *
+ * Generic over the shape for the reason `sortStreamFiles` is: the server holds
+ * `StreamFile` with an upstream `url`, the browser holds `PublicStreamFile` with
+ * a `handle`, and each keeps the field that addresses its own file. Browser-safe:
+ * no `node:*` here or in anything it reaches.
+ */
+import { parseRelease } from "./release";
+import { sortStreamFiles } from "./streamFileSort";
+import { streamCandidates, type SizedFile } from "./videoFiles";
+import type { EpisodeRef } from "./episode";
+
+/**
+ * What the playlist turned out to mean. The caller words the button from this:
+ * a season can be called a season, and anything else must not be.
+ */
+export type RestKind = "season" | "everything";
+
+export interface RestPlaylist {
+  kind: RestKind;
+  /** Session indexes in play order, the current file first. Never empty. */
+  indexes: number[];
+}
+
+/** A file that knows its own position in the session — the `:idx` of its handle. */
+export interface IndexedFile extends SizedFile {
+  index: number;
+}
+
+export function restPlaylist<T extends IndexedFile>(
+  files: readonly T[],
+  index: number,
+): RestPlaylist {
+  // The picker's order, and the episode list's: a playlist that ran E08, E02,
+  // E03 is the bug `sortStreamFiles` was extracted to fix. `streamCandidates`
+  // drops the `.nfo`s, because handing a text file to a media player is how a
+  // playlist stalls halfway through a season.
+  const ordered = sortStreamFiles(streamCandidates(files), "name");
+  const at = ordered.findIndex((file) => file.index === index);
+  // A hand-edited URL, or the index of a file the video filter removed. One
+  // entry is honest: that file does exist and does play.
+  if (at < 0) return { kind: "everything", indexes: [index] };
+
+  const here = episodeOf(ordered[at]!.filename);
+  const rest = ordered.slice(at);
+  if (!here) return { kind: "everything", indexes: rest.map((file) => file.index) };
+
+  // A season means files that name an episode OF THIS SEASON. The current file
+  // is always in, whatever the filter would say about it.
+  const indexes = rest
+    .filter((file, offset) => {
+      if (offset === 0) return true;
+      const ep = episodeOf(file.filename);
+      return ep !== null && ep.season === here.season;
+    })
+    .map((file) => file.index);
+  return { kind: "season", indexes };
+}
+
+/**
+ * The episode a filename commits to, or null.
+ *
+ * BOTH numbers are required. A season pack file and a bonus feature inside a
+ * season folder both parse to a season with no episode, and treating that as
+ * "episode 1 of that season" is what would sweep the extras back in.
+ */
+function episodeOf(filename: string): EpisodeRef | null {
+  const parsed = parseRelease(filename);
+  if (parsed?.season === undefined || parsed.episode === undefined) return null;
+  return { season: parsed.season, episode: parsed.episode };
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run src/util/restPlaylist.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/restPlaylist.ts src/util/restPlaylist.test.ts
+git commit -m "$(printf 'feat(util): define the rest-of-season playlist as one shared rule\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 5: The `.m3u` gains titles, and the right files
+
+**Files:**
+- Modify: `src/web/stream.ts` — imports (~lines 29-30), delete `restOfSession` (~lines 175-194), the `rep === "playlist"` branch (~lines 485-537)
+- Test: `src/web/stream.test.ts` — several existing assertions, listed below
+
+**Interfaces:**
+- Consumes: `playlistTitle(filename)` (Task 3), `restPlaylist(files, index)` and `IndexedFile` (Task 4).
+- Produces: a body of the form `#EXTM3U\n#EXTINF:-1,<title>\n<url>\n…`. Nothing else consumes it in code; the browser only links to it.
+
+> **Read this before writing any test.** Several existing tests read the playlist body *as a single URL* (`res.body.trim()`) or assert `not.toContain("#EXTINF")`. Adding a header and titles makes those either fail or — worse — pass vacuously. CLAUDE.md records this exact trap: a negative assertion whose subject no longer appears anywhere still passes, and proves nothing. Every one is listed here; none may be deleted without a replacement.
+
+- [ ] **Step 1: Add the test helper and update the tests that read the body as one URL**
+
+In `src/web/stream.test.ts`, add near the top of the file (after the imports):
+
+```ts
+/**
+ * The URL lines of a playlist body — everything that is not a directive.
+ *
+ * The body carries `#EXTM3U` and an `#EXTINF` per entry now, so a test that
+ * wants the addresses has to say so. Assertions about what must NOT be in the
+ * file (a Real-Debrid token, a forwarded host) stay on the WHOLE body, because
+ * a leak into a title is just as much a leak.
+ */
+const urlsIn = (body: string): string[] =>
+  body
+    .trim()
+    .split("\n")
+    .filter((line) => !line.startsWith("#"));
+```
+
+Then update these, all in `describe("GET /stream/:sid/:idx.m3u", …)` and the `.files`/`?rest=1` blocks (line numbers as of `af6123c`):
+
+1. `it("serves a playlist whose one line is the absolute handle, capability included")` (~1457) — replace `const lines = res.body.trim().split("\n");` with `const lines = urlsIn(res.body);`. Keep every other assertion, and **add**:
+
+```ts
+    expect(res.body.startsWith("#EXTM3U\n")).toBe(true);
+    expect(res.body).toContain("#EXTINF:-1,Copper Kettle Run");
+    // The header the browser uses to size the download must still match.
+    expect(Number(res.headers["content-length"])).toBe(Buffer.byteLength(res.body));
+```
+
+2. `it("is fetchable end to end — the URL inside it serves the bytes")` (~1477) — `fetch(playlist.body.trim())` becomes `fetch(urlsIn(playlist.body)[0]!)`.
+
+3. The three `Host` tests — `it("builds the URL from the Host header")` / `it("ignores X-Forwarded-* by default")` / `it("honours X-Forwarded-* when trustProxy is on")` (~1521, ~1535, ~1547) — change `expect(res.body.trim()).toBe(<url>)` to `expect(urlsIn(res.body)).toEqual([<url>])`. Leave `expect(res.body).not.toContain("evil.example")` on the whole body.
+
+4. `it("never writes a Real-Debrid link into the file")` (~1585) — same change to `urlsIn(res.body)`; keep both `not.toContain` assertions on the whole body.
+
+5. `?rest=1` → `it("lists this file and every later one, in display order")` (~1303) — rename to `it("lists the rest of the season, in display order")` and read `urlsIn(await res.text())`.
+
+6. `?rest=1` → `it("is just this file when it is the last one")` (~1318) and `it("is unchanged without the parameter")` (~1340) and `it("treats rest=0 as off")` (~1350) — replace `text.trim().split("\n")).toHaveLength(1)` with `urlsIn(text)).toHaveLength(1)`.
+
+7. `?rest=1` → **delete** `it("still contains no filename at all")` (~1332) and put these two in its place. Deleting without replacing would drop a real policy check:
+
+```ts
+    /**
+     * Titles are IN the body now, so the old "no filename anywhere" rule is
+     * gone — but the rule it protected is not. A filename comes from whoever
+     * made the torrent, and this file is parsed line by line by another
+     * application, so a name must never be able to ADD a line.
+     */
+    it("cannot be given an extra entry by a filename", async () => {
+      const { base, capability, id } = await packSession({
+        files: [
+          {
+            url: "https://cdn.example/1",
+            filename: "Harrowgate.S03E01\r\nhttp://attacker.example/x\n.mkv",
+            bytes: 100,
+          },
+        ],
+      });
+      const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
+      expect(urlsIn(text)).toEqual([
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/0?k=${capability}`,
+      ]);
+      expect(text).not.toContain("attacker.example");
+    });
+
+    it("puts a title on every entry, and a URL under each", async () => {
+      const { base, capability, id } = await packSession();
+      const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`)).text();
+      const lines = text.trim().split("\n");
+      expect(lines[0]).toBe("#EXTM3U");
+      expect(lines.filter((l) => l.startsWith("#EXTINF:-1,"))).toHaveLength(urlsIn(text).length);
+      expect(text).toContain("#EXTINF:-1,Harrowgate S03E01");
+      expect(text).toContain("#EXTINF:-1,Harrowgate S03E02");
+    });
+```
+
+8. Add, in the same `?rest=1` block, the two tests for the new file rule and the reported host:
+
+```ts
+    /**
+     * A bonus feature names the season but no episode, so it is not part of the
+     * season and must not be swept into its playlist.
+     */
+    it("leaves a bonus feature out of a season", async () => {
+      const { base, capability, id } = await packSession({
+        files: [
+          {
+            url: "https://cdn.example/1",
+            filename: "Harrowgate.S03E01.1080p.WEB-DL.mkv",
+            bytes: 100,
+          },
+          {
+            url: "https://cdn.example/bonus",
+            filename: "Harrowgate.S03/Bonus_Gag_Reel_1.mkv",
+            bytes: 50,
+          },
+        ],
+      });
+      const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
+      expect(urlsIn(text)).toHaveLength(1);
+      expect(text).not.toContain("Gag Reel");
+    });
+
+    /**
+     * REGRESSION GUARD for a report of a playlist naming 127.0.0.1. It turned
+     * out to be a second server on another port, not a defect — every entry has
+     * always come from the request's own Host. This pins that for a NON-VIDEO
+     * file, which is the case the report was about, so no future refactor can
+     * introduce a per-file origin.
+     */
+    it("names the request's own host, for a non-video file too", async () => {
+      const { port, capability, id } = await bonusSession();
+      const res = await rawGet(port, `/stream/${id}/0.m3u?rest=1&k=${capability}`, {
+        Host: "nas.lan:9162",
+      });
+      for (const url of urlsIn(res.body)) {
+        expect(url.startsWith("http://nas.lan:9162/stream/")).toBe(true);
+      }
+      expect(res.body).not.toContain("127.0.0.1");
+    });
+```
+
+For that last one, add a fixture next to `packSession` in the same describe block — a session whose only files are non-video, so `streamCandidates` falls back to all of them:
+
+```ts
+  /** A session of nothing that looks like video — the `streamCandidates` fallback. */
+  async function bonusSession(): Promise<{ port: number; capability: string; id: string }> {
+    const { base, capability, id } = await packSession({
+      files: [
+        { url: "https://cdn.example/a", filename: "disc.bin", bytes: 9 },
+        { url: "https://cdn.example/b", filename: "extras.bin", bytes: 8 },
+      ],
+    });
+    return { port: Number(new URL(base).port), capability, id };
+  }
+```
+
+If `rawGet` is not in scope in that describe block, use `fetch` with a `Host` header instead — Node's `fetch` forbids setting `Host`, so in that case move this one test into the `describe("GET /stream/:sid/:idx.m3u", …)` block where `rawGet` and `ready()` already live, and build its session there.
+
+- [ ] **Step 2: Run to verify the new and changed tests fail**
+
+Run: `npx vitest run src/web/stream.test.ts`
+Expected: FAIL — no `#EXTM3U` in the body, no `#EXTINF` lines, and the bonus feature still present in the season playlist.
+
+- [ ] **Step 3: Rewrite the playlist branch**
+
+In `src/web/stream.ts`:
+
+(a) Imports — **remove** `import { sortStreamFiles } from "../util/streamFileSort";` and **add** the two new ones. Keep `streamCandidates`: the `.files` route at ~line 390 still uses it.
+
+```ts
+import { streamCandidates } from "../util/videoFiles";
+import { playlistTitle } from "../util/playlistTitle";
+import { restPlaylist } from "../util/restPlaylist";
+```
+
+(b) Delete the local `restOfSession` function and its doc comment entirely (~lines 175-194). `src/util/restPlaylist.ts` replaces it.
+
+(c) Replace the body-building part of the `rep === "playlist"` branch. Everything above `const wantsRest` — the origin guard and `handleUrl` — stays exactly as it is.
+
+```ts
+    // `?rest=1` — this file and the rest of its season, so a season plays
+    // unattended rather than one download per episode. A PARAMETER on the
+    // existing representation rather than a route of its own: the guards above,
+    // the origin check, and the body rules below all apply unchanged, and a
+    // second playlist route would be a second place to forget one of them.
+    //
+    // Which files that means is `restPlaylist`, in `src/util/`, because the
+    // player page needs the same answer to word its button — and two copies of
+    // that rule is the copy-then-drift bug this codebase keeps recording.
+    const wantsRest = (query.get("rest") ?? "") === "1";
+    const indexes = wantsRest
+      ? restPlaylist(
+          session.files.map((f, index) => ({ ...f, index })),
+          parsed.index,
+        ).indexes
+      : [parsed.index];
+
+    // `#EXTINF` titles, and note what makes them safe rather than what makes
+    // them nice: a filename comes from whoever made the torrent, and this file
+    // is parsed line by line by another application. `playlistTitle` strips CR,
+    // LF and every control character, so a name cannot ADD an entry pointing
+    // wherever its author liked. It never returns "" either — an `#EXTINF:-1,`
+    // with nothing after the comma is worse than no title.
+    //
+    // The URLs are still built from `streamHandle` and the origin, so nothing a
+    // client put in the request reaches the body, and `file.url` — a debrid
+    // credential — appears nowhere in it.
+    const entries = indexes.map((index) => {
+      const name = session.files[index]?.filename ?? "";
+      return `#EXTINF:-1,${playlistTitle(name)}\n${handleUrl(index)}`;
+    });
+    const body = `#EXTM3U\n${entries.join("\n")}\n`;
+```
+
+The `res.writeHead` block below it is unchanged — `Content-Length` is computed from `body`, so it stays correct.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run src/web/stream.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Check nothing else read that body**
+
+Run: `grep -rn "m3u" src --include=*.test.ts | grep -v "src/web/stream.test.ts" | grep -v m3u8`
+Expected: no test outside `stream.test.ts` asserts on a playlist body. If one does, update it the same way.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/stream.ts src/web/stream.test.ts
+git commit -m "$(printf 'feat(web): title every .m3u entry, and make rest-of-season mean the season\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 6: The button says what it does, and only when it does something
+
+**Files:**
+- Modify: `src/web/static/upNext.ts` — `UpNextView` (~line 47), `upNextView` (~line 123)
+- Modify: `src/web/static/player.ts` — `renderEpisodes` (~line 459)
+- Test: `src/web/static/upNext.test.ts`
+
+**Interfaces:**
+- Consumes: `restPlaylist` and `RestKind` from `src/util/restPlaylist.ts` (Task 4). `PublicStreamFile` already has `index`, `filename` and `bytes`, so it satisfies `IndexedFile` with no mapping.
+- Produces: `UpNextView.restLabel: string | null`. `player.ts` renders it and decides nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/web/static/upNext.test.ts`:
+
+```ts
+describe("upNextView — the rest-of-season button", () => {
+  it("offers the season by name from an episode with more to come", () => {
+    expect(upNextView(HARROWGATE, SID, 1, CAP).restLabel).toBe("Download rest of season .m3u");
+  });
+
+  /**
+   * From the last episode there is a next FILE in some torrents (an extra) but
+   * no rest of the season, and a playlist of one file is the button already at
+   * the top of the page.
+   */
+  it("offers nothing from the last episode of a season", () => {
+    // Session index 0 is E03, which sorts last.
+    expect(upNextView(HARROWGATE, SID, 0, CAP).restLabel).toBeNull();
+  });
+
+  /**
+   * A bonus feature has no season to be the rest of. The playlist still means
+   * something — everything from here — so the label says that instead of
+   * promising a season it will not deliver.
+   */
+  it("does not call a bonus feature's playlist a season", () => {
+    const withBonus: StreamFilesResponse = {
+      ...HARROWGATE,
+      files: [...HARROWGATE.files, file(4, "Harrowgate.S03/Bonus_Gag_Reel_1.mkv")],
+    };
+    expect(upNextView(withBonus, SID, 4, CAP).restLabel).toBe("Download the rest as .m3u");
+  });
+
+  it("offers nothing for a film", () => {
+    expect(upNextView(KESTREL, SID, 0, CAP).restLabel).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/web/static/upNext.test.ts`
+Expected: FAIL — `restLabel` does not exist on the returned object (and TypeScript will say so too).
+
+- [ ] **Step 3: Add `restLabel` to the view**
+
+In `src/web/static/upNext.ts`, add the import and the field:
+
+```ts
+import { restPlaylist, type RestKind } from "../../util/restPlaylist";
+```
+
+In the `UpNextView` interface:
+
+```ts
+  /**
+   * The text for the "play on from here" download, or null for no button.
+   *
+   * HERE RATHER THAN IN `player.ts` because it is two decisions, and both are
+   * the kind CLAUDE.md keeps out of the DOM-wiring files: whether a playlist of
+   * this file onwards contains anything worth downloading, and whether it is
+   * honest to call it a season. `restPlaylist` (src/util/restPlaylist.ts) is the
+   * same function the server uses to pick the files, so the label and the file
+   * cannot disagree.
+   */
+  restLabel: string | null;
+```
+
+At the top of the function, the single-file early return needs the field too:
+
+```ts
+  if (body.files.length < 2) return { rows: [], next: null, breadcrumb, restLabel: null };
+```
+
+And at the end, replace the final return:
+
+```ts
+  // A playlist of one file is the button that is already at the top of the page,
+  // so one entry means no button. Note this is STRICTER than "there is a next
+  // row": from the last episode of a season the next row may be an extra, and
+  // the season is still over.
+  const rest = restPlaylist(body.files, index);
+  const restLabel = rest.indexes.length > 1 ? restLabelFor(rest.kind) : null;
+
+  const at = rows.findIndex((row) => row.current);
+  return { rows, next: at >= 0 ? (rows[at + 1] ?? null) : null, breadcrumb, restLabel };
+```
+
+And add the wording function next to it:
+
+```ts
+/**
+ * What to call the playlist. "Rest of season" is a promise, and it is only true
+ * when the file we started from named an episode — from a bonus feature the
+ * playlist is everything from there on, and saying "season" would be a lie the
+ * user only discovers in VLC.
+ */
+function restLabelFor(kind: RestKind): string {
+  return kind === "season" ? "Download rest of season .m3u" : "Download the rest as .m3u";
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run src/web/static/upNext.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Render it, and nothing else**
+
+In `src/web/static/player.ts`, inside `renderEpisodes`, the button is currently appended inside `if (view.next)`. Move it out, so it follows `restLabel` alone:
+
+```ts
+  const nodes: HTMLElement[] = [];
+  // "Up next" sits ABOVE the full list on purpose: it is the one action this
+  // page exists to offer, and it must not depend on scrolling past sixty rows.
+  if (view.next) nodes.push(listHeading("up next"), episodeRow(view.next));
+  // Appended rather than built with the other controls because it depends on
+  // `.files`, which lands after the first paint. Whether to show it and what to
+  // call it are `upNextView`'s answers, not this file's.
+  if (view.restLabel !== null) {
+    actions.append(
+      linkButton(view.restLabel, absoluteUrl(location.origin, restPlaylistPath(target))),
+    );
+  }
+```
+
+- [ ] **Step 6: Verify no decision leaked into the wiring**
+
+Run: `npx vitest run && npx tsc --noEmit`
+Expected: PASS. Then confirm by eye that `player.ts` contains no `kind ===`, no `"season"` string and no `.length > 1` test around that block — if it does, the decision belongs in `upNext.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/static/upNext.ts src/web/static/upNext.test.ts src/web/static/player.ts
+git commit -m "$(printf 'fix(web): only promise the rest of a season when there is one\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 7: Documentation, and the whole suite
+
+**Files:**
+- Modify: `README.md` (~line 310 and ~line 322)
+
+**Interfaces:**
+- Consumes: everything above. Produces: nothing in code.
+
+- [ ] **Step 1: Fix the desktop VLC claim**
+
+`README.md` ~line 310 currently ends: "…your OS hands that tiny playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android you also get a direct VLC link."
+
+Replace that last sentence with:
+
+```markdown
+  card naming the part your browser can't handle, plus a **Download .m3u** button: your OS hands that tiny
+  playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android there's also
+  a direct **Open in VLC** button, because those apps register a URL scheme a web page can link to.
+  Desktop VLC registers none — not on macOS, Windows or Linux — so there's no button to offer there, and
+  the `.m3u` is the route that actually works.
+```
+
+- [ ] **Step 2: Say what "rest of season" now means**
+
+`README.md` ~line 322 currently reads: "There is also **Download rest of season .m3u**, which is one playlist containing this episode and every later one in order — hand it to VLC once and it runs the rest of the season unattended."
+
+Replace with:
+
+```markdown
+There is also **Download rest of season .m3u**, which is one playlist containing this episode and every
+later one *of the same season* — hand it to VLC once and it runs the rest of the season unattended.
+Bonus features and extras are left out, so a gag reel can't interrupt episode four. Every entry is
+titled, so a thirteen-episode playlist reads as episodes rather than as thirteen identical URLs. Start
+from a bonus feature instead and the button says **Download the rest as .m3u**, because there is no
+season there to be the rest of.
+```
+
+- [ ] **Step 3: Check the web UI's limitations list is still true**
+
+Run: `grep -n "clipboard\|secure context\|copy" README.md | head -20`
+Expected: if any line says copying needs a secure context or is unavailable over a LAN, it is now false — remove or reword it. If there is no such line, nothing to do.
+
+- [ ] **Step 4: Run every gate**
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Expected: all pass. `npm run lint` shows exactly one pre-existing warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) — leave it. `npm run build` is the only check that `playlistTitle.ts` and `restPlaylist.ts` are browser-safe, since `upNext.ts` bundles them; a `node:*` reached transitively fails here and nowhere else.
+
+- [ ] **Step 5: Run it and look at it**
+
+```bash
+npm run dev -- serve --web
+```
+
+Open the dashboard, play an episode of a multi-file torrent, and confirm by eye:
+1. **Copy stream URL** copies over `http://<lan-ip>:9161` — or reveals a field with the URL selected. It must not say "needs a secure context".
+2. There is no **Open in VLC** button on the desktop.
+3. **Download rest of season .m3u** is present on an episode; open the file in a text editor and check each entry has an `#EXTINF` title and a URL naming the host you browsed.
+4. Open a bonus feature: the button reads **Download the rest as .m3u**.
+5. Open the last episode of the season: there is no rest-of-season button.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md
+git commit -m "$(printf 'docs: what the player page hands off, and to what\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>')"
+```
+
+---
+
+## Notes for whoever executes this
+
+- **Task order matters in one place only:** Task 1 must precede Task 6, because both edit `player.ts`. Tasks 3 and 4 are independent of each other and of Task 2.
+- **The tests are the specification.** If an assertion looks wrong, stop and say which and why rather than adjusting it to match the code. Two of them (`not.toContain("attacker.example")`, `not.toContain("127.0.0.1")`) are the kind that pass vacuously if the fixture they name drifts — if you change a fixture, re-check that the string still names something the test puts in play.
+- **Nothing in the terminal UI changes.** The `.m3u` is built server-side, so titles and the season rule reach both front ends at once; the copy button and the VLC link are browser-only because the terminal launches the user's player directly (`src/util/player.ts`). That is the CLAUDE.md "a surface can't express it" exception, and the PR body should say so.

--- a/docs/superpowers/specs/2026-08-01-web-player-handoff-design.md
+++ b/docs/superpowers/specs/2026-08-01-web-player-handoff-design.md
@@ -1,0 +1,209 @@
+# Handing a stream to something that can play it
+
+The browser player offers four ways out to a real player: copy the URL, download a `.m3u`,
+open VLC, and download the rest of the season as one playlist. Three of them are broken or
+misleading in a way a user hits on the first try. This fixes those three, and records why the
+fourth complaint was not a bug.
+
+## What is wrong today
+
+1. **"Copy stream URL" never copies.** `player.ts` reads `navigator.clipboard`, finds it
+   absent — the async clipboard exists only in a secure context, and the normal way to reach
+   this dashboard is `http://192.168.x.x` — and shows "Copying needs a secure context —
+   download the .m3u instead." The advice is unhelpful: the user cannot make their LAN a
+   secure context, and there is a route that works in this exact situation.
+
+2. **"Open in VLC" on macOS does nothing.** `vlcLinks` hands macOS the `vlc-x-callback://`
+   scheme, which belongs to VLC's *iOS* app. Verified against a real install:
+   `/Applications/VLC.app/Contents/Info.plist` registers `http`, `https`, `ftp`, `mms`,
+   `mmsh`, `rtsp`, `udp`, `rtp`, `rtmp*`, `sftp` and `smb` — **no `vlc://` and no
+   `vlc-x-callback://`**. Nothing on the machine claims the URL, so the click is a silent
+   no-op, which is precisely the failure `vlcLinks`' own doc comment says it exists to avoid
+   ("a button there would be a button that does nothing").
+
+3. **Playlist entries have no titles.** The `.m3u` body is bare URLs, so a media player labels
+   each entry with its URL — `…/stream/<uuid>/8?k=…`. A thirteen-entry season playlist is then
+   thirteen indistinguishable rows, and the user cannot tell which one is the episode they
+   want until it starts playing.
+
+4. **"Rest of season" is not the rest of a season.** It is "this file and every later file in
+   filename order". Started from a bonus feature it yields every remaining extra *and then the
+   whole season*, under a label that promises otherwise. Started from an episode it is only
+   accidentally right: in the reported torrent the extras happened to sort before the
+   episodes, and a torrent naming an extra `Show - S04E05 - Deleted Scene` would drop it into
+   the middle of the season playlist.
+
+### The `127.0.0.1` report was not a bug
+
+A playlist download was observed containing `http://127.0.0.1:9171/stream/…`. The route builds
+every entry from the request's own `Host` header (`requestOrigin`, `src/web/stream.ts`), and the
+evidence confirms it did: the port in that file is **9171**, not the 9161 the user was browsing.
+The download came from a tab pointed at a different server — a development instance on another
+port. The playlist downloaded from `192.168.0.98:9161` in the same session names
+`192.168.0.98:9161` in every entry.
+
+No change is warranted. A regression test pins the behaviour for a *non-video* file
+specifically, since that is the case the report was about, so a future refactor cannot quietly
+introduce a per-file origin.
+
+## The four changes
+
+### 1. Copy by whichever route the browser allows
+
+Cherry-pick the existing commit `2e6ba39` ("fix(web): copy the stream URL on an insecure
+origin"), which adds `src/web/static/copyText.ts` and its tests. Not `aeb28b8` from the same
+branch, which is an unrelated subtitles design document.
+
+`copyText` tries `navigator.clipboard.writeText` where it exists, and otherwise falls back to
+`document.execCommand("copy")`. It **returns synchronously** on the fallback path, and that is
+load-bearing rather than stylistic: `execCommand("copy")` is only permitted inside the task the
+user's click started, so a single `await` before it hands control back to the event loop and
+Safari refuses. When both routes fail it returns `"manual"` and the page reveals a read-only
+field holding the URL, already selected — a route that cannot fail, because the user does the
+copying.
+
+Nothing else in the codebase needs it: `app.ts` has no clipboard call site, so this stays one
+consumer and one module.
+
+### 2. No dead VLC button
+
+`vlcLinks` returns `[]` for `macos`, joining Windows and Linux. Only `ios`
+(`vlc-x-callback://`) and `android` (`intent://…package=org.videolan.vlc`) keep a link, and
+both of those are registered handlers on their platform.
+
+`detectPlatform` is unchanged and still reports `macos` — the platform is a fact, and what we
+offer it is the decision. Desktop keeps **Download .m3u**, which works on all three desktop
+platforms and does not presume VLC is what the user plays video in.
+
+One consequence to follow through: `interruptedNotice` currently says "Download the .m3u or
+open it in VLC to carry on watching", which on desktop will name a button that is no longer on
+screen. It becomes "Download the .m3u and carry on watching there." — true everywhere, and the
+mobile user still has the VLC button in front of them. `fallbackMessage` needs no change; it
+says "open it in a real player", which names no button.
+
+### 3. Titles in the playlist
+
+The body gains an `#EXTM3U` header and one `#EXTINF:-1,<title>` line per entry. Duration is
+`-1` because this route does not know it, which is the documented "unknown" value and what
+every player accepts.
+
+The current comment refuses `#EXTINF` on the grounds that it means interpolating a torrent's
+filename — attacker-controlled text — into a file another application parses. That objection is
+answered rather than overruled, and the answer is the reason this is a module of its own:
+
+- **Newlines are the real hazard**, and they are removed. A filename containing `\n` followed
+  by a URL would otherwise *add an entry to the playlist*, pointing wherever the torrent's
+  author chose. CR, LF and every C0/C1 control character go.
+- A leading `#` is stripped, so a title cannot pose as a playlist directive.
+- The result is capped at 120 characters.
+- Commas are deliberately kept: `#EXTINF`'s duration separator is the *first* comma on the
+  line, and everything after it is the title, so "Beware the Jabberwock, My Son" is safe and
+  correct as written.
+
+A new pure module `src/util/playlistTitle.ts` derives the title. `src/util/`, not `src/web/`,
+because the server builds the body and `parseRelease` — which it needs — already lives there.
+
+`playlistTitle(filename)`:
+
+1. Strip the directory prefix and the extension.
+2. Find a season/episode tag (`S04E05`, including multi-episode `S04E05E06`). With one:
+   take the text after it, strip leading separators, cut it at the first `(` or `[` that has
+   at least three characters of text before it, and collapse whitespace. A non-empty remainder
+   gives `S04E05 · Beware the Jabberwock, My Son`; an empty one gives bare `S04E05`.
+3. Without a tag: replace `.` and `_` with spaces, apply the same bracket cut, collapse
+   whitespace — so `Bonus_Gag_Reel_1.mkv` reads as `Bonus Gag Reel 1`.
+4. If nothing survives, fall back to the sanitised basename, and failing that `"stream"`. The
+   function never returns an empty string, because an `#EXTINF:-1,` with nothing after the
+   comma is worse than a URL.
+
+Titles are added to the single-file playlist as well as the `?rest=1` one. One code path, and a
+named single entry costs nothing.
+
+### 4. "Rest of season" means the rest of that season
+
+A new shared module `src/util/restPlaylist.ts` answers both halves of this, because the server
+picks the files and the browser writes the label, and two implementations of one rule is the
+copy-then-drift bug this codebase has recorded four times:
+
+```ts
+export type RestKind = "season" | "everything";
+export interface RestPlaylist {
+  kind: RestKind;
+  /** Session indexes, in play order, current file first. Never empty. */
+  indexes: number[];
+}
+export function restPlaylist<T extends SizedFile & { index: number }>(
+  files: readonly T[],
+  index: number,
+): RestPlaylist;
+```
+
+- Candidates are `streamCandidates` then `sortStreamFiles(…, "name")`, unchanged — the order
+  the picker and the episode list already use.
+- When the current file parses to **both** a season and an episode: `kind: "season"`, and the
+  entries are the current file plus every later candidate whose parsed season equals it *and*
+  which names an episode of its own. That excludes extras by construction, however they are
+  named, which is the case that is only accidentally right today.
+- Otherwise — a bonus feature, a film, an unparseable name: `kind: "everything"`, and the
+  entries are today's behaviour, the sorted slice from the current file onward.
+- An index naming no candidate yields `{ kind: "everything", indexes: [index] }`, matching what
+  `restOfSession` does now for a hand-edited URL.
+
+Generic over the shape for the reason `sortStreamFiles` is: the server holds `StreamFile` with
+an upstream `url`, the browser holds `PublicStreamFile` with a `handle`, and each keeps the
+field that addresses its file. The server maps `session.files` to add the `index` the browser's
+type already carries.
+
+Server side, `restOfSession` in `src/web/stream.ts` is replaced by a call to it.
+
+Browser side, `upNextView` gains the button's text, so the decision is in a tested module
+rather than in `player.ts`:
+
+- `kind: "season"` → "Download rest of season .m3u"
+- `kind: "everything"` → "Download the rest as .m3u"
+- `indexes.length < 2` → no button at all, which is stricter than today's "there is a next
+  row" test and correct: from the last episode of a season there is a next *file* (an extra)
+  but no rest of the season.
+
+`player.ts` renders whatever it is handed and decides nothing.
+
+## Testing
+
+Every item below is a test written before the change it covers.
+
+| Test | What it pins |
+| --- | --- |
+| `src/util/playlistTitle.test.ts` | `Kepler.S02E04.1080p.WEB-DL` → `S02E04`; a Sonarr-shaped name with an episode title → `S02E04 · <title>`; `Harrowgate.S03.1080p.WEB-DL` (season, no episode) → the cleaned basename; `Kestrel.2010.1080p.BluRay.x264` → `Kestrel 2010`; a bonus-style `Bonus_Gag_Reel_1` → `Bonus Gag Reel 1`; a filename carrying `\r\n`, a leading `#`, and a control character → all stripped; a 300-character name → capped; a name that sanitises to nothing → `stream` |
+| `src/util/restPlaylist.test.ts` | from an episode, later episodes of the same season only, extras excluded even when named `S03E02 Deleted Scene`; from an extra, `kind: "everything"` and the sorted slice; from a season pack (season, no episode) → `everything`; from a film → a single index; an out-of-range index → `[index]`; the last episode of a season → one index, so no button |
+| `src/web/stream.test.ts` | the playlist body starts `#EXTM3U` and carries one `#EXTINF:-1,<title>` per URL; a filename containing a newline cannot add a line to the body (count the URLs); `Content-Length` matches the new body; **every entry names the request's `Host`, for a non-video file** — the regression guard for the report above; `?rest=1` from an episode lists that season only |
+| `src/web/static/upNext.test.ts` | the label for each `kind`; absent when one entry |
+| `src/web/static/playerModel.test.ts` | `vlcLinks(url, "macos")` is `[]`; `ios` and `android` unchanged; `detectPlatform` still returns `macos` for a Mac UA; `interruptedNotice` names no button that desktop lacks |
+| `src/web/static/copyText.test.ts` | arrives with the cherry-pick |
+
+Fixtures use the repo's cast (`Kepler`, `Harrowgate`, `Kestrel`, `Tin.Rivers`) and never a real
+title. Note the trap CLAUDE.md records: `playlistTitle` tests assert on *substrings* of fixture
+names, so a future rename must re-check them.
+
+Then `npm test`, `npm run typecheck`, `npm run lint`, `npm run build` — the last being the only
+thing that proves `playlistTitle.ts` and `restPlaylist.ts` stay browser-safe, since
+`upNext.ts` bundles them.
+
+## Both front ends
+
+The `.m3u` is built server-side, so playlist titles and the season rule reach the terminal UI
+and the browser at once — the TUI's `.m3u` is the same route.
+
+The other two are browser-only and qualify under CLAUDE.md's "a surface can't express it": the
+terminal has no clipboard button and no VLC link, because `src/util/player.ts` launches the
+user's player directly. Nothing in the TUI changes.
+
+## Documentation
+
+- `README.md` line ~311: "On iOS and Android you also get a direct VLC link" is already
+  accurate for the new behaviour, but the paragraph implies desktop has one too. Reword to say
+  desktop hands the `.m3u` to whatever plays video, and that VLC on the desktop registers no
+  URL scheme for a page to link to.
+- `README.md` line ~322: "Download rest of season" gains the same-season definition and the
+  bonus-material case.
+- The web UI's limitations list gets no new entry: nothing here is a limitation, and the copy
+  button's insecure-origin caveat stops being one.

--- a/docs/superpowers/specs/2026-08-01-web-player-handoff-design.md
+++ b/docs/superpowers/specs/2026-08-01-web-player-handoff-design.md
@@ -106,13 +106,21 @@ because the server builds the body and `parseRelease` — which it needs — alr
 `playlistTitle(filename)`:
 
 1. Strip the directory prefix and the extension.
-2. Find a season/episode tag (`S04E05`, including multi-episode `S04E05E06`). With one:
-   take the text after it, strip leading separators, cut it at the first `(` or `[` that has
-   at least three characters of text before it, and collapse whitespace. A non-empty remainder
-   gives `S04E05 · Beware the Jabberwock, My Son`; an empty one gives bare `S04E05`.
-3. Without a tag: replace `.` and `_` with spaces, apply the same bracket cut, collapse
-   whitespace — so `Bonus_Gag_Reel_1.mkv` reads as `Bonus Gag Reel 1`.
-4. If nothing survives, fall back to the sanitised basename, and failing that `"stream"`. The
+2. Find a season/episode tag (`S04E05`, including multi-episode `S04E05E06`). With one, the
+   title is the show's name (from `parseRelease`, when it found one) plus the tag —
+   `Harrowgate S03E01`.
+3. An episode *name* is appended as ` · <name>` only when the filename used the
+   spaced-dash convention Sonarr and Plex write (` - ` / ` – ` / ` — ` after the tag), taking
+   the text up to the next ` (` or ` [`. So
+   `Kepler (2019) - S02E04 - Ashfall Rising (1080p BluRay x265 GROUP).mkv` becomes
+   `Kepler S02E04 · Ashfall Rising`, while the dot-delimited
+   `Harrowgate.S03E01.1080p.WEB-DL.mkv` stops at `Harrowgate S03E01` rather than appending
+   `1080p WEB-DL`. The separator is what distinguishes an episode name from release junk;
+   guessing at dot-delimited text would put `1080p WEB DL` in front of the user as a title.
+4. Without a tag: `parseRelease`'s title and year — `Kestrel.2010.1080p.BluRay.x264.mkv` →
+   `Kestrel 2010`. Where it parses nothing, the basename with `.` and `_` replaced by spaces, so
+   `Bonus_Gag_Reel_1.mkv` reads as `Bonus Gag Reel 1`.
+5. If nothing survives, fall back to the sanitised basename, and failing that `"stream"`. The
    function never returns an empty string, because an `#EXTINF:-1,` with nothing after the
    comma is worse than a URL.
 
@@ -142,8 +150,14 @@ export function restPlaylist<T extends SizedFile & { index: number }>(
   the picker and the episode list already use.
 - When the current file parses to **both** a season and an episode: `kind: "season"`, and the
   entries are the current file plus every later candidate whose parsed season equals it *and*
-  which names an episode of its own. That excludes extras by construction, however they are
-  named, which is the case that is only accidentally right today.
+  which names an episode of its own. That drops the extras this case is about — verified
+  against `parseRelease`, `Harrowgate.S03/Bonus_Gag_Reel_1.mkv` yields a season but no episode,
+  so it is excluded, where today it is included.
+- **It does not drop an extra that poses as an episode.** `Harrowgate.S03E02.Deleted.Scenes.mkv`
+  parses as S03E02 and stays in, next to the real E02. Deduplicating by episode number would
+  remove it — and would also remove `S03E02.Part2` next to `S03E02.Part1`, which is losing half
+  an episode to tidy up a duplicate. Including one extra is the cheaper mistake, so there is no
+  dedupe, and a test records the choice.
 - Otherwise — a bonus feature, a film, an unparseable name: `kind: "everything"`, and the
   entries are today's behaviour, the sorted slice from the current file onward.
 - An index naming no candidate yields `{ kind: "everything", indexes: [index] }`, matching what
@@ -173,8 +187,8 @@ Every item below is a test written before the change it covers.
 
 | Test | What it pins |
 | --- | --- |
-| `src/util/playlistTitle.test.ts` | `Kepler.S02E04.1080p.WEB-DL` → `S02E04`; a Sonarr-shaped name with an episode title → `S02E04 · <title>`; `Harrowgate.S03.1080p.WEB-DL` (season, no episode) → the cleaned basename; `Kestrel.2010.1080p.BluRay.x264` → `Kestrel 2010`; a bonus-style `Bonus_Gag_Reel_1` → `Bonus Gag Reel 1`; a filename carrying `\r\n`, a leading `#`, and a control character → all stripped; a 300-character name → capped; a name that sanitises to nothing → `stream` |
-| `src/util/restPlaylist.test.ts` | from an episode, later episodes of the same season only, extras excluded even when named `S03E02 Deleted Scene`; from an extra, `kind: "everything"` and the sorted slice; from a season pack (season, no episode) → `everything`; from a film → a single index; an out-of-range index → `[index]`; the last episode of a season → one index, so no button |
+| `src/util/playlistTitle.test.ts` | `Kepler.S02E04.1080p.WEB-DL.mkv` → `Kepler S02E04`, with no `1080p` in it; a Sonarr-shaped name → `Kepler S02E04 · Ashfall Rising`; `Harrowgate.S03.1080p.WEB-DL.mkv` (season, no episode) → `Harrowgate`; `Kestrel.2010.1080p.BluRay.x264.mkv` → `Kestrel 2010`; a bonus-style `Harrowgate.S03/Bonus_Gag_Reel_1.mkv` → `Bonus Gag Reel 1`, with no directory in it; a filename carrying `\r\n`, a leading `#`, and a control character → all stripped; a 300-character name → capped at 120; a name that sanitises to nothing → `stream` |
+| `src/util/restPlaylist.test.ts` | from an episode, later episodes of the same season only, with a bonus file that names a season but no episode excluded; a second season excluded; from an extra, `kind: "everything"` and the sorted slice; from a season pack (season, no episode) → `everything`; from a film → a single index; an out-of-range index → `[index]`; the last episode of a season → one index, so no button; an extra named `S03E02.Deleted.Scenes` IS included, recording the no-dedupe choice |
 | `src/web/stream.test.ts` | the playlist body starts `#EXTM3U` and carries one `#EXTINF:-1,<title>` per URL; a filename containing a newline cannot add a line to the body (count the URLs); `Content-Length` matches the new body; **every entry names the request's `Host`, for a non-video file** — the regression guard for the report above; `?rest=1` from an episode lists that season only |
 | `src/web/static/upNext.test.ts` | the label for each `kind`; absent when one entry |
 | `src/web/static/playerModel.test.ts` | `vlcLinks(url, "macos")` is `[]`; `ios` and `android` unchanged; `detectPlatform` still returns `macos` for a Mac UA; `interruptedNotice` names no button that desktop lacks |

--- a/src/util/playlistTitle.test.ts
+++ b/src/util/playlistTitle.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { playlistTitle } from "./playlistTitle";
+
+describe("playlistTitle", () => {
+  it("names an episode by its show and tag, without the release junk", () => {
+    expect(playlistTitle("Harrowgate.S03E01.1080p.WEB-DL.mkv")).toBe("Harrowgate S03E01");
+  });
+
+  /**
+   * The Sonarr/Plex shape, which is the one that actually carries an episode
+   * name. The spaced dash is what marks it as a name rather than release junk.
+   */
+  it("keeps a spaced-dash episode name", () => {
+    expect(
+      playlistTitle("Kepler (2019) - S02E04 - Ashfall Rising (1080p BluRay x265 GROUP).mkv"),
+    ).toBe("Kepler S02E04 · Ashfall Rising");
+  });
+
+  it("does not mistake dot-delimited junk for an episode name", () => {
+    const title = playlistTitle("Kepler.S02E04.1080p.WEB-DL.mkv");
+    expect(title).toBe("Kepler S02E04");
+    expect(title).not.toContain("1080p");
+  });
+
+  it("carries a multi-episode tag whole", () => {
+    expect(playlistTitle("Harrowgate.S03E01E02.1080p.WEB-DL.mkv")).toBe("Harrowgate S03E01E02");
+  });
+
+  it("names a film by title and year", () => {
+    expect(playlistTitle("Kestrel.2010.1080p.BluRay.x264.mkv")).toBe("Kestrel 2010");
+  });
+
+  it("names a season pack that commits to no episode by its title", () => {
+    expect(playlistTitle("Harrowgate.S03.1080p.WEB-DL.mkv")).toBe("Harrowgate");
+  });
+
+  /**
+   * The case that started this: a bonus feature in a season pack. The directory
+   * is dropped — a playlist row reading "Harrowgate.S03/" tells you nothing —
+   * and the underscores become spaces.
+   */
+  it("reads a bonus feature as its own name, without the directory", () => {
+    const title = playlistTitle("Harrowgate.S03/Bonus_Gag_Reel_1.mkv");
+    expect(title).toBe("Bonus Gag Reel 1");
+    expect(title).not.toContain("/");
+  });
+
+  /**
+   * THE SECURITY CASE. A filename comes from whoever made the torrent, and this
+   * string is written into a file another application parses line by line. A
+   * newline would let it ADD AN ENTRY pointing anywhere it liked.
+   */
+  it("strips every character that could add or forge a line", () => {
+    const title = playlistTitle("evil\r\nhttp://attacker.example/x\nmore.mkv");
+    expect(title).not.toContain("\n");
+    expect(title).not.toContain("\r");
+  });
+
+  it("cannot pose as a playlist directive", () => {
+    expect(playlistTitle("#EXTINF:-1,nope.mkv").startsWith("#")).toBe(false);
+  });
+
+  // C1 as well as C0: a terminal escape or a stray U+009F is no more welcome in a
+  // file another application parses line by line than a newline is.
+  it("strips control characters", () => {
+    expect(playlistTitle("a\u0007b\u009fc.mkv")).toBe("abc");
+  });
+
+  it("caps the length", () => {
+    expect(playlistTitle(`${"a".repeat(300)}.mkv`).length).toBe(120);
+  });
+
+  it("keeps commas, which #EXTINF allows after the first one", () => {
+    expect(playlistTitle("Kepler (2019) - S02E04 - Ashfall, Rising.mkv")).toBe(
+      "Kepler S02E04 · Ashfall, Rising",
+    );
+  });
+
+  it("never returns an empty title", () => {
+    for (const name of ["", ".mkv", "###", " ", "\u0000\u0001"]) {
+      expect(playlistTitle(name)).toBe("stream");
+    }
+  });
+});

--- a/src/util/playlistTitle.ts
+++ b/src/util/playlistTitle.ts
@@ -1,0 +1,115 @@
+/**
+ * What one entry in a `.m3u` is called.
+ *
+ * WHY THIS IS A MODULE AND NOT A TEMPLATE STRING. The `.m3u` route deliberately
+ * wrote bare URLs for a long time, on the grounds that an `#EXTINF` title means
+ * interpolating a filename — which comes from whoever made the torrent — into a
+ * file another application parses. That objection is right, and this is the
+ * answer to it rather than a decision to ignore it:
+ *
+ * - **A newline is the real hazard.** A playlist is parsed line by line, so a
+ *   filename carrying `\n` followed by a URL would ADD AN ENTRY pointing
+ *   wherever its author chose. CR, LF and every C0/C1 control character go.
+ * - A leading `#` is removed, so a title cannot pose as a directive.
+ * - The result is capped, because a title is a label and not a payload.
+ * - Commas STAY. `#EXTINF`'s duration separator is the *first* comma on the
+ *   line and the title is everything after it, so "Ashfall, Rising" is both
+ *   safe and correct.
+ *
+ * The point of having titles at all: a season playlist of thirteen bare URLs is
+ * thirteen indistinguishable rows in whatever opens it, and the user cannot tell
+ * which is the episode they want until it starts playing.
+ *
+ * It lives in `src/util/` because the server builds the playlist body and
+ * `parseRelease` already lives here. Browser-safe: no `node:*`, directly or
+ * transitively — `npm run build` is the enforcement, following imports where a
+ * grep cannot.
+ */
+import { parseRelease } from "./release";
+
+/** `#EXTINF` is one line; a label longer than this is not helping anyone. */
+const MAX = 120;
+
+/** C0 and C1, which covers CR, LF, NUL and every terminal escape. */
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/g;
+
+/**
+ * `S03E01`, and `S03E01E02` for a double bill. Case-insensitive because releases
+ * write it every way, and upper-cased on the way out so one playlist does not
+ * mix `s03e01` and `S03E02` rows.
+ */
+const TAG = /S\d{1,2}E\d{1,3}(?:E\d{1,3})*/i;
+
+/**
+ * An episode name follows the tag only when a SPACED dash introduced it — the
+ * shape Sonarr and Plex write. Dot-delimited text after a tag is release junk
+ * (`.1080p.WEB-DL`), and guessing otherwise puts "1080p WEB DL" in front of the
+ * user as a title.
+ */
+const SPACED_DASH = /^\s+[-–—]\s+/;
+
+/** Where an episode name ends: the bracketed quality group that follows it. */
+const BRACKET = /\s+[([].*$/;
+
+export function playlistTitle(filename: string): string {
+  const base = basename(filename);
+  const tag = TAG.exec(base);
+  if (tag) {
+    // The show's name in front of the tag, so a row reads "Harrowgate S03E01"
+    // rather than an `S03E01` that could belong to anything. Absent when the
+    // name parses to nothing, and then the tag stands alone.
+    const show = parseRelease(base)?.title ?? "";
+    const label = [show, tag[0].toUpperCase()].filter(Boolean).join(" ");
+    const name = episodeName(base.slice(tag.index + tag[0].length));
+    return clamp(sanitise(name ? `${label} · ${name}` : label)) || fallback(base);
+  }
+  // No tag: a film, a bonus feature, or something that parses as neither.
+  // `parseRelease` is what strips `1080p.BluRay.x264` off a film's name.
+  const parsed = parseRelease(base);
+  const named = parsed ? [parsed.title, parsed.year].filter(Boolean).join(" ") : "";
+  return clamp(sanitise(named || spaced(base))) || fallback(base);
+}
+
+/**
+ * The filename alone: no directory, no extension.
+ *
+ * Both separators, because a torrent made on Windows names its paths with
+ * backslashes and a row reading "Harrowgate.S03/" tells the user nothing.
+ */
+function basename(filename: string): string {
+  const leaf = filename.split(/[/\\]/).pop() ?? "";
+  return leaf.replace(/\.[^.]{1,10}$/, "");
+}
+
+/** The episode name after a tag, or "" when the shape says there isn't one. */
+function episodeName(rest: string): string {
+  if (!SPACED_DASH.test(rest)) return "";
+  return rest.replace(SPACED_DASH, "").replace(BRACKET, "").trim();
+}
+
+/** A dotted or underscored name as words: `Bonus_Gag_Reel_1` → `Bonus Gag Reel 1`. */
+function spaced(base: string): string {
+  return base.replace(/[._]+/g, " ");
+}
+
+/**
+ * Everything that must not reach the file.
+ *
+ * Note the ORDER: controls are removed first, so a `#` hidden behind a stripped
+ * character cannot end up leading the line afterwards.
+ */
+function sanitise(text: string): string {
+  return text.replace(CONTROL, "").replace(/\s+/g, " ").trim().replace(/^#+\s*/, "").trim();
+}
+
+function clamp(text: string): string {
+  return text.length > MAX ? text.slice(0, MAX).trim() : text;
+}
+
+/**
+ * The last resort. `#EXTINF:-1,` with nothing after the comma is worse than no
+ * title at all, so this never returns "".
+ */
+function fallback(base: string): string {
+  return clamp(sanitise(spaced(base))) || "stream";
+}

--- a/src/util/restPlaylist.test.ts
+++ b/src/util/restPlaylist.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { restPlaylist, type IndexedFile } from "./restPlaylist";
+
+function file(index: number, filename: string, bytes = 1024 ** 3): IndexedFile {
+  return { index, filename, bytes };
+}
+
+/**
+ * A season pack shaped like the one that prompted this: episodes named out of
+ * order, a bonus feature that names the season but no episode, and a `.nfo` the
+ * picker already drops.
+ */
+const PACK: IndexedFile[] = [
+  file(0, "Harrowgate.S03E03.1080p.WEB-DL.mkv"),
+  file(1, "Harrowgate.S03E01.1080p.WEB-DL.mkv"),
+  file(2, "Harrowgate.S03/readme.nfo"),
+  file(3, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
+  file(4, "Harrowgate.S03/Bonus_Gag_Reel_1.mkv"),
+];
+
+describe("restPlaylist", () => {
+  it("from an episode, plays the rest of that season", () => {
+    expect(restPlaylist(PACK, 1)).toEqual({ kind: "season", indexes: [1, 3, 0] });
+  });
+
+  /**
+   * THE BUG. Started from an episode, the old rule was "every later file in name
+   * order", which swept the bonus feature into the season playlist.
+   */
+  it("leaves out a bonus feature that names no episode", () => {
+    expect(restPlaylist(PACK, 1).indexes).not.toContain(4);
+  });
+
+  it("leaves out the non-video files the picker leaves out", () => {
+    expect(restPlaylist(PACK, 1).indexes).not.toContain(2);
+  });
+
+  it("is one entry from the last episode of a season", () => {
+    // Session index 0 is E03, which sorts last of the three episodes.
+    expect(restPlaylist(PACK, 0)).toEqual({ kind: "season", indexes: [0] });
+  });
+
+  /**
+   * From a bonus feature there is no season to be the rest of, so the meaning
+   * falls back to "everything from here" — and the caller labels it that way.
+   */
+  it("from a bonus feature, takes everything from there on", () => {
+    const out = restPlaylist(PACK, 4);
+    expect(out.kind).toBe("everything");
+    expect(out.indexes[0]).toBe(4);
+  });
+
+  it("stops at the season boundary in a multi-season pack", () => {
+    const two: IndexedFile[] = [
+      file(0, "Kepler.S01E01.1080p.WEB-DL.mkv"),
+      file(1, "Kepler.S01E02.1080p.WEB-DL.mkv"),
+      file(2, "Kepler.S02E01.1080p.WEB-DL.mkv"),
+    ];
+    expect(restPlaylist(two, 0)).toEqual({ kind: "season", indexes: [0, 1] });
+  });
+
+  it("is a single entry for a film", () => {
+    const film = [file(0, "Kestrel.2010.1080p.BluRay.x264.mkv")];
+    expect(restPlaylist(film, 0)).toEqual({ kind: "everything", indexes: [0] });
+  });
+
+  /**
+   * A file that names a season but no episode is not an episode, so there is no
+   * season to continue — the same branch a bonus feature takes.
+   */
+  it("treats a file naming a season but no episode as everything", () => {
+    const pack = [
+      file(0, "Harrowgate.S03.1080p.WEB-DL.mkv"),
+      file(1, "Harrowgate.S03.extras.mkv"),
+    ];
+    expect(restPlaylist(pack, 0).kind).toBe("everything");
+  });
+
+  it("falls back to just that index when it names no candidate", () => {
+    expect(restPlaylist(PACK, 99)).toEqual({ kind: "everything", indexes: [99] });
+    // The .nfo is not a candidate, so asking for it is the same case.
+    expect(restPlaylist(PACK, 2)).toEqual({ kind: "everything", indexes: [2] });
+  });
+
+  /**
+   * RECORDED CHOICE, not an oversight: an extra that poses as an episode stays
+   * in. Deduplicating by episode number would drop it — and would equally drop
+   * `S03E02.Part2` next to `S03E02.Part1`, which loses half an episode to tidy up
+   * a duplicate. Including one extra is the cheaper mistake.
+   */
+  it("keeps an extra that names an episode of its own", () => {
+    const posing: IndexedFile[] = [
+      file(0, "Harrowgate.S03E01.1080p.WEB-DL.mkv"),
+      file(1, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
+      file(2, "Harrowgate.S03E02.Deleted.Scenes.mkv"),
+    ];
+    expect(restPlaylist(posing, 0).indexes).toEqual([0, 1, 2]);
+  });
+});

--- a/src/util/restPlaylist.test.ts
+++ b/src/util/restPlaylist.test.ts
@@ -7,8 +7,14 @@ function file(index: number, filename: string, bytes = 1024 ** 3): IndexedFile {
 
 /**
  * A season pack shaped like the one that prompted this: episodes named out of
- * order, a bonus feature that names the season but no episode, and a `.nfo` the
- * picker already drops.
+ * order, extras that name no episode, and a `.nfo` the picker already drops.
+ *
+ * TWO extras, and the difference between them is what makes these tests mean
+ * anything. `Bonus_Gag_Reel_1` sorts BEFORE the episodes (`S03/` beats `S03E01`
+ * under numeric collation), so a playlist starting at an episode would never
+ * reach it however the filter behaved — an assertion about it alone would pass
+ * without this module existing. `Harrowgate.Trailer.mkv` sorts AFTER all three
+ * episodes, so only the season filter keeps it out.
  */
 const PACK: IndexedFile[] = [
   file(0, "Harrowgate.S03E03.1080p.WEB-DL.mkv"),
@@ -16,6 +22,7 @@ const PACK: IndexedFile[] = [
   file(2, "Harrowgate.S03/readme.nfo"),
   file(3, "Harrowgate.S03E02.1080p.WEB-DL.mkv"),
   file(4, "Harrowgate.S03/Bonus_Gag_Reel_1.mkv"),
+  file(5, "Harrowgate.Trailer.mkv"),
 ];
 
 describe("restPlaylist", () => {
@@ -25,10 +32,16 @@ describe("restPlaylist", () => {
 
   /**
    * THE BUG. Started from an episode, the old rule was "every later file in name
-   * order", which swept the bonus feature into the season playlist.
+   * order", which swept the extras into the season playlist.
+   *
+   * Index 5 is the trailer, which sorts AFTER all three episodes — so this fails
+   * under the old rule rather than passing by accident of the ordering. Index 4
+   * is asserted too, but only the trailer proves the filter runs.
    */
-  it("leaves out a bonus feature that names no episode", () => {
-    expect(restPlaylist(PACK, 1).indexes).not.toContain(4);
+  it("leaves out an extra that names no episode", () => {
+    const { indexes } = restPlaylist(PACK, 1);
+    expect(indexes).not.toContain(5);
+    expect(indexes).not.toContain(4);
   });
 
   it("leaves out the non-video files the picker leaves out", () => {
@@ -48,6 +61,8 @@ describe("restPlaylist", () => {
     const out = restPlaylist(PACK, 4);
     expect(out.kind).toBe("everything");
     expect(out.indexes[0]).toBe(4);
+    // It sorts first, so "everything from here" really is everything playable.
+    expect(out.indexes).toEqual([4, 1, 3, 0, 5]);
   });
 
   it("stops at the season boundary in a multi-season pack", () => {

--- a/src/util/restPlaylist.ts
+++ b/src/util/restPlaylist.ts
@@ -1,0 +1,85 @@
+/**
+ * Which files a "play on from here" playlist contains — the rule, shared.
+ *
+ * WHY IT IS HERE AND NOT IN `src/web/stream.ts`, where it started. Two surfaces
+ * need the same answer: the server picks the files that go into the `.m3u`, and
+ * the player page decides what the button is called and whether to show it at
+ * all. Two implementations of one rule is the copy-then-drift bug this codebase
+ * has recorded four times, so the rule is in one place and both call it.
+ *
+ * WHAT WAS WRONG WITH THE OLD RULE. "This file and every later one in name order"
+ * is only accidentally right. Started from a bonus feature it yields every
+ * remaining extra and then the whole season, under a button that says "rest of
+ * season" — which is what a user reported. Started from an episode it happens to
+ * be correct only while the extras sort clear of the episodes, and a torrent that
+ * names one `Show.S03E02.Deleted.Scenes` breaks even that.
+ *
+ * Generic over the shape for the reason `sortStreamFiles` is: the server holds
+ * `StreamFile` with an upstream `url`, the browser holds `PublicStreamFile` with a
+ * `handle`, and each keeps the field that addresses its own file. Browser-safe:
+ * no `node:*` here or in anything it reaches — `npm run build` is what proves it.
+ */
+import { parseRelease } from "./release";
+import { sortStreamFiles } from "./streamFileSort";
+import { streamCandidates, type SizedFile } from "./videoFiles";
+import type { EpisodeRef } from "./episode";
+
+/**
+ * What the playlist turned out to mean. The caller words the button from this: a
+ * season may be called a season, and anything else must not be.
+ */
+export type RestKind = "season" | "everything";
+
+export interface RestPlaylist {
+  kind: RestKind;
+  /** Session indexes in play order, the current file first. Never empty. */
+  indexes: number[];
+}
+
+/** A file that knows its own position in the session — the `:idx` of its handle. */
+export interface IndexedFile extends SizedFile {
+  index: number;
+}
+
+export function restPlaylist<T extends IndexedFile>(
+  files: readonly T[],
+  index: number,
+): RestPlaylist {
+  // The picker's order, and the episode list's: a playlist that ran E08, E02, E03
+  // is the bug `sortStreamFiles` was extracted to fix. `streamCandidates` drops
+  // the `.nfo`s, because handing a text file to a media player is how a playlist
+  // stalls halfway through a season.
+  const ordered = sortStreamFiles(streamCandidates(files), "name");
+  const at = ordered.findIndex((file) => file.index === index);
+  // A hand-edited URL, or the index of a file the video filter removed. One entry
+  // is the honest answer: that file does exist and does play.
+  if (at < 0) return { kind: "everything", indexes: [index] };
+
+  const here = episodeOf(ordered[at]!.filename);
+  const rest = ordered.slice(at);
+  if (!here) return { kind: "everything", indexes: rest.map((file) => file.index) };
+
+  // A season means the files that name an episode OF THIS SEASON. The current
+  // file is always in, whatever the filter would otherwise say about it.
+  const indexes = rest
+    .filter((file, offset) => {
+      if (offset === 0) return true;
+      const ep = episodeOf(file.filename);
+      return ep !== null && ep.season === here.season;
+    })
+    .map((file) => file.index);
+  return { kind: "season", indexes };
+}
+
+/**
+ * The episode a filename commits to, or null.
+ *
+ * BOTH numbers are required. A season-pack file and a bonus feature inside a
+ * season folder both parse to a season with no episode, and treating that as
+ * "episode 1 of that season" is exactly what would sweep the extras back in.
+ */
+function episodeOf(filename: string): EpisodeRef | null {
+  const parsed = parseRelease(filename);
+  if (parsed?.season === undefined || parsed.episode === undefined) return null;
+  return { season: parsed.season, episode: parsed.episode };
+}

--- a/src/web/static/copyText.test.ts
+++ b/src/web/static/copyText.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { copyNotice, copyText, type CopyPorts } from "./copyText";
+
+const STREAM_URL = "http://192.168.1.20:8080/stream/abc";
+
+function ports(over: Partial<CopyPorts> = {}): CopyPorts {
+  return { writeAsync: null, writeLegacy: () => false, ...over };
+}
+
+describe("copyText", () => {
+  it("uses the async clipboard when the browser exposes one", async () => {
+    const written: string[] = [];
+    let legacyTries = 0;
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: async (text) => {
+          written.push(text);
+        },
+        writeLegacy: () => {
+          legacyTries += 1;
+          return true;
+        },
+      }),
+    );
+    expect(result).toBe("copied");
+    expect(written).toEqual([STREAM_URL]);
+    expect(legacyTries).toBe(0);
+  });
+
+  it("falls back to the legacy copy when there is no async clipboard", () => {
+    // The insecure-origin case, which is the normal way this dashboard is
+    // reached over a LAN: navigator.clipboard is not merely restricted, it is
+    // undefined, so there is nothing to try first.
+    const written: string[] = [];
+    const result = copyText(
+      STREAM_URL,
+      ports({
+        writeLegacy: (text) => {
+          written.push(text);
+          return true;
+        },
+      }),
+    );
+    expect(result).toBe("copied");
+    expect(written).toEqual([STREAM_URL]);
+  });
+
+  it("attempts the legacy copy synchronously, without an intervening await", () => {
+    // THE POINT OF THIS FILE. document.execCommand("copy") is only permitted
+    // inside the task the user's click started; a single await before it hands
+    // control back to the event loop and Safari refuses the copy. So the
+    // no-async-clipboard path must not return a promise, and must have already
+    // called writeLegacy by the time copyText returns.
+    let called = false;
+    const result = copyText(STREAM_URL, ports({ writeLegacy: () => ((called = true), true) }));
+    expect(called).toBe(true);
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it("asks for the manual field when the legacy copy is refused too", () => {
+    expect(copyText(STREAM_URL, ports({ writeLegacy: () => false }))).toBe("manual");
+  });
+
+  it("tries the legacy copy when the async clipboard rejects", async () => {
+    // A secure origin can still refuse: writeText rejects when the document is
+    // not focused, which is easy to hit on a second monitor.
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: () => Promise.reject(new Error("not focused")),
+        writeLegacy: () => true,
+      }),
+    );
+    expect(result).toBe("copied");
+  });
+
+  it("asks for the manual field when both routes fail", async () => {
+    const result = await copyText(
+      STREAM_URL,
+      ports({ writeAsync: () => Promise.reject(new Error("denied")), writeLegacy: () => false }),
+    );
+    expect(result).toBe("manual");
+  });
+
+  it("still reaches the legacy copy when the async clipboard throws synchronously", async () => {
+    // Some hardened browsers throw from writeText rather than rejecting.
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: () => {
+          throw new Error("blocked");
+        },
+        writeLegacy: () => true,
+      }),
+    );
+    expect(result).toBe("copied");
+  });
+});
+
+describe("copyNotice", () => {
+  it("says the same thing however the copy happened", () => {
+    // The user does not care which clipboard API worked, and a notice that
+    // mentioned the legacy route would only invite the question.
+    expect(copyNotice("copied")).toBe("Stream URL copied.");
+  });
+
+  it("points at the field it is about to reveal when copying is refused", () => {
+    const notice = copyNotice("manual");
+    // "the field", not "below": the field renders inside .actions, which sits
+    // above the notice. Verified in a browser — an earlier wording said below
+    // and pointed the wrong way.
+    expect(notice).toContain("field");
+    // And it no longer sends the user off to download a .m3u instead, which was
+    // the old advice when there was nothing else on offer.
+    expect(notice).not.toContain("secure context");
+    expect(notice).not.toContain(".m3u");
+  });
+});

--- a/src/web/static/copyText.ts
+++ b/src/web/static/copyText.ts
@@ -1,0 +1,106 @@
+// Putting a string on the clipboard from a page that is very often not on a
+// secure origin.
+//
+// `copyText` is the decision and is unit-tested. `clipboardPorts` and
+// `legacyClipboardWrite` are wiring — they read `navigator` and build a DOM
+// node, neither of which a test in this repo can reach — so they are kept to
+// the minimum that reading them end to end is enough.
+
+/** What the caller must do next: nothing, or reveal the manual field. */
+export type CopyOutcome = "copied" | "manual";
+
+export interface CopyPorts {
+  /**
+   * `navigator.clipboard.writeText`, or null where the browser did not expose
+   * one. Null is the common case here, not the exotic one: the async clipboard
+   * exists only in a secure context — https, localhost or 127.0.0.1 — and this
+   * dashboard is normally reached at http://192.168.x.x over a LAN.
+   */
+  writeAsync: ((text: string) => Promise<void>) | null;
+  /** The `document.execCommand("copy")` route. Returns whether it took. */
+  writeLegacy: (text: string) => boolean;
+}
+
+/**
+ * Copy `text`, by whichever route this browser allows.
+ *
+ * **Returns synchronously when there is no async clipboard, and that is the
+ * whole point of the signature.** `document.execCommand("copy")` is only
+ * permitted inside the task the user's click started; a single `await` before
+ * it returns control to the event loop and Safari refuses. So the insecure
+ * origin path — the one that matters, since it is why this function exists —
+ * must reach `writeLegacy` with no microtask in between, and cannot be an
+ * `async function`. Callers hand the union to `Promise.resolve`.
+ *
+ * The async route is still tried first where it exists: it is the supported
+ * API, it does not need a throwaway element, and it works when the legacy one
+ * has been disabled. When it rejects — which a secure origin still does if the
+ * document is not focused — the legacy route gets its turn anyway.
+ */
+export function copyText(text: string, ports: CopyPorts): CopyOutcome | Promise<CopyOutcome> {
+  const legacy = (): CopyOutcome => (ports.writeLegacy(text) ? "copied" : "manual");
+  if (ports.writeAsync === null) return legacy();
+  try {
+    return ports.writeAsync(text).then(
+      (): CopyOutcome => "copied",
+      // Past the await the gesture is gone, so this attempt may well be
+      // refused as well. It costs nothing to make, and a refusal lands on the
+      // manual field, which is where a browser this strict was heading anyway.
+      legacy,
+    );
+  } catch {
+    // Some hardened browsers throw from writeText rather than rejecting.
+    return legacy();
+  }
+}
+
+export function copyNotice(outcome: CopyOutcome): string {
+  return outcome === "copied"
+    ? "Stream URL copied."
+    : "This browser won't let the page copy — the URL is in the field, already selected.";
+}
+
+/** The ports as this browser actually provides them. */
+export function clipboardPorts(): CopyPorts {
+  const clip: Clipboard | undefined = navigator.clipboard;
+  return {
+    writeAsync: clip ? (text) => clip.writeText(text) : null,
+    writeLegacy: legacyClipboardWrite,
+  };
+}
+
+/**
+ * The pre-`navigator.clipboard` copy: select a throwaway textarea, then ask the
+ * document to copy the selection. Deprecated, unfailingly available, and the
+ * only thing that works on an insecure origin.
+ *
+ * The styling is load-bearing. `display:none` and `visibility:hidden` both make
+ * the selection silently empty, so the element has to be genuinely on screen —
+ * `position:fixed` with zero opacity keeps it out of sight and out of the
+ * layout's way. `setSelectionRange` is there for iOS, which ignores `select()`
+ * on a readonly field by itself.
+ */
+export function legacyClipboardWrite(text: string): boolean {
+  const field = document.createElement("textarea");
+  // A property assignment, not markup — `value` is never parsed as HTML.
+  field.value = text;
+  field.setAttribute("readonly", "");
+  field.setAttribute("aria-hidden", "true");
+  field.style.position = "fixed";
+  field.style.top = "0";
+  field.style.left = "0";
+  field.style.opacity = "0";
+  document.body.append(field);
+  let copied = false;
+  try {
+    field.select();
+    field.setSelectionRange(0, text.length);
+    // Deprecated, and staying: the replacement does not exist on the origins
+    // this branch is here for.
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+  field.remove();
+  return copied;
+}

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -31,6 +31,7 @@ import {
   type FallbackReason,
   type PlayerTarget,
 } from "./playerModel";
+import { clipboardPorts, copyNotice, copyText } from "./copyText";
 import { mountHls } from "./hlsMount";
 import { breadcrumbFor, upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
@@ -52,8 +53,11 @@ let noticeTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * `persist` for a notice the user must still be able to read after they look
- * back at the screen. The copy-button notices are acknowledgements of something
- * the user just did and self-clear; a stream that died mid-playback is not, and
+ * back at the screen. Most copy-button notices are acknowledgements of
+ * something the user just did and self-clear — the exception is the one that
+ * asks the user to copy the revealed field by hand, which is an instruction
+ * rather than an acknowledgement and outlives its four seconds. A stream that
+ * died mid-playback is not an acknowledgement either, and
  * a four-second explanation of a video that is going to stay frozen is worse
  * than none — they would be left with the silence this notice exists to break.
  */
@@ -82,6 +86,37 @@ function button(label: string, onClick: () => void): HTMLButtonElement {
   b.textContent = label;
   b.addEventListener("click", onClick);
   return b;
+}
+
+/**
+ * The last resort when the browser refuses to copy on the page's behalf: the
+ * URL, in a field, already selected, so ⌘C or Ctrl+C finishes the job.
+ *
+ * It lives inside `actions` so that the per-target `replaceChildren` clears it;
+ * a stale URL left under a different file would be worse than no field at all.
+ */
+let manualField: HTMLInputElement | null = null;
+
+function revealManualCopy(url: string): void {
+  if (manualField === null) {
+    manualField = document.createElement("input");
+    manualField.type = "text";
+    manualField.className = "manual-copy";
+    manualField.readOnly = true;
+    manualField.setAttribute("aria-label", "Stream URL");
+    actions.append(manualField);
+  }
+  // A property assignment, not markup.
+  manualField.value = url;
+  manualField.focus();
+  manualField.select();
+  // iOS ignores select() on a readonly field by itself.
+  manualField.setSelectionRange(0, url.length);
+}
+
+function clearManualCopy(): void {
+  manualField?.remove();
+  manualField = null;
 }
 
 function linkButton(label: string, href: string): HTMLAnchorElement {
@@ -273,24 +308,27 @@ async function render(): Promise<void> {
   const controls: (HTMLButtonElement | HTMLAnchorElement)[] = [
     linkButton("Download .m3u", playlist),
     button("Copy stream URL", () => {
-      // clipboard.writeText is unavailable on insecure origins — which is the
-      // normal way this dashboard is reached over a LAN — and rejects when the
-      // page is not focused. Both are reported rather than swallowed, because a
-      // copy button that silently does nothing is worse than no button.
-      const clip = navigator.clipboard;
-      if (!clip) {
-        showNotice("Copying needs a secure context — download the .m3u instead.");
-        return;
-      }
-      void clip.writeText(stream).then(
-        () => showNotice("Stream URL copied."),
-        () => showNotice("Couldn't copy — download the .m3u instead."),
-      );
+      // copyText must be called straight from the click with nothing awaited in
+      // front of it: on an insecure origin — the normal way this dashboard is
+      // reached over a LAN — it copies via execCommand, which the browser only
+      // permits inside the task the gesture started.
+      const outcome = copyText(stream, clipboardPorts());
+      void Promise.resolve(outcome).then((result) => {
+        // Persisted for "manual" alone: that notice is an instruction attached
+        // to a field that stays on screen, so letting it self-clear would leave
+        // an unlabelled selected URL box and no reason for it.
+        showNotice(copyNotice(result), { persist: result === "manual" });
+        if (result === "manual") revealManualCopy(stream);
+        else clearManualCopy();
+      });
     }),
   ];
   for (const link of vlcLinks(stream, detectPlatform(navigator.userAgent))) {
     controls.push(linkButton(link.label, link.href));
   }
+  // replaceChildren drops any field left over from the previous target, so the
+  // reference has to go with it.
+  manualField = null;
   actions.replaceChildren(...controls);
 
   // The rest of the torrent, and the bookkeeping — BEFORE the playability

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -508,17 +508,14 @@ function renderEpisodes(body: StreamFilesResponse, target: PlayerTarget): void {
   const nodes: HTMLElement[] = [];
   // "Up next" sits ABOVE the full list on purpose: it is the one action this
   // page exists to offer, and it must not depend on scrolling past sixty rows.
-  if (view.next) {
-    nodes.push(listHeading("up next"), episodeRow(view.next));
-    // Only when there IS something after this one — a playlist of one file is
-    // the button that is already at the top of the page. Appended rather than
-    // built with the others because it depends on `.files`, which lands after
-    // the first paint.
+  if (view.next) nodes.push(listHeading("up next"), episodeRow(view.next));
+  // Appended rather than built with the other controls because it depends on
+  // `.files`, which lands after the first paint. WHETHER to show it and WHAT to
+  // call it are `upNextView`'s answers, not this file's — it used to hang off
+  // "is there a next row", which offered "rest of season" from a bonus feature.
+  if (view.restLabel !== null) {
     actions.append(
-      linkButton(
-        "Download rest of season .m3u",
-        absoluteUrl(location.origin, restPlaylistPath(target)),
-      ),
+      linkButton(view.restLabel, absoluteUrl(location.origin, restPlaylistPath(target))),
     );
   }
   nodes.push(listHeading(view.next ? "all episodes" : "everything in this torrent"));

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -252,16 +252,19 @@ describe("detectPlatform", () => {
 describe("vlcLinks", () => {
   const url = "http://box.local:9162/stream/sid-1/0?k=cap-1";
 
-  it("offers the x-callback scheme on iOS and macOS", () => {
-    for (const platform of ["ios", "macos"] as const) {
-      expect(vlcLinks(url, platform)).toEqual([
-        {
-          id: "vlc-callback",
-          label: "Open in VLC",
-          href: `vlc-x-callback://x-callback-url/stream?url=${encodeURIComponent(url)}`,
-        },
-      ]);
-    }
+  it("offers the x-callback scheme on iOS", () => {
+    expect(vlcLinks(url, "ios")).toEqual([
+      {
+        id: "vlc-callback",
+        label: "Open in VLC",
+        href: `vlc-x-callback://x-callback-url/stream?url=${encodeURIComponent(url)}`,
+      },
+    ]);
+  });
+
+  // The platform is still detected; only what we offer it changed.
+  it("still recognises a Mac", () => {
+    expect(detectPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe("macos");
   });
 
   it("offers an intent on Android, carrying the original scheme", () => {
@@ -289,10 +292,18 @@ describe("vlcLinks", () => {
     expect(href.split("#Intent;")).toHaveLength(2);
   });
 
-  // Desktop Windows and Linux register no VLC URL scheme; a button there is a
-  // button that does nothing.
-  it("offers nothing on other platforms", () => {
-    expect(vlcLinks(url, "other")).toEqual([]);
+  /**
+   * NO DESKTOP REGISTERS A VLC URL SCHEME, macOS included — which is where this
+   * was wrong: macOS sat in the iOS branch above and got `vlc-x-callback://`, a
+   * scheme belonging to the iOS app alone, so the click was a silent no-op.
+   * Verified against a real install: VLC.app's Info.plist registers http, https,
+   * ftp, mms, mmsh, rtsp, udp, rtp, rtmp*, sftp and smb, and nothing else. A
+   * button here is a button that does nothing, so there is no button.
+   */
+  it("offers nothing on desktop, macOS included", () => {
+    for (const platform of ["macos", "other"] as const) {
+      expect(vlcLinks(url, platform)).toEqual([]);
+    }
   });
 
   it("offers no intent for a URL that is not http(s)", () => {
@@ -342,9 +353,15 @@ describe("interruptedNotice", () => {
     expect(notice).not.toContain("container");
   });
 
-  it("points at the hand-off that does work", () => {
+  /**
+   * Specifically the `.m3u`, and NOT VLC. Desktop has no VLC button any more —
+   * no desktop registers the scheme — so naming one sends the user looking for a
+   * control that is not on screen. The `.m3u` button is there on every platform.
+   */
+  it("points at the hand-off that does work, and names no absent button", () => {
     for (const reason of ["error", "stall"] as const) {
-      expect(interruptedNotice(reason)).toMatch(/\.m3u|VLC/);
+      expect(interruptedNotice(reason)).toContain(".m3u");
+      expect(interruptedNotice(reason)).not.toContain("VLC");
     }
   });
 

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -251,13 +251,21 @@ function androidIntent(absolute: string): string | null {
 /**
  * The "open in VLC" links that can actually work on this platform.
  *
- * Empty on desktop Windows and Linux, and that is the point: neither has a
- * registered `vlc://`-style scheme, so a button there would be a button that
- * does nothing. Those platforms get the `.m3u` download, which does work, and
- * are not offered a dead control next to it.
+ * Empty on EVERY desktop — Windows, Linux and macOS — and that is the point:
+ * none of them registers a `vlc://`-style scheme, so a button there would be a
+ * button that does nothing. Those platforms get the `.m3u` download, which does
+ * work, and are not offered a dead control next to it.
+ *
+ * macOS used to sit in the iOS branch below, and that was exactly the bug this
+ * comment describes. `vlc-x-callback://` belongs to VLC's *iOS* app; the desktop
+ * app registers no scheme of its own — checked against a real install, VLC.app's
+ * Info.plist claims http, https, ftp, mms, mmsh, rtsp, udp, rtp, rtmp*, sftp and
+ * smb and nothing else — so the click went nowhere, with nothing on screen to
+ * explain why. Desktop is also the platform least safe to assume about: VLC may
+ * simply not be what the user plays video in, and the `.m3u` opens whatever is.
  */
 export function vlcLinks(absolute: string, platform: Platform): ExternalLink[] {
-  if (platform === "ios" || platform === "macos") {
+  if (platform === "ios") {
     return [
       {
         id: "vlc-callback",
@@ -355,14 +363,19 @@ export const PLAYBACK_STALL_MS = 30_000;
  * video and has room; this is a one-line notice sitting under a player the user
  * is still looking at, and they know what they were watching.
  *
- * Both branches point at the `.m3u` and VLC, because those buttons are still on
- * screen and — for the provider-transcode failure this exists for — they are the
- * route that genuinely works: the playlist streams the original file rather than
- * anything the provider had to transcode first.
+ * Both branches point at the `.m3u`, because that button is still on screen and —
+ * for the provider-transcode failure this exists for — it is the route that
+ * genuinely works: the playlist streams the original file rather than anything
+ * the provider had to transcode first.
+ *
+ * It names the `.m3u` and NOT VLC, which it used to do. `vlcLinks` offers nothing
+ * on any desktop, so on the platform most likely to be reading this there is no
+ * VLC button to look for — and the `.m3u` is what opens whichever player they do
+ * use. A notice that names an absent control sends the user hunting for it.
  */
 export function interruptedNotice(reason: FallbackReason): string {
   if (reason === "stall") {
-    return "Playback stopped — no more of the stream arrived. Download the .m3u or open it in VLC to carry on watching.";
+    return "Playback stopped — no more of the stream arrived. Download the .m3u and carry on watching there.";
   }
-  return "Playback stopped partway through — the stream failed upstream. Download the .m3u or open it in VLC to carry on watching.";
+  return "Playback stopped partway through — the stream failed upstream. Download the .m3u and carry on watching there.";
 }

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1293,6 +1293,22 @@ select:focus-visible {
   outline-offset: 1px;
 }
 
+/* The URL, spelled out, for when the browser refuses to copy it on the page's
+   behalf — which is every insecure origin, i.e. most LANs. It takes the whole
+   row rather than sitting between the buttons: it appears mid-gesture, and a
+   new element that reflowed the buttons the user is aiming at would be worse
+   than the problem it solves. */
+.manual-copy {
+  flex-basis: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.35rem;
+  background: var(--sunken);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
 /* ---------------------------------------------------------------------------
    The saved pane. Two lists side by side on a wide screen and stacked on a
    phone, using .rows and .row from the search pane rather than a third row

--- a/src/web/static/upNext.test.ts
+++ b/src/web/static/upNext.test.ts
@@ -38,6 +38,41 @@ const KESTREL: StreamFilesResponse = {
   files: [file(0, "Kestrel.2010.1080p.BluRay.x264.mkv")],
 };
 
+describe("upNextView — the rest-of-season button", () => {
+  it("offers the season by name from an episode with more to come", () => {
+    expect(upNextView(HARROWGATE, SID, 1, CAP).restLabel).toBe("Download rest of season .m3u");
+  });
+
+  /**
+   * From the last episode there is a next FILE in some torrents (an extra) but no
+   * rest of the season, and a playlist of one file is the button already at the
+   * top of the page. This is why the test is `restPlaylist`'s answer and not
+   * "is there a next row".
+   */
+  it("offers nothing from the last episode of a season", () => {
+    // Session index 0 is E03, which sorts last.
+    expect(upNextView(HARROWGATE, SID, 0, CAP).restLabel).toBeNull();
+  });
+
+  /**
+   * An extra has no season to be the rest of. The playlist still means something
+   * — everything from here — so the label says that rather than promising a
+   * season it will not deliver. `Harrowgate.Trailer.mkv` sorts after the
+   * episodes, so there really is something after it to include.
+   */
+  it("does not call an extra's playlist a season", () => {
+    const withExtra: StreamFilesResponse = {
+      ...HARROWGATE,
+      files: [file(4, "Harrowgate.Bonus_Gag_Reel_1.mkv"), ...HARROWGATE.files],
+    };
+    expect(upNextView(withExtra, SID, 4, CAP).restLabel).toBe("Download the rest as .m3u");
+  });
+
+  it("offers nothing for a film", () => {
+    expect(upNextView(KESTREL, SID, 0, CAP).restLabel).toBeNull();
+  });
+});
+
 describe("upNextView — the list", () => {
   it("orders the files the way the picker does, not the way the torrent did", () => {
     const view = upNextView(HARROWGATE, SID, 0, CAP);

--- a/src/web/static/upNext.ts
+++ b/src/web/static/upNext.ts
@@ -15,6 +15,7 @@
  * with them.
  */
 import { parseRelease } from "../../util/release";
+import { restPlaylist, type RestKind } from "../../util/restPlaylist";
 import { sortStreamFiles } from "../../util/streamFileSort";
 import { fileLabel, playerPath } from "./streamFlow";
 import { searchForRoute, DEFAULT_ROUTE } from "./route";
@@ -67,6 +68,18 @@ export interface UpNextView {
   next: EpisodeRow | null;
   /** The show or film this session is, and a search that finds it. Never null. */
   breadcrumb: Breadcrumb;
+  /**
+   * The text for the "play on from here" download, or null for no button.
+   *
+   * HERE RATHER THAN IN `player.ts` because it is two decisions, and both are the
+   * kind CLAUDE.md keeps out of the DOM-wiring files: whether a playlist from this
+   * file onwards contains anything worth downloading, and whether it is honest to
+   * call it a season. `restPlaylist` (src/util/restPlaylist.ts) is the same
+   * function the server uses to pick the files, so the label and the file it
+   * downloads cannot disagree — which they did: a bonus feature offered "rest of
+   * season" and delivered every remaining extra followed by the whole show.
+   */
+  restLabel: string | null;
 }
 
 /** The dashboard, for when a release name tells us nothing to search for. */
@@ -127,7 +140,7 @@ export function upNextView(
   capability: string,
 ): UpNextView {
   const breadcrumb = breadcrumbFor(body.name);
-  if (body.files.length < 2) return { rows: [], next: null, breadcrumb };
+  if (body.files.length < 2) return { rows: [], next: null, breadcrumb, restLabel: null };
 
   // "name", the picker's default: a season pack listed in whatever order the
   // torrent named its files is the bug `sortStreamFiles` was extracted to fix,
@@ -155,6 +168,24 @@ export function upNextView(
     };
   });
 
+  // A playlist of one file is the button that is already at the top of the page,
+  // so one entry means no button. Note this is STRICTER than "there is a next
+  // row": from the last episode of a season the next row may well be an extra,
+  // and the season is still over.
+  const rest = restPlaylist(body.files, index);
+  const restLabel = rest.indexes.length > 1 ? restLabelFor(rest.kind) : null;
+
   const at = rows.findIndex((row) => row.current);
-  return { rows, next: at >= 0 ? (rows[at + 1] ?? null) : null, breadcrumb };
+  return { rows, next: at >= 0 ? (rows[at + 1] ?? null) : null, breadcrumb, restLabel };
+}
+
+/**
+ * What to call the playlist.
+ *
+ * "Rest of season" is a promise, and it is only true when the file we started
+ * from named an episode. From a bonus feature the playlist is everything from
+ * there on, and calling that a season is a lie the user only discovers in VLC.
+ */
+function restLabelFor(kind: RestKind): string {
+  return kind === "season" ? "Download rest of season .m3u" : "Download the rest as .m3u";
 }

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -20,6 +20,20 @@ import type { TorrentStreamSession } from "../integrations/torrentStream";
 import type { StreamFile } from "../util/player";
 import type { Runtime } from "../daemon/runtime";
 
+/**
+ * The URL lines of a playlist body — everything that is not a directive.
+ *
+ * The body carries `#EXTM3U` and an `#EXTINF` per entry now, so a test that wants
+ * the addresses has to say so. Assertions about what must NOT be in the file (a
+ * Real-Debrid token, a forwarded host, an injected line) stay on the WHOLE body,
+ * because a leak into a title is just as much a leak.
+ */
+const urlsIn = (body: string): string[] =>
+  body
+    .trim()
+    .split("\n")
+    .filter((line) => !line.startsWith("#"));
+
 // The bytes the fake WebTorrent server serves. Big enough that a range request
 // is a real slice of it and that a client can abandon one mid-flight.
 const MEDIA = Buffer.from(
@@ -1300,11 +1314,11 @@ describe("GET /stream/:sid/:idx.files", () => {
    * per line and plays the rest of the season unattended.
    */
   describe("?rest=1", () => {
-    it("lists this file and every later one, in display order", async () => {
+    it("lists the rest of the season, in display order", async () => {
       const { base, capability, id } = await packSession();
       const res = await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`);
       expect(res.status).toBe(200);
-      const lines = (await res.text()).trim().split("\n");
+      const lines = urlsIn(await res.text());
       // Session index 1 is E01, which sorts first — so all three, in E01, E02,
       // E03 order, which is session indexes 1, 3, 0.
       expect(lines).toEqual([
@@ -1318,7 +1332,7 @@ describe("GET /stream/:sid/:idx.files", () => {
       const { base, capability, id } = await packSession();
       // Session index 0 is E03, which sorts last.
       const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
-      expect(text.trim().split("\n")).toHaveLength(1);
+      expect(urlsIn(text)).toHaveLength(1);
     });
 
     it("skips the non-video files the picker skips", async () => {
@@ -1328,19 +1342,75 @@ describe("GET /stream/:sid/:idx.files", () => {
       expect(text).not.toContain(`/stream/${id}/2?`);
     });
 
-    it("still contains no filename at all", async () => {
+    /**
+     * Titles are IN the body now, so the old "no filename anywhere" rule is gone
+     * — but the rule it protected is not. A filename comes from whoever made the
+     * torrent, and this file is parsed line by line by another application, so a
+     * name must never be able to ADD a line.
+     */
+    it("cannot be given an extra entry by a filename", async () => {
+      const { base, capability, id } = await packSession({
+        files: [
+          {
+            url: "https://cdn.example/1",
+            filename: "Harrowgate.S03E01\r\nhttp://attacker.example/x\n.mkv",
+            bytes: 100,
+          },
+        ],
+      });
+      const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
+      expect(urlsIn(text)).toEqual([
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/0?k=${capability}`,
+      ]);
+      expect(text).not.toContain("attacker.example");
+    });
+
+    it("puts a title on every entry, and a URL under each", async () => {
       const { base, capability, id } = await packSession();
       const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=1&k=${capability}`)).text();
-      // The whole point of the plain-URL body: another application parses this
-      // file, and nothing in it comes from a release name.
-      expect(text).not.toContain("Harrowgate");
-      expect(text).not.toContain("#EXTINF");
+      const lines = text.trim().split("\n");
+      expect(lines[0]).toBe("#EXTM3U");
+      expect(lines.filter((l) => l.startsWith("#EXTINF:-1,"))).toHaveLength(urlsIn(text).length);
+      expect(text).toContain("#EXTINF:-1,Harrowgate S03E01");
+      expect(text).toContain("#EXTINF:-1,Harrowgate S03E02");
+    });
+
+    /**
+     * An extra names no episode, so it is not part of the season and must not be
+     * swept into its playlist. This is the report that prompted the change: "rest
+     * of season" handed over the gag reels too.
+     *
+     * The extra is named `Harrowgate.Trailer.mkv` DELIBERATELY, because it sorts
+     * after the episode. A `Harrowgate.S03/Bonus…` name sorts *before* every
+     * episode, so a playlist starting at E01 would never have reached it and this
+     * test would pass with or without the filter.
+     */
+    it("leaves an extra out of a season", async () => {
+      const { base, capability, id } = await packSession({
+        files: [
+          {
+            url: "https://cdn.example/1",
+            filename: "Harrowgate.S03E01.1080p.WEB-DL.mkv",
+            bytes: 100,
+          },
+          {
+            url: "https://cdn.example/trailer",
+            filename: "Harrowgate.Trailer.mkv",
+            bytes: 50,
+          },
+        ],
+      });
+      const text = await (await fetch(`${base}/stream/${id}/0.m3u?rest=1&k=${capability}`)).text();
+      expect(urlsIn(text)).toEqual([
+        `http://127.0.0.1:${new URL(base).port}/stream/${id}/0?k=${capability}`,
+      ]);
+      expect(text).not.toContain("Trailer");
     });
 
     it("is unchanged without the parameter", async () => {
       const { base, capability, id } = await packSession();
       const text = await (await fetch(`${base}/stream/${id}/1.m3u?k=${capability}`)).text();
-      expect(text.trim().split("\n")).toHaveLength(1);
+      expect(urlsIn(text)).toHaveLength(1);
     });
 
     /**
@@ -1350,7 +1420,7 @@ describe("GET /stream/:sid/:idx.files", () => {
     it("treats rest=0 as off", async () => {
       const { base, capability, id } = await packSession();
       const text = await (await fetch(`${base}/stream/${id}/1.m3u?rest=0&k=${capability}`)).text();
-      expect(text.trim().split("\n")).toHaveLength(1);
+      expect(urlsIn(text)).toHaveLength(1);
     });
   });
 });
@@ -1463,7 +1533,12 @@ describe("GET /stream/:sid/:idx.m3u", () => {
       'attachment; filename="Copper.Kettle.Run.m3u"',
     );
     expect(res.headers["cache-control"]).toBe("no-store");
-    const lines = res.body.trim().split("\n");
+    // The header and one titled entry, so a player names the row rather than
+    // showing the URL. Content-Length must still describe what was written.
+    expect(res.body.startsWith("#EXTM3U\n")).toBe(true);
+    expect(res.body).toContain("#EXTINF:-1,Copper Kettle Run");
+    expect(Number(res.headers["content-length"])).toBe(Buffer.byteLength(res.body));
+    const lines = urlsIn(res.body);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toBe(`http://127.0.0.1:${port}/stream/${id}/0?k=${capability}`);
     // Absolute, and playable on its own: a relative URL is meaningless once the
@@ -1476,7 +1551,7 @@ describe("GET /stream/:sid/:idx.m3u", () => {
   it("is fetchable end to end — the URL inside it serves the bytes", async () => {
     const { port, capability, id } = await ready();
     const playlist = await rawGet(port, `/stream/${id}/0.m3u?k=${capability}`);
-    const res = await fetch(playlist.body.trim());
+    const res = await fetch(urlsIn(playlist.body)[0]!);
     expect(res.status).toBe(200);
     expect(Buffer.from(await res.arrayBuffer()).equals(MEDIA)).toBe(true);
   });
@@ -1518,7 +1593,34 @@ describe("GET /stream/:sid/:idx.m3u", () => {
     const res = await rawGet(port, `/stream/${id}/0.m3u?k=${capability}`, {
       Host: "nas.lan:9162",
     });
-    expect(res.body.trim()).toBe(`http://nas.lan:9162/stream/${id}/0?k=${capability}`);
+    expect(urlsIn(res.body)).toEqual([`http://nas.lan:9162/stream/${id}/0?k=${capability}`]);
+  });
+
+  /**
+   * REGRESSION GUARD for a report of a playlist naming 127.0.0.1. It turned out
+   * to be a second server on another port — the entries have always come from
+   * the request's own Host — but the report was specifically about a NON-VIDEO
+   * file (a gag reel in a season pack), which takes the `streamCandidates`
+   * fallback path. This pins that no future refactor gives such a file an origin
+   * of its own.
+   */
+  it("names the request's own host for a non-video file too", async () => {
+    upstream = await startUpstream();
+    const { reg, id, capability } = await torrentSession([
+      { url: `${upstream.base}/webtorrent/hash/disc.bin`, filename: "disc.bin", bytes: 9 },
+      { url: `${upstream.base}/webtorrent/hash/extras.bin`, filename: "extras.bin", bytes: 8 },
+    ]);
+    await start(reg, { token: "server-token" });
+    const res = await rawGet(handle!.port, `/stream/${id}/0.m3u?rest=1&k=${capability}`, {
+      Host: "nas.lan:9162",
+    });
+    expect(res.status).toBe(200);
+    const urls = urlsIn(res.body);
+    expect(urls).toHaveLength(2);
+    for (const url of urls) {
+      expect(url.startsWith("http://nas.lan:9162/stream/")).toBe(true);
+    }
+    expect(res.body).not.toContain("127.0.0.1");
   });
 
   /**
@@ -1532,7 +1634,7 @@ describe("GET /stream/:sid/:idx.m3u", () => {
       "X-Forwarded-Host": "evil.example",
       "X-Forwarded-Proto": "https",
     });
-    expect(res.body.trim()).toBe(`http://nas.lan:9162/stream/${id}/0?k=${capability}`);
+    expect(urlsIn(res.body)).toEqual([`http://nas.lan:9162/stream/${id}/0?k=${capability}`]);
     expect(res.body).not.toContain("evil.example");
   });
 
@@ -1543,7 +1645,7 @@ describe("GET /stream/:sid/:idx.m3u", () => {
       "X-Forwarded-Host": "torlnk.example",
       "X-Forwarded-Proto": "https",
     });
-    expect(res.body.trim()).toBe(`https://torlnk.example/stream/${id}/0?k=${capability}`);
+    expect(urlsIn(res.body)).toEqual([`https://torlnk.example/stream/${id}/0?k=${capability}`]);
   });
 
   it("400s rather than guessing when the Host is unusable", async () => {
@@ -1580,9 +1682,9 @@ describe("GET /stream/:sid/:idx.m3u", () => {
     await start(reg);
     const res = await rawGet(handle!.port, "/stream/sid-rd/0.m3u?k=cap-rd");
     expect(res.status).toBe(200);
-    expect(res.body.trim()).toBe(
+    expect(urlsIn(res.body)).toEqual([
       `http://127.0.0.1:${handle!.port}/stream/sid-rd/0?k=cap-rd`,
-    );
+    ]);
     expect(res.body).not.toContain("SECRETTOKEN123");
     expect(res.body).not.toContain("real-debrid.example");
   });

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -27,7 +27,8 @@ import type { ProbeCache } from "../core/probeCache";
 import type { HlsVerdictCache } from "../core/hlsVerdictCache";
 import type { StreamSession, StreamSessionRegistry } from "../core/streamSession";
 import { streamCandidates } from "../util/videoFiles";
-import { sortStreamFiles } from "../util/streamFileSort";
+import { playlistTitle } from "../util/playlistTitle";
+import { restPlaylist } from "../util/restPlaylist";
 import type { StreamFilesResponse, StreamInfoResponse } from "./wire";
 import {
   HTTP_AND_HTTPS,
@@ -169,28 +170,6 @@ export function splitRepresentation(urlPath: string): { path: string; rep: Strea
     return { path: urlPath.slice(0, -FILES_SUFFIX.length), rep: "files" };
   }
   return { path: urlPath, rep: "media" };
-}
-
-/**
- * The session indexes for `?rest=1`: this file, then every later one.
- *
- * "Later" is in DISPLAY order, not session order — the two differ whenever a
- * torrent names its files in some order of its own, which is most of them, and
- * a playlist in session order would run E08 then E02. `sortStreamFiles` is the
- * ordering the picker and the player page's episode list already use, so all
- * three agree about what "the rest of the season" means.
- *
- * Returns just `[index]` when the file is not among the candidates — a `.nfo`
- * addressed directly, say. That is the pre-`rest` behaviour, which is the right
- * answer for a file that is not part of any run.
- */
-function restOfSession(session: StreamSession, index: number): number[] {
-  const ordered = sortStreamFiles(
-    streamCandidates(session.files.map((file, at) => ({ ...file, at }))),
-    "name",
-  );
-  const from = ordered.findIndex((file) => file.at === index);
-  return from >= 0 ? ordered.slice(from).map((file) => file.at) : [index];
 }
 
 const PLAY_BASE = "/play";
@@ -499,26 +478,40 @@ export async function handleStreamRequest(
     const handleUrl = (index: number): string =>
       `${origin}${streamHandle(parsed.sid, index)}?k=${encodeURIComponent(k!)}`;
 
-    // `?rest=1` — this file and every later one, so a season plays unattended
-    // rather than one download per episode. A PARAMETER on the existing
-    // representation rather than a route of its own: the guards above, the
-    // origin check, and the body rule below all apply unchanged, and a second
-    // playlist route would be a second place to forget one of them.
+    // `?rest=1` — this file and the rest of its season, so a season plays
+    // unattended rather than one download per episode. A PARAMETER on the
+    // existing representation rather than a route of its own: the guards above,
+    // the origin check, and the body rules below all apply unchanged, and a
+    // second playlist route would be a second place to forget one of them.
     //
-    // Order is `sortStreamFiles`, the module the picker and the player page's
-    // episode list already share — a playlist that ran E08, E02, E03 would be
-    // the same bug that helper was extracted to fix — and `streamCandidates`
-    // drops the `.nfo`s, because handing a text file to a media player is how a
-    // playlist stalls halfway through a season.
+    // WHICH files that is, is `restPlaylist` in `src/util/`, not a rule written
+    // here: the player page needs the same answer to word its button — "rest of
+    // season" is a promise, and it was being made for playlists that were
+    // nothing of the kind — and two copies of one rule is the copy-then-drift
+    // bug this codebase has recorded four times.
     const wantsRest = (query.get("rest") ?? "") === "1";
-    const indexes = wantsRest ? restOfSession(session, parsed.index) : [parsed.index];
+    const indexes = wantsRest
+      ? restPlaylist(
+          session.files.map((f, index) => ({ ...f, index })),
+          parsed.index,
+        ).indexes
+      : [parsed.index];
 
-    // Bare URLs, no #EXTM3U and no #EXTINF title. Every player accepts the
-    // simplest form, and the alternative would mean interpolating a torrent's
-    // filename — attacker-controlled text — into a file another application
-    // parses. Nothing in this body is derived from the media at all, and adding
-    // a second entry does not change that.
-    const body = `${indexes.map(handleUrl).join("\n")}\n`;
+    // `#EXTINF` titles, and note what makes them safe rather than what makes
+    // them nice: a filename comes from whoever made the torrent, and this file
+    // is parsed line by line by another application. `playlistTitle` strips CR,
+    // LF and every control character, so a name cannot ADD an entry pointing
+    // wherever its author liked, and it can never return "" — an `#EXTINF:-1,`
+    // with nothing after the comma is worse than no title. Without them a
+    // thirteen-episode playlist is thirteen indistinguishable URLs.
+    //
+    // The URLs are still built from `streamHandle` and the request's own origin,
+    // so nothing a client put in the path is reflected into the body, and
+    // `file.url` — a debrid credential — appears nowhere in it.
+    const entries = indexes.map(
+      (index) => `#EXTINF:-1,${playlistTitle(session.files[index]?.filename ?? "")}\n${handleUrl(index)}`,
+    );
+    const body = `#EXTM3U\n${entries.join("\n")}\n`;
     res.writeHead(200, {
       // The content type is what makes the browser hand the file to the OS
       // instead of rendering it. text/plain and octet-stream both end with the


### PR DESCRIPTION
## What and why

Four things the player page offers as a way out to a real player. Three of them were
broken or misleading on the first try, and one report turned out not to be a bug at all.

**"Copy stream URL" never copied.** It read `navigator.clipboard`, found it absent — the
async clipboard exists only in a secure context, and the normal way to reach this dashboard
is `http://192.168.x.x` — and then said *"Copying needs a secure context — download the
.m3u instead."* You cannot make your LAN a secure context, so that was a dead end offered
in place of a route that works. `copyText.ts` now tries the async clipboard where it exists
and falls back to `document.execCommand("copy")`, **returning synchronously** to do it:
that call is only permitted inside the task the click started, so a single `await` first
and Safari refuses. When both fail it reveals a read-only field with the URL already
selected — a route that cannot fail, because the user does the copying.

**"Open in VLC" did nothing on macOS.** `vlcLinks` put macOS in the iOS branch and handed
it `vlc-x-callback://`, which belongs to VLC's *iOS* app. Checked against a real install —
`/Applications/VLC.app/Contents/Info.plist` registers `http`, `https`, `ftp`, `mms`,
`mmsh`, `rtsp`, `udp`, `rtp`, `rtmp*`, `sftp`, `smb` and **no scheme of its own** — so
nothing on the machine claimed the URL and the click was a silent no-op. That is exactly
what `vlcLinks`' own doc comment says it exists to prevent ("a button there would be a
button that does nothing"). macOS now joins Windows and Linux in getting no button, and
keeps the `.m3u`, which works on all three and does not assume VLC is what you watch things
in. `interruptedNotice` stops naming VLC for the same reason.

**Playlist entries had no titles**, so a thirteen-episode season playlist was thirteen
indistinguishable `…/stream/<uuid>/8?k=…` rows and you could not tell which was which until
one started playing. The body now carries `#EXTM3U` and an `#EXTINF:-1,<title>` per entry.

**"Rest of season" was not the rest of a season.** It meant "this file and every later one
in filename order". Started from a bonus feature it handed over every remaining extra *and
then the whole season*, under a button promising otherwise. Started from an episode it was
right only by luck: in the reported torrent the extras happened to sort clear of the
episodes, and a release naming one `Show - S04E05 - Deleted Scene` would have dropped it
into the middle of your season.

### The `127.0.0.1` report was not a bug

A downloaded playlist was seen naming `http://127.0.0.1:9171/…`. Every entry has always
been built from the request's own `Host` (`requestOrigin`), and it had been: the **port in
that file was 9171, not the 9161 being browsed** — the download came from a tab pointed at a
different server, a dev instance on another port. A playlist downloaded from
`192.168.0.98:9161` in the same session names `192.168.0.98:9161` throughout. No change,
but there is now a regression test pinning it for a *non-video* file specifically, since
that is what the report was about, so no refactor can quietly introduce a per-file origin.

### Design notes

- **`playlistTitle` answers the objection the old comment raised** rather than overruling
  it. A filename comes from whoever made the torrent and this file is parsed line by line by
  another application, so **a newline is the real hazard** — it would *add an entry* pointing
  anywhere its author liked. CR, LF and every C0/C1 control character go, a leading `#`
  cannot forge a directive, and length is capped. Commas stay: `#EXTINF` treats only the
  first comma as a separator, so `Ashfall, Rising` is both safe and correct.
- An episode name is taken **only when a spaced dash introduced it** (` - `), the shape
  Sonarr and Plex write. Dot-delimited text after the tag is release junk, and guessing
  would have put `1080p WEB DL` on screen as a title.
- **`restPlaylist` lives in `src/util/`** because the server picks the files and the browser
  words the button from the same answer. Two implementations of one rule is the
  copy-then-drift bug this repo has recorded four times.
- **No dedupe by episode number.** An extra posing as `S03E02` still gets in. Deduping would
  remove it — and would equally remove `S03E02.Part2` next to `Part1`, which loses half an
  episode to tidy up a duplicate. A test records the choice.
- The button appears only when the playlist has more than one entry, which is **stricter
  than "there is a next row"**: from the last episode of a season the next file may be an
  extra, and the season is still over.

### Both front ends

The `.m3u` is built server-side, so titles and the season rule reach the terminal and the
browser at once. The copy button and the VLC link are browser-only under CLAUDE.md's "a
surface can't express it": the terminal has no clipboard button and no URL scheme to link
to, because `src/util/player.ts` launches the user's player directly. Nothing in the TUI
changes.

### Verified by running it, not only by tests

On a real insecure LAN origin (`http://192.168.0.249:9174`, `isSecureContext: false`,
`navigator.clipboard` undefined): clicking Copy reported "Stream URL copied." and the system
clipboard held `http://192.168.0.249:9174/stream/sid-x/0?k=nope`. No **Open in VLC** button
rendered on macOS Chrome.

**Not verified:** the rest-of-season button in a live session, which needs a real stream to
exist. Its server half is covered end to end against a real `http.Server` in
`stream.test.ts` and its label logic in `upNext.test.ts`; what is untested is the three
lines of DOM wiring that render the string.

**Left alone deliberately:** `preview/web-player-fallback.png` still shows an *Open in VLC*
button. It is a photograph of older behaviour, and regenerating README screenshots is the
repo owner's call.

### Test notes, both traps CLAUDE.md warns about

- `not.toContain("#EXTINF")` asserted the *opposite* of this change. It is replaced by two
  tests keeping the rule it protected: a filename cannot add a line, and every entry has a
  title. Several assertions read the body as a single URL (one `fetch`ed it verbatim) and
  now go through a `urlsIn()` helper; the negative assertions about leaks stay on the whole
  body, because a leak into a title is still a leak.
- The extras fixture is named `Harrowgate.Trailer.mkv` **on purpose**. A
  `Harrowgate.S03/Bonus_Gag_Reel_1.mkv` name sorts *before* every episode under numeric
  collation, so a playlist starting at E01 would never reach it and the test would have
  passed with or without the filter. Confirmed by watching it fail on the old rule first.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (2578 tests)
- [x] New logic has a test (vitest; `playlistTitle`, `restPlaylist`, `upNext`, `stream`)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, no keys
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a, no `Store` fields
- [x] OS-touching code works on Windows, macOS, and Linux — the point of the VLC change; the two new modules are pure and browser-safe (`npm run build` passes)
- [x] One concern, with a Conventional Commits title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
