### PR TITLE
fix(web): copy the stream URL on an insecure origin

### DIFF
--- a/docs/superpowers/specs/2026-08-01-subtitles-design.md
+++ b/docs/superpowers/specs/2026-08-01-subtitles-design.md
@@ -1,0 +1,220 @@
+# Subtitles
+
+**Date:** 2026-08-01
+**Status:** Approved (design)
+**Builds on:** the streaming stack (`src/web/stream.ts`, `src/util/videoFiles.ts`,
+`src/core/probe.ts`) and the web player page.
+
+## Motivation
+
+torlink has no subtitle support of any kind. `README.md:229` says so plainly —
+"**No subtitles, no scrubber.**" — and the original streaming design listed them
+out of scope. Two distinct things are missing, and they were found by
+investigating one report ("I couldn't get subtitles for a season pack I was
+playing through the .m3u in VLC").
+
+**Embedded tracks are invisible.** The reported pack turned out to have no
+sibling subtitle files at all: ten mp4s, each with three muxed `mov_text` tracks
+(spa/eng/por). Those tracks survive torlink's byte-range proxy intact — verified
+with ffprobe against a live `/stream` URL, and VLC's mp4 demuxer logs all three
+when handed the `.m3u`:
+
+    adding track[Id 0x4] subtitle (enable)  language spa
+    adding track[Id 0x5] subtitle (disable) language eng
+    adding track[Id 0x6] subtitle (disable) language por
+
+So that case was never broken — VLC auto-enabled **Spanish**, and English sat
+loaded but off under Subtitle → Sub Track. Nothing in torlink told the user the
+tracks existed or which one was playing. The browser player is worse: it has no
+subtitle support at all, and for this file it cannot play the video either
+(HEVC + eac3, no provider HLS), so the user gets the fallback card with no
+indication that subtitles are sitting inside the file.
+
+**Sibling subtitle files are unreachable.** `streamCandidates`
+(`src/util/videoFiles.ts:83`) filters every non-video file out before either
+front end draws a picker. That is right for choosing *what to play*, but it means
+a release shipping `Subs/` or `Episode.S01E01.en.srt` hides those files
+completely. They are byte-addressable on the server — `src/web/stream.ts:336`
+never checks extension — but nothing lists them, links them, or associates them
+with a video.
+
+## Scope
+
+**In scope**
+
+- Sibling subtitle files: matched to the chosen video, served as WebVTT, attached
+  in both front ends.
+- Embedded subtitle tracks: detected by the existing ffprobe call and *reported*.
+- Both front ends, per the two-front-ends rule in `CLAUDE.md`.
+
+**Out of scope**
+
+- **Extracting embedded tracks.** Would require spawning ffmpeg, which torlink
+  never does in production (`findFfmpeg` in `src/util/ffmpegBin.ts:137` has no
+  production caller). It would also only pay off for files the browser can
+  already play — not the HEVC/eac3 case that prompted this.
+- **Fetching subtitles from the internet** (OpenSubtitles and friends). A
+  separate feature with its own credentials, rate limits and licensing.
+- **Rendering ASS/SSA in the browser.** Needs a real subtitle engine; `<track>`
+  cannot do it. Those files are still matched and still handed to VLC/mpv, which
+  render them natively.
+- **Probing in the TUI.** VLC lists embedded tracks in its own menu the moment it
+  opens the file; a 15-second ffprobe to print the same information first is a
+  cost with no return.
+
+## Design
+
+### 1. Shared pure modules
+
+Two new dependency-free modules beside `videoFiles.ts`, imported by both
+surfaces. The reason is the one `videoFiles.ts` gives in its own header: this
+project has been bitten three times by a hand-copied helper drifting between the
+front ends. Two copies of "which subtitle goes with this episode" would drift the
+same way and the divergence would be invisible until someone compared screens.
+
+**`src/util/subtitleFiles.ts`**
+
+    isSubtitleFilename(name)   srt, vtt, ass, ssa, sub
+    subtitlesFor(video, files) the three rules below, in order
+    subtitleLanguage(name)     language token + forced/sdh flags
+    preferredSubtitle(matches) English, else the first
+
+Matching rules, first rule that yields anything wins:
+
+1. **Basename prefix** — the subtitle's basename starts with the video's
+   basename. `Show.S01E01.1080p.mkv` ← `Show.S01E01.1080p.eng.srt`.
+2. **Shared SxxExx token** — both paths carry the same season/episode token.
+   Catches the `Subs/` folder layout scene releases actually use:
+   `Subs/Show.S01E01/2_English.srt`.
+3. **Single video** — if the torrent has exactly one video file, every subtitle
+   in it belongs to that video. `Kestrel.2010.1080p.mkv` ← `Subs/English.srt`.
+
+Rules stop there deliberately. Fuzzy title matching was considered and rejected:
+it would occasionally attach the wrong episode's subtitle, which is worse than
+attaching none.
+
+Two categories of subtitle, which are not interchangeable:
+
+| | `srt`, `vtt` | `ass`, `ssa`, `sub` |
+| --- | --- | --- |
+| Browser `<track>` | yes | no — needs a subtitle engine |
+| VLC / mpv attach | yes | yes, rendered natively |
+
+**`src/util/srtToVtt.ts`** — pure text transform. Strips a BOM, normalises CRLF,
+emits the `WEBVTT` header, converts `,` to `.` in timestamps, drops cue index
+lines. A file that is already WebVTT passes through unchanged. Decoding falls
+back to latin1 when the bytes are not valid UTF-8, because `.srt` files are
+frequently Windows-1252 and a mojibake subtitle is worse than none.
+
+`videoFiles.ts` is **not** modified. Subtitles must stay out of
+`streamCandidates` or they become things the user can pick to *play*.
+
+### 2. Server: one new representation, one changed
+
+**`.vtt` joins `.m3u` and `.info`** in `splitRepresentation`
+(`src/web/stream.ts:157`), which means it inherits every session, capability,
+readiness and bounds guard already in that path. It fetches the subtitle's bytes
+upstream, converts, and serves `text/vtt; charset=utf-8`.
+
+Two guards this representation needs that the others do not:
+
+- **Refuse any index whose filename is not a subtitle extension.** Without it,
+  `.vtt` is a general-purpose "fetch this file into memory and call it text"
+  route pointed at a 12 GB video.
+- **Cap the body at 4 MiB.** A subtitle is kilobytes; anything larger is not one.
+
+**The `.m3u` gains an input-slave line**, and only when a preferred subtitle
+exists:
+
+    #EXTM3U
+    #EXTVLCOPT:input-slave=http://host/stream/<sid>/7.vtt?k=<cap>
+    http://host/stream/<sid>/2?k=<cap>
+
+Both URLs are built from `streamHandle` and the re-encoded capability, so the
+existing constraint at `src/web/stream.ts:446` still holds exactly: nothing in
+the body is derived from the torrent's own text. With no match the body stays
+byte-identical to today's single bare URL.
+
+`.info` grows `subtitles: { embedded: EmbeddedSubtitle[], files: SubtitleFile[] }`,
+typed in `src/web/wire.ts`.
+
+### 3. Embedded tracks: widen the probe, do not extract
+
+`ffprobeArgs` (`src/core/probe.ts:29`) adds `stream_tags=language,title` to its
+`-show_entries`, and `parseFfprobe` stops discarding rows with
+`codec_type === "subtitle"`. That is the entire change — ffprobe is already a
+runtime dependency, so this costs nothing new.
+
+`MediaFacts` gains `subtitles: EmbeddedSubtitle[]`, which `classifyFromName`
+returns empty: a filename cannot know what is muxed inside.
+
+`src/core/probe.test.ts:78` currently asserts subtitle streams are ignored. That
+test inverts.
+
+### 4. Browser player
+
+- Matched `srt`/`vtt` files become real `<track kind="subtitles" srclang label>`
+  children of the `<video>`, giving the browser's native CC menu. The first
+  English track gets `default`.
+- The **fallback card** — the "needs a real player" case — gains a line naming
+  the embedded track languages: *"Subtitles in this file: English, Spanish,
+  Portuguese — pick one in your player."* This is what turns the reported dead
+  end into useful information.
+- The decision of which tracks to build is a pure `src/web/static/subtitleModel.ts`
+  with real tests. `player.ts` stays DOM wiring, per the rule in `CLAUDE.md` that
+  has been caught in review twice.
+
+### 5. TUI
+
+- `StreamFilePrompt` marks candidates that have matching subtitle files.
+- `launchPlayer` takes an optional subtitle URL and applies a flag table:
+
+      mpv      --sub-file=<url>
+      mpvnet   --sub-file=<url>
+      iina     --mpv-sub-file=<url>
+      vlc      --input-slave=<url>
+      <other>  no flag
+
+  An unknown or user-configured player command launches unchanged, and the notice
+  says the subtitle was not attached rather than staying silent about it.
+- No probing. See Scope.
+
+## Error handling
+
+Every failure is soft, matching the house style:
+
+- **No subtitle matches** — the `.m3u` is byte-identical to today's, no `<track>`
+  elements, no marks in the picker. The feature is invisible when it has nothing
+  to say.
+- **Upstream fetch of a subtitle fails** — `502`, matching what `proxyUpstream`
+  already does for an unreachable upstream. The video is unaffected: a `<track>`
+  whose URL fails leaves the video playing without captions, which is the
+  browser's own behaviour and needs no handling from us.
+- **Conversion produces nothing usable** — served as-is rather than as an empty
+  file, on the grounds that VLC may still parse what our transform did not.
+- **ffprobe unavailable or times out** — unchanged from today. `probeUrl` returns
+  null, the caller falls back to `classifyFromName`, and `subtitles.embedded` is
+  empty. No new failure mode.
+
+## Testing
+
+- `subtitleFiles.test.ts` — the three rules, including the case each exists for,
+  plus the negative: an unrelated `.srt` in a multi-episode pack matches nothing.
+- `srtToVtt.test.ts` — timestamp conversion, index stripping, BOM, CRLF, latin1
+  fallback, already-VTT passthrough.
+- `stream.test.ts` — the `.vtt` representation: capability enforced, non-subtitle
+  index refused, size cap, and the `.m3u` both with and without a match. The
+  existing negative assertions in that file are checked against the rename trap
+  documented in `CLAUDE.md`.
+- `subtitleModel.test.ts` — which `<track>` elements get built, which is
+  `default`, and that ASS/SSA never becomes a `<track>`.
+- `probe.test.ts` — the inverted assertion, plus language and title tags.
+- Fixtures use the invented cast from `CLAUDE.md` (`Kepler.S02E04`,
+  `Harrowgate.S03`, `Kestrel.2010`).
+
+## Documentation
+
+`README.md:229` currently states there are no subtitles. It changes to describe
+what now works and what does not: sibling files yes, embedded tracks reported but
+not rendered in the browser, ASS/SSA in external players only. The web UI's own
+limitations list is checked in the same pass, per `CLAUDE.md`.

--- a/src/web/static/copyText.test.ts
+++ b/src/web/static/copyText.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { copyNotice, copyText, type CopyPorts } from "./copyText";
+
+const STREAM_URL = "http://192.168.1.20:8080/stream/abc";
+
+function ports(over: Partial<CopyPorts> = {}): CopyPorts {
+  return { writeAsync: null, writeLegacy: () => false, ...over };
+}
+
+describe("copyText", () => {
+  it("uses the async clipboard when the browser exposes one", async () => {
+    const written: string[] = [];
+    let legacyTries = 0;
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: async (text) => {
+          written.push(text);
+        },
+        writeLegacy: () => {
+          legacyTries += 1;
+          return true;
+        },
+      }),
+    );
+    expect(result).toBe("copied");
+    expect(written).toEqual([STREAM_URL]);
+    expect(legacyTries).toBe(0);
+  });
+
+  it("falls back to the legacy copy when there is no async clipboard", () => {
+    // The insecure-origin case, which is the normal way this dashboard is
+    // reached over a LAN: navigator.clipboard is not merely restricted, it is
+    // undefined, so there is nothing to try first.
+    const written: string[] = [];
+    const result = copyText(
+      STREAM_URL,
+      ports({
+        writeLegacy: (text) => {
+          written.push(text);
+          return true;
+        },
+      }),
+    );
+    expect(result).toBe("copied");
+    expect(written).toEqual([STREAM_URL]);
+  });
+
+  it("attempts the legacy copy synchronously, without an intervening await", () => {
+    // THE POINT OF THIS FILE. document.execCommand("copy") is only permitted
+    // inside the task the user's click started; a single await before it hands
+    // control back to the event loop and Safari refuses the copy. So the
+    // no-async-clipboard path must not return a promise, and must have already
+    // called writeLegacy by the time copyText returns.
+    let called = false;
+    const result = copyText(STREAM_URL, ports({ writeLegacy: () => ((called = true), true) }));
+    expect(called).toBe(true);
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it("asks for the manual field when the legacy copy is refused too", () => {
+    expect(copyText(STREAM_URL, ports({ writeLegacy: () => false }))).toBe("manual");
+  });
+
+  it("tries the legacy copy when the async clipboard rejects", async () => {
+    // A secure origin can still refuse: writeText rejects when the document is
+    // not focused, which is easy to hit on a second monitor.
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: () => Promise.reject(new Error("not focused")),
+        writeLegacy: () => true,
+      }),
+    );
+    expect(result).toBe("copied");
+  });
+
+  it("asks for the manual field when both routes fail", async () => {
+    const result = await copyText(
+      STREAM_URL,
+      ports({ writeAsync: () => Promise.reject(new Error("denied")), writeLegacy: () => false }),
+    );
+    expect(result).toBe("manual");
+  });
+
+  it("still reaches the legacy copy when the async clipboard throws synchronously", async () => {
+    // Some hardened browsers throw from writeText rather than rejecting.
+    const result = await copyText(
+      STREAM_URL,
+      ports({
+        writeAsync: () => {
+          throw new Error("blocked");
+        },
+        writeLegacy: () => true,
+      }),
+    );
+    expect(result).toBe("copied");
+  });
+});
+
+describe("copyNotice", () => {
+  it("says the same thing however the copy happened", () => {
+    // The user does not care which clipboard API worked, and a notice that
+    // mentioned the legacy route would only invite the question.
+    expect(copyNotice("copied")).toBe("Stream URL copied.");
+  });
+
+  it("points at the field it is about to reveal when copying is refused", () => {
+    const notice = copyNotice("manual");
+    // "the field", not "below": the field renders inside .actions, which sits
+    // above the notice. Verified in a browser — an earlier wording said below
+    // and pointed the wrong way.
+    expect(notice).toContain("field");
+    // And it no longer sends the user off to download a .m3u instead, which was
+    // the old advice when there was nothing else on offer.
+    expect(notice).not.toContain("secure context");
+    expect(notice).not.toContain(".m3u");
+  });
+});

