### PR TITLE
Fix what the browser does when things go wrong, and the phone it is used on

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,13 @@ anything other than loopback requires a token.
 #### What the browser can't do yet
 
 - **No restarting a stopped seed.** Stopping one drops it out of the status payload into history, which
-  the browser can't see.
+  the browser can't see. (A failed *download* is a different thing and does have a **Retry** button.)
+- **No exporting a `.torrent` and no "open folder".** Both are TUI-only: one needs a file the browser
+  would have to be handed, the other means opening a file manager on the machine torlink is running on,
+  which a phone on your sofa is not.
+- **Two keyboard shortcuts, not the terminal's hundred-odd.** `/` focuses the search box from anywhere
+  and the arrow keys walk the results. There is no `?` overlay — the browser is buttons, and the
+  shortcuts worth having on a surface you mostly touch are few.
 - **No subtitles, no scrubber.** [Continue watching](#continue-watching) does play the next episode
   automatically when a row names one — it just can't resume *where* you left off, because nothing here
   reads back from mpv, iina, vlc, or a browser tab; none of them report a position.

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -154,6 +154,28 @@ describe("handleApi", () => {
     expect(res.body).toMatchObject({ ok: true, action: "pause" });
     expect(pause).toHaveBeenCalledWith(HASH);
   });
+
+  /**
+   * `retry` exposes `queue.retry`, which the TUI has reached since it shipped
+   * (the `f` key on the queue pane) and no HTTP caller could. Without it a
+   * failed download offers a browser `pause` and `resume` — one meaningless,
+   * the other a no-op, since `resume` only un-pauses and a failed item is not
+   * paused — so the queue's dead rows had no recovery at all.
+   */
+  it("retries a known download on POST /control", async () => {
+    const retry = vi.fn();
+    runtime.queue = { has: (id: string) => id === HASH, retry } as unknown as Runtime["queue"];
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"retry"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, action: "retry" });
+    expect(retry).toHaveBeenCalledWith(HASH);
+  });
+
+  it("404s a retry for an unknown torrent rather than silently doing nothing", async () => {
+    runtime.queue = { has: () => false, retry: vi.fn() } as unknown as Runtime["queue"];
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"retry"}`);
+    expect(res.status).toBe(404);
+  });
 });
 
 describe("parseControl", () => {

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -97,6 +97,7 @@ export function extractMagnet(bodyText: string): string | null {
 export const CONTROL_ACTIONS = [
   "pause", // pause an active/queued download
   "resume", // resume a paused download
+  "retry", // re-run a FAILED download (resume only un-pauses; it cannot)
   "start-seed", // (re)start seeding a finished torrent
   "stop-seed", // stop seeding but keep the files
   "remove", // forget the torrent, keep files on disk
@@ -147,6 +148,15 @@ export async function applyControl(
       if (!q.has(id)) return "not-found";
       q.resume(id);
       return "ok";
+    // Distinct from `resume`, not a synonym: `resume` un-pauses, and a failed
+    // item is not paused, so it was a no-op on exactly the rows that needed
+    // something to happen. `queue.retry` clears the error and re-runs the
+    // pipeline — re-resolving through the *currently active* debrid provider,
+    // which is why it cannot just be a client-side "pause then resume".
+    case "retry":
+      if (!q.has(id)) return "not-found";
+      q.retry(id);
+      return "ok";
     case "stop-seed":
       if (!q.getSeed(id)) return "not-found";
       q.stopSeeding(id);
@@ -188,6 +198,10 @@ export function statusPayload(runtime: Runtime): StatusPayload {
     progress: it.progress,
     peers: it.peers,
     speed: it.speed,
+    // Conditional rather than `error: it.error`, matching toPublicSession's
+    // rule: the wire type marks it optional, and a key whose value is undefined
+    // is dropped by JSON.stringify but present to any in-process consumer.
+    ...(it.error === undefined ? {} : { error: it.error }),
   }));
   const seeds = runtime.queue.getSeeds().map((s) => ({
     id: s.id,

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -362,25 +362,75 @@ function showNotice(message: string): void {
  * the row that failed.
  */
 function showError(message: string, action?: { label: string; run: () => void }): void {
-  alertLine.textContent = message;
-  if (action) {
-    alertAction.textContent = action.label;
+  showAlert({ message, tone: "error", action });
+}
+
+/**
+ * How long an undo stays offered.
+ *
+ * Long enough to notice a mis-tap and react — the whole reason this exists is a
+ * 26px `remove` a few millimetres from `play` on a phone — and short enough not
+ * to sit over the list. Errors get no timer at all: they persist.
+ */
+const UNDO_MS = 8000;
+
+/**
+ * "Removed · Undo".
+ *
+ * The alternative was a native `confirm()` before every delete, and this is
+ * better on the surface that matters: a confirm interrupts the ninety-nine
+ * removals that were meant in order to catch the one that wasn't, whereas an
+ * undo costs the ninety-nine nothing. It is also what makes the deletion honest
+ * about having happened, which a dialog asking permission does not.
+ *
+ * Not offered where the server cannot put the thing back — see the call sites.
+ */
+function showUndo(message: string, undo: () => void): void {
+  showAlert({ message, tone: "info", action: { label: "Undo", run: undo }, timeoutMs: UNDO_MS });
+}
+
+let alertTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showAlert(opts: {
+  message: string;
+  tone: "error" | "info";
+  action?: { label: string; run: () => void };
+  /** Absent means it stays until dismissed, which is what an error does. */
+  timeoutMs?: number;
+}): void {
+  alertLine.textContent = opts.message;
+  alertBox.classList.toggle("alert-info", opts.tone === "info");
+  if (opts.action) {
+    const { label, run } = opts.action;
+    alertAction.textContent = label;
     alertAction.hidden = false;
-    // Replaced wholesale rather than added to: this element is reused for every
-    // error, and a listener left behind would fire the previous failure's retry.
+    // Assigned, not added: this element is reused for every alert, and a
+    // listener left behind would fire the PREVIOUS one's action — undoing a
+    // removal the user has since made twice, or retrying a play they gave up on.
     alertAction.onclick = () => {
       hideError();
-      action.run();
+      run();
     };
   } else {
     alertAction.hidden = true;
     alertAction.onclick = null;
   }
+  if (alertTimer !== null) clearTimeout(alertTimer);
+  alertTimer =
+    opts.timeoutMs === undefined
+      ? null
+      : setTimeout(() => {
+          alertTimer = null;
+          hideError();
+        }, opts.timeoutMs);
   alertBox.hidden = false;
 }
 
 function hideError(): void {
+  if (alertTimer !== null) clearTimeout(alertTimer);
+  alertTimer = null;
   alertBox.hidden = true;
+  alertBox.classList.remove("alert-info");
   alertLine.textContent = "";
   alertAction.hidden = true;
   alertAction.onclick = null;
@@ -3244,6 +3294,17 @@ async function removeSavedSearch(query: string): Promise<void> {
   if (!body) return;
   savedState = applySavedSearchesResponse(savedState, body);
   renderSaved();
+  // A saved search is the user's own typing and nothing else in the app holds a
+  // copy, so a mis-tap on a 26px button next to `search` lost it for good.
+  // `toggle` re-adds it, because it is absent now.
+  showUndo(`Removed “${query}”.`, () => {
+    void (async () => {
+      const back = await postSaved("/api/saved-searches", savedSearchesBody(query, "toggle"));
+      if (!back) return;
+      savedState = applySavedSearchesResponse(savedState, back);
+      renderSaved();
+    })();
+  });
 }
 
 // Called by the favourite button on each search row.
@@ -3263,8 +3324,20 @@ async function removeFromLibrary(infoHash: string, name: string): Promise<void> 
   savedState = applyLibraryResponse(savedState, body);
   renderSaved();
   renderResults();
+  // Same reasoning as removeSavedSearch. The watched-episode count does not
+  // survive the round trip — the server keeps that per info hash and a re-add
+  // starts a fresh favourite — so the undo restores the row, not its history.
+  showUndo(`Removed “${shortName(name)}”.`, () => {
+    void toggleLibrary({ infoHash, name });
+  });
 }
 
+// NO UNDO HERE, and the reason is the server rather than an oversight:
+// `POST /api/continue-watching` takes one action, `remove`, because nothing
+// plays a title and then un-plays it — so there is no request that would put
+// the row back. It is also the least costly of the three to lose: the row is
+// derived from stream history and reappears the next time the title is played,
+// where a saved search and a favourite are gone for good.
 async function removeContinueWatching(key: string): Promise<void> {
   const body = await postSaved("/api/continue-watching", continueWatchingBody(key));
   if (!body) return;

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -1370,8 +1370,9 @@ function renderTabs(): void {
       button.type = "button";
       button.className = "tab";
       button.textContent = group;
-      button.setAttribute("role", "tab");
-      button.setAttribute("aria-selected", String(group === searchView.group));
+      // aria-pressed, matching #views: this is a toggle button, not a tab. See
+      // the comment on #tabs in index.html for why the tablist role went.
+      button.setAttribute("aria-pressed", String(group === searchView.group));
       button.addEventListener("click", () => {
         const plan = tabClickPlan(searchView, group, queryInput.value);
         if (plan.action === "ignore") return;

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -192,6 +192,7 @@ import { authHeadersFor, readStoredToken, storeToken } from "./token";
 import { routeFromSearch, urlForRoute, type RouteState } from "./route";
 import { rememberReturn } from "./returnTo";
 import { foldRecent, magnetFor, readRecent, writeRecent } from "./recentSearches";
+import { clipboardPorts, copyNotice, copyText } from "./copyText";
 
 const EMPTY_TEXT = "Nothing in the queue.";
 const NOTICE_MS = 4000;
@@ -2122,21 +2123,25 @@ function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivEleme
   copyButton.textContent = "copy magnet";
   tagControl(copyButton, rowKey, "copy");
   copyButton.addEventListener("click", () => {
-    // Same two failure modes as the player page's copy button, reported for the
-    // same reason: clipboard.writeText does not exist on an insecure origin —
-    // which is the normal way this dashboard is reached over a LAN — and
-    // rejects when the page is not focused. A copy button that silently does
-    // nothing is worse than no button.
-    const clip = navigator.clipboard;
     const magnet = magnetFor(result.infoHash, result.name);
-    if (!clip) {
-      showNotice("Copying needs a secure context (https or localhost).");
-      return;
-    }
-    void clip.writeText(magnet).then(
-      () => showNotice("Magnet copied."),
-      () => showNotice("Couldn't copy that magnet."),
-    );
+    // THROUGH copyText, not navigator.clipboard directly. `navigator.clipboard`
+    // exists only in a secure context, and the normal way this dashboard is
+    // reached is a LAN address — so a bare `writeText` here would do nothing but
+    // explain itself on the very surface this button is for. copyText falls back
+    // to execCommand, which is why it must be called straight from the click
+    // with nothing awaited in front of it: the browser only permits that inside
+    // the task the gesture started.
+    const outcome = copyText(magnet, clipboardPorts());
+    void Promise.resolve(outcome).then((res) => {
+      if (res === "copied") {
+        showNotice(copyNotice(res, "Magnet"));
+        return;
+      }
+      // Refused. The alert is this page's equivalent of the player's read-only
+      // field: it persists, and its line is selectable text — so putting the
+      // magnet in it means the button still gets the user what they came for.
+      showError(`${copyNotice(res, "Magnet", "the message below")}\n${magnet}`);
+    });
   });
   actions.append(copyButton);
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -2140,7 +2140,7 @@ function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivEleme
       // Refused. The alert is this page's equivalent of the player's read-only
       // field: it persists, and its line is selectable text — so putting the
       // magnet in it means the button still gets the user what they came for.
-      showError(`${copyNotice(res, "Magnet", "the message below")}\n${magnet}`);
+      showError(`${copyNotice(res, "Magnet", "below — select it and copy")}\n${magnet}`);
     });
   });
   actions.append(copyButton);

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -133,6 +133,7 @@ import {
   applySaved,
   applySavedSearchesResponse,
   continueWatchingBody,
+  continueWatchingGroup,
   continueWatchingFallbackQuery,
   continueWatchingStatus,
   continueWatchingSub,
@@ -1408,6 +1409,13 @@ async function loadSources(): Promise<void> {
   renderTabs();
   renderResults();
   renderPrefs();
+  // AND the saved pane, which is new here: its Continue-watching rows carry
+  // artwork now, and whether to fetch any depends on `omdbConfigured` — which
+  // arrives in this response. `loadSaved` and `loadSources` are both fired
+  // unawaited at boot, and saved usually wins, so without this the rows are
+  // built while the answer is still "no key" and stay blank until something
+  // else happens to re-render them.
+  renderSaved();
 
   const claimHint = reccClaimHint(sources?.reccAccount);
   reccClaimHintLine.textContent = claimHint ?? "";
@@ -1930,7 +1938,9 @@ const posterObserver: IntersectionObserver | null =
           // Stop watching this frame specifically; the others stay armed.
           posterObserver?.unobserve(entry.target);
           const pending = posterTargets.get(entry.target);
-          if (pending) startPoster(pending.release, entry.target as HTMLElement, pending.compact);
+          if (pending) {
+            startPoster(pending.release, entry.target as HTMLElement, pending.compact, pending.group);
+          }
         }
       })
     : null;
@@ -1938,10 +1948,17 @@ const posterObserver: IntersectionObserver | null =
 // What each observed frame is waiting for. A WeakMap so a frame discarded by a
 // re-render is collectable — a Map keyed on elements would be the leak this
 // design is avoiding, just spelled differently.
-const posterTargets = new WeakMap<Element, { release: string; compact: boolean }>();
+const posterTargets = new WeakMap<
+  Element,
+  { release: string; compact: boolean; group?: string }
+>();
 
-function startPoster(release: string, host: HTMLElement, compact: boolean): void {
-  const outcome = resultPosters.want(release, searchView.group);
+function startPoster(release: string, host: HTMLElement, compact: boolean, group?: string): void {
+  // `group` is what OMDb is asked to look the title up as. It defaults to the
+  // search tab because that is where posters started — but the Continue-watching
+  // rows are not part of a search, and asking for a show under whatever tab the
+  // user last clicked would look it up as a film.
+  const outcome = resultPosters.want(release, group ?? searchView.group);
   if (!(outcome instanceof Promise)) {
     paintPoster(host, outcome, compact);
     return;
@@ -1962,7 +1979,12 @@ function startPoster(release: string, host: HTMLElement, compact: boolean): void
  * naturally ~20 picks and needs no such gate, which is why its own mount is
  * eager.
  */
-function mountResultPoster(release: string, host: HTMLElement, compact: boolean): void {
+function mountResultPoster(
+  release: string,
+  host: HTMLElement,
+  compact: boolean,
+  group?: string,
+): void {
   const known = resultPosters.peek(release);
   if (known !== undefined) {
     // Settled already: paint it and never observe it. This is the path almost
@@ -1977,10 +1999,10 @@ function mountResultPoster(release: string, host: HTMLElement, compact: boolean)
   // hole, and the row does not resize when the image lands.
   host.replaceChildren();
   if (posterObserver === null) {
-    startPoster(release, host, compact);
+    startPoster(release, host, compact, group);
     return;
   }
-  posterTargets.set(host, { release, compact });
+  posterTargets.set(host, { release, compact, group });
   posterObserver.observe(host);
 }
 
@@ -3445,7 +3467,7 @@ function renderLibraryRow(f: PublicFavourite): HTMLLIElement {
 // string `renderLibraryRow`'s `name` is.
 function renderContinueRow(item: PublicStreamHistoryItem): HTMLLIElement {
   const li = document.createElement("li");
-  li.className = "row";
+  li.className = "row continue-row";
 
   const head = document.createElement("div");
   head.className = "result-head";
@@ -3454,6 +3476,22 @@ function renderContinueRow(item: PublicStreamHistoryItem): HTMLLIElement {
   name.textContent = item.title;
   name.title = item.rawName;
   head.append(name);
+
+  // ARTWORK. This was the only pane in the app with none — five grey text slabs
+  // in a product whose search and For You panes are both poster walls — and it
+  // is the pane most likely to be opened from a sofa, where recognising a show
+  // by its cover is the entire interaction. The whole point of "continue
+  // watching" is that you already know what these are.
+  //
+  // The SAME cache and the same lazy mount the results list uses, keyed on the
+  // release name, so a title showing in both places is fetched once and the
+  // daily-capped OMDb key is spent once. Small: this is a resume list, not a
+  // browse, and the row stays a row.
+  const poster = document.createElement("div");
+  poster.className = "poster continue-poster";
+  if (postersApply(continueWatchingGroup(item), sources?.omdbConfigured === true)) {
+    mountResultPoster(item.rawName, poster, true, continueWatchingGroup(item));
+  }
 
   const meta = document.createElement("span");
   meta.className = "row-meta";
@@ -3519,7 +3557,13 @@ function renderContinueRow(item: PublicStreamHistoryItem): HTMLLIElement {
   remove.addEventListener("click", () => void removeContinueWatching(item.key));
   actions.append(remove);
 
-  li.append(head, meta, actions);
+  // The poster is a sibling of the text column, not inside it: the row becomes
+  // a two-column grid (see .continue-row) so the artwork spans title, subtitle
+  // and buttons rather than sitting above them.
+  const body = document.createElement("div");
+  body.className = "continue-body";
+  body.append(head, meta, actions);
+  li.append(poster, body);
   return li;
 }
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -191,6 +191,7 @@ import { SUGGEST_DEBOUNCE_MS, shouldQueryFor } from "../../util/titleSuggest";
 import { authHeadersFor, readStoredToken, storeToken } from "./token";
 import { routeFromSearch, urlForRoute, type RouteState } from "./route";
 import { rememberReturn } from "./returnTo";
+import { foldRecent, magnetFor, readRecent, writeRecent } from "./recentSearches";
 
 const EMPTY_TEXT = "Nothing in the queue.";
 const NOTICE_MS = 4000;
@@ -233,6 +234,7 @@ const viewReccTab = el<HTMLButtonElement>("view-recc");
 const viewSavedTab = el<HTMLButtonElement>("view-saved");
 const viewQueueTab = el<HTMLButtonElement>("view-queue");
 const queueCount = el<HTMLSpanElement>("queue-count");
+const recentStrip = el<HTMLDivElement>("recent");
 const paneSearch = el<HTMLElement>("pane-search");
 const paneRecc = el<HTMLElement>("pane-recc");
 const paneSaved = el<HTMLElement>("pane-saved");
@@ -1300,6 +1302,41 @@ let seededExpansion = false;
 // rows that are not rendered.
 let currentRows: GroupRow<PublicSearchResult>[] = [];
 
+let recent: string[] = readRecent();
+
+/**
+ * The recent-search chips.
+ *
+ * Hidden while the box has something in it: once you are typing, `#suggest` is
+ * the list that matters and two dropdowns stacked under one input is a mess.
+ * Hidden when empty too, so a fresh install shows nothing rather than an empty
+ * strip explaining itself.
+ */
+function renderRecent(): void {
+  const show = recent.length > 0 && queryInput.value.trim() === "";
+  recentStrip.hidden = !show;
+  if (!show) {
+    recentStrip.replaceChildren();
+    return;
+  }
+  recentStrip.replaceChildren(
+    ...recent.map((query) => {
+      // createElement + textContent: this is the user's own typing, but it has
+      // been through localStorage, which anything on this origin can write.
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = "saved-query recent-chip";
+      chip.textContent = query;
+      chip.title = `Search for ${query}`;
+      chip.addEventListener("click", () => {
+        queryInput.value = query;
+        startSearch(query);
+      });
+      return chip;
+    }),
+  );
+}
+
 /**
  * Put what the user is doing into the address bar.
  *
@@ -1497,6 +1534,13 @@ function startSearch(raw: string): void {
   // After searchView.query is set, so the address bar names the search actually
   // running rather than the one before it.
   syncUrl();
+  // Recorded on RUN, not on submit: this is also the path a recent chip, a saved
+  // search, a Continue-watching fallback and the player's "find a playable
+  // release" all take, and every one of them is a search worth being able to get
+  // back to. foldRecent ignores the blank query that means browse.
+  recent = foldRecent(recent, query);
+  writeRecent(recent);
+  renderRecent();
 
   const source = new EventSource(searchUrl(query, searchView.group, token));
   searchStream = source;
@@ -1725,6 +1769,8 @@ async function loadSuggest(raw: string, seq: number): Promise<void> {
 }
 
 queryInput.addEventListener("input", () => {
+  // The chips give way to #suggest as soon as there is something to suggest on.
+  renderRecent();
   if (suggestTimer !== null) clearTimeout(suggestTimer);
   // The capability flag from /api/sources, so a reccd-less server never spends
   // a request per character discovering that again.
@@ -2062,6 +2108,37 @@ function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivEleme
     debridButton.addEventListener("click", () => void addResult(result, "debrid"));
     actions.append(debridButton);
   }
+
+  // The terminal's `y`. The browser had no way at all to get a magnet out of a
+  // result — the one thing you need to hand a release to any other client, or
+  // to paste back into the queue's own add box.
+  //
+  // Built client-side by magnetFor rather than shipped on the wire, and that is
+  // not a shortcut: `PublicSearchResult` deliberately carries no magnet, because
+  // the tracker list would be a few hundred bytes per row for something almost
+  // no row needs. A hash-and-name magnet is what `y` copies too.
+  const copyButton = document.createElement("button");
+  copyButton.type = "button";
+  copyButton.textContent = "copy magnet";
+  tagControl(copyButton, rowKey, "copy");
+  copyButton.addEventListener("click", () => {
+    // Same two failure modes as the player page's copy button, reported for the
+    // same reason: clipboard.writeText does not exist on an insecure origin —
+    // which is the normal way this dashboard is reached over a LAN — and
+    // rejects when the page is not focused. A copy button that silently does
+    // nothing is worse than no button.
+    const clip = navigator.clipboard;
+    const magnet = magnetFor(result.infoHash, result.name);
+    if (!clip) {
+      showNotice("Copying needs a secure context (https or localhost).");
+      return;
+    }
+    void clip.writeText(magnet).then(
+      () => showNotice("Magnet copied."),
+      () => showNotice("Couldn't copy that magnet."),
+    );
+  });
+  actions.append(copyButton);
 
   return actions;
 }
@@ -3695,6 +3772,7 @@ function openApp(payload: StatusPayload): void {
   // savedState: without this, a hit already in the library opens reading
   // "favourite" and the first click removes it.
   void loadSaved();
+  renderRecent();
   queryInput.focus();
   // `?prefs=1` — the player page's "Avoid this next time", from the card that
   // says a release cannot play here. A ONE-SHOT INTENT, not view state, so it is

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -202,6 +202,10 @@ const magnetInput = el<HTMLInputElement>("magnet");
 const rowsList = el<HTMLUListElement>("rows");
 const emptyNote = el<HTMLParagraphElement>("empty");
 const notice = el<HTMLParagraphElement>("notice");
+const alertBox = el<HTMLDivElement>("alert");
+const alertLine = el<HTMLSpanElement>("alert-line");
+const alertAction = el<HTMLButtonElement>("alert-action");
+const alertDismiss = el<HTMLButtonElement>("alert-dismiss");
 const conn = el<HTMLSpanElement>("conn");
 const picker = el<HTMLDialogElement>("picker");
 const pickerTitle = el<HTMLParagraphElement>("picker-title");
@@ -338,6 +342,48 @@ function showNotice(message: string): void {
     notice.hidden = true;
   }, NOTICE_MS);
 }
+
+/**
+ * Something went wrong. Says so until the user says otherwise.
+ *
+ * SEPARATE FROM showNotice, and the split is the fix. `showNotice` writes into a
+ * paragraph in normal flow and hides it after four seconds, which is right for
+ * "Added." and wrong for every failure: a play that fails ninety seconds into a
+ * resolve reports to a paragraph the user scrolled past long ago, so the app
+ * simply goes quiet. This project already diagnosed that once — it is why
+ * `#prepare` is fixed to the viewport — and this applies the same remedy to the
+ * alarming case rather than only the reassuring one.
+ *
+ * `action` is the difference between reporting a failure and letting the user
+ * do something about it. Without it, "try again" means scrolling back to find
+ * the row that failed.
+ */
+function showError(message: string, action?: { label: string; run: () => void }): void {
+  alertLine.textContent = message;
+  if (action) {
+    alertAction.textContent = action.label;
+    alertAction.hidden = false;
+    // Replaced wholesale rather than added to: this element is reused for every
+    // error, and a listener left behind would fire the previous failure's retry.
+    alertAction.onclick = () => {
+      hideError();
+      action.run();
+    };
+  } else {
+    alertAction.hidden = true;
+    alertAction.onclick = null;
+  }
+  alertBox.hidden = false;
+}
+
+function hideError(): void {
+  alertBox.hidden = true;
+  alertLine.textContent = "";
+  alertAction.hidden = true;
+  alertAction.onclick = null;
+}
+
+alertDismiss.addEventListener("click", hideError);
 
 // The waiting line, or null to take it down. This is runPlay's `progress` effect
 // — separate from `notice` because this one persists for the length of a resolve
@@ -612,13 +658,13 @@ async function control(id: string, action: string): Promise<void> {
       body: JSON.stringify({ id, action }),
     });
   } catch {
-    showNotice(`${action} failed — the server is not responding.`);
+    showError(`${action} failed — the server is not responding.`);
     setConn("lost");
     return;
   }
   if (res.ok) return;
   const body = await readEnvelope(res);
