### PR TITLE
feat: subtitles, in both front ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,13 @@ anything other than loopback requires a token.
 - **Two keyboard shortcuts, not the terminal's hundred-odd.** `/` focuses the search box from anywhere
   and the arrow keys walk the results. There is no `?` overlay — the browser is buttons, and the
   shortcuts worth having on a surface you mostly touch are few.
-- **No subtitles, no scrubber.** [Continue watching](#continue-watching) does play the next episode
+- **No scrubber.** [Continue watching](#continue-watching) does play the next episode
   automatically when a row names one — it just can't resume *where* you left off, because nothing here
   reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
+- **Subtitles, partly.** A `.srt` or `.vtt` shipped alongside the video is matched to it and shown in
+  the browser's own subtitle menu; ASS and SSA are handed to external players, which render them, but
+  the browser can't. Tracks muxed *inside* the file are named on the fallback card so you know they're
+  there — pulling one out would mean running ffmpeg, which torlink doesn't do.
 - **No settings page, but there is a settings control.** Tokens, sources, limits and folders are still
   TUI-only — the browser has no page for them, and that includes reccd's own URL and bearer token; the
   browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the

--- a/README.md
+++ b/README.md
@@ -236,11 +236,15 @@ anything other than loopback requires a token.
   automatically when a row names one — it just can't resume *where* you left off, because nothing here
   reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
 - **Subtitles, partly.** A `.srt` or `.vtt` shipped alongside the video is matched to it and shown in
-  the browser's own subtitle menu. ASS and SSA are matched too, but only the terminal hands them to
-  mpv, iina or vlc, which render them natively — the browser doesn't offer them at all, in its player
-  or in its "Download .m3u", because there's no way to show one without re-encoding it, and torlink
-  doesn't run ffmpeg. Tracks muxed *inside* the file are named on the fallback card so you know
-  they're there — pulling one out has the same ffmpeg problem.
+  the browser's own subtitle menu, and offered next to "Download .m3u" as a "Download subtitle" link
+  for anyone who'd rather open it themselves. When torlink itself launches the player, mpv and iina
+  take that same file side-loaded automatically; VLC doesn't — there's no VLC 3 command-line flag that
+  side-loads a subtitle from a URL (the obvious ones either misfile it as an audio track or resolve it
+  as a local path), so a VLC user gets the download link instead of a broken automatic attempt. ASS and
+  SSA are matched too, but the browser doesn't offer them anywhere — no track, no download link —
+  because there's no way to show one without re-encoding it, and torlink doesn't run ffmpeg. Tracks
+  muxed *inside* the file are named on the fallback card so you know they're there — pulling one out
+  has the same ffmpeg problem.
 - **No settings page, but there is a settings control.** Tokens, sources, limits and folders are still
   TUI-only — the browser has no page for them, and that includes reccd's own URL and bearer token; the
   browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the

--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ anything other than loopback requires a token.
   automatically when a row names one — it just can't resume *where* you left off, because nothing here
   reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
 - **Subtitles, partly.** A `.srt` or `.vtt` shipped alongside the video is matched to it and shown in
-  the browser's own subtitle menu; ASS and SSA are handed to external players, which render them, but
-  the browser can't. Tracks muxed *inside* the file are named on the fallback card so you know they're
-  there — pulling one out would mean running ffmpeg, which torlink doesn't do.
+  the browser's own subtitle menu. ASS and SSA are matched too, but only the terminal hands them to
+  mpv, iina or vlc, which render them natively — the browser doesn't offer them at all, in its player
+  or in its "Download .m3u", because there's no way to show one without re-encoding it, and torlink
+  doesn't run ffmpeg. Tracks muxed *inside* the file are named on the fallback card so you know
+  they're there — pulling one out has the same ffmpeg problem.
 - **No settings page, but there is a settings control.** Tokens, sources, limits and folders are still
   TUI-only — the browser has no page for them, and that includes reccd's own URL and bearer token; the
   browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the

--- a/docs/superpowers/plans/2026-08-01-subtitles.md
+++ b/docs/superpowers/plans/2026-08-01-subtitles.md
@@ -1,0 +1,2098 @@
+# Subtitles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Match sibling subtitle files to the video being played and attach them in both front ends, and report embedded subtitle tracks that ffprobe already sees but currently discards.
+
+**Architecture:** Two dependency-free modules in `src/util/` hold every decision (which subtitle belongs to which video; SRT→WebVTT text conversion), so the TUI and the browser bundle share one implementation. The server gains a `.vtt` representation on the existing stream handle — inheriting its session, capability, readiness and bounds guards — and the `.m3u` gains a VLC `input-slave` line when a subtitle matches. `parseFfprobe` stops discarding subtitle rows; nothing extracts them.
+
+**Tech Stack:** TypeScript, Node 22+, vitest, Ink (TUI), tsup (browser bundle), ffprobe (already a runtime dependency).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-subtitles-design.md`
+
+## Global Constraints
+
+- **A feature ships in both front ends.** `src/ui` (terminal) and `src/web` (browser) are two front ends over one core. See `CLAUDE.md`.
+- **`src/web` must not import from `src/ui`**, and `src/core` must not import from either. Lint enforces this. Share by moving code down into `src/util/`.
+- **`src/util/subtitleFiles.ts` and `src/util/srtToVtt.ts` must stay dependency-free** — no `node:*`, no transitive import that reaches one. They are bundled for the browser. `npm run build` is the enforcement.
+- **No `innerHTML` / `insertAdjacentHTML` / `document.write` / `outerHTML` anywhere in `src/web/static/`.** Every node is `createElement` + `textContent`. Subtitle filenames come from whoever made the torrent.
+- **`app.ts` and `player.ts` are DOM wiring only.** A conditional deciding *what to show* or *what to send* belongs in a pure module. Caught in review twice.
+- **Test fixtures name invented titles, never real ones.** Use the cast in `CLAUDE.md`: `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`.
+- **Before saying it's done:** `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) — leave it.
+- **Conventional Commits**, and fail soft: no subtitle match must leave every existing behaviour byte-identical.
+
+## File Structure
+
+**Created**
+
+| File | Responsibility |
+| --- | --- |
+| `src/util/subtitleFiles.ts` | Which subtitle files exist, which video each belongs to, what language it is. Pure, browser-safe. |
+| `src/util/subtitleFiles.test.ts` | Tests for the above. |
+| `src/util/srtToVtt.ts` | SRT text → WebVTT text. Pure, browser-safe. |
+| `src/util/srtToVtt.test.ts` | Tests for the above. |
+| `src/web/static/subtitleModel.ts` | Which `<track>` elements the player page should build, and the fallback card's embedded-track line. Pure, tested. |
+| `src/web/static/subtitleModel.test.ts` | Tests for the above. |
+| `src/util/subtitleFlags.ts` | Player command → subtitle CLI flag. Pure, Node-side only but no imports. |
+| `src/util/subtitleFlags.test.ts` | Tests for the above. |
+
+**Modified**
+
+| File | Change |
+| --- | --- |
+| `src/util/playability.ts` | `MediaFacts` gains `subtitles: EmbeddedSubtitle[]`; `classifyFromName` returns `[]`. |
+| `src/core/probe.ts` | `ffprobeArgs` requests language/title tags; `parseFfprobe` keeps subtitle rows. |
+| `src/core/probe.test.ts` | The "ignores subtitle streams" test inverts. |
+| `src/web/wire.ts` | `StreamInfoResponse` gains `subtitles`; new `SubtitleFile` type. |
+| `src/web/stream.ts` | `.vtt` representation; `.m3u` input-slave line; `.info` reports subtitles. |
+| `src/web/static/playerModel.ts` | `subtitlePath()` builder. |
+| `src/web/static/player.ts` | Build `<track>` elements; fallback card shows embedded languages. |
+| `src/util/player.ts` | `launchPlayer` takes an optional subtitle URL. |
+| `src/ui/App.tsx` | Pass the matched subtitle URL through to launch. |
+| `src/ui/components/StreamFilePrompt.tsx` | Mark rows that have subtitles. |
+| `README.md` | Replace "No subtitles, no scrubber." |
+
+---
+
+### Task 1: Subtitle file matching
+
+**Files:**
+- Create: `src/util/subtitleFiles.ts`
+- Test: `src/util/subtitleFiles.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `isSubtitleFilename(filename: string): boolean`
+  - `isBrowserRenderable(filename: string): boolean` — true for `srt`/`vtt` only
+  - `subtitleLanguage(filename: string): { code: string; label: string }` — `code` is a 2-letter BCP-47 tag or `""`; `label` is human text like `"English"`, `"English (forced)"`, or the bare basename when no language is detected
+  - `subtitlesFor<T extends NamedFile>(video: T, files: readonly T[]): T[]`
+  - `preferredSubtitle<T extends NamedFile>(matches: readonly T[]): T | null`
+  - Re-uses `NamedFile` from `./videoFiles`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/subtitleFiles.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  isBrowserRenderable,
+  isSubtitleFilename,
+  preferredSubtitle,
+  subtitleLanguage,
+  subtitlesFor,
+} from "./subtitleFiles";
+
+const f = (filename: string): { filename: string } => ({ filename });
+
+describe("isSubtitleFilename", () => {
+  it("accepts the five subtitle extensions", () => {
+    for (const ext of ["srt", "vtt", "ass", "ssa", "sub"]) {
+      expect(isSubtitleFilename(`Kestrel.2010.1080p.${ext}`)).toBe(true);
+    }
+  });
+
+  it("rejects video and everything else", () => {
+    expect(isSubtitleFilename("Kestrel.2010.1080p.BluRay.x264.mkv")).toBe(false);
+    expect(isSubtitleFilename("readme.nfo")).toBe(false);
+    expect(isSubtitleFilename("no-extension")).toBe(false);
+  });
+
+  it("is case insensitive", () => {
+    expect(isSubtitleFilename("Kestrel.2010.EN.SRT")).toBe(true);
+  });
+});
+
+describe("isBrowserRenderable", () => {
+  it("is true for srt and vtt, which convert to WebVTT", () => {
+    expect(isBrowserRenderable("Kestrel.2010.eng.srt")).toBe(true);
+    expect(isBrowserRenderable("Kestrel.2010.eng.vtt")).toBe(true);
+  });
+
+  it("is false for ass, ssa and sub", () => {
+    // <track> cannot render these without a subtitle engine. They are still
+    // matched and still handed to VLC/mpv, which render them natively.
+    expect(isBrowserRenderable("Kestrel.2010.eng.ass")).toBe(false);
+    expect(isBrowserRenderable("Kestrel.2010.eng.ssa")).toBe(false);
+    expect(isBrowserRenderable("Kestrel.2010.eng.sub")).toBe(false);
+  });
+});
+
+describe("subtitleLanguage", () => {
+  it("reads a three-letter code before the extension", () => {
+    expect(subtitleLanguage("Kepler.S02E04.1080p.WEB-DL.eng.srt")).toEqual({
+      code: "en",
+      label: "English",
+    });
+  });
+
+  it("reads a two-letter code", () => {
+    expect(subtitleLanguage("Kepler.S02E04.es.srt").code).toBe("es");
+  });
+
+  it("reads a spelled-out language anywhere in the path", () => {
+    expect(subtitleLanguage("Subs/Kepler.S02E04/3_Portuguese.srt")).toEqual({
+      code: "pt",
+      label: "Portuguese",
+    });
+  });
+
+  it("marks forced and SDH variants in the label but keeps the code", () => {
+    expect(subtitleLanguage("Kepler.S02E04.eng.forced.srt")).toEqual({
+      code: "en",
+      label: "English (forced)",
+    });
+    expect(subtitleLanguage("Kepler.S02E04.eng.sdh.srt")).toEqual({
+      code: "en",
+      label: "English (SDH)",
+    });
+  });
+
+  it("falls back to the basename when no language is detectable", () => {
+    // Better than labelling every unknown "Subtitles": a user with two of them
+    // needs to tell them apart, and the filename is the only thing that does.
+    expect(subtitleLanguage("Subs/2_track.srt")).toEqual({ code: "", label: "2_track" });
+  });
+
+  it("does not read a language out of the show title", () => {
+    // "Ashfall" contains no code, but a naive scan for "as" or "fa" would find
+    // one. Language tokens must be delimited.
+    expect(subtitleLanguage("Ashfall.1999.1080p.srt").code).toBe("");
+  });
+});
+
+describe("subtitlesFor", () => {
+  it("rule 1: matches a subtitle whose basename starts with the video's", () => {
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const sub = f("Kepler.S02E04.1080p.WEB-DL.eng.srt");
+    expect(subtitlesFor(video, [video, sub, f("readme.nfo")])).toEqual([sub]);
+  });
+
+  it("rule 2: matches on a shared SxxExx token across folders", () => {
+    // The layout scene season packs actually use, and the reason rule 1 alone
+    // is not enough.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const mine = f("Subs/Kepler.S02E04/2_English.srt");
+    const theirs = f("Subs/Kepler.S02E05/2_English.srt");
+    expect(subtitlesFor(video, [video, mine, theirs])).toEqual([mine]);
+  });
+
+  it("rule 2 does not fire across different seasons", () => {
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const other = f("Subs/Kepler.S03E04/2_English.srt");
+    expect(subtitlesFor(video, [video, other])).toEqual([]);
+  });
+
+  it("rule 3: a lone video takes every subtitle in the torrent", () => {
+    const video = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    const a = f("Subs/English.srt");
+    const b = f("Subs/Spanish.srt");
+    expect(subtitlesFor(video, [video, a, b])).toEqual([a, b]);
+  });
+
+  it("rule 3 does NOT fire when the torrent holds several videos", () => {
+    // THE REGRESSION THIS GUARDS. A season pack plus one unmatched subtitle
+    // must attach that subtitle to nothing, rather than to all ten episodes.
+    const e04 = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const e05 = f("Kepler.S02E05.1080p.WEB-DL.mkv");
+    const orphan = f("Subs/whatever.srt");
+    expect(subtitlesFor(e04, [e04, e05, orphan])).toEqual([]);
+  });
+
+  it("prefers rule 1 over rule 2 rather than merging them", () => {
+    // A pack with both layouts: the exact-basename match is the confident one,
+    // and returning both would put a duplicate language in the track menu.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const exact = f("Kepler.S02E04.1080p.WEB-DL.eng.srt");
+    const folder = f("Subs/Kepler.S02E04/2_English.srt");
+    expect(subtitlesFor(video, [video, exact, folder])).toEqual([exact]);
+  });
+
+  it("returns nothing when the torrent has no subtitles at all", () => {
+    // The season pack that prompted this feature: ten episodes, nothing else.
+    const video = f("Harrowgate.S03.1080p.WEB-DL.mkv");
+    expect(subtitlesFor(video, [video])).toEqual([]);
+  });
+
+  it("rule 3 does not fire for several NON-episodic videos either", () => {
+    // The case the rule-2 early return cannot cover, and the one that matters
+    // for a movie-pack torrent: two videos carrying no SxxExx token at all, so
+    // control actually reaches rule 3's `videos.length === 1` guard. Without
+    // this, that guard could be replaced by `return subs` and the suite would
+    // stay green.
+    const a = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    const b = f("Ashfall.1999.1080p.mkv");
+    const orphan = f("Subs/English.srt");
+    expect(subtitlesFor(a, [a, b, orphan])).toEqual([]);
+  });
+
+  it("never matches the video against itself", () => {
+    const video = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    expect(subtitlesFor(video, [video])).toEqual([]);
+  });
+});
+
+describe("preferredSubtitle", () => {
+  it("prefers English over whatever came first", () => {
+    const spa = f("Kepler.S02E04.spa.srt");
+    const eng = f("Kepler.S02E04.eng.srt");
+    expect(preferredSubtitle([spa, eng])).toBe(eng);
+  });
+
+  it("prefers a plain English track over a forced one", () => {
+    // A forced track only subtitles the foreign-language lines, so handing it
+    // to VLC as THE subtitle would leave most dialogue bare.
+    const forced = f("Kepler.S02E04.eng.forced.srt");
+    const full = f("Kepler.S02E04.eng.srt");
+    expect(preferredSubtitle([forced, full])).toBe(full);
+  });
+
+  it("falls back to the first when no English exists", () => {
+    const spa = f("Kepler.S02E04.spa.srt");
+    const por = f("Kepler.S02E04.por.srt");
+    expect(preferredSubtitle([spa, por])).toBe(spa);
+  });
+
+  it("returns null for no matches", () => {
+    expect(preferredSubtitle([])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/util/subtitleFiles.test.ts`
+Expected: FAIL — `Cannot find module './subtitleFiles'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/subtitleFiles.ts`:
+
+```ts
+/**
+ * Which subtitle file belongs to which video, and what language it is in.
+ *
+ * THIS MODULE MUST STAY DEPENDENCY-FREE, for the reason ./videoFiles.ts gives
+ * at length: it is imported by src/util/player.ts (Node) *and* by the browser
+ * bundle, and this codebase has recorded four bugs caused by a helper being
+ * copied between the two front ends and then drifting. A `node:*` import here —
+ * or any import that transitively reaches one — breaks `npm run build`, loudly,
+ * which is the enforcement.
+ *
+ * Deliberately separate from ./videoFiles.ts rather than added to it: a
+ * subtitle must never enter `streamCandidates`, or it becomes something the
+ * user can pick to *play*.
+ */
+import { isVideoFilename, type NamedFile } from "./videoFiles";
+
+const SUBTITLE_EXTS = new Set(["srt", "vtt", "ass", "ssa", "sub"]);
+
+// The two a <track> can carry, once srtToVtt has run. ass/ssa/sub need a real
+// subtitle engine to render, which the browser has no equivalent of.
+const RENDERABLE_EXTS = new Set(["srt", "vtt"]);
+
+function ext(name: string): string {
+  const i = name.lastIndexOf(".");
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : "";
+}
+
+/** Whether a filename looks like a subtitle, by extension. */
+export function isSubtitleFilename(filename: string): boolean {
+  return SUBTITLE_EXTS.has(ext(filename));
+}
+
+/** Whether the browser can show this one as a `<track>` after conversion. */
+export function isBrowserRenderable(filename: string): boolean {
+  return RENDERABLE_EXTS.has(ext(filename));
+}
+
+// Path and extension stripped: "Subs/Kepler.S02E04/2_English.srt" -> "2_English".
+function basename(path: string): string {
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const name = slash >= 0 ? path.slice(slash + 1) : path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+// Languages worth naming. Two- and three-letter codes plus the English name,
+// all mapping to one BCP-47 tag so <track srclang> is always well-formed.
+const LANGUAGES: { code: string; label: string; tokens: string[] }[] = [
+  { code: "en", label: "English", tokens: ["en", "eng", "english"] },
+  { code: "es", label: "Spanish", tokens: ["es", "spa", "esp", "spanish", "castellano", "latino"] },
+  { code: "pt", label: "Portuguese", tokens: ["pt", "por", "portuguese", "brazilian"] },
+  { code: "fr", label: "French", tokens: ["fr", "fre", "fra", "french"] },
+  { code: "de", label: "German", tokens: ["de", "ger", "deu", "german"] },
+  { code: "it", label: "Italian", tokens: ["it", "ita", "italian"] },
+  { code: "nl", label: "Dutch", tokens: ["nl", "dut", "nld", "dutch"] },
+  { code: "pl", label: "Polish", tokens: ["pl", "pol", "polish"] },
+  { code: "ru", label: "Russian", tokens: ["ru", "rus", "russian"] },
+  { code: "ja", label: "Japanese", tokens: ["ja", "jpn", "japanese"] },
+  { code: "ko", label: "Korean", tokens: ["ko", "kor", "korean"] },
+  { code: "zh", label: "Chinese", tokens: ["zh", "chi", "zho", "chinese"] },
+  { code: "ar", label: "Arabic", tokens: ["ar", "ara", "arabic"] },
+  { code: "sv", label: "Swedish", tokens: ["sv", "swe", "swedish"] },
+  { code: "da", label: "Danish", tokens: ["da", "dan", "danish"] },
+  { code: "no", label: "Norwegian", tokens: ["no", "nor", "norwegian"] },
+  { code: "fi", label: "Finnish", tokens: ["fi", "fin", "finnish"] },
+  { code: "tr", label: "Turkish", tokens: ["tr", "tur", "turkish"] },
+];
+
+// Split on every separator a release name uses, so a token match is delimited.
+// Without this, "Ashfall" contains "as" and "fa" and every file would look
+// Spanish or Persian — a real failure mode, not a hypothetical one.
+function tokensOf(path: string): string[] {
+  return path.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/**
+ * The language of a subtitle file, read from its path.
+ *
+ * Scans the WHOLE path, not just the basename: the `Subs/` layout puts the
+ * language in the filename ("2_English.srt") while the flat layout puts it
+ * before the extension ("…​.eng.srt"), and both are common.
+ *
+ * Later tokens win. "Kepler.S02E04.German.Dub.eng.srt" is an English subtitle
+ * for a German dub, and the token nearest the extension is the subtitle's own.
+ */
+export function subtitleLanguage(filename: string): { code: string; label: string } {
+  const tokens = tokensOf(filename);
+  let found: { code: string; label: string } | null = null;
+  for (const token of tokens) {
+    const hit = LANGUAGES.find((l) => l.tokens.includes(token));
+    if (hit) found = { code: hit.code, label: hit.label };
+  }
+  if (!found) return { code: "", label: basename(filename) };
+  // A forced track subtitles only the foreign-language lines and an SDH one
+  // adds sound description. Both are the same language and a different thing to
+  // choose, so the distinction belongs in the label, not the code.
+  if (tokens.includes("forced")) return { ...found, label: `${found.label} (forced)` };
+  if (tokens.includes("sdh")) return { ...found, label: `${found.label} (SDH)` };
+  return found;
+}
+
+// "S02E04" as written by anything: S02E04, s02e04, 2x04.
+const EPISODE_RE = /\bs(\d{1,2})[\s._-]*e(\d{1,3})\b|\b(\d{1,2})x(\d{2,3})\b/i;
+
+function episodeToken(path: string): string | null {
+  const m = EPISODE_RE.exec(path);
+  if (!m) return null;
+  const season = m[1] ?? m[3];
+  const episode = m[2] ?? m[4];
+  if (!season || !episode) return null;
+  return `s${Number(season)}e${Number(episode)}`;
+}
+
+/**
+ * The subtitle files that belong to one video, by three rules in order. The
+ * first rule that yields anything wins — they are not merged, because a pack
+ * carrying both layouts would otherwise show the same language twice.
+ *
+ * 1. The subtitle's basename starts with the video's basename.
+ * 2. Both paths carry the same SxxExx token — the `Subs/` folder layout.
+ * 3. The torrent holds exactly one video, so every subtitle in it is that
+ *    video's.
+ *
+ * Fuzzy title matching was considered and rejected: it would occasionally
+ * attach the wrong episode's subtitle, which is worse than attaching none.
+ */
+export function subtitlesFor<T extends NamedFile>(video: T, files: readonly T[]): T[] {
+  const subs = files.filter((f) => f !== video && isSubtitleFilename(f.filename));
+  if (subs.length === 0) return [];
+
+  const videoBase = basename(video.filename).toLowerCase();
+  const byPrefix = subs.filter((s) => basename(s.filename).toLowerCase().startsWith(videoBase));
+  if (byPrefix.length > 0) return byPrefix;
+
+  const token = episodeToken(video.filename);
+  if (token) {
+    const byEpisode = subs.filter((s) => episodeToken(s.filename) === token);
+    if (byEpisode.length > 0) return byEpisode;
+    // A video that names an episode and found no subtitle naming the same one
+    // stops here. Falling through to rule 3 would be impossible anyway (a pack
+    // has several videos), but stopping says why.
+    return [];
+  }
+
+  const videos = files.filter((f) => isVideoFilename(f.filename));
+  return videos.length === 1 ? subs : [];
+}
+
+/**
+ * The one subtitle to hand a player that accepts only one.
+ *
+ * English first because that is what this audience overwhelmingly wants, and a
+ * full track over a forced one because a forced track subtitles only the
+ * foreign-language lines — handing it over as THE subtitle would leave most of
+ * the dialogue bare. The browser gets all of them regardless; only the external
+ * player is limited to one.
+ */
+export function preferredSubtitle<T extends NamedFile>(matches: readonly T[]): T | null {
+  if (matches.length === 0) return null;
+  const english = matches.filter((m) => subtitleLanguage(m.filename).code === "en");
+  const full = english.find((m) => !subtitleLanguage(m.filename).label.includes("("));
+  return full ?? english[0] ?? matches[0] ?? null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/util/subtitleFiles.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/subtitleFiles.ts src/util/subtitleFiles.test.ts
+git commit -m "feat(util): match sibling subtitle files to a video"
+```
+
+---
+
+### Task 2: SRT to WebVTT conversion
+
+**Files:**
+- Create: `src/util/srtToVtt.ts`
+- Test: `src/util/srtToVtt.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `srtToVtt(text: string): string`
+  - `decodeSubtitle(bytes: Uint8Array): string` — UTF-8 with a latin1 fallback
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/srtToVtt.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { decodeSubtitle, srtToVtt } from "./srtToVtt";
+
+describe("srtToVtt", () => {
+  it("adds the WEBVTT header", () => {
+    expect(srtToVtt("1\n00:00:01,000 --> 00:00:02,000\nHello\n")).toMatch(/^WEBVTT\n/);
+  });
+
+  it("converts comma decimals to dots in timestamps", () => {
+    // The only difference between the two formats that actually stops a
+    // browser parsing the file.
+    const out = srtToVtt("1\n00:01:02,345 --> 00:01:04,567\nHello\n");
+    expect(out).toContain("00:01:02.345 --> 00:01:04.567");
+    expect(out).not.toContain(",345");
+  });
+
+  it("drops the numeric cue index lines", () => {
+    const out = srtToVtt("1\n00:00:01,000 --> 00:00:02,000\nFirst\n\n2\n00:00:03,000 --> 00:00:04,000\nSecond\n");
+    expect(out).not.toMatch(/^\s*1\s*$/m);
+    expect(out).not.toMatch(/^\s*2\s*$/m);
+    expect(out).toContain("First");
+    expect(out).toContain("Second");
+  });
+
+  it("keeps a numeric line that is dialogue, not an index", () => {
+    // A cue whose text is "1998" must survive. Only a bare number IMMEDIATELY
+    // followed by a timestamp line is an index.
+    const out = srtToVtt("1\n00:00:01,000 --> 00:00:02,000\n1998\n");
+    expect(out).toContain("1998");
+  });
+
+  it("strips a UTF-8 BOM", () => {
+    // A BOM before WEBVTT makes the browser reject the whole file.
+    const out = srtToVtt("\uFEFF1\n00:00:01,000 --> 00:00:02,000\nHello\n");
+    expect(out.startsWith("WEBVTT")).toBe(true);
+  });
+
+  it("normalises CRLF line endings", () => {
+    const out = srtToVtt("1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n");
+    expect(out).not.toContain("\r");
+    expect(out).toContain("00:00:01.000 --> 00:00:02.000");
+  });
+
+  it("passes an existing WebVTT file through unchanged apart from newlines", () => {
+    const vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n";
+    expect(srtToVtt(vtt)).toBe(vtt);
+  });
+
+  it("does not double the header on a WebVTT file with a BOM", () => {
+    const out = srtToVtt("\uFEFFWEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHi\n");
+    expect(out.match(/WEBVTT/g)).toHaveLength(1);
+  });
+
+  it("keeps hour-less timestamps working", () => {
+    // Some encoders write MM:SS,mmm. WebVTT allows it, so leave it alone apart
+    // from the separator.
+    expect(srtToVtt("1\n01:02,345 --> 01:04,567\nHi\n")).toContain("01:02.345 --> 01:04.567");
+  });
+
+  it("returns a bare header for empty input rather than an empty file", () => {
+    expect(srtToVtt("")).toBe("WEBVTT\n");
+  });
+});
+
+describe("decodeSubtitle", () => {
+  it("decodes UTF-8", () => {
+    const bytes = new TextEncoder().encode("Grüße");
+    expect(decodeSubtitle(bytes)).toBe("Grüße");
+  });
+
+  it("falls back to latin1 for bytes that are not valid UTF-8", () => {
+    // .srt files are frequently Windows-1252. Decoding those as UTF-8 yields
+    // U+FFFD replacement characters, and a mojibake subtitle is worse than
+    // none — so an invalid sequence means "this was never UTF-8".
+    const latin1 = new Uint8Array([0x47, 0x72, 0xfc, 0xdf, 0x65]); // "Grüße" in latin1
+    expect(decodeSubtitle(latin1)).toBe("Grüße");
+  });
+
+  it("does not mistake valid UTF-8 multibyte text for latin1", () => {
+    const bytes = new TextEncoder().encode("日本語");
+    expect(decodeSubtitle(bytes)).toBe("日本語");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/util/srtToVtt.test.ts`
+Expected: FAIL — `Cannot find module './srtToVtt'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/srtToVtt.ts`:
+
+```ts
+/**
+ * SRT text to WebVTT text.
+ *
+ * `<track>` accepts WebVTT and nothing else, so this is what makes a sibling
+ * .srt showable in a browser. The two formats are near-identical: the
+ * differences that matter are a required header, `.` instead of `,` as the
+ * millisecond separator, and cue index lines that WebVTT does not use.
+ *
+ * DEPENDENCY-FREE, like ./subtitleFiles.ts and for the same reason — it is
+ * bundled for the browser as well as run in Node. No `node:*`, and note that
+ * `Buffer` is a node global: decodeSubtitle uses TextDecoder, which both have.
+ */
+
+const TIMESTAMP_RE = /^(.*\d)[,.](\d{1,3})(\s*-->\s*)(.*\d)[,.](\d{1,3})(.*)$/;
+
+/** True for a line that is only digits — a candidate SRT cue index. */
+function isIndexLine(line: string): boolean {
+  return /^\d+$/.test(line.trim());
+}
+
+function isTimestampLine(line: string): boolean {
+  return line.includes("-->");
+}
+
+/**
+ * Convert, or pass through if it is already WebVTT.
+ *
+ * A cue index is dropped only when the NEXT line is a timestamp. A bare number
+ * anywhere else is dialogue — a cue whose text is "1998" is not an index, and
+ * dropping it would silently delete a subtitle line.
+ */
+export function srtToVtt(text: string): string {
+  const clean = text.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+  if (/^WEBVTT/.test(clean)) return clean;
+  if (clean.trim() === "") return "WEBVTT\n";
+
+  const lines = clean.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (isIndexLine(line) && isTimestampLine(lines[i + 1] ?? "")) continue;
+    const m = TIMESTAMP_RE.exec(line);
+    out.push(m ? `${m[1]}.${m[2]}${m[3]}${m[4]}.${m[5]}${m[6]}` : line);
+  }
+  return `WEBVTT\n\n${out.join("\n").replace(/^\n+/, "")}`;
+}
+
+/**
+ * Decode subtitle bytes to text.
+ *
+ * UTF-8 first, strictly: `fatal: true` makes an invalid sequence throw rather
+ * than produce U+FFFD. That distinction is the whole point — .srt files are
+ * frequently Windows-1252, and a subtitle full of replacement characters is
+ * worse than one decoded by the right fallback. latin1 cannot fail, so this
+ * always returns something.
+ */
+export function decodeSubtitle(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return new TextDecoder("windows-1252").decode(bytes);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/util/srtToVtt.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/srtToVtt.ts src/util/srtToVtt.test.ts
+git commit -m "feat(util): convert SRT text to WebVTT"
+```
+
+---
+
+### Task 3: Report embedded subtitle tracks from ffprobe
+
+**Files:**
+- Modify: `src/util/playability.ts` (the `MediaFacts` interface, and `classifyFromName`)
+- Modify: `src/core/probe.ts:29-43` (`ffprobeArgs`), `src/core/probe.ts:45-48` (`ProbeStream`), `src/core/probe.ts:71-103` (`parseFfprobe`)
+- Modify: `src/core/probe.test.ts:78` (the test that inverts)
+- Test: `src/core/probe.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `EmbeddedSubtitle` in `src/util/playability.ts`: `{ language: string; label: string }` where `language` is ffprobe's raw tag (e.g. `"eng"`, `""` when untagged) and `label` is its `title` tag or `""`.
+  - `MediaFacts.subtitles: EmbeddedSubtitle[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/core/probe.test.ts`, REPLACE the existing `it("ignores subtitle and attachment streams", …)` block (starts at line 78) with:
+
+```ts
+  it("reports subtitle streams instead of discarding them", () => {
+    // This test used to assert the opposite. Subtitle rows were dropped, so a
+    // file with three muxed tracks looked identical to one with none, and the
+    // player page could not tell the user they existed. Attachment streams
+    // (fonts, cover art) are still ignored — they are not tracks.
+    const facts = parseFfprobe(
+      output("mov,mp4", [
+        { codec_type: "video", codec_name: "hevc" },
+        { codec_type: "audio", codec_name: "eac3" },
+        { codec_type: "subtitle", codec_name: "mov_text", tags: { language: "spa" } },
+        { codec_type: "subtitle", codec_name: "mov_text", tags: { language: "eng" } },
+        { codec_type: "attachment", codec_name: "ttf" },
+      ]),
+      "mp4",
+    );
+    expect(facts?.subtitles).toEqual([
+      { language: "spa", label: "" },
+      { language: "eng", label: "" },
+    ]);
+  });
+
+  it("keeps a subtitle stream's title tag as its label", () => {
+    const facts = parseFfprobe(
+      output("matroska,webm", [
+        { codec_type: "video", codec_name: "h264" },
+        { codec_type: "subtitle", codec_name: "subrip", tags: { language: "eng", title: "SDH" } },
+      ]),
+      "mkv",
+    );
+    expect(facts?.subtitles).toEqual([{ language: "eng", label: "SDH" }]);
+  });
+
+  it("reports an untagged subtitle stream with an empty language", () => {
+    // Present but unnamed is still information: the player can say "1 subtitle
+    // track" rather than nothing.
+    const facts = parseFfprobe(
+      output("matroska,webm", [
+        { codec_type: "video", codec_name: "h264" },
+        { codec_type: "subtitle", codec_name: "subrip" },
+      ]),
+      "mkv",
+    );
+    expect(facts?.subtitles).toEqual([{ language: "", label: "" }]);
+  });
+
+  it("reports an empty subtitle list for a file with none", () => {
+    const facts = parseFfprobe(
+      output("matroska,webm", [{ codec_type: "video", codec_name: "h264" }]),
+      "mkv",
+    );
+    expect(facts?.subtitles).toEqual([]);
+  });
+
+  it("asks ffprobe for the language and title tags", () => {
+    // Without this the tags are absent from the JSON and every track reports an
+    // empty language — the failure would look like "no subtitles have names".
+    const entries = ffprobeArgs("http://example.test/a.mkv")[
+      ffprobeArgs("http://example.test/a.mkv").indexOf("-show_entries") + 1
+    ];
+    expect(entries).toContain("stream_tags=language,title");
+  });
+```
+
+Check the existing `output(...)` helper at the top of that file: if it does not accept a `tags` field on a stream, widen its parameter type to include `tags?: { language?: string; title?: string }`. Add `ffprobeArgs` to the file's import from `./probe` if it is not already imported.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/core/probe.test.ts`
+Expected: FAIL — `facts.subtitles` is undefined, and the `-show_entries` assertion fails.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/util/playability.ts`, add above `MediaFacts`:
+
+```ts
+/**
+ * One subtitle track muxed inside the file, as ffprobe reports it.
+ *
+ * Reported, never extracted: pulling one out would mean spawning ffmpeg, which
+ * this project does not do in production, and it would only help files the
+ * browser can already play. What this buys is the ability to TELL the user the
+ * tracks are there — the failure that prompted it was a season pack whose three
+ * embedded tracks were invisible in both front ends.
+ */
+export interface EmbeddedSubtitle {
+  /** ffprobe's own language tag ("eng", "spa"), or "" when untagged. */
+  language: string;
+  /** The stream's title tag ("SDH", "Forced"), or "". */
+  label: string;
+}
+```
+
+Add to the `MediaFacts` interface, after `source`:
+
+```ts
+  /**
+   * Subtitle tracks muxed into the file. Always empty from `classifyFromName`:
+   * a release name cannot know what is inside the container.
+   */
+  subtitles: EmbeddedSubtitle[];
+```
+
+In `classifyFromName`, add `subtitles: []` to the returned object.
+
+In `src/core/probe.ts`, change `ffprobeArgs`'s `-show_entries` value from:
+
+```ts
+    "format=format_name:stream=codec_type,codec_name",
+```
+
+to:
+
+```ts
+    "format=format_name:stream=codec_type,codec_name:stream_tags=language,title",
+```
+
+Widen `ProbeStream`:
+
+```ts
+interface ProbeStream {
+  codec_type?: string;
+  codec_name?: string;
+  tags?: { language?: string; title?: string };
+}
+```
+
+In `parseFfprobe`, before the `return`, add:
+
+```ts
+  // Subtitle streams, kept. An earlier version discarded them here, which made
+  // a file with three muxed tracks indistinguishable from one with none.
+  // Attachments (fonts, cover art) are still dropped — they are not tracks.
+  const subtitles = streams
+    .filter((s) => s.codec_type === "subtitle")
+    .map((s) => ({ language: s.tags?.language ?? "", label: s.tags?.title ?? "" }));
+```
+
+and add `subtitles,` to the returned object.
+
+Update the `MediaFacts` import in `src/core/probe.ts:12` to also import `EmbeddedSubtitle` only if you reference the type by name; the `.map` above infers it, so no import change is needed.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx vitest run src/core/probe.test.ts && npm run typecheck`
+Expected: probe tests PASS. Typecheck will FAIL in any file constructing a `MediaFacts` literal without `subtitles` — fix each by adding `subtitles: []`. Check `src/util/playability.test.ts`, `src/web/stream.test.ts`, `src/core/streamRoute.test.ts` and `src/web/static/playerModel.test.ts`.
+
+- [ ] **Step 5: Run everything and commit**
+
+```bash
+npm test && npm run typecheck && npm run lint
+git add src/util/playability.ts src/core/probe.ts src/core/probe.test.ts
+git add -u
+git commit -m "feat(probe): report embedded subtitle tracks instead of discarding them"
+```
+
+---
+
+### Task 4: The `.vtt` representation and the `.m3u` input-slave line
+
+**Files:**
+- Modify: `src/web/stream.ts` — `StreamRep` (line 140), `splitRepresentation` (line 157), the playlist branch (line 431), the `.info` branch (line 341)
+- Modify: `src/web/wire.ts` — `StreamInfoResponse` (line 126)
+- Test: `src/web/stream.test.ts`
+
+**Interfaces:**
+- Consumes: `isSubtitleFilename`, `isBrowserRenderable`, `subtitleLanguage`, `subtitlesFor`, `preferredSubtitle` (Task 1); `decodeSubtitle`, `srtToVtt` (Task 2); `EmbeddedSubtitle` (Task 3).
+- Produces:
+  - `StreamRep` gains `"subtitle"`.
+  - `SubtitleFile` in `src/web/wire.ts`: `{ index: number; filename: string; language: string; label: string; renderable: boolean }`.
+  - `StreamInfoResponse.subtitles: { embedded: EmbeddedSubtitle[]; files: SubtitleFile[] }`.
+  - `MAX_SUBTITLE_BYTES = 4 * 1024 * 1024` exported from `src/web/stream.ts`.
+  - `StreamDeps.fetchSubtitle?: (url: string, allowed: readonly string[]) => Promise<Uint8Array | null>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/web/stream.test.ts`. Follow the file's existing helpers for building `deps`, a ready session and a capability — read the top of the file and reuse them rather than inventing new ones.
+
+```ts
+describe("the .vtt representation", () => {
+  it("serves a matched subtitle as WebVTT", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ], { body: "1\n00:00:01,000 --> 00:00:02,000\nHello\n" });
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/vtt; charset=utf-8");
+    expect(res.body).toMatch(/^WEBVTT/);
+    expect(res.body).toContain("00:00:01.000 --> 00:00:02.000");
+  });
+
+  it("refuses an index that is not a subtitle file", async () => {
+    // THE GUARD THIS ROUTE NEEDS MOST. Without it, .vtt is a general-purpose
+    // "pull this whole file into memory and call it text" route aimed at a
+    // 12 GB video.
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 9e9 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.vtt?k=${cap}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("requires the capability, like every other representation", async () => {
+    const { deps, sid } = readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/1.vtt`);
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses a subtitle larger than the cap", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 9e8 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(413);
+  });
+
+  it("stops reading a body that exceeds the cap even when file.bytes lied", async () => {
+    // file.bytes is what upstream CLAIMED. This is what it actually sent.
+    const { deps, sid, cap } = readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ], { body: "x".repeat(MAX_SUBTITLE_BYTES + 1) });
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(502);
+  });
+
+  it("answers 502 when the upstream subtitle fetch fails", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ], { fail: true });
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("the .m3u with a matched subtitle", () => {
+  it("adds an input-slave line pointing at the .vtt handle", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toBe(
+      `#EXTM3U\n` +
+        `#EXTVLCOPT:input-slave=http://box.test:9161/stream/${sid}/1.vtt?k=${cap}\n` +
+        `http://box.test:9161/stream/${sid}/0?k=${cap}\n`,
+    );
+  });
+
+  it("is byte-identical to the old single-URL form when nothing matches", async () => {
+    // Fail-soft, and the reason this is asserted on the exact bytes: every
+    // player in the world already parses today's playlist, and a feature that
+    // has nothing to add must add nothing.
+    const { deps, sid, cap } = readySession([
+      { filename: "Harrowgate.S03.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+  });
+
+  it("puts no torrent-supplied text in the playlist body", async () => {
+    // The constraint the original one-bare-URL form existed to guarantee. Both
+    // URLs are built from streamHandle and the capability, so a filename with a
+    // newline or a quote in it cannot reach a file another application parses.
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: 'Kepler.S02E04\n#EXTVLCOPT:evil="x".eng.srt', url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).not.toContain("evil");
+    expect(res.body.split("\n").filter(Boolean)).toHaveLength(3);
+  });
+
+  it("prefers the English subtitle for the input-slave", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.spa.srt", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
+  });
+});
+
+describe("the .info subtitle report", () => {
+  it("lists matched sibling files with language and renderability", async () => {
+    const { deps, sid, cap } = readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.spa.ass", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.info?k=${cap}`);
+    const body = JSON.parse(res.body);
+    expect(body.subtitles.files).toEqual([
+      { index: 1, filename: "Kepler.S02E04.eng.srt", language: "en", label: "English", renderable: true },
+      { index: 2, filename: "Kepler.S02E04.spa.ass", language: "es", label: "Spanish", renderable: false },
+    ]);
+  });
+
+  it("reports embedded tracks from the probe", async () => {
+    const { deps, sid, cap } = readySession(
+      [{ filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 }],
+      {
+        probe: {
+          container: "mkv",
+          videoCodec: "hevc",
+          audioCodec: "eac3",
+          source: "probe",
+          subtitles: [{ language: "eng", label: "" }],
+        },
+      },
+    );
+    const res = await request(deps, `/stream/${sid}/0.info?k=${cap}`);
+    expect(JSON.parse(res.body).subtitles.embedded).toEqual([{ language: "eng", label: "" }]);
+  });
+});
+```
+
+Extend the file's session/request helpers as needed so `readySession` accepts `{ body, fail, probe }` and `request` accepts a `host`. Keep them local to the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/stream.test.ts`
+Expected: FAIL — `.vtt` falls through to the media branch, and `body.subtitles` is undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/web/wire.ts`, add before `StreamInfoResponse`:
+
+```ts
+/**
+ * A subtitle file that ships alongside the video in the same torrent, as the
+ * browser is allowed to see it.
+ *
+ * `index` addresses it on `/stream/:sid/:idx.vtt`, the same grammar as the
+ * video's own handle. `renderable` is false for ass/ssa/sub: those are matched
+ * and offered to external players, but `<track>` cannot show them.
+ */
+export interface SubtitleFile {
+  index: number;
+  filename: string;
+  /** BCP-47 tag ("en"), or "" when the filename gave no language. */
+  language: string;
+  /** Human label for a track menu: "English", "English (forced)". */
+  label: string;
+  renderable: boolean;
+}
+```
+
+Add to `StreamInfoResponse`:
+
+```ts
+  /**
+   * What subtitles exist for this file. `embedded` is muxed inside it and is
+   * reported only — nothing extracts it. `files` are siblings in the torrent,
+   * fetchable as WebVTT from `/stream/:sid/:idx.vtt`.
+   */
+  subtitles: { embedded: EmbeddedSubtitle[]; files: SubtitleFile[] };
+```
+
+Import `EmbeddedSubtitle` alongside the existing `Blocker, MediaFacts` import at `src/web/wire.ts:36`.
+
+In `src/web/stream.ts`:
+
+Add the suffix constant next to `PLAYLIST_SUFFIX` and `INFO_SUFFIX`:
+
+```ts
+const SUBTITLE_SUFFIX = ".vtt";
+```
+
+Widen the type at line 140 and the splitter at line 157:
+
+```ts
+export type StreamRep = "media" | "playlist" | "info" | "subtitle";
+```
+
+```ts
+  if (urlPath.endsWith(SUBTITLE_SUFFIX)) {
+    return { path: urlPath.slice(0, -SUBTITLE_SUFFIX.length), rep: "subtitle" };
+  }
+```
+
+Add near the other module constants:
+
+```ts
+/**
+ * The most a subtitle may be. A two-hour SRT is tens of kilobytes; four MiB is
+ * far past any real one. This route reads the whole body into memory to convert
+ * it, so without a cap a caller could aim it at a video file — the extension
+ * check below is the first guard against that and this is the second.
+ */
+export const MAX_SUBTITLE_BYTES = 4 * 1024 * 1024;
+```
+
+Add a helper above `handleStreamRequest`:
+
+```ts
+/**
+ * The sibling subtitle files for one video, as the wire type.
+ *
+ * Server-side because only the server holds the whole file list with its
+ * indexes — `toPublicSession` exposes them, but the `.info` response is where
+ * the player page reads them from, and doing it here means the browser never
+ * has to re-run the matcher.
+ */
+function subtitleFilesFor(session: StreamSession, index: number): SubtitleFile[] {
+  const video = session.files[index];
+  if (!video) return [];
+  const withIndex = session.files.map((f, i) => ({ ...f, index: i }));
+  return subtitlesFor(withIndex[index]!, withIndex).map((s) => {
+    const { code, label } = subtitleLanguage(s.filename);
+    return {
+      index: s.index,
+      filename: s.filename,
+      language: code,
+      label,
+      renderable: isBrowserRenderable(s.filename),
+    };
+  });
+}
+```
+
+In the `.info` branch, change the body construction to:
+
+```ts
+    const body: StreamInfoResponse = {
+      facts,
+      blockers: blockersFor(facts),
+      hls,
+      subtitles: {
+        embedded: facts.subtitles,
+        files: subtitleFilesFor(session, parsed.index),
+      },
+    };
+```
+
+Add the `subtitle` branch immediately after the `.info` branch and before the playlist branch:
+
+```ts
+  // The `.vtt`: a sibling subtitle file, converted for a <track>.
+  //
+  // Two guards this representation needs that the others do not. The extension
+  // check keeps it from being a general-purpose "read a whole file into memory
+  // and call it text" route aimed at a 12 GB video, and the size cap is the
+  // second line of that same defence.
+  if (rep === "subtitle") {
+    if (!isSubtitleFilename(file.filename)) {
+      writeJson(res, 404, { error: "not a subtitle" });
+      return 404;
+    }
+    if (file.bytes > MAX_SUBTITLE_BYTES) {
+      writeJson(res, 413, { error: "subtitle too large" });
+      return 413;
+    }
+    const fetched = await deps.fetchSubtitle(file.url, backendProtocols(session));
+    if (!fetched) {
+      // Same status and the same silence about the URL as proxyUpstream: an
+      // unrestricted link is a credential against the user's account.
+      deps.log("stream: could not fetch subtitle upstream");
+      writeJson(res, 502, { error: "bad upstream" });
+      return 502;
+    }
+    const payload = Buffer.from(srtToVtt(decodeSubtitle(fetched)), "utf8");
+    res.writeHead(200, {
+      "Content-Type": "text/vtt; charset=utf-8",
+      "Content-Length": String(payload.length),
+      // Same reason as the playlist: the URL that produced this carries a
+      // capability for a session that will be reaped.
+      "Cache-Control": "no-store",
+    });
+    if (method !== "HEAD") res.end(payload);
+    else res.end();
+    return 200;
+  }
+```
+
+**`fetchSubtitle` does not exist yet — add it, and do not reach for global `fetch`.** This module talks upstream through `node:http`/`node:https` (line 20-21), and `proxyUpstream` runs every URL through `resolveProxyTarget(target, allowedProtocols, MAX_PROXY_HOPS)` first. That check is not optional decoration: it is what stops a `file://` or redirect-to-anywhere upstream, and the `.vtt` route must not be the one path that skips it.
+
+Add to `StreamDeps`:
+
+```ts
+  /**
+   * Read a whole subtitle file from upstream, or null on any failure.
+   *
+   * Separate from the proxy because this one buffers rather than streams — a
+   * subtitle has to be converted before a byte of it can be sent. Injectable so
+   * the `.vtt` route is testable without a network; the default implementation
+   * goes through the same `resolveProxyTarget` allowlist the proxy does, which
+   * is the point of it being here rather than a bare `fetch`.
+   */
+  fetchSubtitle?: (url: string, allowed: readonly string[]) => Promise<Uint8Array | null>;
+```
+
+Implement the default next to `proxyUpstream`, reusing `resolveProxyTarget` and the `http`/`https` request the proxy already builds. Buffer up to `MAX_SUBTITLE_BYTES` and destroy the response if the body exceeds it — the `file.bytes` check above is what upstream *claimed*, and this is what it actually sent.
+
+Also add a small helper for the protocol allowlist, so the `.vtt` branch matches whichever backend the session uses:
+
+```ts
+// The same split the media branch makes: a debrid link is https, a WebTorrent
+// file is served from this machine over http.
+function backendProtocols(session: StreamSession): readonly string[] {
+  return session.backend === "debrid" ? HTTP_AND_HTTPS : HTTP_ONLY;
+}
+```
+
+Read the media branch (around line 472-486) to confirm the exact constant names and the field that distinguishes the backends before writing this.
+
+In the playlist branch, replace the body construction:
+
+```ts
+    const url = `${origin}${streamHandle(parsed.sid, parsed.index)}?k=${encodeURIComponent(k!)}`;
+    // One bare URL when there is no subtitle — byte-identical to what every
+    // player has parsed since this route existed, because a feature with
+    // nothing to add must add nothing.
+    //
+    // With a match, an #EXTVLCOPT:input-slave line, which is how VLC takes a
+    // side-loaded subtitle. Note what is still true: BOTH urls are built from
+    // streamHandle and the re-encoded capability, so nothing derived from the
+    // torrent's own text reaches a file another application parses. That was
+    // the reason the original form was one bare URL and it has not changed.
+    const subs = subtitleFilesFor(session, parsed.index);
+    const preferred = preferredSubtitle(subs);
+    const body = preferred
+      ? `#EXTM3U\n#EXTVLCOPT:input-slave=${origin}${streamHandle(parsed.sid, preferred.index)}.vtt?k=${encodeURIComponent(k!)}\n${url}\n`
+      : `${url}\n`;
+```
+
+Add the imports at the top of `src/web/stream.ts`:
+
+```ts
+import {
+  isBrowserRenderable,
+  isSubtitleFilename,
+  preferredSubtitle,
+  subtitleLanguage,
+  subtitlesFor,
+} from "../util/subtitleFiles";
+import { decodeSubtitle, srtToVtt } from "../util/srtToVtt";
+import type { SubtitleFile } from "./wire";
+```
+
+`preferredSubtitle` is generic over `NamedFile`, and `SubtitleFile` has a `filename`, so it accepts the mapped array directly.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/web/stream.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/stream.ts src/web/wire.ts src/web/stream.test.ts
+git commit -m "feat(web): serve sibling subtitles as WebVTT and side-load them in the .m3u"
+```
+
+---
+
+### Task 5: The browser player's subtitle decisions
+
+**Files:**
+- Create: `src/web/static/subtitleModel.ts`
+- Test: `src/web/static/subtitleModel.test.ts`
+- Modify: `src/web/static/playerModel.ts` (add `subtitlePath`)
+
+**Interfaces:**
+- Consumes: `StreamInfoResponse`, `SubtitleFile` (Task 4); `PlayerTarget` from `playerModel.ts`.
+- Produces:
+  - `subtitlePath(target: PlayerTarget, index: number): string` in `playerModel.ts`
+  - `TrackSpec = { src: string; srclang: string; label: string; default: boolean }`
+  - `subtitleTracks(info: StreamInfoResponse | null, target: PlayerTarget): TrackSpec[]`
+  - `embeddedNotice(info: StreamInfoResponse | null): string` — `""` when there is nothing to say
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web/static/subtitleModel.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { embeddedNotice, subtitleTracks } from "./subtitleModel";
+import type { PlayerTarget } from "./playerModel";
+import type { StreamInfoResponse } from "../wire";
+
+const target: PlayerTarget = { sid: "abc", index: 0, capability: "cap", filename: "Kepler.S02E04.mkv" };
+
+const info = (over: Partial<StreamInfoResponse>): StreamInfoResponse => ({
+  facts: { container: "mkv", videoCodec: "h264", audioCodec: "aac", source: "probe", subtitles: [] },
+  blockers: [],
+  hls: null,
+  subtitles: { embedded: [], files: [] },
+  ...over,
+});
+
+describe("subtitleTracks", () => {
+  it("builds a track per renderable sibling file", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks).toEqual([
+      { src: "/stream/abc/1.vtt?k=cap", srclang: "en", label: "English", default: true },
+    ]);
+  });
+
+  it("omits files the browser cannot render", () => {
+    // ass/ssa/sub need a subtitle engine. Offering a <track> that shows nothing
+    // is worse than offering none: the menu says the subtitle is on.
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.ass", language: "en", label: "English", renderable: false },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks).toEqual([]);
+  });
+
+  it("defaults the first English track, not the first track", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "a.spa.srt", language: "es", label: "Spanish", renderable: true },
+            { index: 2, filename: "a.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks.map((t) => t.default)).toEqual([false, true]);
+  });
+
+  it("defaults nothing when no track is English", () => {
+    // Turning on a language the user does not read is worse than turning on
+    // nothing; the menu is one click away either way.
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "a.spa.srt", language: "es", label: "Spanish", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks.map((t) => t.default)).toEqual([false]);
+  });
+
+  it("returns nothing for a null info", () => {
+    expect(subtitleTracks(null, target)).toEqual([]);
+  });
+
+  it("encodes the capability into every src", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [{ index: 1, filename: "a.srt", language: "", label: "a", renderable: true }],
+        },
+      }),
+      { ...target, capability: "a b&c" },
+    );
+    expect(tracks[0]?.src).toBe("/stream/abc/1.vtt?k=a%20b%26c");
+  });
+});
+
+describe("embeddedNotice", () => {
+  it("names the languages muxed into the file", () => {
+    // The line that turns the reported dead end into information: three tracks
+    // were inside the file and nothing on screen said so.
+    const notice = embeddedNotice(
+      info({
+        subtitles: {
+          embedded: [
+            { language: "spa", label: "" },
+            { language: "eng", label: "" },
+            { language: "por", label: "" },
+          ],
+          files: [],
+        },
+      }),
+    );
+    expect(notice).toBe(
+      "Subtitles in this file: Spanish, English, Portuguese — pick one in your player.",
+    );
+  });
+
+  it("counts untagged tracks rather than naming them", () => {
+    const notice = embeddedNotice(
+      info({ subtitles: { embedded: [{ language: "", label: "" }], files: [] } }),
+    );
+    expect(notice).toBe("This file has 1 subtitle track — pick it in your player.");
+  });
+
+  it("pluralises a count of untagged tracks", () => {
+    const notice = embeddedNotice(
+      info({
+        subtitles: {
+          embedded: [
+            { language: "", label: "" },
+            { language: "", label: "" },
+          ],
+          files: [],
+        },
+      }),
+    );
+    expect(notice).toContain("2 subtitle tracks");
+  });
+
+  it("says nothing when there are no embedded tracks", () => {
+    expect(embeddedNotice(info({}))).toBe("");
+  });
+
+  it("says nothing for a null info", () => {
+    expect(embeddedNotice(null)).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/static/subtitleModel.test.ts`
+Expected: FAIL — `Cannot find module './subtitleModel'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `src/web/static/playerModel.ts`, next to `infoPath`:
+
+```ts
+/** The `.vtt` path for a sibling subtitle in the same session. */
+export function subtitlePath(target: PlayerTarget, index: number): string {
+  const base = `/stream/${encodeURIComponent(target.sid)}/${index}.vtt`;
+  return target.capability ? `${base}?k=${encodeURIComponent(target.capability)}` : base;
+}
+```
+
+Create `src/web/static/subtitleModel.ts`:
+
+```ts
+// What subtitles the player page should offer, and what it should say about the
+// ones it cannot offer.
+//
+// Pure and tested, because nothing in player.ts is reachable by a unit test and
+// these are decisions about WHAT TO SHOW — exactly the kind of conditional
+// CLAUDE.md keeps out of the wiring file.
+import { subtitlePath, type PlayerTarget } from "./playerModel";
+import type { StreamInfoResponse } from "../wire";
+
+/** One `<track>` the page should build. */
+export interface TrackSpec {
+  src: string;
+  srclang: string;
+  label: string;
+  default: boolean;
+}
+
+/**
+ * The `<track>` elements for this file.
+ *
+ * Only renderable siblings (srt/vtt, converted server-side). An ass/ssa track
+ * would appear in the browser's menu and then show nothing, which is worse than
+ * being absent — the user would think subtitles were on.
+ *
+ * The first English track is `default`; when nothing is English, nothing is,
+ * because switching a viewer into a language they may not read is worse than
+ * leaving the menu one click away.
+ */
+export function subtitleTracks(
+  info: StreamInfoResponse | null,
+  target: PlayerTarget,
+): TrackSpec[] {
+  const files = (info?.subtitles.files ?? []).filter((f) => f.renderable);
+  const firstEnglish = files.find((f) => f.language === "en");
+  return files.map((f) => ({
+    src: subtitlePath(target, f.index),
+    srclang: f.language,
+    label: f.label,
+    default: f === firstEnglish,
+  }));
+}
+
+// ffprobe's tags are ISO 639-2; the page wants words. Only the languages worth
+// naming — anything else falls through to the count form below.
+const LANGUAGE_NAMES: Record<string, string> = {
+  eng: "English",
+  spa: "Spanish",
+  por: "Portuguese",
+  fre: "French",
+  fra: "French",
+  ger: "German",
+  deu: "German",
+  ita: "Italian",
+  dut: "Dutch",
+  nld: "Dutch",
+  pol: "Polish",
+  rus: "Russian",
+  jpn: "Japanese",
+  kor: "Korean",
+  chi: "Chinese",
+  zho: "Chinese",
+  ara: "Arabic",
+  swe: "Swedish",
+  dan: "Danish",
+  nor: "Norwegian",
+  fin: "Finnish",
+  tur: "Turkish",
+};
+
+/**
+ * One line naming the subtitle tracks muxed inside this file, for the fallback
+ * card.
+ *
+ * This exists because of a real report: a season pack whose episodes each
+ * carried three subtitle tracks played fine in VLC with the subtitles right
+ * there in its menu, and nothing in torlink ever said so. The browser cannot
+ * render them — that would mean extracting with ffmpeg — but it can say they
+ * are there, which is the difference between a dead end and an instruction.
+ */
+export function embeddedNotice(info: StreamInfoResponse | null): string {
+  const tracks = info?.subtitles.embedded ?? [];
+  if (tracks.length === 0) return "";
+  const named = tracks.map((t) => LANGUAGE_NAMES[t.language.toLowerCase()]).filter(Boolean);
+  if (named.length === tracks.length) {
+    return `Subtitles in this file: ${named.join(", ")} — pick one in your player.`;
+  }
+  const plural = tracks.length === 1 ? "track" : "tracks";
+  const pronoun = tracks.length === 1 ? "it" : "one";
+  return `This file has ${tracks.length} subtitle ${plural} — pick ${pronoun} in your player.`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/web/static/subtitleModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/subtitleModel.ts src/web/static/subtitleModel.test.ts src/web/static/playerModel.ts
+git commit -m "feat(web): decide which subtitle tracks the player offers"
+```
+
+---
+
+### Task 6: Wire subtitles into the player page
+
+**Files:**
+- Modify: `src/web/static/player.ts` — `showFallback` (line 131), `createVideo` (line 146), the play path (line 320)
+- Modify: `src/web/static/styles.css` — a rule for the embedded-track line
+
+**Interfaces:**
+- Consumes: `subtitleTracks`, `embeddedNotice`, `TrackSpec` (Task 5).
+- Produces: nothing consumed by later tasks.
+
+This task has no unit test — `player.ts` is DOM wiring, which by design has no jsdom in this repo. It is verified by running the app, in Step 3.
+
+- [ ] **Step 1: Make the changes**
+
+In `src/web/static/player.ts`, add to the imports:
+
+```ts
+import { embeddedNotice, subtitleTracks, type TrackSpec } from "./subtitleModel";
+```
+
+Change `showFallback` to take the info and append the embedded line:
+
+```ts
+function showFallback(
+  reason: FallbackReason,
+  filename: string,
+  info: StreamInfoResponse | null = null,
+): void {
+  const card = document.createElement("div");
+  card.className = "card fallback";
+
+  const title = document.createElement("h2");
+  title.textContent = "This one needs a real player";
+
+  const body = document.createElement("p");
+  body.className = "fallback-body";
+  body.textContent = fallbackMessage(reason, filename);
+
+  card.append(title, body);
+
+  // The subtitles the file carries, when it has any. A card that says "open
+  // this elsewhere" and then does not mention the three subtitle tracks inside
+  // is the exact gap this feature exists to close.
+  const subs = embeddedNotice(info);
+  if (subs) {
+    const line = document.createElement("p");
+    line.className = "fallback-subs";
+    line.textContent = subs;
+    card.append(line);
+  }
+
+  stage.replaceChildren(card);
+}
+```
+
+Update both existing calls: the one at `src/web/static/player.ts:284` (`showFallback("no-link", "")`) stays as-is, and the one in the play path becomes `showFallback(chosen.reason ?? "container", target.filename, info)`.
+
+Add a helper next to `createVideo`:
+
+```ts
+/**
+ * Attach subtitle tracks to a `<video>`.
+ *
+ * `label` comes from a filename, i.e. from whoever made the torrent, so it is
+ * set as a property and never as markup — the same rule as everything else in
+ * this file.
+ */
+function addTracks(video: HTMLVideoElement, specs: TrackSpec[]): void {
+  for (const spec of specs) {
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = spec.src;
+    track.srclang = spec.srclang;
+    track.label = spec.label;
+    track.default = spec.default;
+    video.append(track);
+  }
+}
+```
+
+In the play path, after `const info = await fetchInfo(target);`, compute the specs once:
+
+```ts
+  const tracks = subtitleTracks(info, target);
+```
+
+Call `addTracks(video, tracks)` immediately after each `createVideo()` — there are two sites, the `provider-hls` branch and `mountVideo`. For `mountVideo`, thread the specs in as a parameter rather than reaching for a module-level variable, and add them before the element is appended to the stage so no track loads late.
+
+In `src/web/static/styles.css`, add after the `.fallback-body` rule (around line 1196):
+
+```css
+/* The embedded-subtitle line under a fallback card. Dimmer than the
+   explanation above it: it is a useful aside, not the reason for the card. */
+.fallback-subs {
+  margin: 0.6rem 0 0;
+  color: var(--dim);
+  font-size: 0.85rem;
+}
+```
+
+- [ ] **Step 2: Verify it builds and imports nothing node-only**
+
+Run: `npm run build && npm run typecheck && npm run lint`
+Expected: all pass. `npm run build` is the only check that `src/web/static/` imports no `node:*`.
+
+- [ ] **Step 3: Verify by running it**
+
+```bash
+npm run dev -- serve --web --port 8899
+```
+
+Open the dashboard, play a torrent that has a sibling `.srt`, and confirm the browser's CC menu lists it and it renders. Then open one the browser cannot play and confirm the fallback card names the embedded languages. Both are wiring that no test reaches — this step is the verification.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/web/static/player.ts src/web/static/styles.css
+git commit -m "feat(web): show subtitle tracks in the player and name embedded ones on the card"
+```
+
+---
+
+### Task 7: Player subtitle flags for the TUI
+
+**Files:**
+- Create: `src/util/subtitleFlags.ts`
+- Test: `src/util/subtitleFlags.test.ts`
+- Modify: `src/util/player.ts` — `spawnPlayer` (line 217), `openWithApp` (line 238), `launchPlayer` (line 256)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `subtitleArgs(command: string, subtitleUrl: string): string[]` — `[]` for an unknown player
+  - `launchPlayer(command: string, url: string, subtitleUrl?: string): Promise<boolean>` — the existing two-argument calls keep working unchanged
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/util/subtitleFlags.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { subtitleArgs } from "./subtitleFlags";
+
+const URL = "http://box.test:9161/stream/abc/1.vtt?k=cap";
+
+describe("subtitleArgs", () => {
+  it("uses --sub-file for mpv", () => {
+    expect(subtitleArgs("mpv", URL)).toEqual([`--sub-file=${URL}`]);
+  });
+
+  it("uses --sub-file for mpv.net", () => {
+    expect(subtitleArgs("mpvnet", URL)).toEqual([`--sub-file=${URL}`]);
+  });
+
+  it("uses --mpv-sub-file for IINA, which prefixes mpv's own flags", () => {
+    expect(subtitleArgs("iina", URL)).toEqual([`--mpv-sub-file=${URL}`]);
+  });
+
+  it("uses --input-slave for VLC", () => {
+    expect(subtitleArgs("vlc", URL)).toEqual([`--input-slave=${URL}`]);
+  });
+
+  it("recognises a player given as an absolute path", () => {
+    // The configured command is often a full path on Windows and macOS.
+    expect(subtitleArgs("/Applications/VLC.app/Contents/MacOS/VLC", URL)).toEqual([
+      `--input-slave=${URL}`,
+    ]);
+    expect(subtitleArgs("C:\\Program Files\\VideoLAN\\VLC\\vlc.exe", URL)).toEqual([
+      `--input-slave=${URL}`,
+    ]);
+  });
+
+  it("recognises the macOS app-bundle names torlink launches with `open -a`", () => {
+    expect(subtitleArgs("VLC", URL)).toEqual([`--input-slave=${URL}`]);
+    expect(subtitleArgs("IINA", URL)).toEqual([`--mpv-sub-file=${URL}`]);
+  });
+
+  it("returns nothing for an unknown or custom command", () => {
+    // A user's own wrapper script takes whatever arguments it takes. Guessing a
+    // flag would break a launch that works today, so an unknown player gets the
+    // URL alone and the caller says the subtitle was not attached.
+    expect(subtitleArgs("my-player.sh", URL)).toEqual([]);
+    expect(subtitleArgs("", URL)).toEqual([]);
+  });
+
+  it("returns nothing when there is no subtitle url", () => {
+    expect(subtitleArgs("mpv", "")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/util/subtitleFlags.test.ts`
+Expected: FAIL — `Cannot find module './subtitleFlags'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/util/subtitleFlags.ts`:
+
+```ts
+/**
+ * How to tell each media player to side-load a subtitle.
+ *
+ * Kept apart from ./player.ts so the table is testable without spawning
+ * anything, and dependency-free so it stays that way.
+ *
+ * An unknown command gets no flag at all. The configured player may be a user's
+ * own wrapper script that takes arguments we cannot guess, and inventing one
+ * would break a launch that works today — the caller says the subtitle was not
+ * attached rather than risking that.
+ */
+
+// Matched against the command's basename, lowercased, extension stripped — the
+// configured value is as often "/Applications/VLC.app/Contents/MacOS/VLC" or
+// "vlc.exe" as it is "vlc".
+const FLAGS: Record<string, string> = {
+  mpv: "--sub-file",
+  mpvnet: "--sub-file",
+  "mpv.net": "--sub-file",
+  iina: "--mpv-sub-file",
+  "iina-cli": "--mpv-sub-file",
+  vlc: "--input-slave",
+  vlccli: "--input-slave",
+};
+
+function commandKey(command: string): string {
+  const slash = Math.max(command.lastIndexOf("/"), command.lastIndexOf("\\"));
+  const base = (slash >= 0 ? command.slice(slash + 1) : command).toLowerCase();
+  return base.replace(/\.(exe|app|com|bat|cmd)$/, "");
+}
+
+/** The extra argv for a subtitle, or `[]` when we should not pass one. */
+export function subtitleArgs(command: string, subtitleUrl: string): string[] {
+  if (!subtitleUrl) return [];
+  const flag = FLAGS[commandKey(command)];
+  return flag ? [`${flag}=${subtitleUrl}`] : [];
+}
+```
+
+In `src/util/player.ts`, add the import:
+
+```ts
+import { subtitleArgs } from "./subtitleFlags";
+```
+
+Change the three functions to carry extra argv. `spawnPlayer`:
+
+```ts
+function spawnPlayer(command: string, url: string, extra: string[] = []): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn(command, [...extra, url], {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+```
+
+(the rest of the body is unchanged)
+
+`openWithApp` — note the `--args` separator, which is what makes `open -a` pass anything through to the application:
+
+```ts
+function openWithApp(app: string, url: string, extra: string[] = []): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      // `open -a App url` passes the url as a document. Anything after --args
+      // goes to the application instead, so a flag has to sit there or `open`
+      // will treat it as its own and fail.
+      const argv = extra.length > 0 ? ["-a", app, url, "--args", ...extra] : ["-a", app, url];
+      const proc = spawn("open", argv, { stdio: "ignore", windowsHide: true });
+```
+
+(the rest of the body is unchanged)
+
+`launchPlayer`:
+
+```ts
+/**
+ * Launch a media player on a URL. Tries the command directly first (a CLI on
+ * PATH or an absolute path); on macOS, if that can't be spawned, falls back to
+ * `open -a <command>` so a bare app name like "VLC" or "IINA" still works.
+ * Resolves false only when neither route launches anything.
+ *
+ * `subtitleUrl` side-loads a subtitle where the player is one we know the flag
+ * for (see ./subtitleFlags.ts). An unknown player launches exactly as before,
+ * with no flag — the caller is responsible for saying so.
+ */
+export async function launchPlayer(
+  command: string,
+  url: string,
+  subtitleUrl = "",
+): Promise<boolean> {
+  const extra = subtitleArgs(command, subtitleUrl);
+  if (await spawnPlayer(command, url, extra)) return true;
+  if (process.platform === "darwin") return openWithApp(command, url, extra);
+  return false;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/util/subtitleFlags.test.ts src/util/player.test.ts && npm run typecheck`
+Expected: PASS. The existing two-argument `launchPlayer` callers still compile because the third parameter has a default.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/subtitleFlags.ts src/util/subtitleFlags.test.ts src/util/player.ts
+git commit -m "feat(util): side-load a subtitle when launching a known player"
+```
+
+---
+
+### Task 8: Subtitles in the TUI
+
+**Files:**
+- Modify: `src/ui/components/StreamFilePrompt.tsx` — the row rendering
+- Modify: `src/util/player.ts` — `PlayDeps`, `detectAndPlay`, `attemptAutoPlay`
+- Modify: `src/ui/App.tsx:1364` (`playStream`), `:1516` and `:1666` (the two `streamCandidates` call sites), `:1844` (the `setMediaPlayer` launch)
+- Modify: `src/ui/testHarness.ts` if a new `Store` field is added
+- Test: `src/ui/components/StreamFilePrompt.test.tsx`, `src/util/player.test.ts`
+
+**Interfaces:**
+- Consumes: `subtitlesFor`, `preferredSubtitle` (Task 1); `launchPlayer`'s third parameter and `subtitleArgs` (Task 7).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/util/player.test.ts`, following that file's existing `deps`-injection pattern:
+
+```ts
+it("passes the subtitle url through attemptAutoPlay to the launcher", () => {
+  // The path nearly every user takes: a configured player. Wiring only the
+  // after-the-prompt launch would leave the feature dead for all of them.
+  const seen: { command: string; url: string; sub?: string }[] = [];
+  return attemptAutoPlay(
+    "mpv",
+    "http://up.test/v.mkv",
+    "http://up.test/v.eng.srt",
+    {
+      launch: (command, url, sub) => {
+        seen.push({ command, url, sub });
+        return Promise.resolve(true);
+      },
+    },
+  ).then(() => {
+    expect(seen).toEqual([
+      { command: "mpv", url: "http://up.test/v.mkv", sub: "http://up.test/v.eng.srt" },
+    ]);
+  });
+});
+
+it("passes an empty subtitle url when there is none", async () => {
+  let seen = "unset";
+  await attemptAutoPlay("mpv", "http://up.test/v.mkv", "", {
+    launch: (_c, _u, sub) => {
+      seen = sub ?? "undefined";
+      return Promise.resolve(true);
+    },
+  });
+  expect(seen).toBe("");
+});
+```
+
+Add to `src/ui/components/StreamFilePrompt.test.tsx`:
+
+```tsx
+it("marks a file that has a matching subtitle", () => {
+  const files = [
+    { url: "http://up.test/0", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 900 },
+    { url: "http://up.test/1", filename: "Kepler.S02E05.1080p.WEB-DL.mkv", bytes: 900 },
+  ];
+  const { lastFrame } = render(
+    <StreamFilePrompt
+      width={80}
+      files={files}
+      allFiles={[...files, { url: "http://up.test/2", filename: "Kepler.S02E04.eng.srt", bytes: 40 }]}
+      onSelect={() => {}}
+      onCancel={() => {}}
+    />,
+  );
+  const [e04, e05] = lastFrame()!.split("\n").filter((l) => l.includes("Kepler"));
+  expect(e04).toContain("CC");
+  expect(e05).not.toContain("CC");
+});
+
+it("marks nothing when the torrent has no subtitle files", () => {
+  const files = [{ url: "http://up.test/0", filename: "Harrowgate.S03.1080p.WEB-DL.mkv", bytes: 900 }];
+  const { lastFrame } = render(
+    <StreamFilePrompt width={80} files={files} allFiles={files} onSelect={() => {}} onCancel={() => {}} />,
+  );
+  expect(lastFrame()).not.toContain("CC");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/ui/components/StreamFilePrompt.test.tsx src/util/player.test.ts`
+Expected: FAIL — `allFiles` is not a prop, no `CC` marker is rendered, and `attemptAutoPlay` takes no subtitle argument.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/ui/components/StreamFilePrompt.tsx`, add the prop:
+
+```tsx
+  /**
+   * Every file in the torrent, not just the video candidates in `files`.
+   *
+   * The subtitle matcher needs the unfiltered list: `files` has already been
+   * through `streamCandidates`, which drops exactly the .srt files this is
+   * looking for. Defaults to `files`, so a caller that has not been updated
+   * simply shows no markers rather than crashing.
+   */
+  allFiles?: StreamFile[];
+```
+
+Destructure it with `allFiles`, defaulting to `files`, and compute per-row:
+
+```tsx
+  const withSubs = useMemo(() => {
+    const pool = allFiles ?? files;
+    return new Set(files.filter((f) => subtitlesFor(f, pool).length > 0).map((f) => f.url));
+  }, [files, allFiles]);
+```
+
+In the row rendering, add the marker next to the existing watched `✓`:
+
+```tsx
+{withSubs.has(file.url) ? <Text color={COLOR.dim}> CC</Text> : null}
+```
+
+Import `subtitlesFor` from `../../util/subtitleFiles`.
+
+In `src/ui/App.tsx`, pass the unfiltered list at both `StreamFilePrompt` render sites: `allFiles={<the session's full file list>}` — the same array `streamCandidates(...)` is called on.
+
+**There are two launch paths and both need this.** `playStream` (`src/ui/App.tsx:1364`) is the primary one — it calls `attemptAutoPlay` at line 1369 — and `setMediaPlayer` (`src/ui/App.tsx:1844`) is the fallback used after the user types a player command. Wiring only the second would leave the feature dead for everyone whose player is already configured, which is nearly everyone.
+
+Thread the subtitle URL through both. First widen the two helpers in `src/util/player.ts` so the URL has somewhere to travel:
+
+```ts
+export interface PlayDeps {
+  detect?: () => Promise<string | null>;
+  launch?: (command: string, url: string, subtitleUrl?: string) => Promise<boolean>;
+}
+```
+
+`detectAndPlay` and `attemptAutoPlay` each gain a trailing `subtitleUrl = ""` parameter and pass it to `launch(...)`. Both already take `deps` last, so add the new parameter **before** `deps` and update the two internal call sites; every existing caller passes neither and is unaffected.
+
+Then in `src/ui/App.tsx`, give `playStream` a fourth parameter:
+
+```tsx
+const playStream = useCallback(
+  async (url: string, name?: string, onPlayed?: () => void, subtitleUrl = "") => {
+    if (!config) return;
+    const configured = resolveMediaPlayer(config);
+    const outcome = await attemptAutoPlay(configured, url, subtitleUrl);
+```
+
+and at each site that resolves a file to play, compute the subtitle from the session's **unfiltered** list before calling it:
+
+```tsx
+const preferred = preferredSubtitle(subtitlesFor(chosenFile, allFiles));
+void playStream(chosenFile.url, name, onPlayed, preferred?.url ?? "");
+```
+
+Do the same at the `setMediaPlayer` launch (`src/ui/App.tsx:1844`), where `ctx` already carries the pending stream — add the subtitle URL to `pendingStream` when it is set so it survives the prompt, rather than recomputing it there with a file list that scope does not have.
+
+Note this passes the **upstream** URL, not a `/stream/…vtt` handle: the TUI hands players the upstream URL for the video too, so the subtitle must come from the same place. No conversion happens on this path, which is correct — mpv, IINA and VLC all read SRT and ASS natively.
+
+When a subtitle matched but the player is one `subtitleArgs` does not know, say so rather than staying silent. In `playStream`'s success branch:
+
+```tsx
+const attached = subtitleUrl !== "" && subtitleArgs(outcome.player ?? "", subtitleUrl).length > 0;
+const subNote = subtitleUrl !== "" && !attached ? " · subtitle not loaded" : "";
+setNotice(
+  `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}${subNote}`,
+);
+```
+
+Add the imports `src/ui/App.tsx` needs for the above:
+
+```tsx
+import { preferredSubtitle, subtitlesFor } from "../util/subtitleFiles";
+import { subtitleArgs } from "../util/subtitleFlags";
+```
+
+`chosenFile` and `allFiles` in that snippet are whatever the surrounding scope already calls the selected `StreamFile` and the session's unfiltered file array — read the call site and use its own names rather than introducing these.
+
+If any of this requires a new `Store` field, add the matching entry to **both** `makeStore` (`scripts/render-previews-impl.tsx`) and `makeTestStore` (`src/ui/testHarness.ts`) — `npm run previews` and `npm run typecheck` respectively break otherwise.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/ui/ && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Verify by running it**
+
+```bash
+npm run dev
+```
+
+Stream a torrent that has a sibling `.srt`, confirm the picker marks the episode `CC`, and confirm the subtitle is loaded when the player opens.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/components/StreamFilePrompt.tsx src/ui/App.tsx
+git add -u
+git commit -m "feat(tui): mark files with subtitles and side-load them on play"
+```
+
+---
+
+### Task 9: Documentation and the rename-trap sweep
+
+**Files:**
+- Modify: `README.md:229`
+- Verify: the whole suite
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Update the README**
+
+`README.md:229` currently reads:
+
+```markdown
+- **No subtitles, no scrubber.** [Continue watching](#continue-watching) does play the next episode
+  automatically when a row names one — it just can't resume *where* you left off, because nothing here
+  reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
+```
+
+Replace with:
+
+```markdown
+- **No scrubber.** [Continue watching](#continue-watching) does play the next episode
+  automatically when a row names one — it just can't resume *where* you left off, because nothing here
+  reads back from mpv, iina, vlc, or a browser tab; none of them report a position.
+- **Subtitles, partly.** A `.srt` or `.vtt` shipped alongside the video is matched to it and shown in
+  the browser's own subtitle menu; ASS and SSA are handed to external players, which render them, but
+  the browser can't. Tracks muxed *inside* the file are named on the fallback card so you know they're
+  there — pulling one out would mean running ffmpeg, which torlink doesn't do.
+```
+
+- [ ] **Step 2: Check the web UI's limitations list is still true**
+
+Read the surrounding "What the browser can't do yet" section and confirm nothing else in it now contradicts the shipped behaviour. `CLAUDE.md` requires this check on any change that touches the browser's capabilities.
+
+- [ ] **Step 3: Run the rename-trap sweep**
+
+No fixtures were renamed by this plan, but new negative assertions were added. Confirm each still names something the tests actually put in play:
+
+```bash
+grep -rn "not.toContain\|not.toBe" src/web/stream.test.ts src/web/static/subtitleModel.test.ts src/util/subtitleFiles.test.ts | cut -c1-140
+```
+
+For each hit, confirm the string it names is something the test genuinely produces — an assertion that nothing contains `"evil"` is worthless if nothing in the test ever contained it. The `.m3u` injection test is the one that matters: verify the crafted filename actually reaches the code under test.
+
+- [ ] **Step 4: Full verification**
+
+```bash
+npm test && npm run typecheck && npm run lint && npm run build
+```
+
+Expected: all green, with the one known pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: describe what subtitle support does and does not do"
+```

--- a/docs/superpowers/specs/2026-08-01-subtitles-design.md
+++ b/docs/superpowers/specs/2026-08-01-subtitles-design.md
@@ -1,0 +1,220 @@
+# Subtitles
+
+**Date:** 2026-08-01
+**Status:** Approved (design)
+**Builds on:** the streaming stack (`src/web/stream.ts`, `src/util/videoFiles.ts`,
+`src/core/probe.ts`) and the web player page.
+
+## Motivation
+
+torlink has no subtitle support of any kind. `README.md:229` says so plainly —
+"**No subtitles, no scrubber.**" — and the original streaming design listed them
+out of scope. Two distinct things are missing, and they were found by
+investigating one report ("I couldn't get subtitles for a season pack I was
+playing through the .m3u in VLC").
+
+**Embedded tracks are invisible.** The reported pack turned out to have no
+sibling subtitle files at all: ten mp4s, each with three muxed `mov_text` tracks
+(spa/eng/por). Those tracks survive torlink's byte-range proxy intact — verified
+with ffprobe against a live `/stream` URL, and VLC's mp4 demuxer logs all three
+when handed the `.m3u`:
+
+    adding track[Id 0x4] subtitle (enable)  language spa
+    adding track[Id 0x5] subtitle (disable) language eng
+    adding track[Id 0x6] subtitle (disable) language por
+
+So that case was never broken — VLC auto-enabled **Spanish**, and English sat
+loaded but off under Subtitle → Sub Track. Nothing in torlink told the user the
+tracks existed or which one was playing. The browser player is worse: it has no
+subtitle support at all, and for this file it cannot play the video either
+(HEVC + eac3, no provider HLS), so the user gets the fallback card with no
+indication that subtitles are sitting inside the file.
+
+**Sibling subtitle files are unreachable.** `streamCandidates`
+(`src/util/videoFiles.ts:83`) filters every non-video file out before either
+front end draws a picker. That is right for choosing *what to play*, but it means
+a release shipping `Subs/` or `Episode.S01E01.en.srt` hides those files
+completely. They are byte-addressable on the server — `src/web/stream.ts:336`
+never checks extension — but nothing lists them, links them, or associates them
+with a video.
+
+## Scope
+
+**In scope**
+
+- Sibling subtitle files: matched to the chosen video, served as WebVTT, attached
+  in both front ends.
+- Embedded subtitle tracks: detected by the existing ffprobe call and *reported*.
+- Both front ends, per the two-front-ends rule in `CLAUDE.md`.
+
+**Out of scope**
+
+- **Extracting embedded tracks.** Would require spawning ffmpeg, which torlink
+  never does in production (`findFfmpeg` in `src/util/ffmpegBin.ts:137` has no
+  production caller). It would also only pay off for files the browser can
+  already play — not the HEVC/eac3 case that prompted this.
+- **Fetching subtitles from the internet** (OpenSubtitles and friends). A
+  separate feature with its own credentials, rate limits and licensing.
+- **Rendering ASS/SSA in the browser.** Needs a real subtitle engine; `<track>`
+  cannot do it. Those files are still matched and still handed to VLC/mpv, which
+  render them natively.
+- **Probing in the TUI.** VLC lists embedded tracks in its own menu the moment it
+  opens the file; a 15-second ffprobe to print the same information first is a
+  cost with no return.
+
+## Design
+
+### 1. Shared pure modules
+
+Two new dependency-free modules beside `videoFiles.ts`, imported by both
+surfaces. The reason is the one `videoFiles.ts` gives in its own header: this
+project has been bitten three times by a hand-copied helper drifting between the
+front ends. Two copies of "which subtitle goes with this episode" would drift the
+same way and the divergence would be invisible until someone compared screens.
+
+**`src/util/subtitleFiles.ts`**
+
+    isSubtitleFilename(name)   srt, vtt, ass, ssa, sub
+    subtitlesFor(video, files) the three rules below, in order
+    subtitleLanguage(name)     language token + forced/sdh flags
+    preferredSubtitle(matches) English, else the first
+
+Matching rules, first rule that yields anything wins:
+
+1. **Basename prefix** — the subtitle's basename starts with the video's
+   basename. `Show.S01E01.1080p.mkv` ← `Show.S01E01.1080p.eng.srt`.
+2. **Shared SxxExx token** — both paths carry the same season/episode token.
+   Catches the `Subs/` folder layout scene releases actually use:
+   `Subs/Show.S01E01/2_English.srt`.
+3. **Single video** — if the torrent has exactly one video file, every subtitle
+   in it belongs to that video. `Kestrel.2010.1080p.mkv` ← `Subs/English.srt`.
+
+Rules stop there deliberately. Fuzzy title matching was considered and rejected:
+it would occasionally attach the wrong episode's subtitle, which is worse than
+attaching none.
+
+Two categories of subtitle, which are not interchangeable:
+
+| | `srt`, `vtt` | `ass`, `ssa`, `sub` |
+| --- | --- | --- |
+| Browser `<track>` | yes | no — needs a subtitle engine |
+| VLC / mpv attach | yes | yes, rendered natively |
+
+**`src/util/srtToVtt.ts`** — pure text transform. Strips a BOM, normalises CRLF,
+emits the `WEBVTT` header, converts `,` to `.` in timestamps, drops cue index
+lines. A file that is already WebVTT passes through unchanged. Decoding falls
+back to latin1 when the bytes are not valid UTF-8, because `.srt` files are
+frequently Windows-1252 and a mojibake subtitle is worse than none.
+
+`videoFiles.ts` is **not** modified. Subtitles must stay out of
+`streamCandidates` or they become things the user can pick to *play*.
+
+### 2. Server: one new representation, one changed
+
+**`.vtt` joins `.m3u` and `.info`** in `splitRepresentation`
+(`src/web/stream.ts:157`), which means it inherits every session, capability,
+readiness and bounds guard already in that path. It fetches the subtitle's bytes
+upstream, converts, and serves `text/vtt; charset=utf-8`.
+
+Two guards this representation needs that the others do not:
+
+- **Refuse any index whose filename is not a subtitle extension.** Without it,
+  `.vtt` is a general-purpose "fetch this file into memory and call it text"
+  route pointed at a 12 GB video.
+- **Cap the body at 4 MiB.** A subtitle is kilobytes; anything larger is not one.
+
+**The `.m3u` gains an input-slave line**, and only when a preferred subtitle
+exists:
+
+    #EXTM3U
+    #EXTVLCOPT:input-slave=http://host/stream/<sid>/7.vtt?k=<cap>
+    http://host/stream/<sid>/2?k=<cap>
+
+Both URLs are built from `streamHandle` and the re-encoded capability, so the
+existing constraint at `src/web/stream.ts:446` still holds exactly: nothing in
+the body is derived from the torrent's own text. With no match the body stays
+byte-identical to today's single bare URL.
+
+`.info` grows `subtitles: { embedded: EmbeddedSubtitle[], files: SubtitleFile[] }`,
+typed in `src/web/wire.ts`.
+
+### 3. Embedded tracks: widen the probe, do not extract
+
+`ffprobeArgs` (`src/core/probe.ts:29`) adds `stream_tags=language,title` to its
+`-show_entries`, and `parseFfprobe` stops discarding rows with
+`codec_type === "subtitle"`. That is the entire change — ffprobe is already a
+runtime dependency, so this costs nothing new.
+
+`MediaFacts` gains `subtitles: EmbeddedSubtitle[]`, which `classifyFromName`
+returns empty: a filename cannot know what is muxed inside.
+
+`src/core/probe.test.ts:78` currently asserts subtitle streams are ignored. That
+test inverts.
+
+### 4. Browser player
+
+- Matched `srt`/`vtt` files become real `<track kind="subtitles" srclang label>`
+  children of the `<video>`, giving the browser's native CC menu. The first
+  English track gets `default`.
+- The **fallback card** — the "needs a real player" case — gains a line naming
+  the embedded track languages: *"Subtitles in this file: English, Spanish,
+  Portuguese — pick one in your player."* This is what turns the reported dead
+  end into useful information.
+- The decision of which tracks to build is a pure `src/web/static/subtitleModel.ts`
+  with real tests. `player.ts` stays DOM wiring, per the rule in `CLAUDE.md` that
+  has been caught in review twice.
+
+### 5. TUI
+
+- `StreamFilePrompt` marks candidates that have matching subtitle files.
+- `launchPlayer` takes an optional subtitle URL and applies a flag table:
+
+      mpv      --sub-file=<url>
+      mpvnet   --sub-file=<url>
+      iina     --mpv-sub-file=<url>
+      vlc      --input-slave=<url>
+      <other>  no flag
+
+  An unknown or user-configured player command launches unchanged, and the notice
+  says the subtitle was not attached rather than staying silent about it.
+- No probing. See Scope.
+
+## Error handling
+
+Every failure is soft, matching the house style:
+
+- **No subtitle matches** — the `.m3u` is byte-identical to today's, no `<track>`
+  elements, no marks in the picker. The feature is invisible when it has nothing
+  to say.
+- **Upstream fetch of a subtitle fails** — `502`, matching what `proxyUpstream`
+  already does for an unreachable upstream. The video is unaffected: a `<track>`
+  whose URL fails leaves the video playing without captions, which is the
+  browser's own behaviour and needs no handling from us.
+- **Conversion produces nothing usable** — served as-is rather than as an empty
+  file, on the grounds that VLC may still parse what our transform did not.
+- **ffprobe unavailable or times out** — unchanged from today. `probeUrl` returns
+  null, the caller falls back to `classifyFromName`, and `subtitles.embedded` is
+  empty. No new failure mode.
+
+## Testing
+
+- `subtitleFiles.test.ts` — the three rules, including the case each exists for,
+  plus the negative: an unrelated `.srt` in a multi-episode pack matches nothing.
+- `srtToVtt.test.ts` — timestamp conversion, index stripping, BOM, CRLF, latin1
+  fallback, already-VTT passthrough.
+- `stream.test.ts` — the `.vtt` representation: capability enforced, non-subtitle
+  index refused, size cap, and the `.m3u` both with and without a match. The
+  existing negative assertions in that file are checked against the rename trap
+  documented in `CLAUDE.md`.
+- `subtitleModel.test.ts` — which `<track>` elements get built, which is
+  `default`, and that ASS/SSA never becomes a `<track>`.
+- `probe.test.ts` — the inverted assertion, plus language and title tags.
+- Fixtures use the invented cast from `CLAUDE.md` (`Kepler.S02E04`,
+  `Harrowgate.S03`, `Kestrel.2010`).
+
+## Documentation
+
+`README.md:229` currently states there are no subtitles. It changes to describe
+what now works and what does not: sibling files yes, embedded tracks reported but
+not rendered in the browser, ASS/SSA in external players only. The web UI's own
+limitations list is checked in the same pass, per `CLAUDE.md`.

--- a/src/core/probe.test.ts
+++ b/src/core/probe.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { ffprobeArgs, parseFfprobe, probeUrl } from "./probe";
 
-const output = (formatName: string, streams: { codec_type: string; codec_name: string }[]) =>
-  JSON.stringify({ format: { format_name: formatName }, streams });
+const output = (
+  formatName: string,
+  streams: {
+    codec_type: string;
+    codec_name: string;
+    tags?: { language?: string; title?: string };
+  }[],
+) => JSON.stringify({ format: { format_name: formatName }, streams });
 
 describe("ffprobeArgs", () => {
   it("asks for json, quietly, and bounds how much it reads", () => {
@@ -37,6 +43,7 @@ describe("parseFfprobe", () => {
       videoCodec: "h264",
       audioCodec: "aac",
       source: "probe",
+      subtitles: [],
     });
   });
 
@@ -75,16 +82,66 @@ describe("parseFfprobe", () => {
     expect(facts?.audioCodec).toBe("truehd");
   });
 
-  it("ignores subtitle and attachment streams", () => {
+  it("reports subtitle streams instead of discarding them", () => {
+    // This test used to assert the opposite. Subtitle rows were dropped, so a
+    // file with three muxed tracks looked identical to one with none, and the
+    // player page could not tell the user they existed. Attachment streams
+    // (fonts, cover art) are still ignored — they are not tracks.
+    const facts = parseFfprobe(
+      output("mov,mp4", [
+        { codec_type: "video", codec_name: "hevc" },
+        { codec_type: "audio", codec_name: "eac3" },
+        { codec_type: "subtitle", codec_name: "mov_text", tags: { language: "spa" } },
+        { codec_type: "subtitle", codec_name: "mov_text", tags: { language: "eng" } },
+        { codec_type: "attachment", codec_name: "ttf" },
+      ]),
+      "mp4",
+    );
+    expect(facts?.subtitles).toEqual([
+      { language: "spa", label: "" },
+      { language: "eng", label: "" },
+    ]);
+  });
+
+  it("keeps a subtitle stream's title tag as its label", () => {
     const facts = parseFfprobe(
       output("matroska,webm", [
-        { codec_type: "subtitle", codec_name: "subrip" },
         { codec_type: "video", codec_name: "h264" },
+        { codec_type: "subtitle", codec_name: "subrip", tags: { language: "eng", title: "SDH" } },
       ]),
       "mkv",
     );
-    expect(facts?.videoCodec).toBe("h264");
-    expect(facts?.audioCodec).toBe("");
+    expect(facts?.subtitles).toEqual([{ language: "eng", label: "SDH" }]);
+  });
+
+  it("reports an untagged subtitle stream with an empty language", () => {
+    // Present but unnamed is still information: the player can say "1 subtitle
+    // track" rather than nothing.
+    const facts = parseFfprobe(
+      output("matroska,webm", [
+        { codec_type: "video", codec_name: "h264" },
+        { codec_type: "subtitle", codec_name: "subrip" },
+      ]),
+      "mkv",
+    );
+    expect(facts?.subtitles).toEqual([{ language: "", label: "" }]);
+  });
+
+  it("reports an empty subtitle list for a file with none", () => {
+    const facts = parseFfprobe(
+      output("matroska,webm", [{ codec_type: "video", codec_name: "h264" }]),
+      "mkv",
+    );
+    expect(facts?.subtitles).toEqual([]);
+  });
+
+  it("asks ffprobe for the language and title tags", () => {
+    // Without this the tags are absent from the JSON and every track reports an
+    // empty language — the failure would look like "no subtitles have names".
+    const entries = ffprobeArgs("http://example.test/a.mkv")[
+      ffprobeArgs("http://example.test/a.mkv").indexOf("-show_entries") + 1
+    ];
+    expect(entries).toContain("stream_tags=language,title");
   });
 
   it("returns null on output that is not json", () => {

--- a/src/core/probe.ts
+++ b/src/core/probe.ts
@@ -33,7 +33,7 @@ export function ffprobeArgs(url: string): string[] {
     "-print_format",
     "json",
     "-show_entries",
-    "format=format_name:stream=codec_type,codec_name",
+    "format=format_name:stream=codec_type,codec_name:stream_tags=language,title",
     "-analyzeduration",
     ANALYZE_US,
     "-probesize",
@@ -45,6 +45,7 @@ export function ffprobeArgs(url: string): string[] {
 interface ProbeStream {
   codec_type?: string;
   codec_name?: string;
+  tags?: { language?: string; title?: string };
 }
 
 // Worst-first, matching normaliseAudioCodec's ordering in ../util/playability.ts
@@ -92,6 +93,12 @@ export function parseFfprobe(stdout: string, container: string): MediaFacts | nu
     .map((s) => (s.codec_name ?? "").toLowerCase())
     .filter(Boolean);
   const videoCodec = video.toLowerCase();
+  // Subtitle streams, kept. An earlier version discarded them here, which made
+  // a file with three muxed tracks indistinguishable from one with none.
+  // Attachments (fonts, cover art) are still dropped — they are not tracks.
+  const subtitles = streams
+    .filter((s) => s.codec_type === "subtitle")
+    .map((s) => ({ language: s.tags?.language ?? "", label: s.tags?.title ?? "" }));
   return {
     container,
     // avc1 is the mp4 sample-entry name for the same thing h264 is; the rest of
@@ -99,6 +106,7 @@ export function parseFfprobe(stdout: string, container: string): MediaFacts | nu
     videoCodec: videoCodec === "avc1" ? "h264" : videoCodec,
     audioCodec: worstAudio(audio),
     source: "probe",
+    subtitles,
   };
 }
 

--- a/src/core/probeCache.test.ts
+++ b/src/core/probeCache.test.ts
@@ -7,6 +7,7 @@ const facts = (videoCodec: string): MediaFacts => ({
   videoCodec,
   audioCodec: "aac",
   source: "probe",
+  subtitles: [],
 });
 
 describe("ProbeCache", () => {

--- a/src/integrations/debrid/realdebrid.test.ts
+++ b/src/integrations/debrid/realdebrid.test.ts
@@ -305,6 +305,81 @@ describe("resolveMagnet", () => {
     expect(progress.at(-1)).toBe(100);
   });
 
+  it("attaches `path` by zipping selected files with links, positionally", async () => {
+    // /unrestrict/link returns only a basename (`filename` above), never a
+    // path — so the subtitle matcher's folder-layout rule has nothing to read
+    // an SxxExx token from unless it comes from here. Confirmed against a live
+    // account: info.files.filter(selected) is the same length and order as
+    // `links`.
+    const fetchImpl = router((c) => {
+      if (c.method === "POST" && c.url.includes("/torrents/addMagnet")) {
+        return jsonRes(201, { id: "T1", uri: "rd://T1" });
+      }
+      if (c.method === "POST" && c.url.includes("/torrents/selectFiles/T1")) {
+        return emptyRes(204);
+      }
+      if (c.method === "GET" && c.url.includes("/torrents/info/T1")) {
+        return jsonRes(200, {
+          status: "downloaded",
+          progress: 100,
+          links: ["https://rd/link1", "https://rd/link2"],
+          files: [
+            { path: "/Kepler.S02E04.1080p.WEB-DL.mkv", selected: 1 },
+            { path: "/ignored-unselected.nfo", selected: 0 },
+            { path: "/Subs/Kepler.S02E04/2_English.srt", selected: 1 },
+          ],
+        });
+      }
+      if (c.method === "POST" && c.url.includes("/unrestrict/link")) {
+        const link = new URLSearchParams(c.body ?? "").get("link");
+        return link === "https://rd/link1"
+          ? jsonRes(200, { download: "https://dl/1", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", filesize: 1 })
+          : jsonRes(200, { download: "https://dl/2", filename: "2_English.srt", filesize: 2 });
+      }
+      throw new Error(`unexpected call ${c.method} ${c.url}`);
+    });
+    const files = await resolveMagnet("tok", "magnet:?xt=urn:btih:abc", { fetchImpl, sleepImpl: noSleep });
+    expect(files).toEqual([
+      { url: "https://dl/1", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 1, path: "/Kepler.S02E04.1080p.WEB-DL.mkv" },
+      { url: "https://dl/2", filename: "2_English.srt", bytes: 2, path: "/Subs/Kepler.S02E04/2_English.srt" },
+    ]);
+  });
+
+  it("emits no `path` at all when selected-file count and link count disagree (guard)", async () => {
+    // A wrong path is worse than none — it would attach the wrong episode's
+    // subtitle. So a length mismatch (RD reporting something inconsistent, or
+    // this assumption turning out wrong for some account) must not zip at all.
+    const fetchImpl = router((c) => {
+      if (c.method === "POST" && c.url.includes("/torrents/addMagnet")) {
+        return jsonRes(201, { id: "T1", uri: "rd://T1" });
+      }
+      if (c.method === "POST" && c.url.includes("/torrents/selectFiles/T1")) {
+        return emptyRes(204);
+      }
+      if (c.method === "GET" && c.url.includes("/torrents/info/T1")) {
+        return jsonRes(200, {
+          status: "downloaded",
+          progress: 100,
+          links: ["https://rd/link1", "https://rd/link2"],
+          files: [{ path: "/only-one-selected.mkv", selected: 1 }],
+        });
+      }
+      if (c.method === "POST" && c.url.includes("/unrestrict/link")) {
+        const link = new URLSearchParams(c.body ?? "").get("link");
+        return link === "https://rd/link1"
+          ? jsonRes(200, { download: "https://dl/1", filename: "a.mkv", filesize: 1 })
+          : jsonRes(200, { download: "https://dl/2", filename: "b.srt", filesize: 2 });
+      }
+      throw new Error(`unexpected call ${c.method} ${c.url}`);
+    });
+    const files = await resolveMagnet("tok", "magnet:?xt=urn:btih:abc", { fetchImpl, sleepImpl: noSleep });
+    expect(files).toEqual([
+      { url: "https://dl/1", filename: "a.mkv", bytes: 1 },
+      { url: "https://dl/2", filename: "b.srt", bytes: 2 },
+    ]);
+    expect(files.every((f) => f.path === undefined)).toBe(true);
+  });
+
   it("selects all files and sends the magnet as a form body", async () => {
     const calls: Call[] = [];
     await resolveMagnet("tok", "magnet:?xt=urn:btih:abc", {

--- a/src/integrations/debrid/realdebrid.ts
+++ b/src/integrations/debrid/realdebrid.ts
@@ -452,7 +452,7 @@ export async function resolveMagnet(
   }
 
   let links: string[] = [];
-  let selectedPaths: string[] | undefined;
+  let selectedPaths: (string | undefined)[] | undefined;
   let lastProgress = -1;
   let stalledMs = 0;
   for (;;) {
@@ -462,7 +462,11 @@ export async function resolveMagnet(
     onProgress?.(progress);
     if (info.status === DONE_STATUS) {
       links = info.links ?? [];
-      selectedPaths = info.files?.filter((f) => Boolean(f.selected)).map((f) => f.path ?? "");
+      // `f.path ?? ""` would emit an empty string, which is not nullish and so
+      // defeats `matchPath`'s documented fallback to `filename` (subtitleFiles.ts)
+      // — an RD file with no path would carry `path: ""` onto the wire instead
+      // of falling back. Map absent to `undefined`, not `""`.
+      selectedPaths = info.files?.filter((f) => Boolean(f.selected)).map((f) => f.path);
       break;
     }
     if (ERROR_STATUSES.has(info.status)) {

--- a/src/integrations/debrid/realdebrid.ts
+++ b/src/integrations/debrid/realdebrid.ts
@@ -40,11 +40,17 @@ export function isPremiumActive(user: RealDebridUser): boolean {
   return user.type === "premium" && (user.premium ?? 0) > 0;
 }
 
+// One entry per file Real-Debrid knows about the torrent, selected or not —
+// NOT one per `links` entry, and NOT necessarily in the same order `links`
+// arrives in for an arbitrary torrent. `resolveMagnet` below only trusts the
+// zip when `files.filter(selected)` and `links` are the same length; see the
+// comment there for why.
 export interface TorrentInfo {
   status: string;
   progress?: number;
   links?: string[];
   filename?: string;
+  files?: { path?: string; selected?: number }[];
 }
 
 export interface TorrentListItem {
@@ -446,6 +452,7 @@ export async function resolveMagnet(
   }
 
   let links: string[] = [];
+  let selectedPaths: string[] | undefined;
   let lastProgress = -1;
   let stalledMs = 0;
   for (;;) {
@@ -455,6 +462,7 @@ export async function resolveMagnet(
     onProgress?.(progress);
     if (info.status === DONE_STATUS) {
       links = info.links ?? [];
+      selectedPaths = info.files?.filter((f) => Boolean(f.selected)).map((f) => f.path ?? "");
       break;
     }
     if (ERROR_STATUSES.has(info.status)) {
@@ -489,6 +497,21 @@ export async function resolveMagnet(
     throwIfAborted(signal);
     files.push(await unrestrictLink(token, link, opts));
   }
+
+  // /unrestrict/link never returns a path — only a basename — so this is the
+  // only place a `Subs/` folder path can come from for Real-Debrid. Confirmed
+  // against a live account: `info.files.filter(selected)` is the same length
+  // and order as `links`. That is an assumption about an undocumented API, not
+  // a guarantee, so it is checked every time rather than trusted: a length
+  // mismatch means the zip would misalign, attaching one episode's subtitle
+  // path to a completely different episode's file, which is worse than
+  // attaching no path at all. So a mismatch emits nothing rather than a guess.
+  if (selectedPaths && selectedPaths.length === files.length) {
+    files.forEach((f, i) => {
+      f.path = selectedPaths![i];
+    });
+  }
+
   return files;
 }
 

--- a/src/integrations/debrid/torbox.test.ts
+++ b/src/integrations/debrid/torbox.test.ts
@@ -269,11 +269,49 @@ describe("TorBox resolveMagnet", () => {
         url: "https://cdn.torbox.app/dl/kestrel.mkv",
         filename: "Kestrel.2010.1080p.BluRay.x264.mkv",
         bytes: 8_000_000_000,
+        path: "Kestrel.2010.1080p.BluRay.x264.mkv",
       },
     ]);
     const create = calls.find((c) => c.url.includes("createtorrent"))!;
     expect(create.method).toBe("POST");
     expect(create.body).toContain(encodeURIComponent(MAGNET).slice(0, 20));
+  });
+
+  it("carries the full path in `path` while `filename` stays a basename, for the Subs/ layout", async () => {
+    // `file.name` is TorBox's path-like field; `short_name` is the basename.
+    // The subtitle matcher's SxxExx-across-folders rule (subtitlesFor, rule 2)
+    // needs the folder, so `path` must keep it even though `filename` — the
+    // watched-list key and picker label — stays a bare name.
+    const calls: Call[] = [];
+    const fetchImpl = router(
+      {
+        [CREATE]: jsonRes(200, { success: true, data: { torrent_id: 4242, hash: HASH } }),
+        [MYLIST]: jsonRes(
+          200,
+          {
+            success: true,
+            data: torrent({
+              files: [
+                { id: 0, name: "Kepler.S02E04.1080p.WEB-DL.mkv", short_name: "Kepler.S02E04.1080p.WEB-DL.mkv", size: 1 },
+                {
+                  id: 1,
+                  name: "Subs/Kepler.S02E04/2_English.srt",
+                  short_name: "2_English.srt",
+                  size: 2,
+                },
+              ],
+            }),
+          },
+        ),
+        [REQUESTDL]: jsonRes(200, { success: true, data: "https://cdn.torbox.app/dl/x" }),
+      },
+      calls,
+    );
+    const files = await resolveMagnet(TOKEN, MAGNET, { fetchImpl, sleepImpl: noSleep });
+    expect(files[1]).toMatchObject({
+      filename: "Subs/Kepler.S02E04/2_English.srt",
+      path: "Subs/Kepler.S02E04/2_English.srt",
+    });
   });
 
   it("converts TorBox's 0-1 progress into the 0-100 every caller assumes", async () => {

--- a/src/integrations/debrid/torbox.ts
+++ b/src/integrations/debrid/torbox.ts
@@ -417,6 +417,12 @@ export async function resolveMagnet(
       url: await requestDownloadLink(token, id, fileId, opts),
       filename: file.name ?? file.short_name ?? `file-${fileId}`,
       bytes: file.size ?? 0,
+      // `file.name` is TorBox's path-like field ("Subs/Kepler.S02E04/2_English.srt"),
+      // distinct from `short_name` (a basename). `filename` above keeps its own
+      // meaning — watched-list key, picker label — so this is additive, for the
+      // subtitle matcher's folder-layout rule only. Undefined when TorBox gave no
+      // `name` at all, same as `filename`'s own fallback.
+      path: file.name,
     });
   }
   return out;

--- a/src/integrations/torrentStream.ts
+++ b/src/integrations/torrentStream.ts
@@ -57,6 +57,7 @@ function toStreamFiles(
       url: `http://${host}:${port}/webtorrent/${torrent.infoHash}/${encodeURI(rel)}`,
       filename: f.name,
       bytes: f.length,
+      path: rel,
     };
   });
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -32,6 +32,8 @@ import { expandHome, normalizeDownloadDir } from "../config/folder";
 import type { DebridProviderId, DebridStatus } from "../integrations/debrid/types";
 import { getDebridProvider, DEBRID_PROVIDER_IDS } from "../integrations/debrid";
 import { attemptAutoPlay, detectAndPlay, launchPlayer, streamCandidates } from "../util/player";
+import { preferredSubtitle, subtitlesFor } from "../util/subtitleFiles";
+import { subtitleArgs } from "../util/subtitleFlags";
 import type { ResolvedFile } from "../integrations/debrid/realdebrid";
 import { streamTorrent, type TorrentStreamSession } from "../integrations/torrentStream";
 import { postEvent, claimReccAccount } from "../recc/client";
@@ -321,6 +323,9 @@ export function App({
     name?: string;
     onPlayed?: () => void;
     configured?: string;
+    // Carried here (rather than recomputed at the fallback prompt) because that
+    // scope has no file list to recompute it from — see setMediaPlayer.
+    subtitleUrl?: string;
   } | null>(null);
   // Which media-player prompt is showing: the auto-detect/edit choice (after a
   // configured player failed) or the plain command entry.
@@ -348,6 +353,10 @@ export function App({
   // worse than no marker.
   const cachedRequestId = useRef(0);
   const [streamFiles, setStreamFiles] = useState<ResolvedFile[] | null>(null);
+  // The session's UNFILTERED file list — streamFiles has already been through
+  // streamCandidates, which drops exactly the .srt files the subtitle matcher
+  // needs. Kept alongside streamFiles, reset on the same two paths.
+  const [streamAllFiles, setStreamAllFiles] = useState<ResolvedFile[] | null>(null);
   // Episodes streamed from the current picker session (marked ✓, cleared when
   // the picker opens/closes). Union with the favourite's persisted watched list.
   const [streamedFiles, setStreamedFiles] = useState<Set<string>>(new Set());
@@ -1363,14 +1372,19 @@ export function App({
   // Try to play a resolved stream URL: use the configured/detected player, else
   // copy the link to the clipboard and prompt for a player command.
   const playStream = useCallback(
-    async (url: string, name?: string, onPlayed?: () => void) => {
+    async (url: string, name?: string, onPlayed?: () => void, subtitleUrl = "") => {
       if (!config) return;
       const configured = resolveMediaPlayer(config);
-      const outcome = await attemptAutoPlay(configured, url);
+      const outcome = await attemptAutoPlay(configured, url, subtitleUrl);
       if (outcome.played) {
         const copied = await writeClipboard(url);
+        // A subtitle matched but the launched player is one subtitleArgs does not
+        // know a flag for (a wrapper script, say): say so rather than staying
+        // silent about a subtitle that never actually loaded.
+        const attached = subtitleUrl !== "" && subtitleArgs(outcome.player ?? "", subtitleUrl).length > 0;
+        const subNote = subtitleUrl !== "" && !attached ? " · subtitle not loaded" : "";
         setNotice(
-          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}`,
+          `${ICON.done} Streaming ${name ? `${truncate(cleanText(name), 28)} ` : ""}in ${outcome.player}${copied ? " · link copied" : ""}${subNote}`,
         );
         onPlayed?.();
         void postEvent(
@@ -1381,12 +1395,15 @@ export function App({
       }
       // Couldn't play automatically: stash context, copy the link, and open the
       // right prompt — a configured player that failed to launch gets the
-      // auto-detect/edit choice; otherwise the plain command entry.
+      // auto-detect/edit choice; otherwise the plain command entry. The
+      // subtitle URL is carried on pendingStream so it survives to
+      // setMediaPlayer's launch, whose scope has no file list to recompute it.
       setPendingStream({
         url,
         name,
         onPlayed,
         configured: outcome.configuredFailed ? configured : undefined,
+        subtitleUrl,
       });
       await writeClipboard(url);
       setPlayerPromptMode(outcome.configuredFailed ? "choice" : "edit");
@@ -1397,10 +1414,11 @@ export function App({
 
   // Hand a resolved file to the player path and clear any picker/preparing UI.
   const finishStream = useCallback(
-    (file: ResolvedFile, name?: string, onPlayed?: () => void) => {
+    (file: ResolvedFile, name?: string, onPlayed?: () => void, subtitleUrl = "") => {
       setStreamFiles(null);
+      setStreamAllFiles(null);
       setPreparing(null);
-      void playStream(file.url, name ?? file.filename, onPlayed);
+      void playStream(file.url, name ?? file.filename, onPlayed, subtitleUrl);
     },
     [playStream],
   );
@@ -1410,13 +1428,19 @@ export function App({
   // persists watched progress when the current torrent is favourited.
   const playFromPicker = useCallback(
     (file: ResolvedFile) => {
+      const preferred = preferredSubtitle(subtitlesFor(file, streamAllFiles ?? []));
       // Mark streamed/watched ONLY once a player actually launches (the
       // onPlayed callback), so a failed stream never gets a ✓.
-      void playStream(file.url, file.filename, () => {
-        if (streamSource) markPlayed(streamSource.id, file.filename);
-      });
+      void playStream(
+        file.url,
+        file.filename,
+        () => {
+          if (streamSource) markPlayed(streamSource.id, file.filename);
+        },
+        preferred?.url ?? "",
+      );
     },
-    [playStream, streamSource, markPlayed],
+    [playStream, streamSource, markPlayed, streamAllFiles],
   );
 
   const cancelPreparing = useCallback(() => {
@@ -1461,7 +1485,12 @@ export function App({
   // is decided once. `recorded` is the stream-history row this play just wrote,
   // whose `nextEpisode` is the same suggestion the Continue-watching pane shows.
   const openStreamPicker = useCallback(
-    (candidates: ResolvedFile[], input: DownloadInput, recorded: StreamHistoryItem | null) => {
+    (
+      candidates: ResolvedFile[],
+      input: DownloadInput,
+      recorded: StreamHistoryItem | null,
+      allFiles: ResolvedFile[],
+    ) => {
       setStreamedFiles(new Set());
       setStreamSource(input);
       // KEYED BY INFOHASH, not just cleared on read. `openStreamPicker` runs
@@ -1479,6 +1508,7 @@ export function App({
         }),
       );
       setStreamFiles(candidates);
+      setStreamAllFiles(allFiles);
     },
     [config],
   );
@@ -1526,10 +1556,14 @@ export function App({
           );
           const recorded = await recordStreamHistory(input);
           if (candidates.length > 1) {
-            openStreamPicker(candidates, input, recorded);
+            openStreamPicker(candidates, input, recorded, session.files);
           } else {
-            void playStream(candidates[0]!.url, input.name, () =>
-              markPlayed(input.id, candidates[0]!.filename),
+            const preferred = preferredSubtitle(subtitlesFor(candidates[0]!, session.files));
+            void playStream(
+              candidates[0]!.url,
+              input.name,
+              () => markPlayed(input.id, candidates[0]!.filename),
+              preferred?.url ?? "",
             );
           }
         } catch (e) {
@@ -1676,11 +1710,15 @@ export function App({
           const recorded = await recordStreamHistory(input);
           if (candidates.length > 1) {
             setPreparing(null);
-            openStreamPicker(candidates, input, recorded);
+            openStreamPicker(candidates, input, recorded, files);
             return;
           }
-          finishStream(candidates[0]!, input.name, () =>
-            markPlayed(input.id, candidates[0]!.filename),
+          const preferred = preferredSubtitle(subtitlesFor(candidates[0]!, files));
+          finishStream(
+            candidates[0]!,
+            input.name,
+            () => markPlayed(input.id, candidates[0]!.filename),
+            preferred?.url ?? "",
           );
         } catch (e) {
           prepareAbort.current = null;
@@ -1841,7 +1879,7 @@ export function App({
           setNotice(`Media player set: ${cmd}`);
           return;
         }
-        const ok = await launchPlayer(cmd, ctx.url);
+        const ok = await launchPlayer(cmd, ctx.url, ctx.subtitleUrl ?? "");
         if (ok) {
           setNotice(`${ICON.done} Streaming in ${cmd}`);
           ctx.onPlayed?.();
@@ -1864,7 +1902,7 @@ export function App({
       return;
     }
     void (async () => {
-      const player = await detectAndPlay(ctx.url);
+      const player = await detectAndPlay(ctx.url, ctx.subtitleUrl ?? "");
       if (player) {
         setConfig({ ...config, mediaPlayer: player });
         setNotice(`${ICON.done} Streaming in ${player}`);
@@ -2764,6 +2802,7 @@ export function App({
               width={Math.max(24, Math.min(cols - 4, 72))}
               maxRows={Math.max(3, bodyH - 4)}
               files={streamFiles}
+              allFiles={streamAllFiles ?? streamFiles}
               watched={
                 streamSource
                   ? [...watchedFor(config?.favourites ?? [], streamSource.id), ...streamedFiles]
@@ -2787,6 +2826,7 @@ export function App({
               onSelect={playFromPicker}
               onCancel={() => {
                 setStreamFiles(null);
+                setStreamAllFiles(null);
                 setStreamedFiles(new Set());
                 setStreamSource(null);
                 setStreamPreselect(null);

--- a/src/ui/components/StreamFilePrompt.test.tsx
+++ b/src/ui/components/StreamFilePrompt.test.tsx
@@ -125,4 +125,31 @@ describe("StreamFilePrompt", () => {
     );
     expect(lastFrame() ?? "").toContain("1/3");
   });
+
+  it("marks a file that has a matching subtitle", () => {
+    const files = [
+      { url: "http://up.test/0", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 900 },
+      { url: "http://up.test/1", filename: "Kepler.S02E05.1080p.WEB-DL.mkv", bytes: 900 },
+    ];
+    const { lastFrame } = render(
+      <StreamFilePrompt
+        width={80}
+        files={files}
+        allFiles={[...files, { url: "http://up.test/2", filename: "Kepler.S02E04.eng.srt", bytes: 40 }]}
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const [e04, e05] = lastFrame()!.split("\n").filter((l) => l.includes("Kepler"));
+    expect(e04).toContain("CC");
+    expect(e05).not.toContain("CC");
+  });
+
+  it("marks nothing when the torrent has no subtitle files", () => {
+    const files = [{ url: "http://up.test/0", filename: "Harrowgate.S03.1080p.WEB-DL.mkv", bytes: 900 }];
+    const { lastFrame } = render(
+      <StreamFilePrompt width={80} files={files} allFiles={files} onSelect={() => {}} onCancel={() => {}} />,
+    );
+    expect(lastFrame()).not.toContain("CC");
+  });
 });

--- a/src/ui/components/StreamFilePrompt.tsx
+++ b/src/ui/components/StreamFilePrompt.tsx
@@ -4,6 +4,7 @@ import { Panel } from "./Panel";
 import { COLOR, GUTTER, ICON } from "../theme";
 import { formatBytes, cleanText, truncate } from "../../util/format";
 import type { StreamFile } from "../../util/player";
+import { subtitlesFor } from "../../util/subtitleFiles";
 // The ordering rule itself, which used to be a `sortFiles` local to this file.
 // It moved down to src/util when the browser's picker needed it: a season pack
 // listed E01…E10 here and in torrent order there is the copy-then-drift bug this
@@ -13,6 +14,15 @@ import { nextSort, sortStreamFiles, type StreamFileSort } from "../../util/strea
 interface StreamFilePromptProps {
   width: number;
   files: StreamFile[];
+  /**
+   * Every file in the torrent, not just the video candidates in `files`.
+   *
+   * The subtitle matcher needs the unfiltered list: `files` has already been
+   * through `streamCandidates`, which drops exactly the .srt files this is
+   * looking for. Defaults to `files`, so a caller that has not been updated
+   * simply shows no markers rather than crashing.
+   */
+  allFiles?: StreamFile[];
   onSelect: (file: StreamFile) => void;
   onCancel: () => void;
   // Max rows the file list body may occupy. The caller sizes this from the
@@ -49,6 +59,7 @@ interface StreamFilePromptProps {
 export function StreamFilePrompt({
   width,
   files,
+  allFiles,
   onSelect,
   onCancel,
   maxRows = 8,
@@ -69,6 +80,10 @@ export function StreamFilePrompt({
     : 0;
   const clamped = Math.min(cursor ?? opening, Math.max(0, sorted.length - 1));
   const watchedSet = useMemo(() => new Set(watched), [watched]);
+  const withSubs = useMemo(() => {
+    const pool = allFiles ?? files;
+    return new Set(files.filter((f) => subtitlesFor(f, pool).length > 0).map((f) => f.url));
+  }, [files, allFiles]);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -141,6 +156,7 @@ export function StreamFilePrompt({
               <Box width={2} flexShrink={0} marginLeft={1}>
                 <Text dimColor>{watchedSet.has(file.filename) ? ICON.done : ""}</Text>
               </Box>
+              {withSubs.has(file.url) ? <Text dimColor> CC</Text> : null}
               <Box flexShrink={0} marginLeft={1} justifyContent="flex-end">
                 <Text dimColor>{file.bytes > 0 ? formatBytes(file.bytes) : "-"}</Text>
               </Box>

--- a/src/util/playability.test.ts
+++ b/src/util/playability.test.ts
@@ -6,6 +6,7 @@ const facts = (over: Partial<MediaFacts> = {}): MediaFacts => ({
   videoCodec: "h264",
   audioCodec: "aac",
   source: "name",
+  subtitles: [],
   ...over,
 });
 
@@ -26,6 +27,7 @@ describe("classifyFromName", () => {
       videoCodec: "h264",
       audioCodec: "",
       source: "name",
+      subtitles: [],
     });
   });
 
@@ -65,6 +67,7 @@ describe("classifyFromName", () => {
       videoCodec: "",
       audioCodec: "",
       source: "name",
+      subtitles: [],
     });
   });
 });

--- a/src/util/playability.ts
+++ b/src/util/playability.ts
@@ -7,6 +7,22 @@
 // Nothing here imports node:*. It is reachable from the browser bundle.
 import { parseRelease } from "./release";
 
+/**
+ * One subtitle track muxed inside the file, as ffprobe reports it.
+ *
+ * Reported, never extracted: pulling one out would mean spawning ffmpeg, which
+ * this project does not do in production, and it would only help files the
+ * browser can already play. What this buys is the ability to TELL the user the
+ * tracks are there — the failure that prompted it was a season pack whose three
+ * embedded tracks were invisible in both front ends.
+ */
+export interface EmbeddedSubtitle {
+  /** ffprobe's own language tag ("eng", "spa"), or "" when untagged. */
+  language: string;
+  /** The stream's title tag ("SDH", "Forced"), or "". */
+  label: string;
+}
+
 /** What we know about one file's container and codecs, and how we know it. */
 export interface MediaFacts {
   /** Lowercase container: "mkv", "mp4", "webm". Empty when unknown. */
@@ -25,6 +41,11 @@ export interface MediaFacts {
    * deciding whether to spend money (CPU, bandwidth) on the answer.
    */
   source: "probe" | "name";
+  /**
+   * Subtitle tracks muxed into the file. Always empty from `classifyFromName`:
+   * a release name cannot know what is inside the container.
+   */
+  subtitles: EmbeddedSubtitle[];
 }
 
 /** Why a browser will refuse this file. Empty means it should play. */
@@ -115,6 +136,7 @@ export function classifyFromName(filename: string, releaseName?: string): MediaF
     videoCodec: normaliseVideoCodec(parsed?.codec),
     audioCodec: normaliseAudioCodec(parsed?.audioList),
     source: "name",
+    subtitles: [],
   };
 }
 

--- a/src/util/player.test.ts
+++ b/src/util/player.test.ts
@@ -295,7 +295,10 @@ describe("launchPlayer argv construction", () => {
     });
   });
 
-  it("uses open -a with --args separator when subtitle is provided on macOS", async () => {
+  it("launches VLC with the URL alone even when a subtitle is provided", async () => {
+    // VLC has no entry in subtitleFlags.ts: measured against a real VLC 3.0.11,
+    // there is no CLI flag that side-loads a subtitle from a URL, so
+    // `subtitleArgs` returns `[]` for it and no `--args` separator is added.
     vi.stubGlobal("process", { ...process, platform: "darwin" });
     const url = "http://stream.test/file.mkv";
     const subUrl = "http://box.test:9161/stream/abc/1.vtt";
@@ -303,7 +306,7 @@ describe("launchPlayer argv construction", () => {
     await launchPlayer("VLC", url, subUrl);
     expect(spawnCalls).toContainEqual({
       cmd: "open",
-      argv: ["-a", "VLC", url, "--args", "--input-slave=" + subUrl],
+      argv: ["-a", "VLC", url],
     });
   });
 });

--- a/src/util/player.test.ts
+++ b/src/util/player.test.ts
@@ -1,5 +1,26 @@
-import { describe, it, expect } from "vitest";
-import { pickStreamFile, detectPlayer, streamCandidates, attemptAutoPlay, detectAndPlay, type StreamFile } from "./player";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { pickStreamFile, detectPlayer, streamCandidates, attemptAutoPlay, detectAndPlay, launchPlayer, type StreamFile } from "./player";
+
+let spawnCalls: Array<{ cmd: string; argv: string[] }> = [];
+
+vi.mock("node:child_process", () => {
+  return {
+    spawn: vi.fn((cmd: string, argv: string[]) => {
+      spawnCalls.push({ cmd, argv });
+      const mockProc = {
+        on: vi.fn((event: string, callback: () => void) => {
+          // Simulate immediate error for direct spawn (triggers macOS fallback if applicable)
+          if (event === "error") {
+            callback();
+          }
+          return mockProc;
+        }),
+        unref: vi.fn(() => mockProc),
+      };
+      return mockProc;
+    }),
+  };
+});
 
 function f(filename: string, bytes: number): StreamFile {
   return { url: `https://dl/${filename}`, filename, bytes };
@@ -206,5 +227,51 @@ describe("attemptAutoPlay", () => {
       launch: async () => false,
     });
     expect(out).toEqual({ played: false, configuredFailed: false });
+  });
+});
+
+describe("launchPlayer argv construction", () => {
+  beforeEach(() => {
+    spawnCalls = [];
+  });
+
+  it("passes only URL to mpv when no subtitle is provided", async () => {
+    await launchPlayer("mpv", "http://stream.test/file.mkv");
+    expect(spawnCalls).toContainEqual({
+      cmd: "mpv",
+      argv: ["http://stream.test/file.mkv"],
+    });
+  });
+
+  it("passes subtitle flag before URL to mpv when subtitle is provided", async () => {
+    const subUrl = "http://box.test:9161/stream/abc/1.vtt";
+    await launchPlayer("mpv", "http://stream.test/file.mkv", subUrl);
+    expect(spawnCalls).toContainEqual({
+      cmd: "mpv",
+      argv: [`--sub-file=${subUrl}`, "http://stream.test/file.mkv"],
+    });
+  });
+
+  it("uses open -a with URL only when no subtitle on macOS", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const url = "http://stream.test/file.mkv";
+    // First spawn fails so fallback to open -a is used
+    await launchPlayer("VLC", url);
+    expect(spawnCalls).toContainEqual({
+      cmd: "open",
+      argv: ["-a", "VLC", url],
+    });
+  });
+
+  it("uses open -a with --args separator when subtitle is provided on macOS", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const url = "http://stream.test/file.mkv";
+    const subUrl = "http://box.test:9161/stream/abc/1.vtt";
+    // First spawn fails so fallback to open -a is used
+    await launchPlayer("VLC", url, subUrl);
+    expect(spawnCalls).toContainEqual({
+      cmd: "open",
+      argv: ["-a", "VLC", url, "--args", "--input-slave=" + subUrl],
+    });
   });
 });

--- a/src/util/player.test.ts
+++ b/src/util/player.test.ts
@@ -160,7 +160,7 @@ describe("streamCandidates", () => {
 
 describe("detectAndPlay", () => {
   it("returns the detected player when it launches", async () => {
-    const player = await detectAndPlay("http://x", {
+    const player = await detectAndPlay("http://x", "", {
       detect: async () => "mpv",
       launch: async () => true,
     });
@@ -168,7 +168,7 @@ describe("detectAndPlay", () => {
   });
 
   it("returns null when detection finds nothing", async () => {
-    const player = await detectAndPlay("http://x", {
+    const player = await detectAndPlay("http://x", "", {
       detect: async () => null,
       launch: async () => true,
     });
@@ -176,7 +176,7 @@ describe("detectAndPlay", () => {
   });
 
   it("returns null when the detected player fails to launch", async () => {
-    const player = await detectAndPlay("http://x", {
+    const player = await detectAndPlay("http://x", "", {
       detect: async () => "mpv",
       launch: async () => false,
     });
@@ -185,8 +185,40 @@ describe("detectAndPlay", () => {
 });
 
 describe("attemptAutoPlay", () => {
+  it("passes the subtitle url through attemptAutoPlay to the launcher", () => {
+    // The path nearly every user takes: a configured player. Wiring only the
+    // after-the-prompt launch would leave the feature dead for all of them.
+    const seen: { command: string; url: string; sub?: string }[] = [];
+    return attemptAutoPlay(
+      "mpv",
+      "http://up.test/v.mkv",
+      "http://up.test/v.eng.srt",
+      {
+        launch: (command, url, sub) => {
+          seen.push({ command, url, sub });
+          return Promise.resolve(true);
+        },
+      },
+    ).then(() => {
+      expect(seen).toEqual([
+        { command: "mpv", url: "http://up.test/v.mkv", sub: "http://up.test/v.eng.srt" },
+      ]);
+    });
+  });
+
+  it("passes an empty subtitle url when there is none", async () => {
+    let seen = "unset";
+    await attemptAutoPlay("mpv", "http://up.test/v.mkv", "", {
+      launch: (_c, _u, sub) => {
+        seen = sub ?? "undefined";
+        return Promise.resolve(true);
+      },
+    });
+    expect(seen).toBe("");
+  });
+
   it("launches the configured player and reports played", async () => {
-    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+    const out = await attemptAutoPlay("vlc.exe", "http://x", "", {
       launch: async (cmd) => cmd === "vlc.exe",
     });
     expect(out).toEqual({ played: true, player: "vlc.exe", configuredFailed: false });
@@ -194,7 +226,7 @@ describe("attemptAutoPlay", () => {
 
   it("flags a configured player that fails to launch and does NOT auto-detect", async () => {
     let detected = false;
-    const out = await attemptAutoPlay("vlc.exe", "http://x", {
+    const out = await attemptAutoPlay("vlc.exe", "http://x", "", {
       launch: async () => false,
       detect: async () => {
         detected = true;
@@ -206,7 +238,7 @@ describe("attemptAutoPlay", () => {
   });
 
   it("auto-detects and launches when nothing is configured", async () => {
-    const out = await attemptAutoPlay("", "http://x", {
+    const out = await attemptAutoPlay("", "http://x", "", {
       detect: async () => "mpv",
       launch: async () => true,
     });
@@ -214,7 +246,7 @@ describe("attemptAutoPlay", () => {
   });
 
   it("reports not-played (configuredFailed false) when detection finds nothing", async () => {
-    const out = await attemptAutoPlay("", "http://x", {
+    const out = await attemptAutoPlay("", "http://x", "", {
       detect: async () => null,
       launch: async () => true,
     });
@@ -222,7 +254,7 @@ describe("attemptAutoPlay", () => {
   });
 
   it("reports not-played when the detected player fails to launch", async () => {
-    const out = await attemptAutoPlay("", "http://x", {
+    const out = await attemptAutoPlay("", "http://x", "", {
       detect: async () => "mpv",
       launch: async () => false,
     });

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -17,6 +17,15 @@ export interface StreamFile {
   filename: string;
   bytes: number;
   /**
+   * The torrent-relative path, when the producer has one ("Subs/Kepler.S02E04/2_English.srt").
+   * `filename` stays a basename everywhere — it is the persisted watched-list key,
+   * the picker's display string, and what `sortStreamFiles`/`playlistFilename` read
+   * — so this is additive, optional, and read only by the subtitle matcher's
+   * folder-layout rule (`subtitlesFor` in `./subtitleFiles`), which falls back to
+   * `filename` when a producer has none.
+   */
+  path?: string;
+  /**
    * The provider's own id for this file, when a debrid service resolved it.
    * Server-side only: it is the handle their transcode endpoint takes, and it is
    * deliberately absent from `PublicStreamFile` because the browser has no use

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { spawn } from "node:child_process";
+import { subtitleArgs } from "./subtitleFlags";
 
 // The video-first heuristic lives in ./videoFiles because the web UI's browser
 // bundle needs it too and cannot import this module (node:child_process, and
@@ -214,10 +215,10 @@ export async function detectPlayer(deps: DetectDeps = {}): Promise<string | null
 // Spawn a player process directly (the player IS this process and keeps
 // running). Resolves false on a spawn error (e.g. ENOENT), else true shortly
 // after — we don't wait for the player to exit.
-function spawnPlayer(command: string, url: string): Promise<boolean> {
+function spawnPlayer(command: string, url: string, extra: string[] = []): Promise<boolean> {
   return new Promise((resolve) => {
     try {
-      const proc = spawn(command, [url], { detached: true, stdio: "ignore", windowsHide: true });
+      const proc = spawn(command, [...extra, url], { detached: true, stdio: "ignore", windowsHide: true });
       let settled = false;
       const done = (ok: boolean): void => {
         if (settled) return;
@@ -237,10 +238,14 @@ function spawnPlayer(command: string, url: string): Promise<boolean> {
 // macOS: hand the URL to an app bundle via `open -a`. `open` returns promptly
 // (it just launches the app), so we can wait for its exit code: non-zero means
 // the app wasn't found.
-function openWithApp(app: string, url: string): Promise<boolean> {
+function openWithApp(app: string, url: string, extra: string[] = []): Promise<boolean> {
   return new Promise((resolve) => {
     try {
-      const proc = spawn("open", ["-a", app, url], { stdio: "ignore", windowsHide: true });
+      // `open -a App url` passes the url as a document. Anything after --args
+      // goes to the application instead, so a flag has to sit there or `open`
+      // will treat it as its own and fail.
+      const argv = extra.length > 0 ? ["-a", app, url, "--args", ...extra] : ["-a", app, url];
+      const proc = spawn("open", argv, { stdio: "ignore", windowsHide: true });
       proc.on("error", () => resolve(false));
       proc.on("close", (code) => resolve(code === 0));
     } catch {
@@ -254,10 +259,19 @@ function openWithApp(app: string, url: string): Promise<boolean> {
  * PATH or an absolute path); on macOS, if that can't be spawned, falls back to
  * `open -a <command>` so a bare app name like "VLC" or "IINA" still works.
  * Resolves false only when neither route launches anything.
+ *
+ * `subtitleUrl` side-loads a subtitle where the player is one we know the flag
+ * for (see ./subtitleFlags.ts). An unknown player launches exactly as before,
+ * with no flag — the caller is responsible for saying so.
  */
-export async function launchPlayer(command: string, url: string): Promise<boolean> {
-  if (await spawnPlayer(command, url)) return true;
-  if (process.platform === "darwin") return openWithApp(command, url);
+export async function launchPlayer(
+  command: string,
+  url: string,
+  subtitleUrl = "",
+): Promise<boolean> {
+  const extra = subtitleArgs(command, subtitleUrl);
+  if (await spawnPlayer(command, url, extra)) return true;
+  if (process.platform === "darwin") return openWithApp(command, url, extra);
   return false;
 }
 

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -277,7 +277,7 @@ export async function launchPlayer(
 
 export interface PlayDeps {
   detect?: () => Promise<string | null>;
-  launch?: (command: string, url: string) => Promise<boolean>;
+  launch?: (command: string, url: string, subtitleUrl?: string) => Promise<boolean>;
 }
 
 // Outcome of the automatic (no-prompt) part of starting playback.
@@ -294,11 +294,15 @@ export interface AutoPlayOutcome {
 // Auto-detect a player and launch it on the URL. Returns the launched
 // command/path (so the caller can persist it) or null when nothing was detected
 // or the detected player failed to launch. Deps injectable for testing.
-export async function detectAndPlay(url: string, deps: PlayDeps = {}): Promise<string | null> {
+export async function detectAndPlay(
+  url: string,
+  subtitleUrl = "",
+  deps: PlayDeps = {},
+): Promise<string | null> {
   const detect = deps.detect ?? detectPlayer;
   const launch = deps.launch ?? launchPlayer;
   const detected = await detect();
-  if (detected && (await launch(detected, url))) return detected;
+  if (detected && (await launch(detected, url, subtitleUrl))) return detected;
   return null;
 }
 
@@ -310,16 +314,17 @@ export async function detectAndPlay(url: string, deps: PlayDeps = {}): Promise<s
 export async function attemptAutoPlay(
   configured: string,
   url: string,
+  subtitleUrl = "",
   deps: PlayDeps = {},
 ): Promise<AutoPlayOutcome> {
   const launch = deps.launch ?? launchPlayer;
   if (configured) {
-    if (await launch(configured, url)) {
+    if (await launch(configured, url, subtitleUrl)) {
       return { played: true, player: configured, configuredFailed: false };
     }
     return { played: false, configuredFailed: true };
   }
-  const player = await detectAndPlay(url, deps);
+  const player = await detectAndPlay(url, subtitleUrl, deps);
   return player
     ? { played: true, player, configuredFailed: false }
     : { played: false, configuredFailed: false };

--- a/src/util/srtToVtt.test.ts
+++ b/src/util/srtToVtt.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { decodeSubtitle, srtToVtt } from "./srtToVtt";
+
+describe("srtToVtt", () => {
+  it("adds the WEBVTT header", () => {
+    expect(srtToVtt("1\n00:00:01,000 --> 00:00:02,000\nHello\n")).toMatch(/^WEBVTT\n/);
+  });
+
+  it("converts comma decimals to dots in timestamps", () => {
+    // The only difference between the two formats that actually stops a
+    // browser parsing the file.
+    const out = srtToVtt("1\n00:01:02,345 --> 00:01:04,567\nHello\n");
+    expect(out).toContain("00:01:02.345 --> 00:01:04.567");
+    expect(out).not.toContain(",345");
+  });
+
+  it("drops the numeric cue index lines", () => {
+    const out = srtToVtt("1\n00:00:01,000 --> 00:00:02,000\nFirst\n\n2\n00:00:03,000 --> 00:00:04,000\nSecond\n");
+    expect(out).not.toMatch(/^\s*1\s*$/m);
+    expect(out).not.toMatch(/^\s*2\s*$/m);
+    expect(out).toContain("First");
+    expect(out).toContain("Second");
+  });
+
+  it("keeps a numeric line that is dialogue, not an index", () => {
+    // A cue whose text is "1998" must survive. Only a bare number IMMEDIATELY
+    // followed by a timestamp line is an index.
+    const out = srtToVtt("1\n00:00:01,000 --> 00:00:02,000\n1998\n");
+    expect(out).toContain("1998");
+  });
+
+  it("strips a UTF-8 BOM", () => {
+    // A BOM before WEBVTT makes the browser reject the whole file.
+    const out = srtToVtt("\uFEFF1\n00:00:01,000 --> 00:00:02,000\nHello\n");
+    expect(out.startsWith("WEBVTT")).toBe(true);
+  });
+
+  it("normalises CRLF line endings", () => {
+    const out = srtToVtt("1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n");
+    expect(out).not.toContain("\r");
+    expect(out).toContain("00:00:01.000 --> 00:00:02.000");
+  });
+
+  it("passes an existing WebVTT file through unchanged apart from newlines", () => {
+    const vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n";
+    expect(srtToVtt(vtt)).toBe(vtt);
+  });
+
+  it("does not double the header on a WebVTT file with a BOM", () => {
+    const out = srtToVtt("\uFEFFWEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHi\n");
+    expect(out.match(/WEBVTT/g)).toHaveLength(1);
+  });
+
+  it("keeps hour-less timestamps working", () => {
+    // Some encoders write MM:SS,mmm. WebVTT allows it, so leave it alone apart
+    // from the separator.
+    expect(srtToVtt("1\n01:02,345 --> 01:04,567\nHi\n")).toContain("01:02.345 --> 01:04.567");
+  });
+
+  it("returns a bare header for empty input rather than an empty file", () => {
+    expect(srtToVtt("")).toBe("WEBVTT\n");
+  });
+});
+
+describe("decodeSubtitle", () => {
+  it("decodes UTF-8", () => {
+    const bytes = new TextEncoder().encode("Grüße");
+    expect(decodeSubtitle(bytes)).toBe("Grüße");
+  });
+
+  it("falls back to latin1 for bytes that are not valid UTF-8", () => {
+    // .srt files are frequently Windows-1252. Decoding those as UTF-8 yields
+    // U+FFFD replacement characters, and a mojibake subtitle is worse than
+    // none — so an invalid sequence means "this was never UTF-8".
+    const latin1 = new Uint8Array([0x47, 0x72, 0xfc, 0xdf, 0x65]); // "Grüße" in latin1
+    expect(decodeSubtitle(latin1)).toBe("Grüße");
+  });
+
+  it("does not mistake valid UTF-8 multibyte text for latin1", () => {
+    const bytes = new TextEncoder().encode("日本語");
+    expect(decodeSubtitle(bytes)).toBe("日本語");
+  });
+});

--- a/src/util/srtToVtt.ts
+++ b/src/util/srtToVtt.ts
@@ -1,0 +1,63 @@
+/**
+ * SRT text to WebVTT text.
+ *
+ * `<track>` accepts WebVTT and nothing else, so this is what makes a sibling
+ * .srt showable in a browser. The two formats are near-identical: the
+ * differences that matter are a required header, `.` instead of `,` as the
+ * millisecond separator, and cue index lines that WebVTT does not use.
+ *
+ * DEPENDENCY-FREE, like ./subtitleFiles.ts and for the same reason — it is
+ * bundled for the browser as well as run in Node. No `node:*`, and note that
+ * `Buffer` is a node global: decodeSubtitle uses TextDecoder, which both have.
+ */
+
+const TIMESTAMP_RE = /^(.*\d)[,.](\d{1,3})(\s*-->\s*)(.*\d)[,.](\d{1,3})(.*)$/;
+
+/** True for a line that is only digits — a candidate SRT cue index. */
+function isIndexLine(line: string): boolean {
+  return /^\d+$/.test(line.trim());
+}
+
+function isTimestampLine(line: string): boolean {
+  return line.includes("-->");
+}
+
+/**
+ * Convert, or pass through if it is already WebVTT.
+ *
+ * A cue index is dropped only when the NEXT line is a timestamp. A bare number
+ * anywhere else is dialogue — a cue whose text is "1998" is not an index, and
+ * dropping it would silently delete a subtitle line.
+ */
+export function srtToVtt(text: string): string {
+  const clean = text.replace(/^\uFEFF/u, "").replace(/\r\n?/g, "\n");
+  if (/^WEBVTT/.test(clean)) return clean;
+  if (clean.trim() === "") return "WEBVTT\n";
+
+  const lines = clean.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (isIndexLine(line) && isTimestampLine(lines[i + 1] ?? "")) continue;
+    const m = TIMESTAMP_RE.exec(line);
+    out.push(m ? `${m[1]}.${m[2]}${m[3]}${m[4]}.${m[5]}${m[6]}` : line);
+  }
+  return `WEBVTT\n\n${out.join("\n").replace(/^\n+/, "")}`;
+}
+
+/**
+ * Decode subtitle bytes to text.
+ *
+ * UTF-8 first, strictly: `fatal: true` makes an invalid sequence throw rather
+ * than produce U+FFFD. That distinction is the whole point — .srt files are
+ * frequently Windows-1252, and a subtitle full of replacement characters is
+ * worse than one decoded by the right fallback. latin1 cannot fail, so this
+ * always returns something.
+ */
+export function decodeSubtitle(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return new TextDecoder("windows-1252").decode(bytes);
+  }
+}

--- a/src/util/subtitleFiles.test.ts
+++ b/src/util/subtitleFiles.test.ts
@@ -9,6 +9,14 @@ import {
 
 const f = (filename: string): { filename: string } => ({ filename });
 
+// `filename` is a basename only, as `StreamFile.filename` really is — `path`
+// carries the torrent-relative path the `Subs/` layout needs. Mirrors what a
+// real producer (torrentStream.ts, realdebrid.ts, torbox.ts) now emits.
+const fp = (filename: string, path: string): { filename: string; path: string } => ({
+  filename,
+  path,
+});
+
 describe("isSubtitleFilename", () => {
   it("accepts the five subtitle extensions", () => {
     for (const ext of ["srt", "vtt", "ass", "ssa", "sub"]) {
@@ -142,6 +150,25 @@ describe("subtitlesFor", () => {
     const exact = f("Kepler.S02E04.1080p.WEB-DL.eng.srt");
     const folder = f("Subs/Kepler.S02E04/2_English.srt");
     expect(subtitlesFor(video, [video, exact, folder])).toEqual([exact]);
+  });
+
+  it("rule 2 fires from `path` when `filename` is only a basename", () => {
+    // The real shape StreamFile.filename takes: a bare basename, the folder
+    // discarded. Without `path` carrying "Subs/Kepler.S02E04/...", rule 2 has
+    // nothing to read the SxxExx token from and this pack goes unsubtitled.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const mine = fp("2_English.srt", "Subs/Kepler.S02E04/2_English.srt");
+    const theirs = fp("2_English.srt", "Subs/Kepler.S02E05/2_English.srt");
+    expect(subtitlesFor(video, [video, mine, theirs])).toEqual([mine]);
+  });
+
+  it("does NOT fire rule 2 from filename alone when `path` is absent", () => {
+    // The honest fallback: a basename-only subtitle carries no folder, so no
+    // SxxExx token is available anywhere, and the matcher must say "no match"
+    // rather than silently misfiring or guessing.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const orphan = f("2_English.srt");
+    expect(subtitlesFor(video, [video, orphan])).toEqual([]);
   });
 
   it("returns nothing when the torrent has no subtitles at all", () => {

--- a/src/util/subtitleFiles.test.ts
+++ b/src/util/subtitleFiles.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  isBrowserRenderable,
+  isSubtitleFilename,
+  preferredSubtitle,
+  subtitleLanguage,
+  subtitlesFor,
+} from "./subtitleFiles";
+
+const f = (filename: string): { filename: string } => ({ filename });
+
+describe("isSubtitleFilename", () => {
+  it("accepts the five subtitle extensions", () => {
+    for (const ext of ["srt", "vtt", "ass", "ssa", "sub"]) {
+      expect(isSubtitleFilename(`Kestrel.2010.1080p.${ext}`)).toBe(true);
+    }
+  });
+
+  it("rejects video and everything else", () => {
+    expect(isSubtitleFilename("Kestrel.2010.1080p.BluRay.x264.mkv")).toBe(false);
+    expect(isSubtitleFilename("readme.nfo")).toBe(false);
+    expect(isSubtitleFilename("no-extension")).toBe(false);
+  });
+
+  it("is case insensitive", () => {
+    expect(isSubtitleFilename("Kestrel.2010.EN.SRT")).toBe(true);
+  });
+});
+
+describe("isBrowserRenderable", () => {
+  it("is true for srt and vtt, which convert to WebVTT", () => {
+    expect(isBrowserRenderable("Kestrel.2010.eng.srt")).toBe(true);
+    expect(isBrowserRenderable("Kestrel.2010.eng.vtt")).toBe(true);
+  });
+
+  it("is false for ass, ssa and sub", () => {
+    // <track> cannot render these without a subtitle engine. They are still
+    // matched and still handed to VLC/mpv, which render them natively.
+    expect(isBrowserRenderable("Kestrel.2010.eng.ass")).toBe(false);
+    expect(isBrowserRenderable("Kestrel.2010.eng.ssa")).toBe(false);
+    expect(isBrowserRenderable("Kestrel.2010.eng.sub")).toBe(false);
+  });
+});
+
+describe("subtitleLanguage", () => {
+  it("reads a three-letter code before the extension", () => {
+    expect(subtitleLanguage("Kepler.S02E04.1080p.WEB-DL.eng.srt")).toEqual({
+      code: "en",
+      label: "English",
+    });
+  });
+
+  it("reads a two-letter code", () => {
+    expect(subtitleLanguage("Kepler.S02E04.es.srt").code).toBe("es");
+  });
+
+  it("reads a spelled-out language anywhere in the path", () => {
+    expect(subtitleLanguage("Subs/Kepler.S02E04/3_Portuguese.srt")).toEqual({
+      code: "pt",
+      label: "Portuguese",
+    });
+  });
+
+  it("marks forced and SDH variants in the label but keeps the code", () => {
+    expect(subtitleLanguage("Kepler.S02E04.eng.forced.srt")).toEqual({
+      code: "en",
+      label: "English (forced)",
+    });
+    expect(subtitleLanguage("Kepler.S02E04.eng.sdh.srt")).toEqual({
+      code: "en",
+      label: "English (SDH)",
+    });
+  });
+
+  it("falls back to the basename when no language is detectable", () => {
+    // Better than labelling every unknown "Subtitles": a user with two of them
+    // needs to tell them apart, and the filename is the only thing that does.
+    expect(subtitleLanguage("Subs/2_track.srt")).toEqual({ code: "", label: "2_track" });
+  });
+
+  it("does not read a language out of the show title", () => {
+    // "Ashfall" contains no code, but a naive scan for "as" or "fa" would find
+    // one. Language tokens must be delimited.
+    expect(subtitleLanguage("Ashfall.1999.1080p.srt").code).toBe("");
+  });
+});
+
+describe("subtitlesFor", () => {
+  it("rule 1: matches a subtitle whose basename starts with the video's", () => {
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const sub = f("Kepler.S02E04.1080p.WEB-DL.eng.srt");
+    expect(subtitlesFor(video, [video, sub, f("readme.nfo")])).toEqual([sub]);
+  });
+
+  it("rule 2: matches on a shared SxxExx token across folders", () => {
+    // The layout scene season packs actually use, and the reason rule 1 alone
+    // is not enough.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const mine = f("Subs/Kepler.S02E04/2_English.srt");
+    const theirs = f("Subs/Kepler.S02E05/2_English.srt");
+    expect(subtitlesFor(video, [video, mine, theirs])).toEqual([mine]);
+  });
+
+  it("rule 2 does not fire across different seasons", () => {
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const other = f("Subs/Kepler.S03E04/2_English.srt");
+    expect(subtitlesFor(video, [video, other])).toEqual([]);
+  });
+
+  it("rule 3: a lone video takes every subtitle in the torrent", () => {
+    const video = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    const a = f("Subs/English.srt");
+    const b = f("Subs/Spanish.srt");
+    expect(subtitlesFor(video, [video, a, b])).toEqual([a, b]);
+  });
+
+  it("rule 3 does NOT fire when the torrent holds several videos", () => {
+    // THE REGRESSION THIS GUARDS. A season pack plus one unmatched subtitle
+    // must attach that subtitle to nothing, rather than to all ten episodes.
+    const e04 = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const e05 = f("Kepler.S02E05.1080p.WEB-DL.mkv");
+    const orphan = f("Subs/whatever.srt");
+    expect(subtitlesFor(e04, [e04, e05, orphan])).toEqual([]);
+  });
+
+  it("prefers rule 1 over rule 2 rather than merging them", () => {
+    // A pack with both layouts: the exact-basename match is the confident one,
+    // and returning both would put a duplicate language in the track menu.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const exact = f("Kepler.S02E04.1080p.WEB-DL.eng.srt");
+    const folder = f("Subs/Kepler.S02E04/2_English.srt");
+    expect(subtitlesFor(video, [video, exact, folder])).toEqual([exact]);
+  });
+
+  it("returns nothing when the torrent has no subtitles at all", () => {
+    // The Silo case that prompted this feature: ten mp4s, nothing else.
+    const video = f("Harrowgate.S03.1080p.WEB-DL.mkv");
+    expect(subtitlesFor(video, [video])).toEqual([]);
+  });
+
+  it("never matches the video against itself", () => {
+    const video = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    expect(subtitlesFor(video, [video])).toEqual([]);
+  });
+});
+
+describe("preferredSubtitle", () => {
+  it("prefers English over whatever came first", () => {
+    const spa = f("Kepler.S02E04.spa.srt");
+    const eng = f("Kepler.S02E04.eng.srt");
+    expect(preferredSubtitle([spa, eng])).toBe(eng);
+  });
+
+  it("prefers a plain English track over a forced one", () => {
+    // A forced track only subtitles the foreign-language lines, so handing it
+    // to VLC as THE subtitle would leave most dialogue bare.
+    const forced = f("Kepler.S02E04.eng.forced.srt");
+    const full = f("Kepler.S02E04.eng.srt");
+    expect(preferredSubtitle([forced, full])).toBe(full);
+  });
+
+  it("falls back to the first when no English exists", () => {
+    const spa = f("Kepler.S02E04.spa.srt");
+    const por = f("Kepler.S02E04.por.srt");
+    expect(preferredSubtitle([spa, por])).toBe(spa);
+  });
+
+  it("returns null for no matches", () => {
+    expect(preferredSubtitle([])).toBeNull();
+  });
+});

--- a/src/util/subtitleFiles.test.ts
+++ b/src/util/subtitleFiles.test.ts
@@ -171,6 +171,18 @@ describe("subtitlesFor", () => {
     expect(subtitlesFor(video, [video, orphan])).toEqual([]);
   });
 
+  it("treats an empty path the same as an absent one, falling back to filename", () => {
+    // A producer (Real-Debrid) that has no path for a file should mean "no
+    // folder information" — the same as `path` being undefined — not `path: ""`
+    // treated as a real (empty) path that defeats the filename fallback. Rule 1
+    // (basename prefix) would not fire here — the filenames share no prefix —
+    // so this only passes if matchPath actually falls back to `filename` for
+    // an empty `path`, letting rule 2 read the SxxExx token off it.
+    const video = f("Kepler.S02E04.1080p.WEB-DL.mkv");
+    const mine = fp("2_English.S02E04.srt", "");
+    expect(subtitlesFor(video, [video, mine])).toEqual([mine]);
+  });
+
   it("returns nothing when the torrent has no subtitles at all", () => {
     // The season pack that prompted this feature: ten episodes, nothing else.
     const video = f("Harrowgate.S03.1080p.WEB-DL.mkv");

--- a/src/util/subtitleFiles.test.ts
+++ b/src/util/subtitleFiles.test.ts
@@ -123,6 +123,18 @@ describe("subtitlesFor", () => {
     expect(subtitlesFor(e04, [e04, e05, orphan])).toEqual([]);
   });
 
+  it("rule 3 does not fire for several NON-episodic videos either", () => {
+    // The case the rule-2 early return cannot cover, and the one that matters
+    // for a movie-pack torrent: two videos carrying no SxxExx token at all, so
+    // control actually reaches rule 3's `videos.length === 1` guard. Without
+    // this, that guard could be replaced by `return subs` and the suite would
+    // stay green.
+    const a = f("Kestrel.2010.1080p.BluRay.x264.mkv");
+    const b = f("Ashfall.1999.1080p.mkv");
+    const orphan = f("Subs/English.srt");
+    expect(subtitlesFor(a, [a, b, orphan])).toEqual([]);
+  });
+
   it("prefers rule 1 over rule 2 rather than merging them", () => {
     // A pack with both layouts: the exact-basename match is the confident one,
     // and returning both would put a duplicate language in the track menu.
@@ -133,7 +145,7 @@ describe("subtitlesFor", () => {
   });
 
   it("returns nothing when the torrent has no subtitles at all", () => {
-    // The Silo case that prompted this feature: ten mp4s, nothing else.
+    // The season pack that prompted this feature: ten episodes, nothing else.
     const video = f("Harrowgate.S03.1080p.WEB-DL.mkv");
     expect(subtitlesFor(video, [video])).toEqual([]);
   });

--- a/src/util/subtitleFiles.ts
+++ b/src/util/subtitleFiles.ts
@@ -1,0 +1,163 @@
+/**
+ * Which subtitle file belongs to which video, and what language it is in.
+ *
+ * THIS MODULE MUST STAY DEPENDENCY-FREE, for the reason ./videoFiles.ts gives
+ * at length: it is imported by src/util/player.ts (Node) *and* by the browser
+ * bundle, and this codebase has recorded four bugs caused by a helper being
+ * copied between the two front ends and then drifting. A `node:*` import here —
+ * or any import that transitively reaches one — breaks `npm run build`, loudly,
+ * which is the enforcement.
+ *
+ * Deliberately separate from ./videoFiles.ts rather than added to it: a
+ * subtitle must never enter `streamCandidates`, or it becomes something the
+ * user can pick to *play*.
+ */
+import { isVideoFilename, type NamedFile } from "./videoFiles";
+
+const SUBTITLE_EXTS = new Set(["srt", "vtt", "ass", "ssa", "sub"]);
+
+// The two a <track> can carry, once srtToVtt has run. ass/ssa/sub need a real
+// subtitle engine to render, which the browser has no equivalent of.
+const RENDERABLE_EXTS = new Set(["srt", "vtt"]);
+
+function ext(name: string): string {
+  const i = name.lastIndexOf(".");
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : "";
+}
+
+/** Whether a filename looks like a subtitle, by extension. */
+export function isSubtitleFilename(filename: string): boolean {
+  return SUBTITLE_EXTS.has(ext(filename));
+}
+
+/** Whether the browser can show this one as a `<track>` after conversion. */
+export function isBrowserRenderable(filename: string): boolean {
+  return RENDERABLE_EXTS.has(ext(filename));
+}
+
+// Path and extension stripped: "Subs/Kepler.S02E04/2_English.srt" -> "2_English".
+function basename(path: string): string {
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const name = slash >= 0 ? path.slice(slash + 1) : path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+// Languages worth naming. Two- and three-letter codes plus the English name,
+// all mapping to one BCP-47 tag so <track srclang> is always well-formed.
+const LANGUAGES: { code: string; label: string; tokens: string[] }[] = [
+  { code: "en", label: "English", tokens: ["en", "eng", "english"] },
+  { code: "es", label: "Spanish", tokens: ["es", "spa", "esp", "spanish", "castellano", "latino"] },
+  { code: "pt", label: "Portuguese", tokens: ["pt", "por", "portuguese", "brazilian"] },
+  { code: "fr", label: "French", tokens: ["fr", "fre", "fra", "french"] },
+  { code: "de", label: "German", tokens: ["de", "ger", "deu", "german"] },
+  { code: "it", label: "Italian", tokens: ["it", "ita", "italian"] },
+  { code: "nl", label: "Dutch", tokens: ["nl", "dut", "nld", "dutch"] },
+  { code: "pl", label: "Polish", tokens: ["pl", "pol", "polish"] },
+  { code: "ru", label: "Russian", tokens: ["ru", "rus", "russian"] },
+  { code: "ja", label: "Japanese", tokens: ["ja", "jpn", "japanese"] },
+  { code: "ko", label: "Korean", tokens: ["ko", "kor", "korean"] },
+  { code: "zh", label: "Chinese", tokens: ["zh", "chi", "zho", "chinese"] },
+  { code: "ar", label: "Arabic", tokens: ["ar", "ara", "arabic"] },
+  { code: "sv", label: "Swedish", tokens: ["sv", "swe", "swedish"] },
+  { code: "da", label: "Danish", tokens: ["da", "dan", "danish"] },
+  { code: "no", label: "Norwegian", tokens: ["no", "nor", "norwegian"] },
+  { code: "fi", label: "Finnish", tokens: ["fi", "fin", "finnish"] },
+  { code: "tr", label: "Turkish", tokens: ["tr", "tur", "turkish"] },
+];
+
+// Split on every separator a release name uses, so a token match is delimited.
+// Without this, "Ashfall" contains "as" and "fa" and every file would look
+// Spanish or Persian — a real failure mode, not a hypothetical one.
+function tokensOf(path: string): string[] {
+  return path.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/**
+ * The language of a subtitle file, read from its path.
+ *
+ * Scans the WHOLE path, not just the basename: the `Subs/` layout puts the
+ * language in the filename ("2_English.srt") while the flat layout puts it
+ * before the extension ("....eng.srt"), and both are common.
+ *
+ * Later tokens win. "Kepler.S02E04.German.Dub.eng.srt" is an English subtitle
+ * for a German dub, and the token nearest the extension is the subtitle's own.
+ */
+export function subtitleLanguage(filename: string): { code: string; label: string } {
+  const tokens = tokensOf(filename);
+  let found: { code: string; label: string } | null = null;
+  for (const token of tokens) {
+    const hit = LANGUAGES.find((l) => l.tokens.includes(token));
+    if (hit) found = { code: hit.code, label: hit.label };
+  }
+  if (!found) return { code: "", label: basename(filename) };
+  // A forced track subtitles only the foreign-language lines and an SDH one
+  // adds sound description. Both are the same language and a different thing to
+  // choose, so the distinction belongs in the label, not the code.
+  if (tokens.includes("forced")) return { ...found, label: `${found.label} (forced)` };
+  if (tokens.includes("sdh")) return { ...found, label: `${found.label} (SDH)` };
+  return found;
+}
+
+// "S02E04" as written by anything: S02E04, s02e04, 2x04.
+const EPISODE_RE = /\bs(\d{1,2})[\s._-]*e(\d{1,3})\b|\b(\d{1,2})x(\d{2,3})\b/i;
+
+function episodeToken(path: string): string | null {
+  const m = EPISODE_RE.exec(path);
+  if (!m) return null;
+  const season = m[1] ?? m[3];
+  const episode = m[2] ?? m[4];
+  if (!season || !episode) return null;
+  return `s${Number(season)}e${Number(episode)}`;
+}
+
+/**
+ * The subtitle files that belong to one video, by three rules in order. The
+ * first rule that yields anything wins — they are not merged, because a pack
+ * carrying both layouts would otherwise show the same language twice.
+ *
+ * 1. The subtitle's basename starts with the video's basename.
+ * 2. Both paths carry the same SxxExx token — the `Subs/` folder layout.
+ * 3. The torrent holds exactly one video, so every subtitle in it is that
+ *    video's.
+ *
+ * Fuzzy title matching was considered and rejected: it would occasionally
+ * attach the wrong episode's subtitle, which is worse than attaching none.
+ */
+export function subtitlesFor<T extends NamedFile>(video: T, files: readonly T[]): T[] {
+  const subs = files.filter((f) => f !== video && isSubtitleFilename(f.filename));
+  if (subs.length === 0) return [];
+
+  const videoBase = basename(video.filename).toLowerCase();
+  const byPrefix = subs.filter((s) => basename(s.filename).toLowerCase().startsWith(videoBase));
+  if (byPrefix.length > 0) return byPrefix;
+
+  const token = episodeToken(video.filename);
+  if (token) {
+    const byEpisode = subs.filter((s) => episodeToken(s.filename) === token);
+    if (byEpisode.length > 0) return byEpisode;
+    // A video that names an episode and found no subtitle naming the same one
+    // stops here. Falling through to rule 3 would be impossible anyway (a pack
+    // has several videos), but stopping says why.
+    return [];
+  }
+
+  const videos = files.filter((f) => isVideoFilename(f.filename));
+  return videos.length === 1 ? subs : [];
+}
+
+/**
+ * The one subtitle to hand a player that accepts only one.
+ *
+ * English first because that is what this audience overwhelmingly wants, and a
+ * full track over a forced one because a forced track subtitles only the
+ * foreign-language lines — handing it over as THE subtitle would leave most of
+ * the dialogue bare. The browser gets all of them regardless; only the external
+ * player is limited to one.
+ */
+export function preferredSubtitle<T extends NamedFile>(matches: readonly T[]): T | null {
+  if (matches.length === 0) return null;
+  const english = matches.filter((m) => subtitleLanguage(m.filename).code === "en");
+  const full = english.find((m) => !subtitleLanguage(m.filename).label.includes("("));
+  return full ?? english[0] ?? matches[0] ?? null;
+}

--- a/src/util/subtitleFiles.ts
+++ b/src/util/subtitleFiles.ts
@@ -45,26 +45,54 @@ function basename(path: string): string {
 
 // Languages worth naming. Two- and three-letter codes plus the English name,
 // all mapping to one BCP-47 tag so <track srclang> is always well-formed.
-const LANGUAGES: { code: string; label: string; tokens: string[] }[] = [
-  { code: "en", label: "English", tokens: ["en", "eng", "english"] },
-  { code: "es", label: "Spanish", tokens: ["es", "spa", "esp", "spanish", "castellano", "latino"] },
-  { code: "pt", label: "Portuguese", tokens: ["pt", "por", "portuguese", "brazilian"] },
-  { code: "fr", label: "French", tokens: ["fr", "fre", "fra", "french"] },
-  { code: "de", label: "German", tokens: ["de", "ger", "deu", "german"] },
-  { code: "it", label: "Italian", tokens: ["it", "ita", "italian"] },
-  { code: "nl", label: "Dutch", tokens: ["nl", "dut", "nld", "dutch"] },
-  { code: "pl", label: "Polish", tokens: ["pl", "pol", "polish"] },
-  { code: "ru", label: "Russian", tokens: ["ru", "rus", "russian"] },
-  { code: "ja", label: "Japanese", tokens: ["ja", "jpn", "japanese"] },
-  { code: "ko", label: "Korean", tokens: ["ko", "kor", "korean"] },
-  { code: "zh", label: "Chinese", tokens: ["zh", "chi", "zho", "chinese"] },
-  { code: "ar", label: "Arabic", tokens: ["ar", "ara", "arabic"] },
-  { code: "sv", label: "Swedish", tokens: ["sv", "swe", "swedish"] },
-  { code: "da", label: "Danish", tokens: ["da", "dan", "danish"] },
-  { code: "no", label: "Norwegian", tokens: ["no", "nor", "norwegian"] },
-  { code: "fi", label: "Finnish", tokens: ["fi", "fin", "finnish"] },
-  { code: "tr", label: "Turkish", tokens: ["tr", "tur", "turkish"] },
+//
+// `iso3` is a separate, narrower list from `tokens`: `tokens` is every spelling
+// a release name uses (including non-ISO aliases like Spanish "esp"), because
+// `subtitleLanguage` below has to match filenames written by whoever uploaded
+// the torrent. `iso3` is only the language's real ISO 639-2 tag(s) — what
+// ffprobe actually emits — and is what `LANGUAGE_NAMES` below is built from.
+// Conflating the two would let a filename alias like "esp" masquerade as an
+// ffprobe tag it never produces.
+const LANGUAGES: { code: string; label: string; iso3: string[]; tokens: string[] }[] = [
+  { code: "en", label: "English", iso3: ["eng"], tokens: ["en", "eng", "english"] },
+  {
+    code: "es",
+    label: "Spanish",
+    iso3: ["spa"],
+    tokens: ["es", "spa", "esp", "spanish", "castellano", "latino"],
+  },
+  { code: "pt", label: "Portuguese", iso3: ["por"], tokens: ["pt", "por", "portuguese", "brazilian"] },
+  { code: "fr", label: "French", iso3: ["fre", "fra"], tokens: ["fr", "fre", "fra", "french"] },
+  { code: "de", label: "German", iso3: ["ger", "deu"], tokens: ["de", "ger", "deu", "german"] },
+  { code: "it", label: "Italian", iso3: ["ita"], tokens: ["it", "ita", "italian"] },
+  { code: "nl", label: "Dutch", iso3: ["dut", "nld"], tokens: ["nl", "dut", "nld", "dutch"] },
+  { code: "pl", label: "Polish", iso3: ["pol"], tokens: ["pl", "pol", "polish"] },
+  { code: "ru", label: "Russian", iso3: ["rus"], tokens: ["ru", "rus", "russian"] },
+  { code: "ja", label: "Japanese", iso3: ["jpn"], tokens: ["ja", "jpn", "japanese"] },
+  { code: "ko", label: "Korean", iso3: ["kor"], tokens: ["ko", "kor", "korean"] },
+  { code: "zh", label: "Chinese", iso3: ["chi", "zho"], tokens: ["zh", "chi", "zho", "chinese"] },
+  { code: "ar", label: "Arabic", iso3: ["ara"], tokens: ["ar", "ara", "arabic"] },
+  { code: "sv", label: "Swedish", iso3: ["swe"], tokens: ["sv", "swe", "swedish"] },
+  { code: "da", label: "Danish", iso3: ["dan"], tokens: ["da", "dan", "danish"] },
+  { code: "no", label: "Norwegian", iso3: ["nor"], tokens: ["no", "nor", "norwegian"] },
+  { code: "fi", label: "Finnish", iso3: ["fin"], tokens: ["fi", "fin", "finnish"] },
+  { code: "tr", label: "Turkish", iso3: ["tur"], tokens: ["tr", "tur", "turkish"] },
 ];
+
+/**
+ * ffprobe's tags are ISO 639-2, lowercase, three letters — this maps one to the
+ * display name the fallback card and the embedded-subtitle notice both use.
+ *
+ * Built off `LANGUAGES.iso3` rather than duplicated: this table and
+ * `subtitleLanguage` below used to be copied between `src/util` and
+ * `src/web/static` as two separately-maintained lists of the same 22
+ * languages, which is exactly the copy-then-drift shape this codebase has
+ * already recorded four bugs from (see CLAUDE.md). One table, two shapes of
+ * lookup, driven off the same data.
+ */
+export const LANGUAGE_NAMES: Record<string, string> = Object.fromEntries(
+  LANGUAGES.flatMap((l) => l.iso3.map((tag) => [tag, l.label] as const)),
+);
 
 // Split on every separator a release name uses, so a token match is delimited.
 // Without this, "Ashfall" contains "as" and "fa" and every file would look

--- a/src/util/subtitleFiles.ts
+++ b/src/util/subtitleFiles.ts
@@ -14,6 +14,26 @@
  */
 import { isVideoFilename, type NamedFile } from "./videoFiles";
 
+/**
+ * A `NamedFile` that may additionally carry the torrent-relative path
+ * (`StreamFile.path`, `src/util/player.ts`). `filename` is a basename in every
+ * producer, so rule 2 below — the `Subs/<episode>/x.srt` layout — has nothing
+ * to read an `SxxExx` token from unless the path is threaded through. Optional,
+ * because the web's `SubtitleFile` shape (`src/web/wire.ts`) has no need of it:
+ * matching happens server-side against `StreamFile`, which does carry it.
+ */
+export interface PathedFile extends NamedFile {
+  path?: string;
+}
+
+// What subtitlesFor actually reads to find an SxxExx token: the path when the
+// producer supplied one, the (basename) filename otherwise. Never silently
+// invents a path — an absent one means "no folder information", not "assume
+// the flat layout applies".
+function matchPath(f: PathedFile): string {
+  return f.path ?? f.filename;
+}
+
 const SUBTITLE_EXTS = new Set(["srt", "vtt", "ass", "ssa", "sub"]);
 
 // The two a <track> can carry, once srtToVtt has run. ass/ssa/sub need a real
@@ -145,14 +165,18 @@ function episodeToken(path: string): string | null {
  * carrying both layouts would otherwise show the same language twice.
  *
  * 1. The subtitle's basename starts with the video's basename.
- * 2. Both paths carry the same SxxExx token — the `Subs/` folder layout.
+ * 2. Both paths carry the same SxxExx token — the `Subs/` folder layout. Reads
+ *    `path` when present (see `PathedFile`) and falls back to `filename`,
+ *    which is a basename in every real producer and so will rarely carry an
+ *    SxxExx token itself for this rule — the fallback exists so a caller with
+ *    no path still gets an honest "no match" instead of a crash.
  * 3. The torrent holds exactly one video, so every subtitle in it is that
  *    video's.
  *
  * Fuzzy title matching was considered and rejected: it would occasionally
  * attach the wrong episode's subtitle, which is worse than attaching none.
  */
-export function subtitlesFor<T extends NamedFile>(video: T, files: readonly T[]): T[] {
+export function subtitlesFor<T extends PathedFile>(video: T, files: readonly T[]): T[] {
   const subs = files.filter((f) => f !== video && isSubtitleFilename(f.filename));
   if (subs.length === 0) return [];
 
@@ -160,9 +184,9 @@ export function subtitlesFor<T extends NamedFile>(video: T, files: readonly T[])
   const byPrefix = subs.filter((s) => basename(s.filename).toLowerCase().startsWith(videoBase));
   if (byPrefix.length > 0) return byPrefix;
 
-  const token = episodeToken(video.filename);
+  const token = episodeToken(matchPath(video));
   if (token) {
-    const byEpisode = subs.filter((s) => episodeToken(s.filename) === token);
+    const byEpisode = subs.filter((s) => episodeToken(matchPath(s)) === token);
     if (byEpisode.length > 0) return byEpisode;
     // A video that names an episode and found no subtitle naming the same one
     // stops here. Falling through to rule 3 would be impossible anyway (a pack

--- a/src/util/subtitleFiles.ts
+++ b/src/util/subtitleFiles.ts
@@ -29,9 +29,11 @@ export interface PathedFile extends NamedFile {
 // What subtitlesFor actually reads to find an SxxExx token: the path when the
 // producer supplied one, the (basename) filename otherwise. Never silently
 // invents a path — an absent one means "no folder information", not "assume
-// the flat layout applies".
+// the flat layout applies". `||`, not `??`: an empty string is not a path
+// either (a producer with nothing to report should mean "absent", the same as
+// undefined), so it must fall back to filename too, not be used as-is.
 function matchPath(f: PathedFile): string {
-  return f.path ?? f.filename;
+  return f.path || f.filename;
 }
 
 const SUBTITLE_EXTS = new Set(["srt", "vtt", "ass", "ssa", "sub"]);

--- a/src/util/subtitleFlags.test.ts
+++ b/src/util/subtitleFlags.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { subtitleArgs } from "./subtitleFlags";
+
+const URL = "http://box.test:9161/stream/abc/1.vtt?k=cap";
+
+describe("subtitleArgs", () => {
+  it("uses --sub-file for mpv", () => {
+    expect(subtitleArgs("mpv", URL)).toEqual([`--sub-file=${URL}`]);
+  });
+
+  it("uses --sub-file for mpv.net", () => {
+    expect(subtitleArgs("mpvnet", URL)).toEqual([`--sub-file=${URL}`]);
+  });
+
+  it("uses --mpv-sub-file for IINA, which prefixes mpv's own flags", () => {
+    expect(subtitleArgs("iina", URL)).toEqual([`--mpv-sub-file=${URL}`]);
+  });
+
+  it("uses --input-slave for VLC", () => {
+    expect(subtitleArgs("vlc", URL)).toEqual([`--input-slave=${URL}`]);
+  });
+
+  it("recognises a player given as an absolute path", () => {
+    // The configured command is often a full path on Windows and macOS.
+    expect(subtitleArgs("/Applications/VLC.app/Contents/MacOS/VLC", URL)).toEqual([
+      `--input-slave=${URL}`,
+    ]);
+    expect(subtitleArgs("C:\\Program Files\\VideoLAN\\VLC\\vlc.exe", URL)).toEqual([
+      `--input-slave=${URL}`,
+    ]);
+  });
+
+  it("recognises the macOS app-bundle names torlink launches with `open -a`", () => {
+    expect(subtitleArgs("VLC", URL)).toEqual([`--input-slave=${URL}`]);
+    expect(subtitleArgs("IINA", URL)).toEqual([`--mpv-sub-file=${URL}`]);
+  });
+
+  it("returns nothing for an unknown or custom command", () => {
+    // A user's own wrapper script takes whatever arguments it takes. Guessing a
+    // flag would break a launch that works today, so an unknown player gets the
+    // URL alone and the caller says the subtitle was not attached.
+    expect(subtitleArgs("my-player.sh", URL)).toEqual([]);
+    expect(subtitleArgs("", URL)).toEqual([]);
+  });
+
+  it("returns nothing when there is no subtitle url", () => {
+    expect(subtitleArgs("mpv", "")).toEqual([]);
+  });
+});

--- a/src/util/subtitleFlags.test.ts
+++ b/src/util/subtitleFlags.test.ts
@@ -16,22 +16,24 @@ describe("subtitleArgs", () => {
     expect(subtitleArgs("iina", URL)).toEqual([`--mpv-sub-file=${URL}`]);
   });
 
-  it("uses --input-slave for VLC", () => {
-    expect(subtitleArgs("vlc", URL)).toEqual([`--input-slave=${URL}`]);
+  it("gives VLC no flag at all", () => {
+    // Measured against a real VLC 3.0.11: `--input-slave=<url>` loads the
+    // subtitle as an AUDIO track ("loading audio-es slave"), and
+    // `--sub-file=<url>` reaches the right track type but resolves the URL as
+    // a local path, producing garbage. There is no VLC 3 CLI flag that
+    // side-loads a subtitle from a URL, so passing one would silently
+    // misbehave — worse than passing nothing.
+    expect(subtitleArgs("vlc", URL)).toEqual([]);
   });
 
   it("recognises a player given as an absolute path", () => {
     // The configured command is often a full path on Windows and macOS.
-    expect(subtitleArgs("/Applications/VLC.app/Contents/MacOS/VLC", URL)).toEqual([
-      `--input-slave=${URL}`,
-    ]);
-    expect(subtitleArgs("C:\\Program Files\\VideoLAN\\VLC\\vlc.exe", URL)).toEqual([
-      `--input-slave=${URL}`,
-    ]);
+    expect(subtitleArgs("/Applications/VLC.app/Contents/MacOS/VLC", URL)).toEqual([]);
+    expect(subtitleArgs("C:\\Program Files\\VideoLAN\\VLC\\vlc.exe", URL)).toEqual([]);
   });
 
   it("recognises the macOS app-bundle names torlink launches with `open -a`", () => {
-    expect(subtitleArgs("VLC", URL)).toEqual([`--input-slave=${URL}`]);
+    expect(subtitleArgs("VLC", URL)).toEqual([]);
     expect(subtitleArgs("IINA", URL)).toEqual([`--mpv-sub-file=${URL}`]);
   });
 

--- a/src/util/subtitleFlags.ts
+++ b/src/util/subtitleFlags.ts
@@ -13,14 +13,31 @@
 // Matched against the command's basename, lowercased, extension stripped — the
 // configured value is as often "/Applications/VLC.app/Contents/MacOS/VLC" or
 // "vlc.exe" as it is "vlc".
+//
+// mpv/mpv.net are MEASURED (VLC 3.0.11's box, a real http:// subtitle URL,
+// mpv's own IPC track-list): `--sub-file=<url>` loads it as
+// `{"type":"sub","external":true,"selected":true}`. IINA is NOT measured —
+// its `--mpv-sub-file` entry is inferred from the fact that IINA wraps mpv
+// and forwards `--mpv-`-prefixed options, but nobody has run this against a
+// real IINA build.
+//
+// VLC has no entry, and deliberately so — there is no CLI flag that side-loads
+// a subtitle from a URL in VLC 3. Measured: `--input-slave=<url>` loads the
+// file, but as an AUDIO track (`loading audio-es slave: ...`), not a subtitle
+// one. `--sub-file=<url>` reaches the right track category but VLC resolves
+// the argument as a local path, producing garbage
+// (`file:///.../http%3A//host/...`). Also tried and also wrong:
+// `--input-slave=subtitle:<url>`, `--input-slave=<url>#subtitle`, and
+// `:input-slave=<url>` — all load as audio-es. Passing either flag would look
+// like it worked (VLC starts, no error) while silently doing the wrong thing,
+// which is worse than passing nothing — hence no entry, so `subtitleArgs`
+// returns `[]` and the caller says the subtitle was not attached.
 const FLAGS: Record<string, string> = {
   mpv: "--sub-file",
   mpvnet: "--sub-file",
   "mpv.net": "--sub-file",
   iina: "--mpv-sub-file",
   "iina-cli": "--mpv-sub-file",
-  vlc: "--input-slave",
-  vlccli: "--input-slave",
 };
 
 function commandKey(command: string): string {

--- a/src/util/subtitleFlags.ts
+++ b/src/util/subtitleFlags.ts
@@ -1,0 +1,37 @@
+/**
+ * How to tell each media player to side-load a subtitle.
+ *
+ * Kept apart from ./player.ts so the table is testable without spawning
+ * anything, and dependency-free so it stays that way.
+ *
+ * An unknown command gets no flag at all. The configured player may be a user's
+ * own wrapper script that takes arguments we cannot guess, and inventing one
+ * would break a launch that works today — the caller says the subtitle was not
+ * attached rather than risking that.
+ */
+
+// Matched against the command's basename, lowercased, extension stripped — the
+// configured value is as often "/Applications/VLC.app/Contents/MacOS/VLC" or
+// "vlc.exe" as it is "vlc".
+const FLAGS: Record<string, string> = {
+  mpv: "--sub-file",
+  mpvnet: "--sub-file",
+  "mpv.net": "--sub-file",
+  iina: "--mpv-sub-file",
+  "iina-cli": "--mpv-sub-file",
+  vlc: "--input-slave",
+  vlccli: "--input-slave",
+};
+
+function commandKey(command: string): string {
+  const slash = Math.max(command.lastIndexOf("/"), command.lastIndexOf("\\"));
+  const base = (slash >= 0 ? command.slice(slash + 1) : command).toLowerCase();
+  return base.replace(/\.(exe|app|com|bat|cmd)$/, "");
+}
+
+/** The extra argv for a subtitle, or `[]` when we should not pass one. */
+export function subtitleArgs(command: string, subtitleUrl: string): string[] {
+  if (!subtitleUrl) return [];
+  const flag = FLAGS[commandKey(command)];
+  return flag ? [`${flag}=${subtitleUrl}`] : [];
+}

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -41,6 +41,7 @@ import { backTarget, readReturn } from "./returnTo";
 import {
   createTrackFailureTracker,
   embeddedNotice,
+  subtitleDownload,
   subtitleTracks,
   type TrackSpec,
 } from "./subtitleModel";
@@ -447,6 +448,10 @@ async function render(): Promise<void> {
   // error that, for mkv in Chrome, never even fires.
   const info = await fetchInfo(target);
   const tracks = subtitleTracks(info, target);
+  const download = subtitleDownload(info, target);
+  if (download) {
+    actions.appendChild(linkButton(download.label, download.href));
+  }
   const chosen = chooseSource(info, target.filename);
   if (chosen.rung === "card") {
     showFallback(chosen.reason ?? "container", target.filename, info?.facts, info);

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -38,6 +38,7 @@ import { mountHls } from "./hlsMount";
 import { breadcrumbFor, escapeRoutes, upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
 import { backTarget, readReturn } from "./returnTo";
+import { embeddedNotice, subtitleTracks, type TrackSpec } from "./subtitleModel";
 import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
 
 const el = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
@@ -139,7 +140,12 @@ function linkButton(label: string, href: string): HTMLAnchorElement {
  * `<video>` is removed rather than hidden, so nothing keeps buffering a file
  * that is not going to play and no black rectangle is left behind it.
  */
-function showFallback(reason: FallbackReason, filename: string, facts?: MediaFacts): void {
+function showFallback(
+  reason: FallbackReason,
+  filename: string,
+  facts?: MediaFacts,
+  info: StreamInfoResponse | null = null,
+): void {
   const card = document.createElement("div");
   card.className = "card fallback";
 
@@ -155,6 +161,18 @@ function showFallback(reason: FallbackReason, filename: string, facts?: MediaFac
   body.textContent = fallbackMessage(reason, filename, facts);
 
   card.append(title, body);
+
+  // The subtitles the file carries, when it has any. A card that says "open
+  // this elsewhere" and then does not mention the three subtitle tracks inside
+  // is the exact gap this feature exists to close. It sits above the escape
+  // routes below because it is about THIS file — the links are about leaving it.
+  const subs = embeddedNotice(info);
+  if (subs) {
+    const line = document.createElement("p");
+    line.className = "fallback-subs";
+    line.textContent = subs;
+    card.append(line);
+  }
 
   // TWO WAYS OUT, because this card is the end of the most common journey
   // through the app and it used to be a cul-de-sac that blamed the browser.
@@ -187,6 +205,25 @@ function createVideo(): HTMLVideoElement {
   // all — without pulling the whole file through the proxy behind it.
   video.preload = "metadata";
   return video;
+}
+
+/**
+ * Attach subtitle tracks to a `<video>`.
+ *
+ * `label` comes from a filename, i.e. from whoever made the torrent, so it is
+ * set as a property and never as markup — the same rule as everything else in
+ * this file.
+ */
+function addTracks(video: HTMLVideoElement, specs: TrackSpec[]): void {
+  for (const spec of specs) {
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = spec.src;
+    track.srclang = spec.srclang;
+    track.label = spec.label;
+    track.default = spec.default;
+    video.append(track);
+  }
 }
 
 /**
@@ -301,10 +338,11 @@ function tryPlay(video: HTMLVideoElement): void {
   void video.play().catch(() => {});
 }
 
-function mountVideo(target: PlayerTarget, src: string): void {
+function mountVideo(target: PlayerTarget, src: string, tracks: TrackSpec[]): void {
   const video = createVideo();
   video.src = src;
   watch(video, target);
+  addTracks(video, tracks);
   stage.replaceChildren(video);
   tryPlay(video);
 }
@@ -389,14 +427,16 @@ async function render(): Promise<void> {
   // browser refuses is now known up front rather than discovered by a decode
   // error that, for mkv in Chrome, never even fires.
   const info = await fetchInfo(target);
+  const tracks = subtitleTracks(info, target);
   const chosen = chooseSource(info, target.filename);
   if (chosen.rung === "card") {
-    showFallback(chosen.reason ?? "container", target.filename, info?.facts);
+    showFallback(chosen.reason ?? "container", target.filename, info?.facts, info);
     return;
   }
   if (chosen.rung === "provider-hls" && info?.hls) {
     const video = createVideo();
     const settle = watch(video, target);
+    addTracks(video, tracks);
     stage.replaceChildren(video);
     // The manifest is on the provider's own host, so no capability is appended:
     // it is already a capability, being an unguessable URL minted for this file.
@@ -404,7 +444,7 @@ async function render(): Promise<void> {
     tryPlay(video);
     return;
   }
-  mountVideo(target, stream);
+  mountVideo(target, stream, tracks);
 }
 
 /**

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -38,7 +38,12 @@ import { mountHls } from "./hlsMount";
 import { breadcrumbFor, escapeRoutes, upNextView, type EpisodeRow } from "./upNext";
 import { authHeadersFor, readStoredToken } from "./token";
 import { backTarget, readReturn } from "./returnTo";
-import { embeddedNotice, subtitleTracks, type TrackSpec } from "./subtitleModel";
+import {
+  createTrackFailureTracker,
+  embeddedNotice,
+  subtitleTracks,
+  type TrackSpec,
+} from "./subtitleModel";
 import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
 
 const el = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
@@ -213,8 +218,18 @@ function createVideo(): HTMLVideoElement {
  * `label` comes from a filename, i.e. from whoever made the torrent, so it is
  * set as a property and never as markup — the same rule as everything else in
  * this file.
+ *
+ * A `<track>` that fails to load — the sibling `.vtt` route 502s, or the
+ * session was reaped — otherwise just stays in the menu and shows nothing
+ * when picked, which is the same silent-freeze shape as the mid-playback
+ * stall this file already has an answer for. `error` is bound per element and
+ * routed through a fresh `createTrackFailureTracker()` (one per mount, so a
+ * page navigation starts clean); the tracker decides WHETHER a given failure
+ * is worth a notice and WHAT it says, and this function only asks it and
+ * forwards a non-null answer to `showNotice`.
  */
 function addTracks(video: HTMLVideoElement, specs: TrackSpec[]): void {
+  const tracker = createTrackFailureTracker();
   for (const spec of specs) {
     const track = document.createElement("track");
     track.kind = "subtitles";
@@ -222,6 +237,10 @@ function addTracks(video: HTMLVideoElement, specs: TrackSpec[]): void {
     track.srclang = spec.srclang;
     track.label = spec.label;
     track.default = spec.default;
+    track.addEventListener("error", () => {
+      const message = tracker.report(spec);
+      if (message !== null) showNotice(message, { persist: true });
+    });
     video.append(track);
   }
 }

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -152,7 +152,7 @@ describe("filesPath", () => {
 
 describe("chooseSource", () => {
   const info = (over: Partial<StreamInfoResponse> = {}): StreamInfoResponse => ({
-    facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" as const },
+    facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" as const, subtitles: [] },
     blockers: [],
     hls: null,
     ...over,
@@ -187,7 +187,7 @@ describe("chooseSource", () => {
     expect(
       chooseSource(
         info({
-          facts: { container: "mp4", videoCodec: "hevc", audioCodec: "aac", source: "probe" as const },
+          facts: { container: "mp4", videoCodec: "hevc", audioCodec: "aac", source: "probe" as const, subtitles: [] },
           blockers: ["video"],
         }),
         "Tin.Rivers.2024.2160p.mp4",

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -155,6 +155,7 @@ describe("chooseSource", () => {
     facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" as const, subtitles: [] },
     blockers: [],
     hls: null,
+    subtitles: { embedded: [], files: [] },
     ...over,
   });
 
@@ -337,7 +338,7 @@ describe("fallbackMessage", () => {
    * and one they can only accept.
    */
   it("names the codec the server actually found", () => {
-    const facts = { container: "mkv", videoCodec: "hevc", audioCodec: "dts", source: "probe" as const };
+    const facts = { container: "mkv", videoCodec: "hevc", audioCodec: "dts", source: "probe" as const, subtitles: [] };
     expect(fallbackMessage("video-codec", "a.mkv", facts)).toContain("HEVC");
     expect(fallbackMessage("video-codec", "a.mkv", facts)).not.toContain("or AV1");
     expect(fallbackMessage("audio-codec", "a.mkv", facts)).toContain("DTS");
@@ -351,12 +352,12 @@ describe("fallbackMessage", () => {
    * so the card must not state it as fact the way a probe result is stated.
    */
   it("hedges a codec that was only inferred from the release name", () => {
-    const guessed = { container: "mkv", videoCodec: "hevc", audioCodec: "", source: "name" as const };
+    const guessed = { container: "mkv", videoCodec: "hevc", audioCodec: "", source: "name" as const, subtitles: [] };
     expect(fallbackMessage("video-codec", "a.mkv", guessed)).toContain("looks like");
   });
 
   it("falls back to the old prose when the server told us nothing", () => {
-    const unknown = { container: "", videoCodec: "", audioCodec: "", source: "name" as const };
+    const unknown = { container: "", videoCodec: "", audioCodec: "", source: "name" as const, subtitles: [] };
     expect(fallbackMessage("video-codec", "a.mkv", unknown)).toContain("HEVC or AV1");
     expect(fallbackMessage("video-codec", "a.mkv")).toContain("HEVC or AV1");
   });

--- a/src/web/static/playerModel.ts
+++ b/src/web/static/playerModel.ts
@@ -138,6 +138,12 @@ export function filesPath(target: PlayerTarget): string {
   return repPath(target, ".files");
 }
 
+/** The `.vtt` path for a sibling subtitle in the same session. */
+export function subtitlePath(target: PlayerTarget, index: number): string {
+  const base = `/stream/${encodeURIComponent(target.sid)}/${index}.vtt`;
+  return target.capability ? `${base}?k=${encodeURIComponent(target.capability)}` : base;
+}
+
 /**
  * Where the bytes for this file should come from.
  *

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1371,6 +1371,14 @@ select:focus-visible {
   overflow-wrap: anywhere;
 }
 
+/* The embedded-subtitle line under a fallback card. Dimmer than the
+   explanation above it: it is a useful aside, not the reason for the card. */
+.fallback-subs {
+  margin: 0.6rem 0 0;
+  color: var(--dim);
+  font-size: 0.85rem;
+}
+
 /* The two ways out. Links rather than buttons, and below the explanation rather
    than beside the .m3u controls: those hand this file to another application,
    these are about not being on this screen again. Keeping them visually

--- a/src/web/static/subtitleModel.test.ts
+++ b/src/web/static/subtitleModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createTrackFailureTracker,
   embeddedNotice,
+  subtitleDownload,
   subtitleErrorNotice,
   subtitleTracks,
   type TrackSpec,
@@ -102,6 +103,67 @@ describe("subtitleTracks", () => {
       { ...target, capability: "a b&c" },
     );
     expect(tracks[0]?.src).toBe("/stream/abc/1.vtt?k=a%20b%26c");
+  });
+});
+
+describe("subtitleDownload", () => {
+  // Exists because the .m3u no longer carries an input-slave line (VLC 3
+  // refuses it as an unsafe option) — this is what a VLC user gets instead: a
+  // link they can save and open by hand.
+  it("points at the preferred renderable subtitle's .vtt handle", () => {
+    const download = subtitleDownload(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(download).toEqual({ label: "Download subtitle", href: "/stream/abc/1.vtt?k=cap" });
+  });
+
+  it("prefers the English file among several matches", () => {
+    const download = subtitleDownload(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "a.spa.srt", language: "es", label: "Spanish", renderable: true },
+            { index: 2, filename: "a.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(download?.href).toBe("/stream/abc/2.vtt?k=cap");
+  });
+
+  it("ignores a non-renderable match", () => {
+    // Same rule as subtitleTracks: an .ass/.ssa source run through the .vtt
+    // route produces bytes valid as neither format, so it must not be offered.
+    const download = subtitleDownload(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.ass", language: "en", label: "English", renderable: false },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(download).toBeNull();
+  });
+
+  it("returns null when nothing matched", () => {
+    expect(subtitleDownload(info({}), target)).toBeNull();
+  });
+
+  it("returns null for a null info", () => {
+    expect(subtitleDownload(null, target)).toBeNull();
   });
 });
 

--- a/src/web/static/subtitleModel.test.ts
+++ b/src/web/static/subtitleModel.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { embeddedNotice, subtitleTracks } from "./subtitleModel";
+import type { PlayerTarget } from "./playerModel";
+import type { StreamInfoResponse } from "../wire";
+
+const target: PlayerTarget = { sid: "abc", index: 0, capability: "cap", filename: "Kepler.S02E04.mkv" };
+
+const info = (over: Partial<StreamInfoResponse>): StreamInfoResponse => ({
+  facts: { container: "mkv", videoCodec: "h264", audioCodec: "aac", source: "probe", subtitles: [] },
+  blockers: [],
+  hls: null,
+  subtitles: { embedded: [], files: [] },
+  ...over,
+});
+
+describe("subtitleTracks", () => {
+  it("builds a track per renderable sibling file", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks).toEqual([
+      { src: "/stream/abc/1.vtt?k=cap", srclang: "en", label: "English", default: true },
+    ]);
+  });
+
+  it("omits files the browser cannot render", () => {
+    // ass/ssa/sub need a subtitle engine. Offering a <track> that shows nothing
+    // is worse than offering none: the menu says the subtitle is on.
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "Kepler.S02E04.eng.ass", language: "en", label: "English", renderable: false },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks).toEqual([]);
+  });
+
+  it("defaults the first English track, not the first track", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "a.spa.srt", language: "es", label: "Spanish", renderable: true },
+            { index: 2, filename: "a.eng.srt", language: "en", label: "English", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks.map((t) => t.default)).toEqual([false, true]);
+  });
+
+  it("defaults nothing when no track is English", () => {
+    // Turning on a language the user does not read is worse than turning on
+    // nothing; the menu is one click away either way.
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [
+            { index: 1, filename: "a.spa.srt", language: "es", label: "Spanish", renderable: true },
+          ],
+        },
+      }),
+      target,
+    );
+    expect(tracks.map((t) => t.default)).toEqual([false]);
+  });
+
+  it("returns nothing for a null info", () => {
+    expect(subtitleTracks(null, target)).toEqual([]);
+  });
+
+  it("encodes the capability into every src", () => {
+    const tracks = subtitleTracks(
+      info({
+        subtitles: {
+          embedded: [],
+          files: [{ index: 1, filename: "a.srt", language: "", label: "a", renderable: true }],
+        },
+      }),
+      { ...target, capability: "a b&c" },
+    );
+    expect(tracks[0]?.src).toBe("/stream/abc/1.vtt?k=a%20b%26c");
+  });
+});
+
+describe("embeddedNotice", () => {
+  it("names the languages muxed into the file", () => {
+    // The line that turns the reported dead end into information: three tracks
+    // were inside the file and nothing on screen said so.
+    const notice = embeddedNotice(
+      info({
+        subtitles: {
+          embedded: [
+            { language: "spa", label: "" },
+            { language: "eng", label: "" },
+            { language: "por", label: "" },
+          ],
+          files: [],
+        },
+      }),
+    );
+    expect(notice).toBe(
+      "Subtitles in this file: Spanish, English, Portuguese — pick one in your player.",
+    );
+  });
+
+  it("counts untagged tracks rather than naming them", () => {
+    const notice = embeddedNotice(
+      info({ subtitles: { embedded: [{ language: "", label: "" }], files: [] } }),
+    );
+    expect(notice).toBe("This file has 1 subtitle track — pick it in your player.");
+  });
+
+  it("pluralises a count of untagged tracks", () => {
+    const notice = embeddedNotice(
+      info({
+        subtitles: {
+          embedded: [
+            { language: "", label: "" },
+            { language: "", label: "" },
+          ],
+          files: [],
+        },
+      }),
+    );
+    expect(notice).toContain("2 subtitle tracks");
+  });
+
+  it("says nothing when there are no embedded tracks", () => {
+    expect(embeddedNotice(info({}))).toBe("");
+  });
+
+  it("says nothing for a null info", () => {
+    expect(embeddedNotice(null)).toBe("");
+  });
+});

--- a/src/web/static/subtitleModel.test.ts
+++ b/src/web/static/subtitleModel.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { embeddedNotice, subtitleTracks } from "./subtitleModel";
+import {
+  createTrackFailureTracker,
+  embeddedNotice,
+  subtitleErrorNotice,
+  subtitleTracks,
+  type TrackSpec,
+} from "./subtitleModel";
 import type { PlayerTarget } from "./playerModel";
 import type { StreamInfoResponse } from "../wire";
 
@@ -96,6 +102,62 @@ describe("subtitleTracks", () => {
       { ...target, capability: "a b&c" },
     );
     expect(tracks[0]?.src).toBe("/stream/abc/1.vtt?k=a%20b%26c");
+  });
+});
+
+describe("subtitleErrorNotice", () => {
+  it("names the language that failed", () => {
+    const spec: TrackSpec = { src: "/stream/abc/1.vtt?k=cap", srclang: "en", label: "English", default: true };
+    expect(subtitleErrorNotice(spec)).toBe(
+      "English subtitles couldn't load — try another language or turn them off.",
+    );
+  });
+
+  it("falls back to a generic word when the label is empty", () => {
+    const spec: TrackSpec = { src: "/stream/abc/1.vtt?k=cap", srclang: "", label: "", default: false };
+    expect(subtitleErrorNotice(spec)).toBe(
+      "Subtitles subtitles couldn't load — try another language or turn them off.",
+    );
+  });
+});
+
+describe("createTrackFailureTracker", () => {
+  // A torrent can carry nine or ten subtitle files. If every one of them
+  // failed, a straight one-notice-per-error wiring would produce nine or ten
+  // toasts — which is its own way of drowning the user in noise instead of
+  // silence. The tracker is what keeps that from reaching player.ts.
+  const spec = (src: string, label: string): TrackSpec => ({ src, srclang: "en", label, default: false });
+
+  it("reports the first failure of a track", () => {
+    const tracker = createTrackFailureTracker();
+    expect(tracker.report(spec("/stream/abc/1.vtt", "English"))).toBe(
+      "English subtitles couldn't load — try another language or turn them off.",
+    );
+  });
+
+  it("does not repeat a notice for the same track failing again", () => {
+    // A retried fetch, or more than one `error` event for one selection, is
+    // not new information — the user already has the answer.
+    const tracker = createTrackFailureTracker();
+    tracker.report(spec("/stream/abc/1.vtt", "English"));
+    expect(tracker.report(spec("/stream/abc/1.vtt", "English"))).toBeNull();
+  });
+
+  it("still reports a different track failing", () => {
+    // The user trying a second language after the first failed is a new
+    // action with a new answer, not spam.
+    const tracker = createTrackFailureTracker();
+    tracker.report(spec("/stream/abc/1.vtt", "English"));
+    expect(tracker.report(spec("/stream/abc/2.vtt", "Spanish"))).toBe(
+      "Spanish subtitles couldn't load — try another language or turn them off.",
+    );
+  });
+
+  it("does not report a track that never failed", () => {
+    const tracker = createTrackFailureTracker();
+    expect(tracker.report(spec("/stream/abc/1.vtt", "English"))).not.toBeNull();
+    // sanity: a fresh tracker starts with nothing reported
+    expect(createTrackFailureTracker().report(spec("/stream/abc/1.vtt", "English"))).not.toBeNull();
   });
 });
 

--- a/src/web/static/subtitleModel.test.ts
+++ b/src/web/static/subtitleModel.test.ts
@@ -175,10 +175,10 @@ describe("subtitleErrorNotice", () => {
     );
   });
 
-  it("falls back to a generic word when the label is empty", () => {
+  it("reads naturally when the label is empty, rather than stuttering", () => {
     const spec: TrackSpec = { src: "/stream/abc/1.vtt?k=cap", srclang: "", label: "", default: false };
     expect(subtitleErrorNotice(spec)).toBe(
-      "Subtitles subtitles couldn't load — try another language or turn them off.",
+      "Subtitles couldn't load — try another language or turn them off.",
     );
   });
 });

--- a/src/web/static/subtitleModel.ts
+++ b/src/web/static/subtitleModel.ts
@@ -51,6 +51,52 @@ export function subtitleTracks(
  * render them — that would mean extracting with ffmpeg — but it can say they
  * are there, which is the difference between a dead end and an instruction.
  */
+/**
+ * What to say when a `<track>` the page offered fails to load — the sibling
+ * `.vtt` route answered 502, or the session was reaped between the menu being
+ * built and the user picking a language from it.
+ *
+ * Names the language rather than staying generic, because the whole point is
+ * to replace "I turned subtitles on and nothing happened" with an answer to
+ * *why*: the file itself, not the browser, is what's missing.
+ */
+export function subtitleErrorNotice(spec: TrackSpec): string {
+  const language = spec.label || "Subtitles";
+  return `${language} subtitles couldn't load — try another language or turn them off.`;
+}
+
+/**
+ * Decides which `<track>` load failures are worth a notice, so a file with
+ * nine or ten sibling subtitle files doesn't turn one bad session into a wall
+ * of the same message.
+ *
+ * A `<track>` is not fetched at all until it is enabled — the browser does not
+ * probe every menu entry up front — so an `error` event almost always means
+ * the user just selected that language and it failed *right now*. That is
+ * worth reporting: it is the one thing on screen they were waiting on.
+ *
+ * What it is not worth repeating is the SAME track failing twice (a retry, or
+ * more than one `error` event for one selection): once told, telling again
+ * adds nothing. Each report is remembered by `src`, which is unique per track,
+ * so switching to a different language after a failure still gets its own
+ * notice — that failure is new information — while re-selecting the one that
+ * already failed does not nag a second time.
+ */
+export interface TrackFailureTracker {
+  report(spec: TrackSpec): string | null;
+}
+
+export function createTrackFailureTracker(): TrackFailureTracker {
+  const reported = new Set<string>();
+  return {
+    report(spec: TrackSpec): string | null {
+      if (reported.has(spec.src)) return null;
+      reported.add(spec.src);
+      return subtitleErrorNotice(spec);
+    },
+  };
+}
+
 export function embeddedNotice(info: StreamInfoResponse | null): string {
   const tracks = info?.subtitles.embedded ?? [];
   if (tracks.length === 0) return "";

--- a/src/web/static/subtitleModel.ts
+++ b/src/web/static/subtitleModel.ts
@@ -42,16 +42,6 @@ export function subtitleTracks(
 }
 
 /**
- * One line naming the subtitle tracks muxed inside this file, for the fallback
- * card.
- *
- * This exists because of a real report: a season pack whose episodes each
- * carried three subtitle tracks played fine in VLC with the subtitles right
- * there in its menu, and nothing in torlink ever said so. The browser cannot
- * render them — that would mean extracting with ffmpeg — but it can say they
- * are there, which is the difference between a dead end and an instruction.
- */
-/**
  * What to say when a `<track>` the page offered fails to load — the sibling
  * `.vtt` route answered 502, or the session was reaped between the menu being
  * built and the user picking a language from it.
@@ -61,8 +51,8 @@ export function subtitleTracks(
  * *why*: the file itself, not the browser, is what's missing.
  */
 export function subtitleErrorNotice(spec: TrackSpec): string {
-  const language = spec.label || "Subtitles";
-  return `${language} subtitles couldn't load — try another language or turn them off.`;
+  if (!spec.label) return "Subtitles couldn't load — try another language or turn them off.";
+  return `${spec.label} subtitles couldn't load — try another language or turn them off.`;
 }
 
 /**
@@ -131,6 +121,16 @@ export function subtitleDownload(
   return { label: "Download subtitle", href: subtitlePath(target, preferred.index) };
 }
 
+/**
+ * One line naming the subtitle tracks muxed inside this file, for the fallback
+ * card.
+ *
+ * This exists because of a real report: a season pack whose episodes each
+ * carried three subtitle tracks played fine in VLC with the subtitles right
+ * there in its menu, and nothing in torlink ever said so. The browser cannot
+ * render them — that would mean extracting with ffmpeg — but it can say they
+ * are there, which is the difference between a dead end and an instruction.
+ */
 export function embeddedNotice(info: StreamInfoResponse | null): string {
   const tracks = info?.subtitles.embedded ?? [];
   if (tracks.length === 0) return "";

--- a/src/web/static/subtitleModel.ts
+++ b/src/web/static/subtitleModel.ts
@@ -1,0 +1,90 @@
+// What subtitles the player page should offer, and what it should say about the
+// ones it cannot offer.
+//
+// Pure and tested, because nothing in player.ts is reachable by a unit test and
+// these are decisions about WHAT TO SHOW — exactly the kind of conditional
+// CLAUDE.md keeps out of the wiring file.
+import { subtitlePath, type PlayerTarget } from "./playerModel";
+import type { StreamInfoResponse } from "../wire";
+
+/** One `<track>` the page should build. */
+export interface TrackSpec {
+  src: string;
+  srclang: string;
+  label: string;
+  default: boolean;
+}
+
+/**
+ * The `<track>` elements for this file.
+ *
+ * Only renderable siblings (srt/vtt, converted server-side). An ass/ssa track
+ * would appear in the browser's menu and then show nothing, which is worse than
+ * being absent — the user would think subtitles were on.
+ *
+ * The first English track is `default`; when nothing is English, nothing is,
+ * because switching a viewer into a language they may not read is worse than
+ * leaving the menu one click away.
+ */
+export function subtitleTracks(
+  info: StreamInfoResponse | null,
+  target: PlayerTarget,
+): TrackSpec[] {
+  const files = (info?.subtitles.files ?? []).filter((f) => f.renderable);
+  const firstEnglish = files.find((f) => f.language === "en");
+  return files.map((f) => ({
+    src: subtitlePath(target, f.index),
+    srclang: f.language,
+    label: f.label,
+    default: f === firstEnglish,
+  }));
+}
+
+// ffprobe's tags are ISO 639-2; the page wants words. Only the languages worth
+// naming — anything else falls through to the count form below.
+const LANGUAGE_NAMES: Record<string, string> = {
+  eng: "English",
+  spa: "Spanish",
+  por: "Portuguese",
+  fre: "French",
+  fra: "French",
+  ger: "German",
+  deu: "German",
+  ita: "Italian",
+  dut: "Dutch",
+  nld: "Dutch",
+  pol: "Polish",
+  rus: "Russian",
+  jpn: "Japanese",
+  kor: "Korean",
+  chi: "Chinese",
+  zho: "Chinese",
+  ara: "Arabic",
+  swe: "Swedish",
+  dan: "Danish",
+  nor: "Norwegian",
+  fin: "Finnish",
+  tur: "Turkish",
+};
+
+/**
+ * One line naming the subtitle tracks muxed inside this file, for the fallback
+ * card.
+ *
+ * This exists because of a real report: a season pack whose episodes each
+ * carried three subtitle tracks played fine in VLC with the subtitles right
+ * there in its menu, and nothing in torlink ever said so. The browser cannot
+ * render them — that would mean extracting with ffmpeg — but it can say they
+ * are there, which is the difference between a dead end and an instruction.
+ */
+export function embeddedNotice(info: StreamInfoResponse | null): string {
+  const tracks = info?.subtitles.embedded ?? [];
+  if (tracks.length === 0) return "";
+  const named = tracks.map((t) => LANGUAGE_NAMES[t.language.toLowerCase()]).filter(Boolean);
+  if (named.length === tracks.length) {
+    return `Subtitles in this file: ${named.join(", ")} — pick one in your player.`;
+  }
+  const plural = tracks.length === 1 ? "track" : "tracks";
+  const pronoun = tracks.length === 1 ? "it" : "one";
+  return `This file has ${tracks.length} subtitle ${plural} — pick ${pronoun} in your player.`;
+}

--- a/src/web/static/subtitleModel.ts
+++ b/src/web/static/subtitleModel.ts
@@ -6,7 +6,7 @@
 // CLAUDE.md keeps out of the wiring file.
 import { subtitlePath, type PlayerTarget } from "./playerModel";
 import type { StreamInfoResponse } from "../wire";
-import { LANGUAGE_NAMES } from "../../util/subtitleFiles";
+import { LANGUAGE_NAMES, preferredSubtitle } from "../../util/subtitleFiles";
 
 /** One `<track>` the page should build. */
 export interface TrackSpec {
@@ -95,6 +95,40 @@ export function createTrackFailureTracker(): TrackFailureTracker {
       return subtitleErrorNotice(spec);
     },
   };
+}
+
+/** A "Download subtitle" link for the player page's action row, or none. */
+export interface SubtitleDownload {
+  label: string;
+  href: string;
+}
+
+/**
+ * The preferred renderable subtitle's `.vtt` URL, as a download link — or
+ * `null` when nothing matched.
+ *
+ * This exists because the `.m3u` no longer carries an `#EXTVLCOPT:input-slave`
+ * line: measured against a real VLC 3.0.11, that line is refused outright
+ * ("unsafe option \"input-slave\" has been ignored for security reasons"), so
+ * it never side-loaded anything. mpv and IINA still get the subtitle
+ * side-loaded via `subtitleArgs` (src/util/subtitleFlags.ts) when torlink
+ * itself launches the player, but VLC users who download the playlist and
+ * open it themselves get nothing that way — this link is what closes that
+ * gap: they can save the file and open it in VLC by hand.
+ *
+ * Only renderable siblings, same rule as `subtitleTracks`: an .ass/.ssa
+ * source would download as bytes that are valid WebVTT syntactically but
+ * carry none of the original styling, and offering it under "Download
+ * subtitle" implies it is the real file, which it is not.
+ */
+export function subtitleDownload(
+  info: StreamInfoResponse | null,
+  target: PlayerTarget,
+): SubtitleDownload | null {
+  const files = (info?.subtitles.files ?? []).filter((f) => f.renderable);
+  const preferred = preferredSubtitle(files);
+  if (!preferred) return null;
+  return { label: "Download subtitle", href: subtitlePath(target, preferred.index) };
 }
 
 export function embeddedNotice(info: StreamInfoResponse | null): string {

--- a/src/web/static/subtitleModel.ts
+++ b/src/web/static/subtitleModel.ts
@@ -6,6 +6,7 @@
 // CLAUDE.md keeps out of the wiring file.
 import { subtitlePath, type PlayerTarget } from "./playerModel";
 import type { StreamInfoResponse } from "../wire";
+import { LANGUAGE_NAMES } from "../../util/subtitleFiles";
 
 /** One `<track>` the page should build. */
 export interface TrackSpec {
@@ -39,33 +40,6 @@ export function subtitleTracks(
     default: f === firstEnglish,
   }));
 }
-
-// ffprobe's tags are ISO 639-2; the page wants words. Only the languages worth
-// naming — anything else falls through to the count form below.
-const LANGUAGE_NAMES: Record<string, string> = {
-  eng: "English",
-  spa: "Spanish",
-  por: "Portuguese",
-  fre: "French",
-  fra: "French",
-  ger: "German",
-  deu: "German",
-  ita: "Italian",
-  dut: "Dutch",
-  nld: "Dutch",
-  pol: "Polish",
-  rus: "Russian",
-  jpn: "Japanese",
-  kor: "Korean",
-  chi: "Chinese",
-  zho: "Chinese",
-  ara: "Arabic",
-  swe: "Swedish",
-  dan: "Danish",
-  nor: "Norwegian",
-  fin: "Finnish",
-  tur: "Turkish",
-};
 
 /**
  * One line naming the subtitle tracks muxed inside this file, for the fallback

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1982,59 +1982,66 @@ describe("the .m3u with a matched subtitle", () => {
   // did anything. So a matched subtitle changes nothing about the playlist
   // body; all these cases are byte-identical to the no-match case.
 
-  it("is byte-identical to the single-URL form even when a subtitle matches", async () => {
+  /**
+   * The playlist for one video, with whatever extra files are alongside it.
+   *
+   * Asserted DIFFERENTIALLY — "same as the playlist without the subtitle" —
+   * rather than against a hardcoded body. The exact bytes are the playlist
+   * route's business and have already changed once (a bare URL became an
+   * `#EXTM3U` with an `#EXTINF` title); pinning them here made these tests fail
+   * for a reason that had nothing to do with subtitles. What this describe block
+   * is actually for is narrower and does not change: a matched subtitle must not
+   * alter the playlist at all.
+   */
+  const playlistFor = async (extra: { filename: string; url: string; bytes: number }[]) => {
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+      ...extra,
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    // The session id is random per call, so normalise it out before comparing
+    // two playlists — otherwise every comparison fails on the id alone.
+    return res.body.split(sid).join("<sid>").split(cap).join("<cap>");
+  };
+
+  it("is unchanged when a renderable subtitle matches", async () => {
+    const withSub = await playlistFor([
       { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
     ]);
-    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+    expect(withSub).toBe(await playlistFor([]));
   });
 
-  it("is byte-identical to the old single-URL form when nothing matches", async () => {
-    // Fail-soft, and the reason this is asserted on the exact bytes: every
-    // player in the world already parses today's playlist, and a feature that
-    // has nothing to add must add nothing.
-    const { deps, sid, cap } = await readySession([
-      { filename: "Harrowgate.S03.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+  it("is unchanged when only a non-renderable subtitle matches", async () => {
+    const withAss = await playlistFor([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.ass", url: "http://up.test/s", bytes: 40 },
     ]);
-    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+    expect(withAss).toBe(await playlistFor([]));
   });
 
-  it("puts no torrent-supplied text in the playlist body", async () => {
-    // The constraint the one-bare-URL form exists to guarantee. The URL is
-    // built from streamHandle and the capability, so a filename with a
-    // newline or a quote in it cannot reach a file another application parses.
+  it("is unchanged when both a renderable and a non-renderable subtitle match", async () => {
+    const withBoth = await playlistFor([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.ass", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    expect(withBoth).toBe(await playlistFor([]));
+  });
+
+  it("puts no SUBTITLE-supplied text in the playlist body", async () => {
+    // The video's own name does reach the body, as a `#EXTINF` title that
+    // `playlistTitle` has stripped of CR, LF and control characters — that is
+    // the playlist route's own guarantee and it has its own tests. This one is
+    // about the subtitle: a matched subtitle contributes nothing to the body,
+    // so a crafted subtitle filename cannot add a line to a file another
+    // application parses however it is written.
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
       { filename: 'Kepler.S02E04\n#EXTVLCOPT:evil="x".eng.srt', url: "http://up.test/s", bytes: 40 },
     ]);
     const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
     expect(res.body).not.toContain("evil");
-    expect(res.body.split("\n").filter(Boolean)).toHaveLength(1);
-  });
-
-  it("is byte-identical when only a non-renderable subtitle matches", async () => {
-    // An .ass-only match used to still be treated as "no usable subtitle" by
-    // the input-slave logic; now there is no logic left to have an opinion —
-    // the body is the same either way.
-    const { deps, sid, cap } = await readySession([
-      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
-      { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s", bytes: 40 },
-    ]);
-    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
-  });
-
-  it("is byte-identical when both a renderable and non-renderable subtitle match", async () => {
-    const { deps, sid, cap } = await readySession([
-      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
-      { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s1", bytes: 40 },
-      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
-    ]);
-    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+    expect(res.body).not.toContain("EXTVLCOPT");
+    // #EXTM3U, one #EXTINF, one URL — the subtitle added no fourth line.
+    expect(res.body.split("\n").filter(Boolean)).toHaveLength(3);
   });
 });
 

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -8,6 +8,7 @@ import { startWebServer, type WebServerHandle } from "./server";
 import {
   isPlayPath,
   isStreamPath,
+  MAX_SUBTITLE_BYTES,
   parsePlayPath,
   parseStreamPath,
   playlistFilename,
@@ -19,6 +20,7 @@ import { StreamSessionRegistry, type StreamSessionDeps } from "../core/streamSes
 import type { TorrentStreamSession } from "../integrations/torrentStream";
 import type { StreamFile } from "../util/player";
 import type { Runtime } from "../daemon/runtime";
+import type { MediaFacts } from "../util/playability";
 
 /**
  * The URL lines of a playlist body — everything that is not a directive.
@@ -1702,6 +1704,206 @@ describe("GET /stream/:sid/:idx.m3u", () => {
     const all = logs.join("\n");
     expect(all).toContain(`GET /stream/${id}/0.m3u -> 200`);
     expect(all).not.toContain(capability);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The .vtt subtitle representation, the .m3u input-slave line, and the .info
+// subtitle report.
+//
+// `readySession`/`request` are local adaptations of the shape the design brief
+// sketched, built on the helpers this file already has (`torrentSession`,
+// `registry`, `start`, `rawGet`): a real `StreamSessionRegistry` and a real
+// `http.Server`, with `fetchSubtitle` and `probeImpl` injected as `StreamDeps`
+// so no network call is ever made for a placeholder `http://up.test/...` URL.
+//
+// `fetchSubtitle`'s fake reproduces the real default's received-bytes
+// contract — returning null once the body would exceed `MAX_SUBTITLE_BYTES` —
+// rather than exercising the real `node:http` path, which is covered by the
+// WebTorrent-proxy tests' pattern already; there is no upstream server for
+// `up.test` to be a real endpoint here.
+async function readySession(
+  files: StreamFile[],
+  opts: { body?: string; fail?: boolean; probe?: MediaFacts } = {},
+): Promise<{ deps: string; sid: string; cap: string }> {
+  const streamDeps: NonNullable<Parameters<typeof startWebServer>[1]>["streamDeps"] = {
+    fetchSubtitle: async () => {
+      if (opts.fail) return null;
+      if (opts.body === undefined) return null;
+      const bytes = new TextEncoder().encode(opts.body);
+      if (bytes.length > MAX_SUBTITLE_BYTES) return null;
+      return bytes;
+    },
+    // Never null → skip probing an unreachable host: without this, a `.info`
+    // request with no `probe` override would fall through to the real
+    // `probeUrl`, which would try to actually reach `up.test`.
+    probeImpl: async () => opts.probe ?? null,
+  };
+  const { reg, id, capability } = await torrentSession(files, "cap-vtt", "sid-vtt");
+  // Tokened so a non-loopback Host (used by the .m3u host tests) is accepted.
+  const base = await start(reg, { streamDeps, token: "server-token" });
+  return { deps: base, sid: id, cap: capability };
+}
+
+function request(
+  deps: string,
+  path: string,
+  opts: { host?: string } = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  const port = Number(new URL(deps).port);
+  return rawGet(port, path, opts.host ? { Host: opts.host } : {});
+}
+
+describe("the .vtt representation", () => {
+  it("serves a matched subtitle as WebVTT", async () => {
+    const { deps, sid, cap } = await readySession(
+      [
+        { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+        { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
+      ],
+      { body: "1\n00:00:01,000 --> 00:00:02,000\nHello\n" },
+    );
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/vtt; charset=utf-8");
+    expect(res.body).toMatch(/^WEBVTT/);
+    expect(res.body).toContain("00:00:01.000 --> 00:00:02.000");
+  });
+
+  it("refuses an index that is not a subtitle file", async () => {
+    // THE GUARD THIS ROUTE NEEDS MOST. Without it, .vtt is a general-purpose
+    // "pull this whole file into memory and call it text" route aimed at a
+    // 12 GB video.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 9e9 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.vtt?k=${cap}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("requires the capability, like every other representation", async () => {
+    const { deps, sid } = await readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/1.vtt`);
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses a subtitle larger than the cap", async () => {
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 9e8 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(413);
+  });
+
+  it("stops reading a body that exceeds the cap even when file.bytes lied", async () => {
+    // file.bytes is what upstream CLAIMED. This is what it actually sent.
+    const { deps, sid, cap } = await readySession(
+      [
+        { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+        { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+      ],
+      { body: "x".repeat(MAX_SUBTITLE_BYTES + 1) },
+    );
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(502);
+  });
+
+  it("answers 502 when the upstream subtitle fetch fails", async () => {
+    const { deps, sid, cap } = await readySession(
+      [
+        { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },
+        { filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt", url: "http://up.test/s", bytes: 40 },
+      ],
+      { fail: true },
+    );
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("the .m3u with a matched subtitle", () => {
+  it("adds an input-slave line pointing at the .vtt handle", async () => {
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toBe(
+      `#EXTM3U\n` +
+        `#EXTVLCOPT:input-slave=http://box.test:9161/stream/${sid}/1.vtt?k=${cap}\n` +
+        `http://box.test:9161/stream/${sid}/0?k=${cap}\n`,
+    );
+  });
+
+  it("is byte-identical to the old single-URL form when nothing matches", async () => {
+    // Fail-soft, and the reason this is asserted on the exact bytes: every
+    // player in the world already parses today's playlist, and a feature that
+    // has nothing to add must add nothing.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Harrowgate.S03.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+  });
+
+  it("puts no torrent-supplied text in the playlist body", async () => {
+    // The constraint the original one-bare-URL form existed to guarantee. Both
+    // URLs are built from streamHandle and the capability, so a filename with a
+    // newline or a quote in it cannot reach a file another application parses.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: 'Kepler.S02E04\n#EXTVLCOPT:evil="x".eng.srt', url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).not.toContain("evil");
+    expect(res.body.split("\n").filter(Boolean)).toHaveLength(3);
+  });
+
+  it("prefers the English subtitle for the input-slave", async () => {
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.spa.srt", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
+  });
+});
+
+describe("the .info subtitle report", () => {
+  it("lists matched sibling files with language and renderability", async () => {
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.spa.ass", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.info?k=${cap}`);
+    const body = JSON.parse(res.body);
+    expect(body.subtitles.files).toEqual([
+      { index: 1, filename: "Kepler.S02E04.eng.srt", language: "en", label: "English", renderable: true },
+      { index: 2, filename: "Kepler.S02E04.spa.ass", language: "es", label: "Spanish", renderable: false },
+    ]);
+  });
+
+  it("reports embedded tracks from the probe", async () => {
+    const { deps, sid, cap } = await readySession(
+      [{ filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 }],
+      {
+        probe: {
+          container: "mkv",
+          videoCodec: "hevc",
+          audioCodec: "eac3",
+          source: "probe",
+          subtitles: [{ language: "eng", label: "" }],
+        },
+      },
+    );
+    const res = await request(deps, `/stream/${sid}/0.info?k=${cap}`);
+    expect(JSON.parse(res.body).subtitles.embedded).toEqual([{ language: "eng", label: "" }]);
   });
 });
 

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1781,6 +1781,20 @@ describe("the .vtt representation", () => {
     expect(res.status).toBe(404);
   });
 
+  it("refuses an .ass sibling too, even though it is a subtitle file", async () => {
+    // The route's OWN guard, not just its two callers'. `isSubtitleFilename`
+    // would accept this and hand back "WEBVTT" glued to raw ASS markup — valid
+    // as neither format. The two callers (the .m3u's `renderable` filter and
+    // `subtitleTracks`) already keep this from being reached today; this test
+    // pins the route itself so that stays true if a future caller forgets.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.1080p.WEB-DL.eng.ass", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.status).toBe(404);
+  });
+
   it("requires the capability, like every other representation", async () => {
     const { deps, sid } = await readySession([
       { filename: "Kestrel.2010.1080p.BluRay.x264.mkv", url: "http://up.test/v", bytes: 900 },

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -989,6 +989,7 @@ describe("GET /stream/:sid/:idx.info", () => {
           videoCodec: "hevc",
           audioCodec: "dts",
           source: "probe" as const,
+          subtitles: [],
         }),
       },
     });
@@ -1005,7 +1006,13 @@ describe("GET /stream/:sid/:idx.info", () => {
       streamDeps: {
         probeImpl: async () => {
           probes += 1;
-          return { container: "mkv", videoCodec: "h264", audioCodec: "aac", source: "probe" as const };
+          return {
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            source: "probe" as const,
+            subtitles: [],
+          };
         },
       },
     });

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1718,8 +1718,9 @@ describe("GET /stream/:sid/:idx.m3u", () => {
 });
 
 // ---------------------------------------------------------------------------
-// The .vtt subtitle representation, the .m3u input-slave line, and the .info
-// subtitle report.
+// The .vtt subtitle representation, the .m3u playlist (which no longer gains
+// an input-slave line for a matched subtitle — see the describe block below),
+// and the .info subtitle report.
 //
 // `readySession`/`request` are local adaptations of the shape the design brief
 // sketched, built on the helpers this file already has (`torrentSession`,
@@ -1974,17 +1975,20 @@ describe("the .vtt representation", () => {
 });
 
 describe("the .m3u with a matched subtitle", () => {
-  it("adds an input-slave line pointing at the .vtt handle", async () => {
+  // There is no input-slave (or any other) line added here any more. Measured
+  // against a real VLC 3.0.11: `#EXTVLCOPT:input-slave=<url>` is on VLC's
+  // unsafe-option list and is refused inside a `.m3u` ("unsafe option
+  // \"input-slave\" has been ignored for security reasons") — the line never
+  // did anything. So a matched subtitle changes nothing about the playlist
+  // body; all these cases are byte-identical to the no-match case.
+
+  it("is byte-identical to the single-URL form even when a subtitle matches", async () => {
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
       { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
     ]);
     const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toBe(
-      `#EXTM3U\n` +
-        `#EXTVLCOPT:input-slave=http://box.test:9161/stream/${sid}/1.vtt?k=${cap}\n` +
-        `http://box.test:9161/stream/${sid}/0?k=${cap}\n`,
-    );
+    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
   });
 
   it("is byte-identical to the old single-URL form when nothing matches", async () => {
@@ -1999,8 +2003,8 @@ describe("the .m3u with a matched subtitle", () => {
   });
 
   it("puts no torrent-supplied text in the playlist body", async () => {
-    // The constraint the original one-bare-URL form existed to guarantee. Both
-    // URLs are built from streamHandle and the capability, so a filename with a
+    // The constraint the one-bare-URL form exists to guarantee. The URL is
+    // built from streamHandle and the capability, so a filename with a
     // newline or a quote in it cannot reach a file another application parses.
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
@@ -2008,25 +2012,13 @@ describe("the .m3u with a matched subtitle", () => {
     ]);
     const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
     expect(res.body).not.toContain("evil");
-    expect(res.body.split("\n").filter(Boolean)).toHaveLength(3);
+    expect(res.body.split("\n").filter(Boolean)).toHaveLength(1);
   });
 
-  it("prefers the English subtitle for the input-slave", async () => {
-    const { deps, sid, cap } = await readySession([
-      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
-      { filename: "Kepler.S02E04.spa.srt", url: "http://up.test/s1", bytes: 40 },
-      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
-    ]);
-    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
-  });
-
-  it("does not offer a non-renderable subtitle as the input-slave", async () => {
-    // The .vtt route always runs its source through srtToVtt, whatever the
-    // real format was. An .ass sibling run through that converter produces
-    // bytes that are valid neither as WebVTT nor as ASS, so VLC would get a
-    // subtitle file it can't use and silently show nothing. An .ass-only match
-    // must therefore behave exactly like no match: the plain single-URL form.
+  it("is byte-identical when only a non-renderable subtitle matches", async () => {
+    // An .ass-only match used to still be treated as "no usable subtitle" by
+    // the input-slave logic; now there is no logic left to have an opinion —
+    // the body is the same either way.
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
       { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s", bytes: 40 },
@@ -2035,14 +2027,14 @@ describe("the .m3u with a matched subtitle", () => {
     expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
   });
 
-  it("prefers a renderable .srt over a matched .ass for the input-slave", async () => {
+  it("is byte-identical when both a renderable and non-renderable subtitle match", async () => {
     const { deps, sid, cap } = await readySession([
       { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
       { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s1", bytes: 40 },
       { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
     ]);
     const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
-    expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
+    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
   });
 });
 

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1823,6 +1823,55 @@ describe("the .vtt representation", () => {
     const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
     expect(res.status).toBe(502);
   });
+
+  /**
+   * The test above proves the ROUTE's contract ("fetchSubtitle returned null
+   * -> 502"), but the fake fetchSubtitle re-implements the cap itself — it
+   * would still pass if the REAL `defaultFetchSubtitle` buffered the whole
+   * body with `Buffer.concat` and checked the size only after `end`, which is
+   * an unbounded-memory remote DoS. This test runs the real implementation
+   * against a real socket and proves two things a fake cannot: that a body
+   * which never legitimately ends (the `/slow` branch drips forever) is cut
+   * off rather than buffered, and that the upstream connection is actually
+   * torn down — via the same live-socket-count signal the WebTorrent proxy's
+   * own abandonment test uses — rather than merely abandoned mid-read.
+   */
+  it(
+    "stops reading a body that exceeds the cap over a real socket, and closes it",
+    async () => {
+      upstream = await startUpstream();
+      const { reg, id, capability } = await torrentSession(
+        [
+          {
+            filename: "Kestrel.2010.1080p.BluRay.x264.mkv",
+            url: `${upstream.base}/webtorrent/hash/one.mp4`,
+            bytes: MEDIA.length,
+          },
+          // Claimed size is tiny — the claimed-size cap (413) must not be what
+          // stops this request, or the test would prove nothing about the
+          // received-bytes path.
+          {
+            filename: "Kestrel.2010.1080p.BluRay.x264.eng.srt",
+            url: `${upstream.base}/slow`,
+            bytes: 40,
+          },
+        ],
+        "cap-slow-vtt",
+        "sid-slow-vtt",
+      );
+      // No fetchSubtitle override: this is the real defaultFetchSubtitle.
+      const base = await start(reg);
+      const res = await fetch(`${base}/stream/${id}/1.vtt?k=${capability}`);
+      expect(res.status).toBe(502);
+      // Not merely abandoned: the upstream socket is actually gone. `/slow`
+      // drips 4 KiB every 5ms forever and only clears its interval and drops
+      // out of `open` once its response closes, so this can only pass if the
+      // cap destroyed the connection rather than reading it to a "completion"
+      // that never comes.
+      await vi.waitFor(() => expect(upstream!.open.size).toBe(0), { timeout: 10000 });
+    },
+    15000,
+  );
 });
 
 describe("the .m3u with a matched subtitle", () => {

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -1921,6 +1921,30 @@ describe("the .m3u with a matched subtitle", () => {
     const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
     expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
   });
+
+  it("does not offer a non-renderable subtitle as the input-slave", async () => {
+    // The .vtt route always runs its source through srtToVtt, whatever the
+    // real format was. An .ass sibling run through that converter produces
+    // bytes that are valid neither as WebVTT nor as ASS, so VLC would get a
+    // subtitle file it can't use and silently show nothing. An .ass-only match
+    // must therefore behave exactly like no match: the plain single-URL form.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toBe(`http://box.test:9161/stream/${sid}/0?k=${cap}\n`);
+  });
+
+  it("prefers a renderable .srt over a matched .ass for the input-slave", async () => {
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.mkv", url: "http://up.test/v", bytes: 900 },
+      { filename: "Kepler.S02E04.eng.ass", url: "http://up.test/s1", bytes: 40 },
+      { filename: "Kepler.S02E04.eng.srt", url: "http://up.test/s2", bytes: 40 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0.m3u?k=${cap}`, { host: "box.test:9161" });
+    expect(res.body).toContain(`/stream/${sid}/2.vtt?k=${cap}`);
+  });
 });
 
 describe("the .info subtitle report", () => {

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -14,6 +14,7 @@ import {
   playlistFilename,
   requestOrigin,
   splitRepresentation,
+  SUBTITLE_FETCH_TIMEOUT_MS,
 } from "./stream";
 import { DownloadQueue } from "../download/queue";
 import { StreamSessionRegistry, type StreamSessionDeps } from "../core/streamSession";
@@ -123,6 +124,15 @@ async function startUpstream(): Promise<Upstream> {
         });
         res.end(MEDIA);
       }, 30);
+      return;
+    }
+
+    // Accepts the connection and then says NOTHING — not even headers. This is
+    // the WebTorrent-piece-not-arrived-yet case verbatim: the server is waiting
+    // on data it does not have yet, so unlike `/slow` (which at least streams,
+    // and would eventually trip a byte cap) this can only ever be freed by a
+    // timeout or a client disconnect.
+    if (req.url?.startsWith("/never")) {
       return;
     }
 
@@ -1886,6 +1896,81 @@ describe("the .vtt representation", () => {
     },
     15000,
   );
+
+  /**
+   * The hang this exists to prevent: a sibling `.srt` whose pieces have not
+   * arrived yet. `/never` accepts the connection and then sends nothing at
+   * all — no headers, no body, no error — so without a bound
+   * `defaultFetchSubtitle`'s promise (and its socket) would live for the rest
+   * of the process. `/slow` would not prove this: it streams bytes, so it
+   * would eventually trip `MAX_SUBTITLE_BYTES` on its own and the test would
+   * pass even with the timeout deleted. Runs against the real implementation
+   * and a real socket, and the test's own timeout is kept well above
+   * `SUBTITLE_FETCH_TIMEOUT_MS` so a regression (the bound silently removed)
+   * fails the assertion instead of hanging the suite.
+   */
+  it(
+    "gives up on a subtitle upstream that never answers, and closes the socket",
+    async () => {
+      upstream = await startUpstream();
+      const { reg, id, capability } = await torrentSession(
+        [
+          {
+            filename: "Kepler.S02E04.1080p.WEB-DL.mkv",
+            url: `${upstream.base}/webtorrent/hash/one.mp4`,
+            bytes: MEDIA.length,
+          },
+          {
+            filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt",
+            url: `${upstream.base}/never`,
+            bytes: 40,
+          },
+        ],
+        "cap-hang-vtt",
+        "sid-hang-vtt",
+      );
+      const base = await start(reg);
+      const res = await fetch(`${base}/stream/${id}/1.vtt?k=${capability}`);
+      expect(res.status).toBe(502);
+      await vi.waitFor(() => expect(upstream!.open.size).toBe(0), { timeout: 5000 });
+    },
+    SUBTITLE_FETCH_TIMEOUT_MS + 10000,
+  );
+
+  /**
+   * The client-disconnect teardown, matching the WebTorrent proxy's own
+   * abandonment test in shape: a client that goes away before this route ever
+   * answers must not leave the upstream socket (and the timeout timer) alive
+   * for the rest of the process.
+   */
+  it("destroys the upstream subtitle fetch when the client disconnects first", async () => {
+    upstream = await startUpstream();
+    const { reg, id, capability } = await torrentSession(
+      [
+        {
+          filename: "Kepler.S02E04.1080p.WEB-DL.mkv",
+          url: `${upstream.base}/webtorrent/hash/one.mp4`,
+          bytes: MEDIA.length,
+        },
+        {
+          filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt",
+          url: `${upstream.base}/slow`,
+          bytes: 40,
+        },
+      ],
+      "cap-abort-vtt",
+      "sid-abort-vtt",
+    );
+    const base = await start(reg);
+
+    const ac = new AbortController();
+    const pending = fetch(`${base}/stream/${id}/1.vtt?k=${capability}`, { signal: ac.signal });
+    await vi.waitFor(() => expect(upstream!.open.size).toBe(1), { timeout: 3000 });
+
+    ac.abort();
+    await expect(pending).rejects.toThrow();
+    await vi.waitFor(() => expect(upstream!.open.size).toBe(0), { timeout: 3000 });
+  });
 });
 
 describe("the .m3u with a matched subtitle", () => {

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -39,7 +39,6 @@ import {
 } from "./proxyTarget";
 import {
   isBrowserRenderable,
-  preferredSubtitle,
   subtitleLanguage,
   subtitlesFor,
 } from "../util/subtitleFiles";
@@ -613,6 +612,15 @@ export async function handleStreamRequest(
     // session, so nothing a client put in the URL is reflected into the body.
     // The capability is re-encoded from the value that just passed the auth
     // check — omit it and the playlist is a 401 in whatever player opens it.
+    // NOTE, so nobody re-adds it: there is deliberately no
+    // #EXTVLCOPT:input-slave line here for a matched subtitle. Measured
+    // against a real VLC 3.0.11 — `input-slave` is on VLC's unsafe-option
+    // list and is refused outright inside a `.m3u` ("unsafe option
+    // \"input-slave\" has been ignored for security reasons"), precisely so a
+    // downloaded playlist cannot make the player open arbitrary resources.
+    // VLC users get a separate subtitle download link on the player page
+    // instead; `subtitleArgs` in src/util/subtitleFlags.ts gives VLC no flag
+    // for the same reason.
     const handleUrl = (index: number): string =>
       `${origin}${streamHandle(parsed.sid, index)}?k=${encodeURIComponent(k!)}`;
 

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -105,7 +105,11 @@ export interface StreamDeps {
    * goes through the same `resolveProxyTarget` allowlist the proxy does, which
    * is the point of it being here rather than a bare `fetch`.
    */
-  fetchSubtitle?: (url: string, allowed: readonly string[]) => Promise<Uint8Array | null>;
+  fetchSubtitle?: (
+    url: string,
+    allowed: readonly string[],
+    signal?: AbortSignal,
+  ) => Promise<Uint8Array | null>;
 }
 // Note there is deliberately NO injectable HTTP client here. A fake `request`
 // cannot show that a Range header survived a socket, that a 206 came back with
@@ -311,6 +315,16 @@ const PASS_THROUGH = ["content-type", "content-length", "content-range", "accept
  * check below is the first guard against that and this is the second.
  */
 export const MAX_SUBTITLE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * How long `defaultFetchSubtitle` waits for upstream before giving up. A sibling
+ * `.srt`/`.vtt` on WebTorrent can be a piece that has not arrived yet, in which
+ * case the connection is opened and simply never answers — without a bound the
+ * promise (and its socket) would live for the rest of the process. Generous
+ * relative to `MAX_SUBTITLE_BYTES`: a subtitle is at most a few MiB, so anything
+ * still incomplete after this long is stalled, not slow.
+ */
+export const SUBTITLE_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * The sibling subtitle files for one video, as the wire type.
@@ -544,7 +558,17 @@ export async function handleStreamRequest(
       return 413;
     }
     const fetchSubtitle = deps.fetchSubtitle ?? defaultFetchSubtitle;
-    const fetched = await fetchSubtitle(file.url, backendProtocols(session));
+    // This route buffers before it can answer at all, so — unlike proxyUpstream,
+    // which has already written headers by the time a client goes away — there
+    // is nothing yet to distinguish "our own end" from "abandoned": any close
+    // this early is the client leaving, so it always aborts the fetch. The
+    // listener is removed the moment the fetch settles, so a close after that
+    // (the normal end of a completed request) finds nothing to abort.
+    const controller = new AbortController();
+    const onClientClose = (): void => controller.abort();
+    res.on("close", onClientClose);
+    const fetched = await fetchSubtitle(file.url, backendProtocols(session), controller.signal);
+    res.off("close", onClientClose);
     if (!fetched) {
       // Same status and the same silence about the URL as proxyUpstream: an
       // unrestricted link is a credential against the user's account.
@@ -862,22 +886,41 @@ function proxyUpstream(
  * what it claimed — the response is destroyed the moment the buffered total
  * would exceed the cap, which is the second half of that guard (`file.bytes` in
  * the caller is the first, and it is only what upstream claimed).
+ *
+ * Two teardowns, matching `proxyUpstream`'s shape rather than inventing a
+ * second one: a `SUBTITLE_FETCH_TIMEOUT_MS` timer for the case webtorrent just
+ * never answers (a sibling `.srt` whose pieces have not arrived yet holds the
+ * connection open indefinitely), and `signal` for the caller's own
+ * client-disconnect teardown. Either one destroys the in-flight request and
+ * resolves null, exactly like any other upstream failure.
  */
 function defaultFetchSubtitle(
   target: string,
   allowedProtocols: readonly string[],
+  signal?: AbortSignal,
 ): Promise<Uint8Array | null> {
   const first = resolveProxyTarget(target, allowedProtocols, MAX_PROXY_HOPS);
   if (!first.ok) return Promise.resolve(null);
 
   return new Promise<Uint8Array | null>((resolve) => {
     let settled = false;
+    let current: http.ClientRequest | null = null;
     const done = (value: Uint8Array | null): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       resolve(value);
     };
-    let current: http.ClientRequest | null = null;
+    const onAbort = (): void => {
+      current?.destroy();
+      done(null);
+    };
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+      current?.destroy();
+      done(null);
+    }, SUBTITLE_FETCH_TIMEOUT_MS);
+    signal?.addEventListener("abort", onAbort);
 
     const send = (url: URL, hopsRemaining: number): void => {
       const transport = url.protocol === "https:" ? https : http;

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -39,7 +39,6 @@ import {
 } from "./proxyTarget";
 import {
   isBrowserRenderable,
-  isSubtitleFilename,
   preferredSubtitle,
   subtitleLanguage,
   subtitlesFor,
@@ -526,8 +525,17 @@ export async function handleStreamRequest(
   // check keeps it from being a general-purpose "read a whole file into memory
   // and call it text" route aimed at a 12 GB video, and the size cap is the
   // second line of that same defence.
+  //
+  // `isBrowserRenderable`, not `isSubtitleFilename`: this route always runs the
+  // source through `srtToVtt` and answers `text/vtt`, so it must only ever
+  // accept something that conversion can honestly produce. `isSubtitleFilename`
+  // also passes `.ass`/`.ssa`/`.sub`, which would come back as `WEBVTT` followed
+  // by raw ASS markup — neither valid WebVTT nor valid ASS. The two callers
+  // (`subtitleFilesFor`'s `.m3u` filter above and `subtitleTracks` in
+  // `subtitleModel.ts`) already filter to renderable files before reaching here;
+  // this guard is what makes that belt-and-braces rather than the only defence.
   if (rep === "subtitle") {
-    if (!isSubtitleFilename(file.filename)) {
+    if (!isBrowserRenderable(file.filename)) {
       writeJson(res, 404, { error: "not a subtitle" });
       return 404;
     }

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -29,7 +29,7 @@ import type { StreamSession, StreamSessionRegistry } from "../core/streamSession
 import { streamCandidates } from "../util/videoFiles";
 import { playlistTitle } from "../util/playlistTitle";
 import { restPlaylist } from "../util/restPlaylist";
-import type { StreamFilesResponse, StreamInfoResponse } from "./wire";
+import type { StreamFilesResponse, StreamInfoResponse, SubtitleFile } from "./wire";
 import {
   HTTP_AND_HTTPS,
   HTTP_ONLY,
@@ -37,6 +37,14 @@ import {
   resolveRedirect,
   type ProxyRefusal,
 } from "./proxyTarget";
+import {
+  isBrowserRenderable,
+  isSubtitleFilename,
+  preferredSubtitle,
+  subtitleLanguage,
+  subtitlesFor,
+} from "../util/subtitleFiles";
+import { decodeSubtitle, srtToVtt } from "../util/srtToVtt";
 
 /** Diagnostics sink. Same contract as the server's: injected, never `console`. */
 export type StreamLog = (message: string) => void;
@@ -89,6 +97,16 @@ export interface StreamDeps {
    * config, it is handed what it needs.
    */
   proxyDebrid?: boolean;
+  /**
+   * Read a whole subtitle file from upstream, or null on any failure.
+   *
+   * Separate from the proxy because this one buffers rather than streams — a
+   * subtitle has to be converted before a byte of it can be sent. Injectable so
+   * the `.vtt` route is testable without a network; the default implementation
+   * goes through the same `resolveProxyTarget` allowlist the proxy does, which
+   * is the point of it being here rather than a bare `fetch`.
+   */
+  fetchSubtitle?: (url: string, allowed: readonly string[]) => Promise<Uint8Array | null>;
 }
 // Note there is deliberately NO injectable HTTP client here. A fake `request`
 // cannot show that a Range header survived a socket, that a 206 came back with
@@ -139,25 +157,27 @@ export function parseStreamPath(urlPath: string): { sid: string; index: number }
 const PLAYLIST_SUFFIX = ".m3u";
 const INFO_SUFFIX = ".info";
 const FILES_SUFFIX = ".files";
+const SUBTITLE_SUFFIX = ".vtt";
 
 /** Which representation of the stream handle a path is asking for. */
-export type StreamRep = "media" | "playlist" | "info" | "files";
+export type StreamRep = "media" | "playlist" | "info" | "files" | "subtitle";
 
 /**
- * Split a trailing `.m3u`, `.info` or `.files` off a stream path.
+ * Split a trailing `.m3u`, `.info`, `.files` or `.vtt` off a stream path.
  *
  * All are *representations* of the handle, not second resources, so none is a
  * second route: stripping the suffix here means the session lookup, the
  * capability check, the readiness check and the bounds check below are literally
- * the same code for all four. A `.m3u` that skipped the capability would hand
+ * the same code for all five. A `.m3u` that skipped the capability would hand
  * out a playable URL to anyone who guessed a session id, a `.info` that skipped
- * it would hand out a filename and codec list, and a `.files` that skipped it
- * would hand out every filename in the torrent; the only durable way to stop
- * all three is for there to be one guard, not four.
+ * it would hand out a filename and codec list, a `.files` that skipped it would
+ * hand out every filename in the torrent, and a `.vtt` that skipped it would
+ * hand out a subtitle from someone else's session; the only durable way to stop
+ * all four is for there to be one guard, not four.
  *
  * Matched with `endsWith` on an exact lowercase suffix, so `.m3u8`, `.INFO`,
- * `.information` and `.profiles` are all just filenames — a near-miss must fall
- * through to the media branch rather than be helpfully interpreted.
+ * `.information`, `.profiles` and `.VTT` are all just filenames — a near-miss
+ * must fall through to the media branch rather than be helpfully interpreted.
  */
 export function splitRepresentation(urlPath: string): { path: string; rep: StreamRep } {
   if (urlPath.endsWith(PLAYLIST_SUFFIX)) {
@@ -168,6 +188,9 @@ export function splitRepresentation(urlPath: string): { path: string; rep: Strea
   }
   if (urlPath.endsWith(FILES_SUFFIX)) {
     return { path: urlPath.slice(0, -FILES_SUFFIX.length), rep: "files" };
+  }
+  if (urlPath.endsWith(SUBTITLE_SUFFIX)) {
+    return { path: urlPath.slice(0, -SUBTITLE_SUFFIX.length), rep: "subtitle" };
   }
   return { path: urlPath, rep: "media" };
 }
@@ -281,6 +304,44 @@ function writeJson(res: http.ServerResponse, status: number, body: unknown): voi
 // needs to seek: everything else (Date, Connection, whatever the backend adds)
 // is this proxy's business, not the client's.
 const PASS_THROUGH = ["content-type", "content-length", "content-range", "accept-ranges"] as const;
+
+/**
+ * The most a subtitle may be. A two-hour SRT is tens of kilobytes; four MiB is
+ * far past any real one. This route reads the whole body into memory to convert
+ * it, so without a cap a caller could aim it at a video file — the extension
+ * check below is the first guard against that and this is the second.
+ */
+export const MAX_SUBTITLE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * The sibling subtitle files for one video, as the wire type.
+ *
+ * Server-side because only the server holds the whole file list with its
+ * indexes — `toPublicSession` exposes them, but the `.info` response is where
+ * the player page reads them from, and doing it here means the browser never
+ * has to re-run the matcher.
+ */
+function subtitleFilesFor(session: StreamSession, index: number): SubtitleFile[] {
+  const video = session.files[index];
+  if (!video) return [];
+  const withIndex = session.files.map((f, i) => ({ ...f, index: i }));
+  return subtitlesFor(withIndex[index]!, withIndex).map((s) => {
+    const { code, label } = subtitleLanguage(s.filename);
+    return {
+      index: s.index,
+      filename: s.filename,
+      language: code,
+      label,
+      renderable: isBrowserRenderable(s.filename),
+    };
+  });
+}
+
+// The same split the media branch makes: a debrid link is https, a WebTorrent
+// file is served from this machine over http.
+function backendProtocols(session: StreamSession): readonly string[] {
+  return session.backend === "debrid" ? HTTP_AND_HTTPS : HTTP_ONLY;
+}
 
 /**
  * Serve one stream request. Writes the response itself — this route owns its
@@ -443,11 +504,56 @@ export async function handleStreamRequest(
         hls = null;
       }
     }
-    const body: StreamInfoResponse = { facts, blockers: blockersFor(facts), hls };
+    const body: StreamInfoResponse = {
+      facts,
+      blockers: blockersFor(facts),
+      hls,
+      subtitles: {
+        embedded: facts.subtitles,
+        files: subtitleFilesFor(session, parsed.index),
+      },
+    };
     // Note what is NOT in that body: `file.url`. That is a debrid unrestricted
     // link, i.e. a credential against the user's account. The page plays through
     // this handle and never learns where the bytes come from.
     writeJson(res, 200, body);
+    return 200;
+  }
+
+  // The `.vtt`: a sibling subtitle file, converted for a <track>.
+  //
+  // Two guards this representation needs that the others do not. The extension
+  // check keeps it from being a general-purpose "read a whole file into memory
+  // and call it text" route aimed at a 12 GB video, and the size cap is the
+  // second line of that same defence.
+  if (rep === "subtitle") {
+    if (!isSubtitleFilename(file.filename)) {
+      writeJson(res, 404, { error: "not a subtitle" });
+      return 404;
+    }
+    if (file.bytes > MAX_SUBTITLE_BYTES) {
+      writeJson(res, 413, { error: "subtitle too large" });
+      return 413;
+    }
+    const fetchSubtitle = deps.fetchSubtitle ?? defaultFetchSubtitle;
+    const fetched = await fetchSubtitle(file.url, backendProtocols(session));
+    if (!fetched) {
+      // Same status and the same silence about the URL as proxyUpstream: an
+      // unrestricted link is a credential against the user's account.
+      deps.log("stream: could not fetch subtitle upstream");
+      writeJson(res, 502, { error: "bad upstream" });
+      return 502;
+    }
+    const payload = Buffer.from(srtToVtt(decodeSubtitle(fetched)), "utf8");
+    res.writeHead(200, {
+      "Content-Type": "text/vtt; charset=utf-8",
+      "Content-Length": String(payload.length),
+      // Same reason as the playlist: the URL that produced this carries a
+      // capability for a session that will be reaped.
+      "Cache-Control": "no-store",
+    });
+    if (method !== "HEAD") res.end(payload);
+    else res.end();
     return 200;
   }
 
@@ -733,6 +839,95 @@ function proxyUpstream(
     res.on("close", () => {
       if (!res.writableEnded) current?.destroy();
     });
+
+    send(first.url, MAX_PROXY_HOPS);
+  });
+}
+
+/**
+ * The default `StreamDeps.fetchSubtitle`: read a whole subtitle body from
+ * upstream through the same allowlist and redirect handling `proxyUpstream`
+ * uses, buffered rather than piped because the bytes must be fully in hand
+ * before `srtToVtt` can run.
+ *
+ * Enforces `MAX_SUBTITLE_BYTES` against what upstream actually SENDS, not just
+ * what it claimed — the response is destroyed the moment the buffered total
+ * would exceed the cap, which is the second half of that guard (`file.bytes` in
+ * the caller is the first, and it is only what upstream claimed).
+ */
+function defaultFetchSubtitle(
+  target: string,
+  allowedProtocols: readonly string[],
+): Promise<Uint8Array | null> {
+  const first = resolveProxyTarget(target, allowedProtocols, MAX_PROXY_HOPS);
+  if (!first.ok) return Promise.resolve(null);
+
+  return new Promise<Uint8Array | null>((resolve) => {
+    let settled = false;
+    const done = (value: Uint8Array | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let current: http.ClientRequest | null = null;
+
+    const send = (url: URL, hopsRemaining: number): void => {
+      const transport = url.protocol === "https:" ? https : http;
+      const upstream = transport.request(
+        {
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port,
+          path: `${url.pathname}${url.search}`,
+          method: "GET",
+          agent: false,
+        },
+        (up) => {
+          const status = up.statusCode ?? 502;
+          const location = up.headers.location;
+          if (status >= 300 && status < 400 && typeof location === "string") {
+            up.resume();
+            up.on("error", () => {});
+            const next = resolveRedirect(location, url, allowedProtocols, hopsRemaining - 1);
+            if (!next.ok) {
+              done(null);
+              return;
+            }
+            send(next.url, hopsRemaining - 1);
+            return;
+          }
+          if (status < 200 || status >= 300) {
+            up.resume();
+            done(null);
+            return;
+          }
+          const chunks: Buffer[] = [];
+          let total = 0;
+          up.on("data", (chunk: Buffer) => {
+            total += chunk.length;
+            if (total > MAX_SUBTITLE_BYTES) {
+              // What upstream actually sent, not what it claimed in
+              // Content-Length. The caller has already checked `file.bytes`;
+              // this is the check against the body itself.
+              up.destroy();
+              done(null);
+              return;
+            }
+            chunks.push(chunk);
+          });
+          up.on("end", () => {
+            if (!settled) done(new Uint8Array(Buffer.concat(chunks)));
+          });
+          up.on("error", () => done(null));
+        },
+      );
+      current = upstream;
+      upstream.on("error", () => {
+        if (upstream !== current) return;
+        done(null);
+      });
+      upstream.end();
+    };
 
     send(first.url, MAX_PROXY_HOPS);
   });

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -33,7 +33,7 @@
 // a hand-written copy of the picker's shapes — `{ season, episode }` had
 // already drifted once — the exact drift this file was created to stop.
 // Anything with a runtime value in it still does not belong in this module.
-import type { Blocker, MediaFacts } from "../util/playability";
+import type { Blocker, EmbeddedSubtitle, MediaFacts } from "../util/playability";
 import type { EpisodeRef } from "../util/episode";
 import type { FeatureId, MaxResolution } from "../util/releasePick";
 import type { TitleSuggestion } from "../util/titleSuggest";
@@ -122,6 +122,24 @@ export interface PublicStreamFile {
 }
 
 /**
+ * A subtitle file that ships alongside the video in the same torrent, as the
+ * browser is allowed to see it.
+ *
+ * `index` addresses it on `/stream/:sid/:idx.vtt`, the same grammar as the
+ * video's own handle. `renderable` is false for ass/ssa/sub: those are matched
+ * and offered to external players, but `<track>` cannot show them.
+ */
+export interface SubtitleFile {
+  index: number;
+  filename: string;
+  /** BCP-47 tag ("en"), or "" when the filename gave no language. */
+  language: string;
+  /** Human label for a track menu: "English", "English (forced)". */
+  label: string;
+  renderable: boolean;
+}
+
+/**
  * `GET /stream/:sid/:idx.info?k=…` — what this file is, and how to play it.
  *
  * Capability-authenticated rather than bearer-authenticated, and that is the
@@ -139,6 +157,12 @@ export interface StreamInfoResponse {
   blockers: Blocker[];
   /** A provider HLS manifest the browser can play directly, or null. */
   hls: string | null;
+  /**
+   * What subtitles exist for this file. `embedded` is muxed inside it and is
+   * reported only — nothing extracts it. `files` are siblings in the torrent,
+   * fetchable as WebVTT from `/stream/:sid/:idx.vtt`.
+   */
+  subtitles: { embedded: EmbeddedSubtitle[]; files: SubtitleFile[] };
 }
 
 /**


### PR DESCRIPTION
torlink had no subtitle support of any kind — `README.md` said so. This came out of
one report: "I couldn't get subtitles for a season pack I was playing through the
`.m3u` in VLC."

Investigating that turned up two separate gaps, and the reported pack was neither
of them.

## What the report actually was

That pack had **no sibling subtitle files at all** — ten mp4s, each carrying three
muxed `mov_text` tracks. Those tracks already survive torlink's byte-range proxy
intact, and VLC lists them; it had auto-enabled **Spanish**, with English loaded but
off. Nothing was broken. Nothing told the user either, and `probe.ts` discarded
subtitle streams before anything could.

## What ships

|  | Terminal | Browser |
| --- | --- | --- |
| Sibling `.srt` / `.vtt` | `CC` marker in the picker; side-loaded into mpv/IINA | `<track>` in the native subtitle menu, served as WebVTT |
| `.ass` / `.ssa` | side-loaded raw into mpv/IINA, which render them | not offered — `<track>` cannot render them |
| Embedded tracks | VLC's own menu, as always | named on the fallback card |
| VLC | no flag (see below) | "Download subtitle" link |

Matching is three rules in order: basename prefix, shared `SxxExx` token (the `Subs/`
folder layout), then single-video. Fuzzy title matching was considered and rejected —
attaching the wrong episode's subtitle is worse than attaching none.

## Two claims about VLC that testing disproved

Both were mine, and both were in the one place no unit test can reach — what an
external player does with a flag. Measured against VLC 3.0.11 with a real subtitle URL:

- **`#EXTVLCOPT:input-slave` in an `.m3u` is refused outright**:
  `unsafe option "input-slave" has been ignored for security reasons`. It is
  blocklisted precisely so a downloaded playlist cannot make the player open
  arbitrary resources.
- **`--input-slave=<url>` on the CLI loads the subtitle as an *audio* track**
  (`loading audio-es slave`). `--sub-file=<url>` reaches the right category but
  resolves the URL as a local path. `subtitle:` prefixes and `#` type hints also
  load as audio.

**VLC 3 has no CLI flag that side-loads a subtitle from a URL.** So the playlist is
back to the single bare URL it always was, VLC gets no flag rather than one that
misbehaves, and the browser offers a download link instead.

mpv is **verified**, not assumed — via its own IPC `track-list`:
`{"type":"sub","external":true,"selected":true,"codec":"webvtt"}`. IINA's entry is
marked in-code as inferred from mpv rather than measured.

## One deliberate asymmetry

The browser gained a "Download subtitle" button for VLC users; the terminal gained
only a `· subtitle not loaded` note. Flagged explicitly per CLAUDE.md: the terminal
has no download button, and it already puts the stream URL on the clipboard, so the
remedy that fits each surface differs.

## Verified live, not only in tests

Against a real Sintel torrent — a Blender open movie, freely shareable, nine sibling
`.srt` files:

- `.info` matched all nine with correct language names, and excluded `poster.jpg`
- the player built nine `<track>` elements with English defaulted
- **Chrome's own WebVTT parser accepted the conversion: 26 cues, first at 107.25s**
- the `.m3u` is byte-identical to the pre-feature form

The Real-Debrid path guard also earned its keep in the wild: RD served that torrent
as a single `.rar`, so 11 files mapped to 1 link, and it emitted no paths rather than
11 wrong ones.

Separately, the original reported pack now shows
*"Subtitles in this file: Spanish, English, Portuguese — pick one in your player."*

## Not in scope

Extracting embedded tracks would need ffmpeg, which torlink does not run in
production, and would only help files the browser can already play — not the
HEVC/eac3 case that prompted this. Fetching subtitles from OpenSubtitles is a
separate feature with its own credentials and licensing.

`npm test` 2565 passing, `typecheck`, `lint` and `build` clean. Design and plan
committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