--- a/src/web/static/copyText.ts
+++ b/src/web/static/copyText.ts
@@ -1,0 +1,106 @@
+// Putting a string on the clipboard from a page that is very often not on a
+// secure origin.
+//
+// `copyText` is the decision and is unit-tested. `clipboardPorts` and
+// `legacyClipboardWrite` are wiring — they read `navigator` and build a DOM
+// node, neither of which a test in this repo can reach — so they are kept to
+// the minimum that reading them end to end is enough.
+
+/** What the caller must do next: nothing, or reveal the manual field. */
+export type CopyOutcome = "copied" | "manual";
+
+export interface CopyPorts {
+  /**
+   * `navigator.clipboard.writeText`, or null where the browser did not expose
+   * one. Null is the common case here, not the exotic one: the async clipboard
+   * exists only in a secure context — https, localhost or 127.0.0.1 — and this
+   * dashboard is normally reached at http://192.168.x.x over a LAN.
+   */
+  writeAsync: ((text: string) => Promise<void>) | null;
+  /** The `document.execCommand("copy")` route. Returns whether it took. */
+  writeLegacy: (text: string) => boolean;
+}
+
+/**
+ * Copy `text`, by whichever route this browser allows.
+ *
+ * **Returns synchronously when there is no async clipboard, and that is the
+ * whole point of the signature.** `document.execCommand("copy")` is only
+ * permitted inside the task the user's click started; a single `await` before
+ * it returns control to the event loop and Safari refuses. So the insecure
+ * origin path — the one that matters, since it is why this function exists —
+ * must reach `writeLegacy` with no microtask in between, and cannot be an
+ * `async function`. Callers hand the union to `Promise.resolve`.
+ *
+ * The async route is still tried first where it exists: it is the supported
+ * API, it does not need a throwaway element, and it works when the legacy one
+ * has been disabled. When it rejects — which a secure origin still does if the
+ * document is not focused — the legacy route gets its turn anyway.
+ */
+export function copyText(text: string, ports: CopyPorts): CopyOutcome | Promise<CopyOutcome> {
+  const legacy = (): CopyOutcome => (ports.writeLegacy(text) ? "copied" : "manual");
+  if (ports.writeAsync === null) return legacy();
+  try {
+    return ports.writeAsync(text).then(
+      (): CopyOutcome => "copied",
+      // Past the await the gesture is gone, so this attempt may well be
+      // refused as well. It costs nothing to make, and a refusal lands on the
+      // manual field, which is where a browser this strict was heading anyway.
+      legacy,
+    );
+  } catch {
+    // Some hardened browsers throw from writeText rather than rejecting.
+    return legacy();
+  }
+}
+
+export function copyNotice(outcome: CopyOutcome): string {
+  return outcome === "copied"
+    ? "Stream URL copied."
+    : "This browser won't let the page copy — the URL is in the field, already selected.";
+}
+
+/** The ports as this browser actually provides them. */
+export function clipboardPorts(): CopyPorts {
+  const clip: Clipboard | undefined = navigator.clipboard;
+  return {
+    writeAsync: clip ? (text) => clip.writeText(text) : null,
+    writeLegacy: legacyClipboardWrite,
+  };
+}
+
+/**
+ * The pre-`navigator.clipboard` copy: select a throwaway textarea, then ask the
+ * document to copy the selection. Deprecated, unfailingly available, and the
+ * only thing that works on an insecure origin.
+ *
+ * The styling is load-bearing. `display:none` and `visibility:hidden` both make
+ * the selection silently empty, so the element has to be genuinely on screen —
+ * `position:fixed` with zero opacity keeps it out of sight and out of the
+ * layout's way. `setSelectionRange` is there for iOS, which ignores `select()`
+ * on a readonly field by itself.
+ */
+export function legacyClipboardWrite(text: string): boolean {
+  const field = document.createElement("textarea");
+  // A property assignment, not markup — `value` is never parsed as HTML.
+  field.value = text;
+  field.setAttribute("readonly", "");
+  field.setAttribute("aria-hidden", "true");
+  field.style.position = "fixed";
+  field.style.top = "0";
+  field.style.left = "0";
+  field.style.opacity = "0";
+  document.body.append(field);
+  let copied = false;
+  try {
+    field.select();
+    field.setSelectionRange(0, text.length);
+    // Deprecated, and staying: the replacement does not exist on the origins
+    // this branch is here for.
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+  field.remove();
+  return copied;
+}

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -29,6 +29,7 @@ import {
   type FallbackReason,
   type PlayerTarget,
 } from "./playerModel";
+import { clipboardPorts, copyNotice, copyText } from "./copyText";
 import { mountHls } from "./hlsMount";
 import type { StreamInfoResponse } from "../wire";
 
@@ -44,8 +45,11 @@ let noticeTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * `persist` for a notice the user must still be able to read after they look
- * back at the screen. The copy-button notices are acknowledgements of something
- * the user just did and self-clear; a stream that died mid-playback is not, and
+ * back at the screen. Most copy-button notices are acknowledgements of
+ * something the user just did and self-clear — the exception is the one that
+ * asks the user to copy the revealed field by hand, which is an instruction
+ * rather than an acknowledgement and outlives its four seconds. A stream that
+ * died mid-playback is not an acknowledgement either, and
  * a four-second explanation of a video that is going to stay frozen is worse
  * than none — they would be left with the silence this notice exists to break.
  */
@@ -74,6 +78,37 @@ function button(label: string, onClick: () => void): HTMLButtonElement {
   b.textContent = label;
   b.addEventListener("click", onClick);
   return b;
+}
+
+/**
+ * The last resort when the browser refuses to copy on the page's behalf: the
+ * URL, in a field, already selected, so ⌘C or Ctrl+C finishes the job.
+ *
+ * It lives inside `actions` so that the per-target `replaceChildren` clears it;
+ * a stale URL left under a different file would be worse than no field at all.
+ */
+let manualField: HTMLInputElement | null = null;
+
+function revealManualCopy(url: string): void {
+  if (manualField === null) {
+    manualField = document.createElement("input");
+    manualField.type = "text";
+    manualField.className = "manual-copy";
+    manualField.readOnly = true;
+    manualField.setAttribute("aria-label", "Stream URL");
+    actions.append(manualField);
+  }
+  // A property assignment, not markup.
+  manualField.value = url;
+  manualField.focus();
+  manualField.select();
+  // iOS ignores select() on a readonly field by itself.
+  manualField.setSelectionRange(0, url.length);
+}
+
+function clearManualCopy(): void {
+  manualField?.remove();
+  manualField = null;
 }
 
 function linkButton(label: string, href: string): HTMLAnchorElement {
@@ -260,24 +295,27 @@ async function render(): Promise<void> {
   const controls: (HTMLButtonElement | HTMLAnchorElement)[] = [
     linkButton("Download .m3u", playlist),
     button("Copy stream URL", () => {
-      // clipboard.writeText is unavailable on insecure origins — which is the
-      // normal way this dashboard is reached over a LAN — and rejects when the
-      // page is not focused. Both are reported rather than swallowed, because a
-      // copy button that silently does nothing is worse than no button.
-      const clip = navigator.clipboard;
-      if (!clip) {
-        showNotice("Copying needs a secure context — download the .m3u instead.");
-        return;
-      }
-      void clip.writeText(stream).then(
-        () => showNotice("Stream URL copied."),
-        () => showNotice("Couldn't copy — download the .m3u instead."),
-      );
+      // copyText must be called straight from the click with nothing awaited in
+      // front of it: on an insecure origin — the normal way this dashboard is
+      // reached over a LAN — it copies via execCommand, which the browser only
+      // permits inside the task the gesture started.
+      const outcome = copyText(stream, clipboardPorts());
+      void Promise.resolve(outcome).then((result) => {
+        // Persisted for "manual" alone: that notice is an instruction attached
+        // to a field that stays on screen, so letting it self-clear would leave
+        // an unlabelled selected URL box and no reason for it.
+        showNotice(copyNotice(result), { persist: result === "manual" });
+        if (result === "manual") revealManualCopy(stream);
+        else clearManualCopy();
+      });
     }),
   ];
   for (const link of vlcLinks(stream, detectPlatform(navigator.userAgent))) {
     controls.push(linkButton(link.label, link.href));
   }
+  // replaceChildren drops any field left over from the previous target, so the
+  // reference has to go with it.
+  manualField = null;
   actions.replaceChildren(...controls);
 
   // Ask the server what this file actually is before creating any element. This

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1230,6 +1230,22 @@ select:focus-visible {
   outline-offset: 1px;
 }
 
+/* The URL, spelled out, for when the browser refuses to copy it on the page's
+   behalf — which is every insecure origin, i.e. most LANs. It takes the whole
+   row rather than sitting between the buttons: it appears mid-gesture, and a
+   new element that reflowed the buttons the user is aiming at would be worse
+   than the problem it solves. */
+.manual-copy {
+  flex-basis: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.35rem;
+  background: var(--sunken);
+  color: var(--fg);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
 /* ---------------------------------------------------------------------------
    The saved pane. Two lists side by side on a wide screen and stacked on a
    phone, using .rows and .row from the search pane rather than a third row


### PR DESCRIPTION
`navigator.clipboard` exists only in a secure context — https, `localhost` or
`127.0.0.1`. Reach the dashboard at `http://192.168.x.x`, which is the normal way
it is used over a LAN, and the object is simply undefined: the copy button had
nothing to call and could only explain itself.

Two fallbacks, in order:

1. A selected throwaway `<textarea>` plus `document.execCommand("copy")`.
   Deprecated, and the only thing that works on an insecure origin.
2. If that is refused too, the URL is revealed in a read-only field with the text
   already selected, so ⌘C finishes the job. That notice persists rather than
   self-clearing, because it is an instruction attached to on-screen UI.

### One design note worth reading

`copyText` returns `CopyOutcome | Promise<CopyOutcome>` rather than being `async`,
deliberately. `execCommand` is only permitted inside the task the user's click
started, so the no-async-clipboard path — the one this change exists for — has to
reach it with no microtask in between. A test pins that the synchronous path
returns a non-Promise and has already called the legacy write.

### Web-only, on purpose

Per CLAUDE.md's "a feature ships in both front ends" rule, this is the
"a surface can't express it" exception: the TUI copies through
`src/util/clipboard.ts` and has no secure-context concept, so there is nothing to
mirror.

### Verified

Against a real LAN origin in Chrome (`isSecureContext: false`,
`navigator.clipboard` undefined): copied, pasted back to confirm the exact URL,
then forced the second fallback to check the field and its notice. `npm test`,
`typecheck`, `lint` and `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