-  showNotice(body.error ?? `${action} failed (HTTP ${res.status}).`);
+  showError(body.error ?? `${action} failed (HTTP ${res.status}).`);
 }
 
 // ---- streaming ------------------------------------------------------------
@@ -693,7 +739,7 @@ async function startSession(
     // `signal.aborted` immediately after this returns and reports the cancel
     // itself, so this stays silent and lets it.
     if (signal?.aborted) return { kind: "failed" };
-    showNotice("Play failed — the server is not responding.");
+    showError("Play failed — the server is not responding.");
     setConn("lost");
     return { kind: "failed" };
   }
@@ -712,7 +758,7 @@ async function startSession(
   }
   if (!res.ok) {
     const body = await readEnvelope(res);
-    showNotice(body.error ?? `Play failed (HTTP ${res.status}).`);
+    showError(body.error ?? `Play failed (HTTP ${res.status}).`);
     return { kind: "failed" };
   }
 
@@ -723,7 +769,7 @@ async function startSession(
     !body.session ||
     typeof body.session !== "object"
   ) {
-    showNotice("Play failed — the server sent something unreadable.");
+    showError("Play failed — the server sent something unreadable.");
     return { kind: "failed" };
   }
   return {
@@ -991,7 +1037,20 @@ async function play(
         poll: pollSession,
         stop: stopSession,
         confirm: (message) => confirm(message),
-        notice: showNotice,
+        // A cancellation clears itself; a failure persists and offers to go
+        // again. Retrying re-enters this same function with the same arguments,
+        // so "Try again" means exactly what pressing Play again would have
+        // meant — without having to scroll back and find the row.
+        notice: (message, kind) => {
+          if (kind !== "failure") {
+            showNotice(message);
+            return;
+          }
+          showError(message, {
+            label: "Try again",
+            run: () => void play(row, onUnresolved, next),
+          });
+        },
         progress: showPrepare,
         // Closes over THIS row's hash, not a module-level variable — see
         // showPicker's comment for why that distinction is load-bearing.
@@ -2571,13 +2630,13 @@ async function addResult(result: PublicSearchResult, via: AddVia): Promise<void>
       body: JSON.stringify(addBody(result, plan.via)),
     });
   } catch {
-    showNotice("Add failed — the server is not responding.");
+    showError("Add failed — the server is not responding.");
     setConn("lost");
     return;
   }
   const body = await readEnvelope(res);
   if (!res.ok) {
-    showNotice(body.error ?? `Add failed (HTTP ${res.status}).`);
+    showError(body.error ?? `Add failed (HTTP ${res.status}).`);
     return;
   }
   if (body.outcome === "duplicate") {
@@ -3587,7 +3646,7 @@ addForm.addEventListener("submit", (event) => {
         body: JSON.stringify({ magnet }),
       });
     } catch {
-      showNotice("Add failed — the server is not responding.");
+      showError("Add failed — the server is not responding.");
       setConn("lost");
       return;
     }
@@ -3597,7 +3656,7 @@ addForm.addEventListener("submit", (event) => {
       showNotice(body.outcome === "duplicate" ? "Already in the queue." : "Added.");
       return;
     }
-    showNotice(body.error ?? `Add failed (HTTP ${res.status}).`);
+    showError(body.error ?? `Add failed (HTTP ${res.status}).`);
   })();
 });
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -6,9 +6,12 @@
 // Bundled for the browser, so it must import nothing from node:* and nothing in
 // the repo outside this directory.
 import {
+  failureLine,
   formatBytes,
   formatRate,
+  hasFailed,
   mergeRows,
+  rowActions,
   rowsFromStatus,
   shortName,
   type DashRow,
@@ -455,11 +458,9 @@ prepareCancel.addEventListener("click", () => {
   prepareAbort?.abort();
 });
 
-// Every action the row buttons can take. Downloads and seeds expose different
-// sets; `delete` also removes the files, which is why it is offered only where
-// the TUI offers it.
-const DOWNLOAD_ACTIONS = ["pause", "resume", "remove"] as const;
-const SEED_ACTIONS = ["stop-seed", "delete"] as const;
+// Which actions a row offers is `rowActions` in dashboard.ts — a decision, and
+// tested there. It used to be two constants here, and the download one was a
+// fixed ["pause","resume","remove"] that put `pause` on a failed torrent.
 
 // Gate the irreversible actions. pause, resume and stop-seed are all undone by
 // the button next to them, so they fire immediately; remove discards a torrent
@@ -559,8 +560,13 @@ function renderRow(row: DashRow): HTMLLIElement {
   name.title = row.name;
 
   const meta = document.createElement("span");
-  meta.className = "row-meta";
-  meta.textContent = metaLine(row);
+  // A dead torrent's counters describe nothing: `0 peers · —` reads as a
+  // rendering bug rather than as a state. The reason it failed is the only part
+  // of the row anyone can act on, so it takes the line. failureLine is null for
+  // every row that has not failed.
+  const failure = failureLine(row);
+  meta.className = failure ? "row-meta error" : "row-meta";
+  meta.textContent = failure ?? metaLine(row);
   head.append(name, meta);
 
   const bar = document.createElement("div");
@@ -569,6 +575,11 @@ function renderRow(row: DashRow): HTMLLIElement {
   // percent is already clamped to 0..100 by dashboard.ts, so this cannot smuggle
   // anything into the style attribute.
   fill.style.width = `${row.percent}%`;
+  // A torrent that dies at 99% drew 99% of an accent-coloured bar, which is the
+  // strongest signal on the row saying "nearly done" while the weakest — a dim
+  // grey word — said "failed". The bar is the thing people read at a glance, so
+  // it is the thing that has to be honest.
+  if (hasFailed(row)) fill.classList.add("is-failed");
   bar.append(fill);
 
   const actions = document.createElement("div");
@@ -586,8 +597,7 @@ function renderRow(row: DashRow): HTMLLIElement {
     playButton.addEventListener("click", () => void play(row));
     actions.append(playButton);
   }
-  const available: readonly string[] = row.kind === "seed" ? SEED_ACTIONS : DOWNLOAD_ACTIONS;
-  for (const action of available) {
+  for (const action of rowActions(row)) {
     const button = document.createElement("button");
     button.type = "button";
     button.textContent = action;
@@ -625,6 +635,14 @@ function render(): void {
   // it without switching panes — otherwise "did that work?" needs a click.
   queueCount.textContent = rows.length > 0 ? String(rows.length) : "";
   queueCount.hidden = rows.length === 0;
+  // And it says whether anything in there is broken. Without this the badge
+  // reads "2" whether both downloads are running or both are dead, so a user on
+  // any other pane has no reason to look — which is exactly when a failure sits
+  // unnoticed for an evening. The count still reads as a count; only its colour
+  // changes, and the title says why for anyone who cannot see the colour.
+  const failures = rows.filter(hasFailed).length;
+  queueCount.classList.toggle("badge-error", failures > 0);
+  queueCount.title = failures > 0 ? `${failures} failed` : "";
 }
 
 // The server's error envelope. Read defensively: a proxy or a crash can return
@@ -3560,6 +3578,16 @@ function openApp(payload: StatusPayload): void {
   // "favourite" and the first click removes it.
   void loadSaved();
   queryInput.focus();
+  // `?prefs=1` — the player page's "Avoid this next time", from the card that
+  // says a release cannot play here. A ONE-SHOT INTENT, not view state, so it is
+  // read straight off `location` rather than through RouteState: the next
+  // `syncUrl` rebuilds the query from the route and drops it, which is exactly
+  // right. Reloading the page should not keep reopening a disclosure.
+  if (new URLSearchParams(location.search).get("prefs") === "1") {
+    prefsBlock.open = true;
+    prefsBlock.scrollIntoView({ block: "nearest" });
+    syncUrl();
+  }
   // The search the URL asked for — last, and only when there is one.
   //
   // This is what makes coming back from the player work: the player page is a

--- a/src/web/static/copyText.test.ts
+++ b/src/web/static/copyText.test.ts
@@ -126,8 +126,14 @@ describe("copyNotice", () => {
    */
   it("names what was copied and where it went", () => {
     expect(copyNotice("copied", "Magnet")).toBe("Magnet copied.");
-    expect(copyNotice("manual", "Magnet", "the message below")).toContain("the message below");
-    expect(copyNotice("manual", "Magnet", "the message below")).not.toContain("the field");
+    const revealed = copyNotice("manual", "Magnet", "below — select it and copy");
+    expect(revealed).toContain("below — select it and copy");
+    expect(revealed).not.toContain("the field");
+    // The default's "already selected" is TRUE of the player's field, which it
+    // calls select() on, and false of text sitting in the alert. Claiming a
+    // selection that is not there sends someone to press cmd-C on whatever they
+    // had before.
+    expect(revealed).not.toContain("already selected");
   });
 
   it("still defaults to the player page's wording", () => {

--- a/src/web/static/copyText.test.ts
+++ b/src/web/static/copyText.test.ts
@@ -116,4 +116,24 @@ describe("copyNotice", () => {
     expect(notice).not.toContain("secure context");
     expect(notice).not.toContain(".m3u");
   });
+
+  /**
+   * The dashboard's results list copies a magnet through the same `copyText`,
+   * and reveals it in the alert rather than in a field. One function decides
+   * the wording for both so they cannot drift into describing the same refusal
+   * differently — but it has to name the right place, because sending someone's
+   * eyes to a field that does not exist is worse than saying nothing.
+   */
+  it("names what was copied and where it went", () => {
+    expect(copyNotice("copied", "Magnet")).toBe("Magnet copied.");
+    expect(copyNotice("manual", "Magnet", "the message below")).toContain("the message below");
+    expect(copyNotice("manual", "Magnet", "the message below")).not.toContain("the field");
+  });
+
+  it("still defaults to the player page's wording", () => {
+    // The player passes neither argument, so its two messages must be byte-for
+    // -byte what they were before the parameters existed.
+    expect(copyNotice("copied")).toBe("Stream URL copied.");
+    expect(copyNotice("manual")).toContain("the field");
+  });
 });

--- a/src/web/static/copyText.ts
+++ b/src/web/static/copyText.ts
@@ -54,10 +54,28 @@ export function copyText(text: string, ports: CopyPorts): CopyOutcome | Promise<
   }
 }
 
-export function copyNotice(outcome: CopyOutcome): string {
-  return outcome === "copied"
-    ? "Stream URL copied."
-    : "This browser won't let the page copy — the URL is in the field, already selected.";
+/**
+ * What to tell the user, for either outcome.
+ *
+ * `subject` names the thing that was copied and defaults to the player page's,
+ * which was the only caller when this was written. The dashboard's results list
+ * copies a magnet through the same `copyText`, and one function deciding the
+ * wording for both is what stops the two drifting into saying different things
+ * about the same refusal.
+ *
+ * `where` names where the caller is about to put the text, because both callers
+ * do reveal it and they reveal it in different places: the player page appends
+ * a read-only field inside `.actions`, the dashboard puts it in the alert. A
+ * message that pointed at the wrong one would be worse than a vague one — this
+ * text's whole job is to send someone's eyes to the right place.
+ */
+export function copyNotice(
+  outcome: CopyOutcome,
+  subject = "Stream URL",
+  where = "the field",
+): string {
+  if (outcome === "copied") return `${subject} copied.`;
+  return `This browser won't let the page copy — the URL is in ${where}, already selected.`;
 }
 
 /** The ports as this browser actually provides them. */

--- a/src/web/static/copyText.ts
+++ b/src/web/static/copyText.ts
@@ -63,19 +63,20 @@ export function copyText(text: string, ports: CopyPorts): CopyOutcome | Promise<
  * wording for both is what stops the two drifting into saying different things
  * about the same refusal.
  *
- * `where` names where the caller is about to put the text, because both callers
- * do reveal it and they reveal it in different places: the player page appends
- * a read-only field inside `.actions`, the dashboard puts it in the alert. A
- * message that pointed at the wrong one would be worse than a vague one — this
- * text's whole job is to send someone's eyes to the right place.
+ * `where` is the whole trailing clause, not just a place name, because the two
+ * callers differ in more than location. The player page appends a read-only
+ * field and calls `select()` on it, so "already selected" is true there. The
+ * dashboard reveals the magnet as text in the alert, where nothing is selected
+ * — and telling someone their selection is ready when it is not is worse than
+ * saying nothing, because they will press ⌘C and get whatever they had before.
  */
 export function copyNotice(
   outcome: CopyOutcome,
   subject = "Stream URL",
-  where = "the field",
+  where = "in the field, already selected",
 ): string {
   if (outcome === "copied") return `${subject} copied.`;
-  return `This browser won't let the page copy — the URL is in ${where}, already selected.`;
+  return `This browser won't let the page copy — the URL is ${where}.`;
 }
 
 /** The ports as this browser actually provides them. */

--- a/src/web/static/dashboard.test.ts
+++ b/src/web/static/dashboard.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  failureLine,
+  hasFailed,
+  rowActions,
   formatBytes,
   formatRate,
   mergeRows,
@@ -226,5 +229,73 @@ describe("shortName", () => {
     const clipped = shortName("y".repeat(400));
     expect(clipped).toHaveLength(80);
     expect(clipped.endsWith("…")).toBe(true);
+  });
+});
+
+const dl = (over: Partial<DashRow> = {}): DashRow => ({
+  id: "a".repeat(40),
+  name: "Kestrel.2010.1080p.BluRay.x264",
+  kind: "download",
+  status: "downloading",
+  percent: 42,
+  peers: 3,
+  rate: 1024,
+  uploaded: 0,
+  ...over,
+});
+
+describe("rowActions", () => {
+  it("offers pause and resume to a live download", () => {
+    expect(rowActions(dl())).toEqual(["pause", "resume", "remove"]);
+  });
+
+  /**
+   * THE POINT OF THE FUNCTION. This was a fixed array, so a dead torrent
+   * offered `pause` (meaningless) and `resume` (a no-op — resume un-pauses, and
+   * a failed item is not paused). The rows most in need of an action were the
+   * only ones with none that worked.
+   */
+  it("offers retry, not pause, to a failed download", () => {
+    expect(rowActions(dl({ status: "failed" }))).toEqual(["retry", "remove"]);
+  });
+
+  it("leaves seeds alone", () => {
+    expect(rowActions(dl({ kind: "seed" }))).toEqual(["stop-seed", "delete"]);
+  });
+
+  it("does not offer retry to a seed that happens to say failed", () => {
+    // Seeds have their own vocabulary; only a download can be retried.
+    expect(rowActions(dl({ kind: "seed", status: "failed" }))).toEqual(["stop-seed", "delete"]);
+  });
+});
+
+describe("hasFailed", () => {
+  it("is true only for a failed download", () => {
+    expect(hasFailed(dl({ status: "failed" }))).toBe(true);
+    expect(hasFailed(dl())).toBe(false);
+    expect(hasFailed(dl({ kind: "seed", status: "failed" }))).toBe(false);
+  });
+});
+
+describe("failureLine", () => {
+  it("is the server's reason when there is one", () => {
+    expect(failureLine(dl({ status: "failed", error: "Set a Real-Debrid token." }))).toBe(
+      "Set a Real-Debrid token.",
+    );
+  });
+
+  /**
+   * A dead torrent's `0 peers · —` describes nothing and reads as a rendering
+   * bug. Even with no reason from the server, saying so beats showing counters
+   * for a thing that stopped counting.
+   */
+  it("says so when the server gave no reason", () => {
+    expect(failureLine(dl({ status: "failed" }))).toBe("failed — no reason given");
+    expect(failureLine(dl({ status: "failed", error: "   " }))).toBe("failed — no reason given");
+  });
+
+  it("is null for a row that has not failed", () => {
+    expect(failureLine(dl())).toBeNull();
+    expect(failureLine(dl({ kind: "seed", status: "missing" }))).toBeNull();
   });
 });

--- a/src/web/static/dashboard.ts
+++ b/src/web/static/dashboard.ts
@@ -23,6 +23,41 @@ export interface DashRow {
   peers: number;
   rate: number;
   uploaded: number;
+  /** Why a failed download failed. Absent on every other row. */
+  error?: string;
+}
+
+/**
+ * Which actions a row offers.
+ *
+ * A DECISION, not a constant, and it used to be the constant
+ * `["pause","resume","remove"]` for every download whatever its state. That put
+ * `pause` and `resume` on a FAILED row — one meaningless, the other a no-op,
+ * since `resume` un-pauses and a failed item is not paused — so the rows most
+ * in need of an action were the only ones offering none that worked. `retry` is
+ * what the TUI's `f` key has always called.
+ */
+export function rowActions(row: DashRow): readonly string[] {
+  if (row.kind === "seed") return ["stop-seed", "delete"];
+  if (row.status === "failed") return ["retry", "remove"];
+  return ["pause", "resume", "remove"];
+}
+
+/** True when a row is a download that has given up. Drives its colour and its actions. */
+export function hasFailed(row: DashRow): boolean {
+  return row.kind === "download" && row.status === "failed";
+}
+
+/**
+ * The meta line, or the reason it failed when there is one.
+ *
+ * A dead torrent's peer count and transfer rate describe nothing — they are `0
+ * peers · —`, which reads as a rendering bug rather than as a state. The reason
+ * is the only part of that row anyone can act on, so it takes the line.
+ */
+export function failureLine(row: DashRow): string | null {
+  if (!hasFailed(row)) return null;
+  return row.error?.trim() ? row.error.trim() : "failed — no reason given";
 }
 
 /**
@@ -57,6 +92,7 @@ export function rowsFromStatus(payload: StatusPayload): DashRow[] {
     peers: d.peers ?? 0,
     rate: d.speed ?? 0,
     uploaded: 0,
+    ...(typeof d.error === "string" && d.error.trim() ? { error: d.error.trim() } : {}),
   }));
   const seeds = (payload.seeds ?? []).map<DashRow>((s) => ({
     id: s.id,

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -68,6 +68,25 @@
 
     <p id="notice" class="notice" hidden></p>
 
+    <!--
+      Errors do NOT go in #notice above, and that is the whole point of this
+      element. #notice is a paragraph in normal flow that hides itself after four
+      seconds — fine for "Added.", useless for "Play failed (HTTP 502)" ninety
+      seconds into a resolve, because by then the user is a thousand pixels down
+      a browse and the paragraph is off screen. That exact failure is already
+      written up on #prepare below; this applies the same remedy to the alarming
+      case rather than only the reassuring one.
+
+      Fixed to the viewport, persists until dismissed, and carries one optional
+      action so that recovering does not mean scrolling back to re-find the row.
+      role=alert because, unlike the resolve pill, this is news.
+    -->
+    <div id="alert" class="alert" role="alert" hidden>
+      <span id="alert-line" class="alert-line"></span>
+      <button id="alert-action" type="button" hidden></button>
+      <button id="alert-dismiss" type="button" aria-label="Dismiss">✕</button>
+    </div>
+
     <!-- The stream file picker. Shown only when a session resolves to more than
          one playable file; every child below the heading is built by app.js with
          createElement, because the filenames come out of a torrent.

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -163,6 +163,18 @@
           </div>
           <button type="submit">Search</button>
           <button id="save-search" type="button">save search</button>
+          <!--
+            Where you have been. The terminal binds `↑` in its search box to walk
+            back through recent queries; the browser made you retype, or
+            pre-emptively "save search" — which is a different feature with a
+            different meaning (a saved search is a list you curate).
+
+            Chips rather than a key binding because the surface this matters
+            most on is a phone, which has no `↑`. Distinct from #suggest above:
+            that asks reccd what a partial title might be and appears once you
+            have typed; these are yours, need no server, and are there first.
+          -->
+          <div id="recent" class="recent" hidden></div>
         </form>
 
         <!-- Tabs and controls in one PINNED strip. A browse is 25,000px of

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -183,7 +183,19 @@
                category is absent from the response when it is off), so a
                hardcoded tab here could show a category the server will not
                search. -->
-          <div id="tabs" class="tabs" role="tablist"></div>
+          <!--
+            A GROUP OF TOGGLE BUTTONS, not role="tablist" — which is what this
+            was, with `aria-selected` on seven children, `aria-controls` on none
+            of them, and no role="tabpanel" anywhere in the document. A tablist
+            with no panels promises a screen-reader user a structure that is not
+            there, and the arrow-key navigation the pattern implies was never
+            implemented either (all seven sat in the tab order).
+
+            The honest description is the one #views already uses: these are
+            buttons that re-run the search against a different set of sources.
+            Nothing here reveals a pre-rendered panel. app.ts sets aria-pressed.
+          -->
+          <div id="tabs" class="tabs" role="group" aria-label="Category"></div>
 
           <div class="controls">
             <label class="control" for="sort">

--- a/src/web/static/player.html
+++ b/src/web/static/player.html
@@ -27,15 +27,22 @@
     </header>
 
     <!-- Everything below is filled in by player.js from the page's own URL.
-         Nothing is templated server-side: this file ships as static bytes. -->
-    <p id="breadcrumb" class="breadcrumb" hidden></p>
-    <p id="file-name" class="file-name"></p>
-    <div id="stage" class="stage"></div>
-    <div id="actions" class="actions"></div>
-    <p id="notice" class="notice" hidden></p>
-    <!-- The rest of the torrent: what is up next, and everything else in it.
-         Empty for a single-file session, so a film looks exactly as it did. -->
-    <div id="episodes" class="episodes" hidden></div>
+         Nothing is templated server-side: this file ships as static bytes.
+
+         Inside <main>, which it was not: the breadcrumb, the filename, the video
+         and every control sat outside any landmark, so "skip to main content"
+         had nothing to skip to and a screen reader's landmark list showed only
+         the header. The dashboard already has one. -->
+    <main>
+      <p id="breadcrumb" class="breadcrumb" hidden></p>
+      <p id="file-name" class="file-name"></p>
+      <div id="stage" class="stage"></div>
+      <div id="actions" class="actions"></div>
+      <p id="notice" class="notice" hidden></p>
+      <!-- The rest of the torrent: what is up next, and everything else in it.
+           Empty for a single-file session, so a film looks exactly as it did. -->
+      <div id="episodes" class="episodes" hidden></div>
+    </main>
 
     <script type="module" src="/player.js"></script>
   </body>

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -24,6 +24,7 @@ import {
   interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  primaryAction,
   restPlaylistPath,
   routeFailure,
   streamPath,
@@ -32,8 +33,9 @@ import {
   type PlayerTarget,
 } from "./playerModel";
 import { clipboardPorts, copyNotice, copyText } from "./copyText";
+import type { MediaFacts } from "../../util/playability";
 import { mountHls } from "./hlsMount";
-import { breadcrumbFor, upNextView, type EpisodeRow } from "./upNext";
+import { breadcrumbFor, escapeRoutes, upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
 import { backTarget, readReturn } from "./returnTo";
 import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
@@ -137,7 +139,7 @@ function linkButton(label: string, href: string): HTMLAnchorElement {
  * `<video>` is removed rather than hidden, so nothing keeps buffering a file
  * that is not going to play and no black rectangle is left behind it.
  */
-function showFallback(reason: FallbackReason, filename: string): void {
+function showFallback(reason: FallbackReason, filename: string, facts?: MediaFacts): void {
   const card = document.createElement("div");
   card.className = "card fallback";
 
@@ -146,9 +148,31 @@ function showFallback(reason: FallbackReason, filename: string): void {
 
   const body = document.createElement("p");
   body.className = "fallback-body";
-  body.textContent = fallbackMessage(reason, filename);
+  // `facts` is what the server actually probed. Passing it turns "most releases
+  // are MKV with HEVC or DTS audio" into the codec this file really carries,
+  // which is the difference between a message you can act on and one you can
+  // only accept.
+  body.textContent = fallbackMessage(reason, filename, facts);
 
   card.append(title, body);
+
+  // TWO WAYS OUT, because this card is the end of the most common journey
+  // through the app and it used to be a cul-de-sac that blamed the browser.
+  // Both are ordinary links to the dashboard, so they work on a phone that
+  // holds this session's capability and no bearer token.
+  const outs = escapeRoutes(filename);
+  if (outs.length > 0) {
+    const nav = document.createElement("p");
+    nav.className = "fallback-outs";
+    for (const out of outs) {
+      const a = document.createElement("a");
+      a.textContent = out.label;
+      a.href = out.href;
+      nav.append(a);
+    }
+    card.append(nav);
+  }
+
   stage.replaceChildren(card);
 }
 
@@ -305,8 +329,20 @@ async function render(): Promise<void> {
   const stream = absoluteUrl(location.origin, streamPath(target));
   const playlist = absoluteUrl(location.origin, playlistPath(target));
 
+  const platform = detectPlatform(navigator.userAgent);
+  const m3u = linkButton("Download .m3u", playlist);
+  const vlc = vlcLinks(stream, platform).map((link) => linkButton(link.label, link.href));
+
+  // Ordered by what actually works here, not by a fixed list. `primaryAction`
+  // carries the reasoning; the effect is that a phone leads with Open in VLC
+  // rather than with a download its OS will not hand to a player, and the lead
+  // control is the only highlighted one so there is a first thing to press.
+  const lead = primaryAction(platform) === "vlc" && vlc.length > 0 ? vlc : [m3u];
+  const rest = lead === vlc ? [m3u] : vlc;
+  lead[0]?.classList.add("primary");
+
   const controls: (HTMLButtonElement | HTMLAnchorElement)[] = [
-    linkButton("Download .m3u", playlist),
+    ...lead,
     button("Copy stream URL", () => {
       // copyText must be called straight from the click with nothing awaited in
       // front of it: on an insecure origin — the normal way this dashboard is
@@ -322,10 +358,12 @@ async function render(): Promise<void> {
         else clearManualCopy();
       });
     }),
+    ...rest,
   ];
-  for (const link of vlcLinks(stream, detectPlatform(navigator.userAgent))) {
-    controls.push(linkButton(link.label, link.href));
-  }
+  // The vlcLinks append that used to sit here is gone, not lost: `lead` and
+  // `rest` above already place those buttons, and by platform rather than
+  // always last. Appending them again would render VLC twice.
+  //
   // replaceChildren drops any field left over from the previous target, so the
   // reference has to go with it.
   manualField = null;
@@ -353,7 +391,7 @@ async function render(): Promise<void> {
   const info = await fetchInfo(target);
   const chosen = chooseSource(info, target.filename);
   if (chosen.rung === "card") {
-    showFallback(chosen.reason ?? "container", target.filename);
+    showFallback(chosen.reason ?? "container", target.filename, info?.facts);
     return;
   }
   if (chosen.rung === "provider-hls" && info?.hls) {

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -10,6 +10,7 @@ import {
   interruptedNotice,
   parsePlayerLocation,
   playlistPath,
+  primaryAction,
   restPlaylistPath,
   routeFailure,
   streamPath,
@@ -151,7 +152,7 @@ describe("filesPath", () => {
 
 describe("chooseSource", () => {
   const info = (over: Partial<StreamInfoResponse> = {}): StreamInfoResponse => ({
-    facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" },
+    facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" as const },
     blockers: [],
     hls: null,
     ...over,
@@ -186,7 +187,7 @@ describe("chooseSource", () => {
     expect(
       chooseSource(
         info({
-          facts: { container: "mp4", videoCodec: "hevc", audioCodec: "aac", source: "probe" },
+          facts: { container: "mp4", videoCodec: "hevc", audioCodec: "aac", source: "probe" as const },
           blockers: ["video"],
         }),
         "Tin.Rivers.2024.2160p.mp4",
@@ -327,6 +328,38 @@ describe("fallbackMessage", () => {
   it("tells a user with a capability-less link what to do", () => {
     expect(fallbackMessage("no-link", "")).toContain("reopen the player");
   });
+
+  /**
+   * The server already probed this file and told us exactly what it is, and the
+   * card was still guessing in prose — "most releases are MKV with HEVC or DTS
+   * audio", "HEVC or AV1", "usually DTS or TrueHD". Naming the real codec is the
+   * difference between a message a user can act on (search for an x264 release)
+   * and one they can only accept.
+   */
+  it("names the codec the server actually found", () => {
+    const facts = { container: "mkv", videoCodec: "hevc", audioCodec: "dts", source: "probe" as const };
+    expect(fallbackMessage("video-codec", "a.mkv", facts)).toContain("HEVC");
+    expect(fallbackMessage("video-codec", "a.mkv", facts)).not.toContain("or AV1");
+    expect(fallbackMessage("audio-codec", "a.mkv", facts)).toContain("DTS");
+    expect(fallbackMessage("audio-codec", "a.mkv", facts)).not.toContain("usually");
+    expect(fallbackMessage("container", "a.mkv", facts)).toContain("MKV");
+  });
+
+  /**
+   * A guess is labelled as one. `source: "name"` means the codec was inferred
+   * from the release name, and a release named x265 can carry something else —
+   * so the card must not state it as fact the way a probe result is stated.
+   */
+  it("hedges a codec that was only inferred from the release name", () => {
+    const guessed = { container: "mkv", videoCodec: "hevc", audioCodec: "", source: "name" as const };
+    expect(fallbackMessage("video-codec", "a.mkv", guessed)).toContain("looks like");
+  });
+
+  it("falls back to the old prose when the server told us nothing", () => {
+    const unknown = { container: "", videoCodec: "", audioCodec: "", source: "name" as const };
+    expect(fallbackMessage("video-codec", "a.mkv", unknown)).toContain("HEVC or AV1");
+    expect(fallbackMessage("video-codec", "a.mkv")).toContain("HEVC or AV1");
+  });
 });
 
 describe("routeFailure", () => {
@@ -367,5 +400,32 @@ describe("interruptedNotice", () => {
 
   it("distinguishes a stall from an outright failure", () => {
     expect(interruptedNotice("stall")).not.toBe(interruptedNotice("error"));
+  });
+});
+
+describe("primaryAction", () => {
+  /**
+   * On a phone the three controls were in the wrong order twice over: a
+   * downloaded .m3u is not handed to a media player the way a desktop OS does
+   * it, "Copy stream URL" is a riddle rather than an action, and the one that
+   * works was last.
+   */
+  it("leads with VLC on the platforms that have a working scheme", () => {
+    expect(primaryAction("ios")).toBe("vlc");
+    expect(primaryAction("android")).toBe("vlc");
+  });
+
+  it("leads with the .m3u on desktop, where vlcLinks offers nothing", () => {
+    // "other" is Windows and Linux — see Platform. Neither registers a
+    // vlc://-style scheme, so the .m3u is the only control that works there.
+    expect(primaryAction("other")).toBe("m3u");
+  });
+
+  /**
+   * macOS has a working vlc-x-callback scheme, but it also has a desktop OS's
+   * file handling — a downloaded .m3u opens VLC there. The lossless route wins.
+   */
+  it("keeps the .m3u first on macOS", () => {
+    expect(primaryAction("macos")).toBe("m3u");
   });
 });

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -422,10 +422,12 @@ describe("primaryAction", () => {
   });
 
   /**
-   * macOS has a working vlc-x-callback scheme, but it also has a desktop OS's
-   * file handling — a downloaded .m3u opens VLC there. The lossless route wins.
+   * macOS is a desktop, and `vlcLinks` returns nothing for it — the
+   * vlc-x-callback scheme belongs to VLC's iOS app, not the desktop one. So
+   * there is no VLC button to lead with even if this said otherwise.
    */
   it("keeps the .m3u first on macOS", () => {
     expect(primaryAction("macos")).toBe("m3u");
+    expect(vlcLinks("http://x/y", "macos")).toEqual([]);
   });
 });

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -16,6 +16,7 @@ import {
   classifyFromName,
   extensionOf,
   type Blocker,
+  type MediaFacts,
 } from "../../util/playability";
 import type { StreamInfoResponse } from "../wire";
 
@@ -281,6 +282,23 @@ export function vlcLinks(absolute: string, platform: Platform): ExternalLink[] {
   return [];
 }
 
+/**
+ * Which control this platform should lead with.
+ *
+ * The three actions were co-equal, in a fixed order, on every device — and on a
+ * phone that order is wrong twice over. `Download .m3u` leads, but iOS and
+ * Android do not hand a downloaded playlist to a media player the way a desktop
+ * OS does; `Copy stream URL` follows, which is a riddle rather than an action.
+ * The one that works, `Open in VLC`, was last. Where a platform has a working
+ * scheme, that is the button to lead with.
+ *
+ * Desktop keeps `.m3u` first, which is the thing that genuinely works there —
+ * `vlcLinks` returns nothing at all on Windows and Linux.
+ */
+export function primaryAction(platform: Platform): "vlc" | "m3u" {
+  return platform === "ios" || platform === "android" ? "vlc" : "m3u";
+}
+
 /** Why the fallback card is showing. Drives the wording, nothing else. */
 export type FallbackReason =
   | "container"
@@ -290,22 +308,73 @@ export type FallbackReason =
   | "stall"
   | "no-link";
 
-export function fallbackMessage(reason: FallbackReason, filename: string): string {
+/** Display spellings for the codec ids `MediaFacts` normalises to. */
+const CODEC_NAMES: Record<string, string> = {
+  hevc: "HEVC",
+  av1: "AV1",
+  vp9: "VP9",
+  mpeg2: "MPEG-2",
+  h264: "H.264",
+  dts: "DTS",
+  truehd: "TrueHD",
+  eac3: "E-AC-3",
+  ac3: "AC-3",
+  flac: "FLAC",
+  aac: "AAC",
+  opus: "Opus",
+  mp3: "MP3",
+};
+
+/**
+ * How to refer to a codec the server reported, or null when it reported none.
+ *
+ * `source` is honoured rather than ignored: a `probe` result came from ffprobe
+ * and can be stated as fact, while a `name` result was inferred from a release
+ * name — and a release named x265 can carry something else. Saying "is HEVC"
+ * when we only guessed would make the card confidently wrong, which is worse
+ * than the vague prose it replaces.
+ */
+function codecPhrase(facts: MediaFacts | undefined, which: "video" | "audio"): string | null {
+  const id = which === "video" ? facts?.videoCodec : facts?.audioCodec;
+  if (!id) return null;
+  const label = CODEC_NAMES[id] ?? id.toUpperCase();
+  return facts?.source === "probe" ? `is ${label}` : `looks like ${label}`;
+}
+
+export function fallbackMessage(
+  reason: FallbackReason,
+  filename: string,
+  /**
+   * What the server said this file is, when the page got that far. Optional:
+   * `.info` can be unreachable, and the prose below still has to work without
+   * it — that is the message this page showed before the route existed.
+   */
+  facts?: MediaFacts,
+): string {
   const name = filename || "This file";
   if (reason === "no-link") {
     return "This link is incomplete — reopen the player from the dashboard.";
   }
   if (reason === "container") {
-    return `${name} is in a container browsers can't play (most releases are MKV with HEVC or DTS audio). Open it in a real player — the stream itself is fine.`;
+    const container = facts?.container ? facts.container.toUpperCase() : null;
+    return container
+      ? `${name} is ${container}, which browsers can't play. Open it in a real player — the stream itself is fine.`
+      : `${name} is in a container browsers can't play (most releases are MKV with HEVC or DTS audio). Open it in a real player — the stream itself is fine.`;
   }
   // The two below are only reachable now that the server reports real codecs:
   // before that, a container browsers accept was assumed playable and these
   // files failed at the decoder instead, twelve seconds later.
   if (reason === "video-codec") {
-    return `${name} is in a container browsers accept, but its video (HEVC or AV1) is something they can't decode. Open it in a real player — the stream itself is fine.`;
+    const codec = codecPhrase(facts, "video");
+    return codec
+      ? `${name}'s video ${codec}, which browsers can't decode. Open it in a real player — the stream itself is fine.`
+      : `${name} is in a container browsers accept, but its video (HEVC or AV1) is something they can't decode. Open it in a real player — the stream itself is fine.`;
   }
   if (reason === "audio-codec") {
-    return `${name} has audio browsers can't decode — usually DTS or TrueHD. Open it in a real player — the stream itself is fine.`;
+    const codec = codecPhrase(facts, "audio");
+    return codec
+      ? `${name}'s audio ${codec}, which browsers can't decode. Open it in a real player — the stream itself is fine.`
+      : `${name} has audio browsers can't decode — usually DTS or TrueHD. Open it in a real player — the stream itself is fine.`;
   }
   if (reason === "error") {
     return `${name} started but this browser can't decode it. Open it in a real player instead.`;

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -292,8 +292,13 @@ export function vlcLinks(absolute: string, platform: Platform): ExternalLink[] {
  * The one that works, `Open in VLC`, was last. Where a platform has a working
  * scheme, that is the button to lead with.
  *
- * Desktop keeps `.m3u` first, which is the thing that genuinely works there —
- * `vlcLinks` returns nothing at all on Windows and Linux.
+ * EVERY DESKTOP keeps `.m3u` first, macOS included. An earlier version of this
+ * comment justified that for macOS by saying its `vlc-x-callback` scheme worked
+ * but the lossless route won anyway — which was wrong on the first half:
+ * `vlcLinks` establishes that the scheme belongs to VLC's iOS app and the
+ * desktop app registers none, so there is no macOS VLC link to lead with. The
+ * answer is the same either way; the reason is not, and the two must agree or
+ * the next person changes one of them.
  */
 export function primaryAction(platform: Platform): "vlc" | "m3u" {
   return platform === "ios" || platform === "android" ? "vlc" : "m3u";

--- a/src/web/static/recentSearches.test.ts
+++ b/src/web/static/recentSearches.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { RECENT_MAX, foldRecent, magnetFor, parseRecent } from "./recentSearches";
+
+describe("foldRecent", () => {
+  it("puts the newest first", () => {
+    expect(foldRecent(["ashfall"], "kestrel")).toEqual(["kestrel", "ashfall"]);
+  });
+
+  /**
+   * A query run every day would otherwise fill the whole strip with itself.
+   * Moving it to the front is also what a user means by "recent".
+   */
+  it("moves a repeat to the front rather than adding a second copy", () => {
+    expect(foldRecent(["ashfall", "kestrel", "kepler"], "kestrel")).toEqual([
+      "kestrel",
+      "ashfall",
+      "kepler",
+    ]);
+  });
+
+  it("treats a different casing as the same search, keeping the new spelling", () => {
+    // Every source lowercases the query anyway, so two chips would be noise —
+    // and what the user just typed is the spelling they want to see.
+    expect(foldRecent(["kestrel"], "Kestrel")).toEqual(["Kestrel"]);
+  });
+
+  it("trims, so trailing whitespace does not create a near-duplicate", () => {
+    expect(foldRecent(["kestrel"], "  kestrel  ")).toEqual(["kestrel"]);
+    expect(foldRecent([], "  tin rivers ")).toEqual(["tin rivers"]);
+  });
+
+  /**
+   * A blank query is browse mode — a real search, but not one worth
+   * remembering: there is nothing to put on a chip and nothing to go back to.
+   */
+  it("ignores a blank query without disturbing the list", () => {
+    expect(foldRecent(["kestrel"], "")).toEqual(["kestrel"]);
+    expect(foldRecent(["kestrel"], "   ")).toEqual(["kestrel"]);
+  });
+
+  it("caps the list", () => {
+    let list: string[] = [];
+    for (let i = 0; i < RECENT_MAX + 4; i++) list = foldRecent(list, `q${i}`);
+    expect(list).toHaveLength(RECENT_MAX);
+    // The newest survive and the oldest fall off the end.
+    expect(list[0]).toBe(`q${RECENT_MAX + 3}`);
+    expect(list).not.toContain("q0");
+  });
+
+  it("does not mutate the list it was given", () => {
+    const before = ["kestrel"];
+    foldRecent(before, "ashfall");
+    expect(before).toEqual(["kestrel"]);
+  });
+});
+
+/**
+ * localStorage is user-writable and survives upgrades, and every value here
+ * becomes a chip's label. A chip built from a number or an object would render
+ * as "[object Object]".
+ */
+describe("parseRecent", () => {
+  it("reads a stored list", () => {
+    expect(parseRecent('["kestrel","ashfall"]')).toEqual(["kestrel", "ashfall"]);
+  });
+
+  it.each([
+    ["null", null],
+    ["empty", ""],
+    ["not JSON", "{oh no"],
+    ["not an array", '{"a":1}'],
+    ["a bare string", '"kestrel"'],
+    ["a number", "42"],
+  ])("falls back to empty for %s", (_why, raw) => {
+    expect(parseRecent(raw)).toEqual([]);
+  });
+
+  it("drops entries that are not usable queries", () => {
+    expect(parseRecent('["kestrel",1,null,{"a":1},"  ","ashfall"]')).toEqual([
+      "kestrel",
+      "ashfall",
+    ]);
+  });
+
+  it("caps a hand-edited list that is too long", () => {
+    const raw = JSON.stringify(Array.from({ length: 50 }, (_, i) => `q${i}`));
+    expect(parseRecent(raw)).toHaveLength(RECENT_MAX);
+  });
+});
+
+describe("magnetFor", () => {
+  it("builds a hash-and-name magnet", () => {
+    expect(magnetFor("a".repeat(40), "Kestrel.2010.1080p.BluRay.x264")).toBe(
+      `magnet:?xt=urn:btih:${"a".repeat(40)}&dn=Kestrel.2010.1080p.BluRay.x264`,
+    );
+  });
+
+  /**
+   * A release name is a stranger's string and this one is handed to another
+   * application. Anything that could end the parameter early has to be encoded.
+   */
+  it("encodes a name with characters that would break the URL", () => {
+    const magnet = magnetFor("b".repeat(40), "Tin Rivers & Co #1?x=2");
+    expect(magnet).toContain("dn=Tin+Rivers+%26+Co+%231%3Fx%3D2");
+    expect(magnet.split("&")).toHaveLength(2);
+  });
+
+  it("encodes the info hash too", () => {
+    expect(magnetFor("../evil", "x")).toContain("btih:..%2Fevil");
+  });
+});

--- a/src/web/static/recentSearches.ts
+++ b/src/web/static/recentSearches.ts
@@ -1,0 +1,109 @@
+/**
+ * The last few things you searched for, and the magnet for a result.
+ *
+ * Two small pieces of parity with the terminal, which has had both since it
+ * shipped and the browser had neither.
+ *
+ * RECENT SEARCHES. The TUI binds `↑` in its search box to walk back through
+ * recent queries. The browser made you retype, or pre-emptively "save search" —
+ * which is a different feature with a different meaning (a saved search is a
+ * list you curate; a recent search is just where you have been). Shown as chips
+ * rather than bound to a key, because the surface this matters most on is a
+ * phone, which has no `↑`.
+ *
+ * Distinct from `#suggest`, the title-autocomplete combobox: that asks reccd
+ * what a partial title might be and only appears once you have typed. These are
+ * yours, they need no server, and they are there before you type anything.
+ */
+
+const RECENT_KEY = "torlnk.recent";
+
+/**
+ * How many to keep.
+ *
+ * Small on purpose. This is "where was I", not a history feature — a long list
+ * would push the first result further down a phone screen, which is the
+ * opposite of the point, and the chips are only useful while they can all be
+ * read at a glance.
+ */
+export const RECENT_MAX = 6;
+
+/**
+ * Fold a query into the list, newest first.
+ *
+ * A PURE function over the list rather than a storage call, so the dedupe and
+ * cap rules are testable without a DOM. Re-searching something already in the
+ * list MOVES it to the front rather than adding a second copy — otherwise a
+ * query you run every day fills the whole strip with itself.
+ *
+ * A blank query is browse mode, which is a real search but not one worth
+ * remembering: there is nothing to put on a chip and nothing to go back to.
+ */
+export function foldRecent(list: readonly string[], query: string): string[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [...list];
+  // Case-insensitive, because "Kestrel" and "kestrel" are the same search to
+  // every source and two chips saying so would be noise. The NEW spelling wins:
+  // it is what the user just typed.
+  const lower = trimmed.toLowerCase();
+  return [trimmed, ...list.filter((q) => q.toLowerCase() !== lower)].slice(0, RECENT_MAX);
+}
+
+/**
+ * The stored list, or empty.
+ *
+ * PARSED, not cast, for the reason `parseLayout` is: localStorage is
+ * user-writable and survives upgrades. Anything that is not an array of
+ * non-empty strings is discarded rather than rendered — a chip built from a
+ * number or an object would be `[object Object]` at best.
+ */
+export function parseRecent(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((q): q is string => typeof q === "string" && q.trim().length > 0)
+      .map((q) => q.trim())
+      .slice(0, RECENT_MAX);
+  } catch {
+    return [];
+  }
+}
+
+export function readRecent(): string[] {
+  try {
+    return parseRecent(localStorage.getItem(RECENT_KEY));
+  } catch {
+    // Storage blocked (Safari private mode, a hardened profile). No history is
+    // survivable; a dead page is not.
+    return [];
+  }
+}
+
+export function writeRecent(list: readonly string[]): void {
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(list));
+  } catch {
+    /* not remembering is survivable */
+  }
+}
+
+/**
+ * A magnet link for a result, rebuilt from its info hash.
+ *
+ * THE WIRE DOES NOT CARRY MAGNETS, deliberately — `PublicFavourite` documents
+ * why: playing goes through `POST /api/stream { infoHash, name }`, which
+ * rebuilds the magnet server-side with the default tracker list, so shipping
+ * one would be a few hundred bytes of tracker URLs per row to no end. That
+ * reasoning holds, and it is why this builds the SHORT form rather than asking
+ * for the server's.
+ *
+ * A hash-and-name magnet is enough for every client that matters: trackers are
+ * a hint, and any modern client finds peers for a known info hash through the
+ * DHT. The terminal's `y` key copies the same thing.
+ */
+export function magnetFor(infoHash: string, name: string): string {
+  const params = new URLSearchParams({ dn: name });
+  return `magnet:?xt=urn:btih:${encodeURIComponent(infoHash)}&${params.toString()}`;
+}

--- a/src/web/static/savedModel.test.ts
+++ b/src/web/static/savedModel.test.ts
@@ -21,6 +21,7 @@ import {
   savedSearchesStatus,
   savedSearchesToggleNotice,
   type SavedState,
+  continueWatchingGroup,
 } from "./savedModel";
 import type { PublicFavourite, PublicStreamHistoryItem } from "../wire";
 // Fine to import here even though `src/core/streamHistory.ts` pulls in
@@ -490,5 +491,31 @@ describe("continueWatchingStatus", () => {
   it("hides once there are rows", () => {
     const state = { ...emptySaved(), loaded: true, continueWatching: [{ ...base }] };
     expect(continueWatchingStatus(state).show).toBe(false);
+  });
+});
+
+describe("continueWatchingGroup", () => {
+  const item = (over: Partial<PublicStreamHistoryItem>): PublicStreamHistoryItem => ({
+    key: "k",
+    title: "Harrowgate",
+    next: null,
+    rawName: "Harrowgate.S03.1080p.WEB-DL",
+    infoHash: "a".repeat(40),
+    startedAt: 0,
+    ...over,
+  });
+
+  /**
+   * The search tab would be wrong here: these rows are not part of a search, so
+   * a show looked up under whatever tab was last clicked comes back with the
+   * wrong artwork or none.
+   */
+  it("uses the row's own type, not the search tab", () => {
+    expect(continueWatchingGroup(item({ type: "series" }))).toBe("TV");
+    expect(continueWatchingGroup(item({ type: "movie" }))).toBe("Movies");
+  });
+
+  it("falls back to All when the store never decided", () => {
+    expect(continueWatchingGroup(item({}))).toBe("All");
   });
 });

--- a/src/web/static/savedModel.ts
+++ b/src/web/static/savedModel.ts
@@ -296,6 +296,22 @@ export function episodeTag(season: number, episode: number): string {
 }
 
 /**
+ * Which category tab a Continue-watching row's artwork should be looked up as.
+ *
+ * Not the search tab the user last clicked: these rows are not part of a
+ * search, and a show looked up under "Movies" comes back with the wrong poster
+ * or none. `type` is the store's own judgement, written when the row was
+ * recorded, so this is a translation rather than a second guess. Falls back to
+ * `ALL_TAB` when the store never decided — `previewApplies` accepts it and OMDb
+ * is left to work it out.
+ */
+export function continueWatchingGroup(item: PublicStreamHistoryItem): string {
+  if (item.type === "series") return "TV";
+  if (item.type === "movie") return "Movies";
+  return "All";
+}
+
+/**
  * A continue-watching row's subtitle: age, the last episode watched (when this
  * is a series), and the next one to offer (when the server computed one).
  *

--- a/src/web/static/streamFlow.test.ts
+++ b/src/web/static/streamFlow.test.ts
@@ -502,6 +502,11 @@ function harness(over: Partial<PlayEffects> = {}) {
     }[],
     polls: 0,
     progress: [] as (string | null)[],
+    // Paired with `notices` so a test can assert not just WHAT was said but
+    // whether the flow called it a cancellation or a failure — app.ts routes
+    // the two to different places (a self-clearing line vs a persistent alert
+    // with a Try again), so getting the kind wrong is silently losing an error.
+    noticeKinds: [] as (string | undefined)[],
     slept: [] as { ms: number; aborts: boolean }[],
   };
   let clock = 0;
@@ -519,7 +524,10 @@ function harness(over: Partial<PlayEffects> = {}) {
       calls.confirms.push(message);
       return false;
     },
-    notice: (message) => calls.notices.push(message),
+    notice: (message, kind) => {
+      calls.notices.push(message);
+      calls.noticeKinds.push(kind);
+    },
     progress: (line) => calls.progress.push(line),
     choose: (sessionId, capability, _name, files, preselect) =>
       calls.chosen.push({ sessionId, capability, files, preselect }),
@@ -570,6 +578,11 @@ describe("runPlay", () => {
     expect(calls.confirms[0]).toContain("your premium expired");
     expect(calls.opened).toEqual([]);
     expect(calls.notices).toEqual(["Playback cancelled — nothing was streamed."]);
+    // The user declined the prompt, so this is their own doing. It must NOT be
+    // reported as a failure: app.ts turns a failure into a persistent alert
+    // with a Try again, and offering to retry something someone just said no to
+    // is the app arguing with them.
+    expect(calls.noticeKinds).toEqual(["cancelled"]);
   });
 
   it("retries with confirm: true only after the user accepts", async () => {
@@ -707,6 +720,11 @@ describe("runPlay", () => {
     });
     await runPlay(row(), fx);
     expect(calls.notices).toEqual(["Couldn't reach the swarm."]);
+    // A FAILURE, so app.ts keeps it on screen with a Try again. Reported as an
+    // ordinary notice this would clear itself after four seconds — and a play
+    // can fail minutes in, by which point the user is far down a browse and the
+    // line they needed has already gone.
+    expect(calls.noticeKinds).toEqual(["failure"]);
     expect(calls.stopped).toEqual(["s1"]);
     expect(calls.opened).toEqual([]);
   });
@@ -716,6 +734,43 @@ describe("runPlay", () => {
     await runPlay(row(), fx);
     expect(calls.stopped).toEqual(["s1"]);
     expect(calls.opened).toEqual([]);
+    expect(calls.noticeKinds).toEqual(["failure"]);
+  });
+
+  /**
+   * The one thing this distinction exists for: every ending that is not the
+   * user's own cancellation has to be reported as a failure, or it lands in the
+   * self-clearing line and the app goes quiet about something that went wrong.
+   * Asserted as a set over the whole flow rather than per case, so a new ending
+   * added later cannot default to silence unnoticed.
+   */
+  it("calls every non-cancellation ending a failure", async () => {
+    const endings = [
+      // A session that resolves forever, and one that becomes unreadable —
+      // both reached only from a start that SUCCEEDED, which the default
+      // harness's start does not.
+      {
+        name: "resolve timed out",
+        over: {
+          start: async () => started({ state: "resolving" }),
+          poll: async () => session({ state: "resolving", progress: 5 }),
+        },
+      },
+      {
+        name: "session unreadable",
+        over: { start: async () => started({ state: "resolving" }), poll: async () => null },
+      },
+      {
+        name: "session errored",
+        over: { start: async () => started({ state: "error", error: "nope" }) },
+      },
+      { name: "no playable files", over: { start: async () => started({ files: [] }) } },
+    ];
+    for (const ending of endings) {
+      const { fx, calls } = harness(ending.over as Partial<PlayEffects>);
+      await runPlay(row(), fx);
+      expect(`${ending.name}: ${calls.noticeKinds.at(-1)}`).toBe(`${ending.name}: failure`);
+    }
   });
 
   it("says nothing extra when the start itself already failed and reported why", async () => {

--- a/src/web/static/streamFlow.ts
+++ b/src/web/static/streamFlow.ts
@@ -433,8 +433,22 @@ export interface PlayEffects {
   stop(sessionId: string): void;
   /** A blocking yes/no. window.confirm in the browser. */
   confirm(message: string): boolean;
-  /** Transient message in the dashboard's notice line. */
-  notice(message: string): void;
+  /**
+   * A message about how this play ended.
+   *
+   * `kind` exists because the two endings need opposite treatment and this flow
+   * is the only thing that knows which it is. A CANCELLATION is the user's own
+   * doing, already expected, and a line that clears itself is right. A FAILURE
+   * is news the user did not ask for and may not be looking at — a play can fail
+   * ninety seconds into a resolve, by which point they are a thousand pixels
+   * down a browse — so it has to persist and it has to offer a way to retry
+   * without re-finding the row.
+   *
+   * Optional so the parameter can be read as "info unless stated otherwise":
+   * every existing caller and test that ignores it keeps the old behaviour, and
+   * the five failure sites opt in explicitly.
+   */
+  notice(message: string, kind?: "cancelled" | "failure"): void;
   /**
    * The waiting line, or null to take it down.
    *
@@ -556,7 +570,7 @@ export async function runPlay(
   const cancel = (sessionId: string | null): void => {
     if (sessionId) fx.stop(sessionId);
     done();
-    fx.notice(CANCELLED_NOTICE);
+    fx.notice(CANCELLED_NOTICE, "cancelled");
   };
 
   if (signal?.aborted) {
@@ -585,7 +599,7 @@ export async function runPlay(
   if (start.kind === "confirm") {
     if (!fx.confirm(confirmFallbackMessage(start.reason, row.name))) {
       done();
-      fx.notice("Playback cancelled — nothing was streamed.");
+      fx.notice("Playback cancelled — nothing was streamed.", "cancelled");
       return;
     }
     start = await fx.start(row, true, signal);
@@ -594,7 +608,7 @@ export async function runPlay(
     // asking: one prompt per click.
     if (start.kind === "confirm") {
       done();
-      fx.notice("Couldn't start that stream.");
+      fx.notice("Couldn't start that stream.", "failure");
       return;
     }
   }
@@ -612,7 +626,7 @@ export async function runPlay(
     if (decision.kind === "settled") break;
     if (decision.kind === "timeout") {
       done();
-      fx.notice(decision.message);
+      fx.notice(decision.message, "failure");
       fx.stop(sessionId);
       return;
     }
@@ -634,7 +648,7 @@ export async function runPlay(
       // The session is gone or unreadable. Not stopped here: a DELETE we can't
       // read the answer to adds nothing, and the id may not exist at all.
       done();
-      fx.notice("Lost track of that stream — try again.");
+      fx.notice("Lost track of that stream — try again.", "failure");
       return;
     }
     session = next;
@@ -645,12 +659,12 @@ export async function runPlay(
   const outcome = streamOutcome(session, wanted);
   if (outcome.kind === "error") {
     // Already worded for a human by the core, which reuses the TUI's strings.
-    fx.notice(outcome.message);
+    fx.notice(outcome.message, "failure");
     fx.stop(sessionId);
     return;
   }
   if (outcome.kind === "empty") {
-    fx.notice("There is nothing playable in that torrent.");
+    fx.notice("There is nothing playable in that torrent.", "failure");
     fx.stop(sessionId);
     return;
   }

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -319,6 +319,18 @@ button:hover {
     display: block;
   }
 
+  /* AND the name must be blockified with it. `.row-name` is a <span>, so the
+     moment its parent stops being a flex container the span goes back to
+     `display: inline` — where `overflow`, `text-overflow` and `min-width` are
+     all inert, because an inline box is not a box you can clip. The ellipsis
+     above silently stopped applying and a long torrent name pushed the queue
+     pane 310px wider than the viewport: measured `scrollWidth 700` against
+     `clientWidth 390`. The saved pane was unaffected only because its rows keep
+     a flex parent, which blockifies the span for free. */
+  .row-name {
+    display: block;
+  }
+
   .row-meta {
     display: block;
     margin-top: 0.2rem;
@@ -1508,6 +1520,56 @@ select:focus-visible {
   border-radius: 0.5rem;
   background: var(--raised);
   font-size: 0.75rem;
+}
+
+/* The error banner. Deliberately the same object as .prepare — same corner, same
+   size, same shape — because they are the same kind of thing: a message about
+   work the user started that must survive scrolling. Only the colour and the
+   persistence differ, so a user who has learned where the resolve pill appears
+   has already learned where failures appear.
+
+   Above .prepare in the stacking order and offset when both are up: a resolve
+   that fails puts them on screen together for a moment. */
+.alert {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: min(30rem, calc(100vw - 7rem));
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--error);
+  border-radius: 0.5rem;
+  background: var(--raised);
+  font-size: 0.75rem;
+}
+
+.alert:not([hidden]) ~ .prepare {
+  bottom: 4.2rem;
+}
+
+.alert-line {
+  color: var(--fg);
+  overflow-wrap: anywhere;
+}
+
+.alert button {
+  flex-shrink: 0;
+}
+
+#alert-dismiss {
+  /* Square, so the ✕ is not a wide pill next to a text button. */
+  padding: 0.35rem 0.55rem;
+}
+
+@media (max-width: 30rem) {
+  .alert {
+    left: 1rem;
+    right: 1rem;
+    max-width: none;
+  }
 }
 
 .prepare-line {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -351,6 +351,13 @@ button:hover {
   background: var(--accent);
 }
 
+/* A torrent that dies at 99% drew 99% of an accent bar — the strongest signal on
+   the row saying "nearly done" while a dim grey word said "failed". The bar is
+   what gets read at a glance, so the bar is what has to be honest. */
+.bar > span.is-failed {
+  background: var(--error);
+}
+
 .row-actions {
   display: flex;
   flex-wrap: wrap;
@@ -526,6 +533,14 @@ button:hover {
 .badge {
   margin-left: 0.35rem;
   font-variant-numeric: tabular-nums;
+}
+
+/* Something in the queue has failed. Colour only — the number still reads as a
+   number, and `title` carries the same fact for anyone who cannot see the
+   change. Worth the exception to the accent budget (see .tag-quality): this is
+   the one badge that has to pull someone away from another pane. */
+.badge-error {
+  color: var(--error);
 }
 
 /* Category tabs. A wrapped strip rather than a scroller: there are at most
@@ -1225,10 +1240,41 @@ select:focus-visible {
   overflow-wrap: anywhere;
 }
 
+/* The two ways out. Links rather than buttons, and below the explanation rather
+   than beside the .m3u controls: those hand this file to another application,
+   these are about not being on this screen again. Keeping them visually
+   separate is what stops "Find a playable release" reading as a fourth way to
+   play the file you already have. */
+.fallback-outs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.9rem 0 0;
+  font-size: 0.8rem;
+}
+
+.fallback-outs a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.fallback-outs a:hover {
+  text-decoration: underline;
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+/* The one control that actually works on this platform — VLC on a phone, the
+   .m3u everywhere else (see primaryAction). Three co-equal buttons made the
+   user pick, and on iOS two of the three did nothing useful. Borrows `.play`'s
+   accent treatment rather than inventing a second "this one" language. */
+.actions .primary {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 /* The rest of the torrent. Borrows the picker's vocabulary deliberately — this

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1450,6 +1450,42 @@ select:focus-visible {
   }
 }
 
+/* ---- continue watching -------------------------------------------------- *
+
+   The one pane in the app that had no artwork, in a product whose search and
+   For You panes are both poster walls — and the pane most likely to be opened
+   from a sofa, where recognising a show by its cover IS the interaction. The
+   whole premise of a resume list is that you already know what these are.
+
+   A row, not a card: this list is read top to bottom to find one thing, and a
+   grid of ten covers would be a browse. So the poster is a thumbnail in a
+   two-column grid, sized to the row rather than the row to it. */
+.continue-row {
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+/* Overrides .poster's card metrics — that rule centres a 12rem frame with a
+   bottom margin, which is right on a grid card and wrong beside three lines of
+   text. Keeps its 2:3 box, border and sunken background, so an empty frame
+   still reads as artwork that has not arrived rather than as a hole. */
+.continue-poster {
+  max-width: none;
+  margin: 0;
+  width: 3rem;
+}
+
+/* The text column. Its own stack, so the poster spans title, subtitle and
+   buttons instead of the title alone. */
+.continue-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
 .saved-heading {
   margin: 0 0 0.5rem;
   font-size: 0.75rem;

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1560,6 +1560,51 @@ select:focus-visible {
   min-width: 0;
 }
 
+/* Recent searches, under the search box. Full width of the card so they wrap on
+   their own line rather than trailing off the end of the Search button. */
+.recent {
+  flex: 1 0 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+/* A label on the strip, so a lone word under the search box is not a mystery.
+   Rendered from CSS rather than markup because it is punctuation for the list,
+   not content — there is nothing for a screen reader to gain from hearing it
+   before each chip's own accessible name. */
+.recent::before {
+  content: "recent";
+  align-self: center;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+
+/* Quieter than a saved search, which is the distinction worth drawing: a saved
+   search is a list you curated, a recent one is just where you have been.
+   `.saved-query` is borderless — right for a full-width list row, wrong for a
+   chip in a strip, where without an outline it reads as stray text rather than
+   as something to press. */
+/* `.recent .recent-chip`, not `.recent-chip`. It shares `.saved-query`, whose
+   `border: 0; padding: 0` is declared LATER in this file at equal specificity
+   and therefore wins — the same ordering hazard already recorded on `.preview`.
+   The extra class outranks it wherever these rules end up sitting, so a future
+   reshuffle cannot silently flatten the chips back to bare words. */
+.recent .recent-chip {
+  font-size: 0.7rem;
+  color: var(--dim);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 0.2rem 0.6rem;
+}
+
+.recent .recent-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .saved-heading {
   margin: 0 0 0.5rem;
   font-size: 0.75rem;

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -735,6 +735,63 @@ select:focus-visible {
   }
 }
 
+/* ---- touch targets ------------------------------------------------------ *
+
+   Measured at 390x844, nothing on either page reached 44px in its minor axis:
+   the four pane tabs were 26px, every row button 26px with a 6.4px gap, and
+   `.group-toggle` was 20x18 — eight percent of a 44x44 target. This is the
+   surface that is actually touched, and `play` sits a few millimetres from
+   `add` and from `remove`.
+
+   `min-height` plus centring rather than more padding, so a control grows
+   downward into empty space instead of pushing every neighbour apart — the
+   toolbar already wraps to five rows on a phone and taller rows would make that
+   worse. Type sizes are left alone: the problem was the hit area, not legibility.
+
+   Deliberately NOT gated on `(pointer: coarse)`. A narrow window on a laptop
+   gets the same layout, and a 44px control is never wrong for a mouse. */
+@media (max-width: 46rem) {
+  .view-tab,
+  .tabs .tab,
+  /* `.row-actions` is shared by the queue, the results list, the For You cards
+     and all three saved lists — one selector reaches every row control in the
+     app, which is why they were all 26px together. */
+  .row-actions button,
+  .row-actions .button-link,
+  .saved-query,
+  .recc-actions button {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* 6.4px between `play` and `add`, and between `play` and `remove`. On a
+     surface where the consequence of a mis-tap is a ninety-second resolve you
+     did not want, or a saved search silently gone, that is not enough. */
+  .row-actions,
+  .recc-actions {
+    gap: 0.6rem;
+  }
+
+  /* A disclosure triangle is the smallest control in the app and the one that
+     opens a collapsed group of twenty releases, so it is the one worth widening
+     most. */
+  .group-toggle {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Both of these are plain text links in a header, and both are the only way
+     off their screen. 17px and 15px tall respectively before this. */
+  .back,
+  .breadcrumb a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+  }
+}
+
 /* ---- grouped results ---------------------------------------------------- */
 
 /* A heading stands in for every release of one title. It differs from a release
@@ -1454,6 +1511,20 @@ select:focus-visible {
   gap: 0.75rem;
 }
 
+/* One column on a phone. `minmax(10rem, 1fr)` fits two ~185px columns at 390px,
+   and the layout preference is remembered in localStorage — so someone who
+   switched to grid at a desk arrives on their phone to two cramped columns of
+   truncated names and, on mixed results, screen-filling NO POSTER voids.
+
+   The preference is HONOURED rather than overridden: a poster wall is a good
+   way to browse on a phone, it just needs the whole width. One column is the
+   grid done properly here, not a quiet demotion to list. */
+@media (max-width: 46rem) {
+  .results-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 .result-card {
   display: flex;
   flex-direction: column;
@@ -1594,6 +1665,14 @@ select:focus-visible {
 
 .alert:not([hidden]) ~ .prepare {
   bottom: 4.2rem;
+}
+
+/* The same slot carrying an acknowledgement rather than a failure — "Removed ·
+   Undo". Accent, not error: nothing has gone wrong, and painting a successful
+   deletion red would teach the user to distrust the colour that means a real
+   problem two rows up. */
+.alert-info {
+  border-color: var(--accent);
 }
 
 .alert-line {

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -3,7 +3,9 @@
    The palette mirrors the TUI's so the two surfaces read as one tool. */
 
 :root {
-  color-scheme: dark light;
+  /* `dark light` with a hardcoded dark palette: a light-preference OS gets dark
+     form controls and scrollbars to match the page, which is the point. */
+  color-scheme: dark;
   --bg: #12131a;
   --fg: #e6e6ea;
   --dim: #8b8d9b;
@@ -12,11 +14,55 @@
   --error: #f7768e;
   --sunken: #0c0d13;
   --raised: #1b1d29;
+  /* The only two durations in the file, and both are short on purpose. This is
+     a tool: motion here exists to make a state change legible — which button is
+     under the cursor, that a row just arrived — never to be looked at. Anything
+     an operator waits for twice is too long. */
+  --tap: 90ms;
+  --settle: 160ms;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 * {
   box-sizing: border-box;
+}
+
+/* ---- motion -------------------------------------------------------------- *
+
+   There was none: 1500 lines of CSS with no transition, no animation and no
+   keyframes, so every hover, every selection and every appearing panel was
+   instantaneous. That is not restraint, it is a missing layer — an interface
+   that never acknowledges a pointer feels unresponsive even when it is fast.
+
+   Applied by PROPERTY, not by `all` on `*`: `transition: all` would animate
+   layout on the results list as it rebuilds 23 times during a search, which
+   would be both ugly and expensive. Only colour, border and background move —
+   nothing that triggers layout.
+
+   THE REDUCED-MOTION BLOCK IS NOT OPTIONAL. `scrollTo` in app.ts already
+   honours the preference; adding motion without extending the same courtesy
+   would be a regression for anyone who set it. */
+button,
+select,
+input,
+a,
+summary,
+.tag,
+.badge {
+  transition:
+    color var(--tap) ease-out,
+    border-color var(--tap) ease-out,
+    background-color var(--tap) ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }
 
 /* The `hidden` attribute is only `display: none` in the user-agent stylesheet,
@@ -245,6 +291,23 @@ input {
   font: inherit;
 }
 
+/* Chrome's UA placeholder is rgb(117,117,117), which against --sunken measures
+   4.21:1 — the one real contrast failure on the page, and it was there only
+   because ::placeholder was never styled. --dim clears 4.5:1 on every surface
+   this app puts an input on. */
+::placeholder {
+  color: var(--dim);
+  opacity: 1; /* Firefox dims placeholders by default; --dim is already the dim. */
+}
+
+/* `a` and `summary` are in here now. They were not, so a plain anchor — the
+   player's back link, its breadcrumb, the two escape routes on the fallback
+   card — fell to Chrome's UA ring, which is the LIGHT-mode blue rgb(0,95,204).
+   Against this page that measures 3.09:1: it clears WCAG 1.4.11 by nine
+   hundredths, and it is a different colour from every other focused control on
+   the site. */
+a:focus-visible,
+summary:focus-visible,
 input:focus-visible,
 button:focus-visible {
   outline: 1px solid var(--accent);
@@ -428,12 +491,15 @@ button:hover {
   background: rgb(0 0 0 / 55%);
 }
 
+/* NO text-transform HERE. This line renders a release name, and identifying the
+   file is the dialog's entire job — uppercasing it mangles the one string whose
+   exactness is the point, and filenames are case-sensitive on every filesystem
+   this app writes to. The label keeps its small dim treatment without it. */
 .picker-title {
   margin: 0 0 0.6rem;
   font-size: 0.75rem;
   color: var(--dim);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   overflow-wrap: anywhere;
 }
 
@@ -561,7 +627,9 @@ button:hover {
   color: var(--dim);
 }
 
-.tab[aria-selected="true"] {
+/* aria-pressed, matching .view-tab — these are toggle buttons, not tabs. See
+   the comment on #tabs in index.html. */
+.tab[aria-pressed="true"] {
   color: var(--accent);
   border-color: var(--accent);
 }
@@ -1200,11 +1268,17 @@ select:focus-visible {
 
 /* reccd's "because you liked …". Dim and small: it explains the pick, it is not
    the pick. Clamped to two lines so one verbose reason cannot make its card
-   twice the height of its neighbours and tear the grid. */
+   twice the height of its neighbours and tear the grid.
+
+   It was `var(--accent)`, directly under that first sentence — so the
+   explanation was the brightest text on the card, brighter than the title of
+   the thing being recommended, and it spent the accent budget that
+   `.tag-quality` is deliberately denied. The comment was right and the code was
+   wrong; this is the code catching up. */
 .recc-reason {
   margin: 0.3rem 0 0;
   font-size: 0.7rem;
-  color: var(--accent);
+  color: var(--dim);
   overflow-wrap: anywhere;
   display: -webkit-box;
   -webkit-box-orient: vertical;

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1833,6 +1833,11 @@ select:focus-visible {
 .alert-line {
   color: var(--fg);
   overflow-wrap: anywhere;
+  /* pre-line so a message can put a value on its own line — the copy-magnet
+     refusal path puts the magnet itself here for the user to select, and a
+     magnet run into the end of a sentence is not selectable in any useful way.
+     Ordinary single-line messages are unaffected. */
+  white-space: pre-line;
 }
 
 .alert button {

--- a/src/web/static/upNext.test.ts
+++ b/src/web/static/upNext.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { breadcrumbFor, upNextView } from "./upNext";
+import { breadcrumbFor, escapeRoutes, upNextView } from "./upNext";
 import type { PublicStreamFile, StreamFilesResponse } from "../wire";
 
 const SID = "sid-1";
@@ -253,5 +253,36 @@ describe("upNextView — the breadcrumb", () => {
       files: [file(0, "Tin.Rivers.2024.2160p.mkv")],
     };
     expect(upNextView(two, SID, 0, CAP).breadcrumb?.href).toBe("/?q=Tin+Rivers&group=Movies");
+  });
+});
+
+/**
+ * The card these links live on is the end of the most common journey through
+ * the app, and it used to be a cul-de-sac: it named a problem, offered three
+ * ways to hand the file to another application, and no way to avoid landing
+ * there again.
+ */
+describe("escapeRoutes", () => {
+  it("offers a search for the same title and a way to stop it recurring", () => {
+    expect(escapeRoutes("Harrowgate.S03E02.1080p.WEB-DL.mkv")).toEqual([
+      { label: "Find a playable Harrowgate", href: "/?q=Harrowgate&group=TV" },
+      { label: "Avoid this next time", href: "/?prefs=1" },
+    ]);
+  });
+
+  it("sends a film to the Movies tab", () => {
+    expect(escapeRoutes("Kestrel.2010.1080p.BluRay.x264.mkv")[0]).toEqual({
+      label: "Find a playable Kestrel",
+      href: "/?q=Kestrel&group=Movies",
+    });
+  });
+
+  /**
+   * "Search for nothing" is not a route out, so an unparseable name drops that
+   * link rather than offering a broken one. The preferences link survives —
+   * it does not depend on knowing what the file is.
+   */
+  it("drops the search when the filename parses to nothing", () => {
+    expect(escapeRoutes("")).toEqual([{ label: "Avoid this next time", href: "/?prefs=1" }]);
   });
 });

--- a/src/web/static/upNext.ts
+++ b/src/web/static/upNext.ts
@@ -117,6 +117,34 @@ export function breadcrumbFor(name: string): Breadcrumb {
   return href ? { label: parsed.title, href: `/${href}` } : HOME;
 }
 
+/**
+ * The links out of the "needs a real player" card.
+ *
+ * This card is the end of the most common journey through the browser UI, and
+ * it was a cul-de-sac: it named a problem, offered three ways to hand the file
+ * to another application, and gave no way to avoid landing here again. Both
+ * routes below are about NOT being here.
+ *
+ * - "Find a playable release" re-runs the search for the same title. Most shows
+ *   are uploaded several times and an x264 copy is usually one of them, so the
+ *   fix is very often two clicks away and there was nothing pointing at it.
+ * - "Avoid this next time" opens the dashboard's playback preferences, which
+ *   exist precisely to stop a release like this being picked — and which this
+ *   screen never mentioned.
+ *
+ * Empty when the filename parses to nothing, because "search for nothing" is
+ * not a route out. `?prefs=1` is a one-shot intent, not view state: app.ts
+ * opens the disclosure and the next `replaceState` drops the parameter.
+ */
+export function escapeRoutes(filename: string): Breadcrumb[] {
+  const crumb = breadcrumbFor(filename);
+  if (crumb.href === HOME.href) return [{ label: "Avoid this next time", href: "/?prefs=1" }];
+  return [
+    { label: `Find a playable ${crumb.label}`, href: crumb.href },
+    { label: "Avoid this next time", href: "/?prefs=1" },
+  ];
+}
+
 /** The season a file's own name commits to, or null. Season packs name none. */
 function seasonOf(filename: string): number | null {
   const parsed = parseRelease(filename);

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -60,6 +60,16 @@ export interface StatusDownload {
   peers: number;
   /** Bytes per second. */
   speed: number;
+  /**
+   * Why this download failed, when it did. Absent otherwise.
+   *
+   * `QueueItem.error` — the same string the TUI shows. The browser used to get
+   * only the word `failed`, which told the user nothing they could act on: the
+   * two most common values are "Set a Real-Debrid or TorBox token, then download
+   * again" and a tracker's own refusal, and both are the difference between a
+   * row you can fix and a row you can only delete.
+   */
+  error?: string;
 }
 
 /** One torrent being seeded. `uploaded` is bytes; `uploadSpeed` is bytes/sec. */


### PR DESCRIPTION
A design and quality-of-life pass over the browser UI, driven by an Impeccable
`critique` run: an independent design review plus a deterministic detector and
measured browser evidence.

**It scored 21/40.** Nine-tenths of the happy path is above average. The score
is dragged down almost entirely by failure paths — error recovery 1/4, help
1/4 — which is exactly where "nicer every day" lives. The critique snapshot is
committed at `.impeccable/critique/`.

Two of the findings were defects nobody would have found by reading.

## The two P0s

**The queue pane overflowed the viewport by 310px on a phone** — measured
`scrollWidth 700` against `clientWidth 390`. The `max-width: 34rem` block sets
`.row-head` to `display: block`, which reverts `.row-name` (a `<span>`) to
`display: inline`, and `overflow`, `text-overflow` and `min-width` are all
inert on an inline box. The phone fix had silently disabled its own ellipsis.
The saved pane was unaffected only because its rows keep a flex parent.

**Every error went to a four-second paragraph at the top of a 25,000px page.**
This project had already diagnosed that exact problem — it is why `#prepare` is
fixed to the viewport, and the comment there says a user 500px down a browse
"saw nothing at all and pressed play again". The remedy had been applied to the
reassuring case and not the alarming one, so a play that failed ninety seconds
into a resolve reported to a paragraph nobody was looking at. Errors now
persist in a fixed alert with a **Try again**, and `runPlay` says which of its
endings is a cancellation and which is a failure — retrying is right after a
timeout and is the app arguing with you after you decline a prompt.

## Failure states that lead somewhere

A failed download drew 99% of an accent bar under a dim grey "failed" and
offered `pause` and `resume` — one meaningless, the other a no-op, since
`resume` un-pauses and a failed item is not paused. `queue.retry` has existed
since the TUI shipped (its `f` key) and no HTTP caller could reach it. Now:
`retry` is a control action, the bar turns red, the row shows the server's
actual reason instead of `0 peers · —`, and the queue badge says when something
in there is broken.

The player's "needs a real player" card guessed in prose while the server had
already probed the file. It now names the real codec, and hedges when the
answer was inferred from a release name rather than probed. It also stopped
being a cul-de-sac: two links out, one searching the same title for a release
that will play, one opening the playback preferences that exist to prevent this
and that the screen never mentioned. On a phone the buttons are reordered so
the one that works comes first.

## The phone

Measured at 390×844, **nothing on either page reached 44px in its minor axis**:
the four pane tabs 26px, every row button 26px with a 6.4px gap, the group
disclosure 20×18 — eight percent of a 44×44 target. All ≥44 now, verified.

`remove` sat in that 26px strip beside `play` and fired instantly on saved
searches and library favourites, which nothing else keeps a copy of. Both now
offer **Undo** for eight seconds; a confirm would have interrupted the
ninety-nine deletions that were meant in order to catch the one that wasn't.
Continue-watching keeps its instant remove because the server has no request
that would put the row back — and it is the one of the three that reappears by
itself.

## Polish

**1518 lines of CSS contained no transition, animation or keyframe.** Every
hover and selection was instantaneous — not restraint, a missing layer. Two
durations, applied by property rather than `all` on `*` so nothing that
triggers layout moves while the results list rebuilds 23 times during a search,
with the `prefers-reduced-motion` block that `scrollTo` already honoured.

Alongside it: `::placeholder` was never styled, so four inputs used Chrome's UA
grey at **4.21:1** — the one real contrast failure on the page. Plain anchors
were outside the focus-ring rule and fell to Chrome's *light-mode* blue at
3.09:1 on a dark page. `#tabs` claimed `role="tablist"` with `aria-selected` on
seven children, `aria-controls` on none and no tabpanel anywhere — a structure
promised to a screen reader that was not there; they are toggle buttons that
re-run a search, which is what `#views` already says about itself. The player
page had no `<main>`. `.picker-title` uppercased a release name, mangling the
one string whose exactness is that dialog's whole job. And `.recc-reason` was
`var(--accent)` directly beneath a comment reading *"Dim and small: it explains
the pick, it is not the pick."*

## Parity, and one signature moment

Copy magnet and recent-search chips — the terminal's `y` and `↑`, which the
browser had neither of. Magnets are rebuilt client-side from the info hash
rather than added to the wire, because `PublicSearchResult`'s reasoning for
omitting them still holds. Chips rather than a key binding, because the surface
this matters on is a phone and a phone has no `↑`.

And **Continue Watching has artwork**. It was the only pane with none, in a
product whose search and For You panes are both poster walls, and it is the
pane most likely to be opened from a sofa — where recognising a show by its
cover is the whole interaction. Same cache, same lazy mount, so a title in both
places is fetched once. Building it exposed a real bug: `renderSaved` never
re-ran when `/api/sources` landed, and `omdbConfigured` arrives in that
response, so every row was built while the answer was still "no key".

## Deliberately not built

Exporting a `.torrent` and "open folder" — both need something a phone on a
sofa does not have. A `?` shortcuts overlay — thin over two shortcuts. All
three are now stated in the README's limitations list rather than left implied.

## Verification

`npm test` (2579), `npm run typecheck`, `npm run lint` (one documented
pre-existing warning) and `npm run build` all clean. The Impeccable detector
returns zero findings on both markup files.

Then 11 measured checks against the running app at 390×844 and 1440×900, all
passing: queue overflow 390/390 with `.row-name` computing to `block`; every
listed control at exactly 44px; no horizontal overflow on any of the five
panes; placeholder contrast 5.89:1; chips ordered newest-first and hidden once
you type; copy-magnet on all 10 rows; 4/4 continue-watching posters loaded;
transitions at 90ms; the accent focus ring on the player's back link; `#tabs`
`role="group"` with zero `[role=tab]` and zero `[aria-selected]` in the
document; and a clean console on both pages.

One judgement call worth a reviewer's eye: I dropped `role="tablist"` rather
than completing the ARIA pattern, on the grounds that those buttons re-run a
network search rather than revealing panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
