### PR TITLE
feat: cast a stream to a Chromecast, in both front ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ anything other than loopback requires a token.
   because there's no way to show one without re-encoding it, and torlink doesn't run ffmpeg. Tracks
   muxed *inside* the file are named on the fallback card so you know they're there — pulling one out
   has the same ffmpeg problem.
-- **No settings page, but there is a settings control.** Tokens, sources, limits and folders are still
-  TUI-only — the browser has no page for them, and that includes reccd's own URL and bearer token; the
+- **No settings page, but there is a settings control.** Tokens, sources, limits, folders and the
+  [cast device address](#casting-to-a-tv) are still TUI-only — the browser has no page for them, and
+  that includes reccd's own URL and bearer token; the
   browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the
   **For You** tab), never its address or token. It also includes claiming your
   [reccd](#recommendations) account: that's credential entry too, so it stays where tokens live, and the
@@ -324,10 +325,51 @@ give up after twelve seconds:
   while it's on, these releases fall through to the next line too.
 - **Anything left over** — a release streamed from the swarm, or one the provider won't transcode — gets a
   card naming the part your browser can't handle, plus a **Download .m3u** button: your OS hands that tiny
-  playlist to VLC (or whatever your default player is) and it plays there. On iOS and Android there's also
+  playlist to VLC (or whatever your default player is) and it plays there. That card also offers to
+  [cast it](#casting-to-a-tv) when the file is one a Chromecast can play but your browser can't — an MP4
+  carrying AC3 is the common case. On iOS and Android there's also
   a direct **Open in VLC** button, because those apps register a URL scheme a web page can link to.
   Desktop VLC registers none — not on macOS, Windows or Linux — so there's no button to offer there, and
   the `.m3u` is the route that works. It also doesn't assume VLC is what you watch things in.
+
+#### Casting to a TV
+
+Both front ends can put a stream on a Chromecast. In the browser it's a **Cast to TV** button next to the
+other hand-off buttons; in the terminal it's `c` in the stream file picker, which lists what it found and
+casts to the one you pick. Once it's playing you get pause, resume, stop and a position — the seek bar and
+the volume stay with the TV's own remote, which is already in the room.
+
+torlnk drives the device itself rather than going through Google's web SDK, and that's the reason it works
+at all: the SDK only runs on a secure origin, and the normal way to reach this dashboard is
+`http://192.168.x.x`. A cast button built on it would work from `localhost` and nowhere else, which is the
+same dead-button problem desktop VLC has.
+
+What it will and won't play, stated plainly, because a Chromecast is fussier than a browser in one
+direction and less fussy in another:
+
+- **MP4 and WebM carrying H.264 cast directly.** Nothing is transcoded and nothing passes through this
+  machine twice.
+- **AC3 and E-AC3 are passed through to the television.** Your browser refuses those, so this is one case
+  where the TV can play something the dashboard can't — the fallback card offers to cast it. The catch: it's
+  passthrough, so on a TV or receiver that can't decode it you get picture and no sound. Stop the cast and
+  play it locally.
+- **An MKV casts only on the debrid backend**, via the provider's transcode — the same rung the browser
+  player uses. Straight from the swarm there's nothing to transcode it with, so the button says so instead
+  of failing at the television.
+- **HEVC casts on neither backend.** That needs a full re-encode, which needs per-platform hardware
+  acceleration; it's a deliberate gap rather than an oversight, and the `.m3u` hand-off is still there.
+- **The subtitle you'd have seen in the browser goes with it**, as a sidecar track.
+
+Discovery uses mDNS, which does not cross a Docker bridge or a VLAN — so if you run torlnk in a container
+and the list comes back empty, that's why. The device list lets you type an address (`192.168.0.40`, or
+`host:port`) and remembers it, so a device mDNS can't reach still casts.
+
+Two limits worth knowing. Casting needs the television to fetch the file *from this machine*, so a cast
+started in the terminal brings the browser UI up on your LAN address with a token if it isn't already
+running — it tells you when it does, because that's a real change to what the machine is serving. And a
+cast is per-process: one started in the terminal isn't visible to a separate `torlnk serve --web`, and the
+other way round. Where the TUI is hosting the browser UI itself (`shift+w`), it's one process and both
+surfaces see the one cast.
 
 #### The player page knows what else is in the torrent
 

--- a/docs/superpowers/plans/2026-08-01-chromecast.md
+++ b/docs/superpowers/plans/2026-08-01-chromecast.md
@@ -1,0 +1,2834 @@
+# Chromecast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cast a stream to a Chromecast from either front end, with pause/stop and a live position.
+
+**Architecture:** torlink drives the device itself over the CASTV2 protocol from `src/core/cast/`, because the Cast Web Sender SDK is secure-context-only and `serve --web` is plain HTTP on a LAN IP. Both front ends are clients of one registry that lives on `Runtime`. The device always fetches `/stream/<sid>/<idx>?k=…` from torlink's own web server, so there is one URL shape, one auth story, and one source ladder.
+
+**Tech Stack:** TypeScript (ESM, strict, `noUncheckedIndexedAccess`), Node ≥22, vitest, Ink + React (TUI), hand-written DOM (browser bundle, no framework), `multicast-dns` (new runtime dependency).
+
+**Spec:** `docs/superpowers/specs/2026-08-01-chromecast-design.md`. Read it before Task 1; it carries the reasoning this plan only executes.
+
+## Global Constraints
+
+- **Layering, enforced by `eslint.config.js`.** `src/core` must not import from `src/ui` or `src/web`. `src/web` must not import from `src/ui`. `src/core/cast` never builds a URL — callers pass one in.
+- **No `innerHTML` / `insertAdjacentHTML` / `outerHTML` / `document.write` anywhere in `src/web/static/`.** Every node is `createElement` + `textContent`. Release names come from whoever made the torrent.
+- **No decisions in `player.ts` or `app.ts`.** Anything that decides *what to show* or *what to send* goes in a pure module beside it (here: `castModel.ts`). There is no jsdom, deliberately; DOM wiring is verified by running the app.
+- **Config writes are read-modify-write per request:** `loadConfig()` → change → `saveConfig()`. Never hold a snapshot between requests.
+- **Test fixtures never name a real film or show.** Reuse `Kestrel.2010.1080p.BluRay.x264`, `Ashfall.1999.1080p`, `Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP`, `Kepler.S02E04.1080p.WEB-DL`, `Harrowgate.S03.1080p.WEB-DL`. Device names are invented too: `Living Room TV`, `Kitchen display`.
+- **Both front ends, same change.** A new key means **both** halves of `src/ui/keymap.ts` (`HELP_GROUPS` *and* `footerHints`). A new `Store` field means **both** `makeStore` (`scripts/render-previews-impl.tsx`) and `makeTestStore` (`src/ui/testHarness.ts`).
+- **Every task ends green on `npx vitest run <the files it touched>`.** The full gate — `npm test`, `npm run typecheck`, `npm run lint`, `npm run build` — runs in Task 14 and after any task that changes a shared module. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) is expected; leave it.
+- **Commit per task**, Conventional Commits, no `Co-Authored-By` unless the repo's other commits carry one.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/core/cast/protocol.ts` | pure: `CastMessage` encode/decode, length framing, `FrameReader` |
+| `src/core/cast/discover.ts` | mDNS `_googlecast._tcp` query → `CastDevice[]`, plus the configured address |
+| `src/core/cast/connection.ts` | TLS socket, heartbeat, channels, `LAUNCH`/`LOAD`/`PLAY`/`PAUSE`/`STOP`, status |
+| `src/core/cast/session.ts` | `CastSessionRegistry`: the one active cast, its status, its played-file write |
+| `src/core/streamSession.ts` | gains `adopt()` for files the TUI already resolved |
+| `src/util/playability.ts` | gains `PlaybackProfile`, `BROWSER`, `CHROMECAST`, `castContentType` |
+| `src/daemon/runtime.ts` | `Runtime.casts` |
+| `src/web/stream.ts` | `castBlockers` on `.info`; CORS on `.vtt` |
+| `src/web/castOrigin.ts` | the LAN origin a device must fetch from |
+| `src/web/routes.ts` | `GET /api/cast/devices`, `POST /api/cast/start`, `POST /api/cast/command` |
+| `src/web/wire.ts` | `PublicCastDevice`, `CastDevicesResponse`, `CastStatusResponse` |
+| `src/web/static/castModel.ts` | pure: button state, labels, disabled reasons, status line |
+| `src/web/static/player.ts` | DOM wiring only |
+| `src/ui/components/CastPrompt.tsx` | the device list overlay, with an address field |
+| `src/ui/App.tsx` | the cast flow: ensure the web server, adopt a session, drive the registry |
+
+---
+
+### Task 1: The CASTV2 wire format
+
+**Files:**
+- Create: `src/core/cast/protocol.ts`
+- Test: `src/core/cast/protocol.test.ts`
+- Modify: `package.json` (add `multicast-dns`, `@types/multicast-dns` — used from Task 2, installed here so one commit carries the lockfile change)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  export interface CastMessage { sourceId: string; destinationId: string; namespace: string; payload: string }
+  export const MAX_FRAME_BYTES: number;              // 1 << 20
+  export function encodeCastMessage(m: CastMessage): Buffer;   // protobuf body, no length prefix
+  export function decodeCastMessage(body: Buffer): CastMessage;
+  export function frameCastMessage(m: CastMessage): Buffer;     // 4-byte BE length + body
+  export class FrameReader { push(chunk: Buffer): CastMessage[] }
+  ```
+
+- [ ] **Step 1: Install the dependencies**
+
+```bash
+npm install multicast-dns@^7.2.5
+npm install -D @types/multicast-dns@^7.2.4
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/core/cast/protocol.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  FrameReader,
+  MAX_FRAME_BYTES,
+  decodeCastMessage,
+  encodeCastMessage,
+  frameCastMessage,
+  type CastMessage,
+} from "./protocol";
+
+const MSG: CastMessage = {
+  sourceId: "sender-torlink",
+  destinationId: "receiver-0",
+  namespace: "urn:x-cast:com.google.cast.receiver",
+  payload: JSON.stringify({ type: "LAUNCH", appId: "CC1AD845", requestId: 1 }),
+};
+
+describe("encodeCastMessage / decodeCastMessage", () => {
+  it("round-trips every field", () => {
+    expect(decodeCastMessage(encodeCastMessage(MSG))).toEqual(MSG);
+  });
+
+  it("round-trips a payload carrying non-ASCII, so the length prefix is bytes and not characters", () => {
+    const msg = { ...MSG, payload: JSON.stringify({ title: "Kestrel — 2010" }) };
+    expect(decodeCastMessage(encodeCastMessage(msg))).toEqual(msg);
+  });
+
+  it("ignores a field it does not know rather than throwing", () => {
+    // field 7, wire type 0 (varint), value 3 — appended to a valid body.
+    const extended = Buffer.concat([encodeCastMessage(MSG), Buffer.from([0x38, 0x03])]);
+    expect(decodeCastMessage(extended)).toEqual(MSG);
+  });
+});
+
+describe("FrameReader", () => {
+  it("yields one message from a whole frame", () => {
+    const reader = new FrameReader();
+    expect(reader.push(frameCastMessage(MSG))).toEqual([MSG]);
+  });
+
+  it("yields nothing until a frame whose length prefix is split across chunks completes", () => {
+    const reader = new FrameReader();
+    const framed = frameCastMessage(MSG);
+    // Two bytes of the four-byte length: the failure mode every hand-rolled
+    // framer has on its first day.
+    expect(reader.push(framed.subarray(0, 2))).toEqual([]);
+    expect(reader.push(framed.subarray(2, 9))).toEqual([]);
+    expect(reader.push(framed.subarray(9))).toEqual([MSG]);
+  });
+
+  it("yields two messages from one chunk carrying both", () => {
+    const reader = new FrameReader();
+    const second = { ...MSG, payload: JSON.stringify({ type: "PONG" }) };
+    const chunk = Buffer.concat([frameCastMessage(MSG), frameCastMessage(second)]);
+    expect(reader.push(chunk)).toEqual([MSG, second]);
+  });
+
+  it("refuses a frame claiming an absurd length instead of buffering for it", () => {
+    const reader = new FrameReader();
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(MAX_FRAME_BYTES + 1, 0);
+    expect(() => reader.push(header)).toThrow(/refused/);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+Run: `npx vitest run src/core/cast/protocol.test.ts`
+Expected: FAIL — `Failed to resolve import "./protocol"`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/core/cast/protocol.ts`:
+
+```ts
+/**
+ * The CASTV2 wire format, by hand.
+ *
+ * A `CastMessage` is a protobuf with six fields and its shape never varies:
+ * protocol_version (1, varint), source_id (2), destination_id (3), namespace
+ * (4), payload_type (5, varint) and payload_utf8 (6). Everything torlink sends
+ * or reads is JSON in field 6; the binary payload field is never used.
+ *
+ * Sixty lines of encoder is why `protobufjs` is not a dependency here: it is
+ * roughly a megabyte into the bundled CLI, whose whole runtime dependency list
+ * is eleven packages, to encode a message with no variability at all.
+ */
+
+export interface CastMessage {
+  sourceId: string;
+  destinationId: string;
+  namespace: string;
+  /** The JSON body. Field 6, `payload_utf8`. */
+  payload: string;
+}
+
+/**
+ * The largest frame we will assemble.
+ *
+ * A cast reply is a small JSON object; the biggest thing a receiver sends is a
+ * MEDIA_STATUS with track metadata, orders of magnitude under this. The cap
+ * exists because the length prefix arrives from the network: without it, four
+ * bytes from anything listening on port 8009 can make this buffer without
+ * bound.
+ */
+export const MAX_FRAME_BYTES = 1 << 20;
+
+function varint(value: number): Buffer {
+  const out: number[] = [];
+  let v = value;
+  do {
+    let byte = v & 0x7f;
+    v = Math.floor(v / 128);
+    if (v > 0) byte |= 0x80;
+    out.push(byte);
+  } while (v > 0);
+  return Buffer.from(out);
+}
+
+// Wire type 0 is a varint, 2 is length-delimited. Those are the only two here.
+function key(field: number, wire: 0 | 2): Buffer {
+  return varint((field << 3) | wire);
+}
+
+function stringField(field: number, value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([key(field, 2), varint(bytes.length), bytes]);
+}
+
+export function encodeCastMessage(m: CastMessage): Buffer {
+  return Buffer.concat([
+    key(1, 0), varint(0), // protocol_version = CASTV2_1_0
+    stringField(2, m.sourceId),
+    stringField(3, m.destinationId),
+    stringField(4, m.namespace),
+    key(5, 0), varint(0), // payload_type = STRING
+    stringField(6, m.payload),
+  ]);
+}
+
+function readVarint(buf: Buffer, at: number): { value: number; next: number } {
+  let value = 0;
+  let shift = 1;
+  let i = at;
+  for (;;) {
+    if (i >= buf.length) throw new Error("cast frame: truncated varint");
+    const byte = buf[i]!;
+    i += 1;
+    value += (byte & 0x7f) * shift;
+    if ((byte & 0x80) === 0) break;
+    shift *= 128;
+    if (shift > 2 ** 42) throw new Error("cast frame: varint too long");
+  }
+  return { value, next: i };
+}
+
+/**
+ * Read a body into the four fields that matter.
+ *
+ * Unknown fields are skipped rather than rejected: a future receiver adding one
+ * must not stop playback, and the two enum fields we write are skipped by this
+ * same path on the way back in.
+ */
+export function decodeCastMessage(body: Buffer): CastMessage {
+  const out: CastMessage = { sourceId: "", destinationId: "", namespace: "", payload: "" };
+  let at = 0;
+  while (at < body.length) {
+    const k = readVarint(body, at);
+    at = k.next;
+    const field = Math.floor(k.value / 8);
+    const wire = k.value % 8;
+    if (wire === 0) {
+      at = readVarint(body, at).next;
+      continue;
+    }
+    if (wire !== 2) throw new Error(`cast frame: unsupported wire type ${wire}`);
+    const len = readVarint(body, at);
+    at = len.next;
+    const end = at + len.value;
+    if (end > body.length) throw new Error("cast frame: truncated field");
+    const text = body.subarray(at, end).toString("utf8");
+    at = end;
+    if (field === 2) out.sourceId = text;
+    else if (field === 3) out.destinationId = text;
+    else if (field === 4) out.namespace = text;
+    else if (field === 6) out.payload = text;
+  }
+  return out;
+}
+
+export function frameCastMessage(m: CastMessage): Buffer {
+  const body = encodeCastMessage(m);
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+/**
+ * Reassemble frames from a TCP stream.
+ *
+ * Stateful on purpose: a socket hands over arbitrary chunk boundaries, so a
+ * length prefix split across two reads is normal traffic and not an error.
+ */
+export class FrameReader {
+  private buffered = Buffer.alloc(0);
+
+  push(chunk: Buffer): CastMessage[] {
+    this.buffered = this.buffered.length === 0 ? chunk : Buffer.concat([this.buffered, chunk]);
+    const out: CastMessage[] = [];
+    for (;;) {
+      if (this.buffered.length < 4) break;
+      const length = this.buffered.readUInt32BE(0);
+      if (length > MAX_FRAME_BYTES) {
+        throw new Error(`cast frame of ${length} bytes refused`);
+      }
+      if (this.buffered.length < 4 + length) break;
+      out.push(decodeCastMessage(this.buffered.subarray(4, 4 + length)));
+      this.buffered = this.buffered.subarray(4 + length);
+    }
+    return out;
+  }
+}
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `npx vitest run src/core/cast/protocol.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json src/core/cast/protocol.ts src/core/cast/protocol.test.ts
+git commit -m "feat(cast): the CASTV2 wire format, by hand"
+```
+
+---
+
+### Task 2: Discovering devices
+
+**Files:**
+- Create: `src/core/cast/discover.ts`
+- Test: `src/core/cast/discover.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  ```ts
+  export interface CastDevice { id: string; name: string; model: string; host: string; port: number }
+  export const CAST_SERVICE = "_googlecast._tcp.local";
+  export const DISCOVER_TIMEOUT_MS = 2_000;
+  export const DEFAULT_CAST_PORT = 8009;
+  export interface MdnsLike {
+    on(event: "response", cb: (packet: MdnsPacket) => void): void;
+    query(q: { questions: { name: string; type: "PTR" }[] }): void;
+    destroy(): void;
+  }
+  export interface MdnsRecord { name: string; type: string; data: unknown }
+  export interface MdnsPacket { answers?: MdnsRecord[]; additionals?: MdnsRecord[] }
+  export interface DiscoverDeps { mdnsFactory?: () => MdnsLike; timeoutMs?: number; sleep?: (ms: number) => Promise<void> }
+  export function parseManualDevice(raw: string | undefined): CastDevice | null;
+  export function devicesFromPackets(packets: readonly MdnsPacket[]): CastDevice[];
+  export function discover(deps?: DiscoverDeps): Promise<CastDevice[]>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/cast/discover.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CAST_PORT,
+  devicesFromPackets,
+  discover,
+  parseManualDevice,
+  type MdnsLike,
+  type MdnsPacket,
+} from "./discover";
+
+// One device's answer, as multicast-dns reports it: a PTR naming the instance,
+// an SRV with host and port, TXT key=value pairs as Buffers, and an A record.
+function packetFor(opts: {
+  instance: string;
+  target: string;
+  ip: string;
+  port?: number;
+  txt?: string[];
+  withSrv?: boolean;
+}): MdnsPacket {
+  const records = [
+    { name: "_googlecast._tcp.local", type: "PTR", data: opts.instance },
+    ...(opts.withSrv === false
+      ? []
+      : [{ name: opts.instance, type: "SRV", data: { port: opts.port ?? DEFAULT_CAST_PORT, target: opts.target } }]),
+    {
+      name: opts.instance,
+      type: "TXT",
+      data: (opts.txt ?? ["id=abc123", "fn=Living Room TV", "md=Chromecast"]).map((s) => Buffer.from(s)),
+    },
+    { name: opts.target, type: "A", data: opts.ip },
+  ];
+  return { answers: records, additionals: [] };
+}
+
+describe("devicesFromPackets", () => {
+  it("builds a device from SRV, A and TXT", () => {
+    const devices = devicesFromPackets([
+      packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "192.168.0.40" }),
+    ]);
+    expect(devices).toEqual([
+      { id: "abc123", name: "Living Room TV", model: "Chromecast", host: "192.168.0.40", port: 8009 },
+    ]);
+  });
+
+  it("drops an answer with no SRV rather than half-building a device with no port", () => {
+    const devices = devicesFromPackets([
+      packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "192.168.0.40", withSrv: false }),
+    ]);
+    expect(devices).toEqual([]);
+  });
+
+  it("collapses the same device answering on two interfaces, by id", () => {
+    const one = packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "192.168.0.40" });
+    const again = packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "10.8.0.4" });
+    expect(devicesFromPackets([one, again]).map((d) => d.id)).toEqual(["abc123"]);
+  });
+
+  it("falls back to the instance name when TXT carries no fn, so a device is never nameless", () => {
+    const devices = devicesFromPackets([
+      packetFor({
+        instance: "kitchen-display._googlecast._tcp.local",
+        target: "k.local",
+        ip: "192.168.0.41",
+        txt: ["id=k1"],
+      }),
+    ]);
+    expect(devices[0]).toMatchObject({ id: "k1", name: "kitchen-display", model: "" });
+  });
+
+  it("keeps two genuinely different devices", () => {
+    const devices = devicesFromPackets([
+      packetFor({ instance: "a._googlecast._tcp.local", target: "a.local", ip: "192.168.0.40" }),
+      packetFor({
+        instance: "b._googlecast._tcp.local",
+        target: "b.local",
+        ip: "192.168.0.41",
+        txt: ["id=k1", "fn=Kitchen display", "md=Google TV Streamer"],
+      }),
+    ]);
+    expect(devices.map((d) => d.name)).toEqual(["Living Room TV", "Kitchen display"]);
+  });
+});
+
+describe("parseManualDevice", () => {
+  it("takes a bare host and defaults the port", () => {
+    expect(parseManualDevice("192.168.0.40")).toEqual({
+      id: "manual:192.168.0.40:8009",
+      name: "192.168.0.40",
+      model: "",
+      host: "192.168.0.40",
+      port: 8009,
+    });
+  });
+
+  it("takes host:port", () => {
+    expect(parseManualDevice("tv.local:8010")).toMatchObject({ host: "tv.local", port: 8010 });
+  });
+
+  it("is null for absent, blank, or an unusable port", () => {
+    expect(parseManualDevice(undefined)).toBeNull();
+    expect(parseManualDevice("   ")).toBeNull();
+    expect(parseManualDevice("tv.local:not-a-port")).toBeNull();
+    expect(parseManualDevice("tv.local:0")).toBeNull();
+  });
+});
+
+describe("discover", () => {
+  it("queries the cast service, collects what answers within the window, and destroys the socket", async () => {
+    const handlers: ((p: MdnsPacket) => void)[] = [];
+    const query = vi.fn();
+    const destroy = vi.fn();
+    const mdns: MdnsLike = {
+      on: (_event, cb) => { handlers.push(cb); },
+      query,
+      destroy,
+    };
+    const devices = await discover({
+      mdnsFactory: () => mdns,
+      timeoutMs: 1,
+      sleep: async () => {
+        handlers[0]!(packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "192.168.0.40" }));
+      },
+    });
+    expect(query).toHaveBeenCalledWith({
+      questions: [{ name: "_googlecast._tcp.local", type: "PTR" }],
+    });
+    expect(devices.map((d) => d.name)).toEqual(["Living Room TV"]);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it("resolves empty when nothing answers, rather than throwing or hanging", async () => {
+    const mdns: MdnsLike = { on: () => {}, query: () => {}, destroy: () => {} };
+    await expect(discover({ mdnsFactory: () => mdns, timeoutMs: 1, sleep: async () => {} })).resolves.toEqual([]);
+  });
+
+  it("destroys the socket even when the query itself throws", async () => {
+    const destroy = vi.fn();
+    const mdns: MdnsLike = {
+      on: () => {},
+      query: () => { throw new Error("no multicast route"); },
+      destroy,
+    };
+    await expect(discover({ mdnsFactory: () => mdns, timeoutMs: 1, sleep: async () => {} })).resolves.toEqual([]);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `npx vitest run src/core/cast/discover.test.ts`
+Expected: FAIL — cannot resolve `./discover`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/core/cast/discover.ts`:
+
+```ts
+import makeMdns from "multicast-dns";
+
+/**
+ * Finding Chromecasts on the LAN.
+ *
+ * `multicast-dns` is the one dependency this feature takes, and it is the half
+ * worth taking: DNS name compression, several interfaces answering at once and
+ * multicast group membership are real edge cases, where the protocol on top
+ * (see ./protocol.ts) is a fixed six-field message. The factory is injected so
+ * the tests feed canned records and never open a socket.
+ */
+
+export interface CastDevice {
+  /** The device's own id from TXT, or a synthetic one for a configured address. */
+  id: string;
+  name: string;
+  /** TXT `md`, e.g. "Chromecast". Empty when the device did not say. */
+  model: string;
+  host: string;
+  port: number;
+}
+
+export const CAST_SERVICE = "_googlecast._tcp.local";
+export const DEFAULT_CAST_PORT = 8009;
+
+/**
+ * How long to listen for answers.
+ *
+ * A device on the same segment answers in tens of milliseconds; two seconds is
+ * generous for a busy access point and short enough that the device list does
+ * not feel broken. Nothing waits for a *complete* answer set, because there is
+ * no such thing — a television that is off answers never.
+ */
+export const DISCOVER_TIMEOUT_MS = 2_000;
+
+export interface MdnsRecord { name: string; type: string; data: unknown }
+export interface MdnsPacket { answers?: MdnsRecord[]; additionals?: MdnsRecord[] }
+
+/** The part of multicast-dns's surface this module uses. */
+export interface MdnsLike {
+  on(event: "response", cb: (packet: MdnsPacket) => void): void;
+  query(q: { questions: { name: string; type: "PTR" }[] }): void;
+  destroy(): void;
+}
+
+export interface DiscoverDeps {
+  mdnsFactory?: () => MdnsLike;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function txtPairs(data: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!Array.isArray(data)) return out;
+  for (const entry of data) {
+    const text = Buffer.isBuffer(entry) ? entry.toString("utf8") : String(entry);
+    const eq = text.indexOf("=");
+    if (eq > 0) out.set(text.slice(0, eq), text.slice(eq + 1));
+  }
+  return out;
+}
+
+/**
+ * Assemble devices from whatever answered.
+ *
+ * Pure, and separate from the socket for that reason. An answer with no SRV is
+ * dropped: a device with no port is not a device, and inventing 8009 for it
+ * would put a row on screen that cannot be cast to.
+ */
+export function devicesFromPackets(packets: readonly MdnsPacket[]): CastDevice[] {
+  const byId = new Map<string, CastDevice>();
+  for (const packet of packets) {
+    const records = [...(packet.answers ?? []), ...(packet.additionals ?? [])];
+    const srv = records.find((r) => r.type === "SRV");
+    if (!srv || typeof srv.data !== "object" || srv.data === null) continue;
+    const { port, target } = srv.data as { port?: number; target?: string };
+    if (!port || !target) continue;
+    const addressed = records.find((r) => (r.type === "A" || r.type === "AAAA") && r.name === target);
+    const host = typeof addressed?.data === "string" ? addressed.data : target;
+    const txt = txtPairs(records.find((r) => r.type === "TXT")?.data);
+    // The instance name is the fallback because a nameless row cannot be
+    // chosen: "abc._googlecast._tcp.local" reads as "abc", which is at least
+    // something the user can tell apart from the other row.
+    const instance = srv.name.replace(`.${CAST_SERVICE}`, "");
+    const id = txt.get("id") ?? `${host}:${port}`;
+    if (byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      name: txt.get("fn") ?? instance,
+      model: txt.get("md") ?? "",
+      host,
+      port,
+    });
+  }
+  return [...byId.values()];
+}
+
+/**
+ * A device from the configured address, for networks mDNS cannot cross.
+ *
+ * mDNS does not traverse a Docker bridge or a VLAN, and torlink is run behind
+ * both — without this the feature is dead there, behind a message that reads
+ * like a bug. The id is prefixed so nothing can confuse it with a discovered
+ * device's own id.
+ */
+export function parseManualDevice(raw: string | undefined): CastDevice | null {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return null;
+  const colon = trimmed.lastIndexOf(":");
+  let host = trimmed;
+  let port = DEFAULT_CAST_PORT;
+  if (colon > 0) {
+    const tail = trimmed.slice(colon + 1);
+    if (!/^\d+$/.test(tail)) return null;
+    port = Number(tail);
+    if (port < 1 || port > 65_535) return null;
+    host = trimmed.slice(0, colon);
+  }
+  if (!host) return null;
+  return { id: `manual:${host}:${port}`, name: host, model: "", host, port };
+}
+
+export async function discover(deps: DiscoverDeps = {}): Promise<CastDevice[]> {
+  const factory = deps.mdnsFactory ?? (() => makeMdns() as unknown as MdnsLike);
+  const timeoutMs = deps.timeoutMs ?? DISCOVER_TIMEOUT_MS;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const packets: MdnsPacket[] = [];
+  const mdns = factory();
+  try {
+    mdns.on("response", (packet) => { packets.push(packet); });
+    mdns.query({ questions: [{ name: CAST_SERVICE, type: "PTR" }] });
+    await sleep(timeoutMs);
+  } catch {
+    // No multicast route, a firewall, a container with no host network: an
+    // empty list and a message the caller can explain, never a thrown error
+    // in the middle of someone pressing a button.
+  } finally {
+    try { mdns.destroy(); } catch { /* already gone */ }
+  }
+  return devicesFromPackets(packets);
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `npx vitest run src/core/cast/discover.test.ts`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/cast/discover.ts src/core/cast/discover.test.ts
+git commit -m "feat(cast): discover Chromecasts over mDNS, with a configured-address fallback"
+```
+
+---
+
+### Task 3: What a Chromecast will play
+
+**Files:**
+- Modify: `src/util/playability.ts`
+- Test: `src/util/playability.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  export interface PlaybackProfile {
+    containers: ReadonlySet<string>;
+    video: ReadonlySet<string>;
+    audio: ReadonlySet<string>;
+  }
+  export const BROWSER_PROFILE: PlaybackProfile;
+  export const CHROMECAST_PROFILE: PlaybackProfile;
+  export function blockersFor(facts: MediaFacts, profile?: PlaybackProfile): Blocker[]; // default BROWSER_PROFILE
+  export function castContentType(container: string, hls: boolean): string;
+  ```
+  `blockersFor`'s existing single-argument call sites (`src/web/stream.ts`, `src/web/static/playerModel.ts`) keep working unchanged — the profile is an optional second parameter.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/util/playability.test.ts`:
+
+```ts
+import {
+  BROWSER_PROFILE,
+  CHROMECAST_PROFILE,
+  castContentType,
+  // ...existing imports stay
+} from "./playability";
+
+describe("blockersFor with a profile", () => {
+  // THE REGRESSION GUARD for touching a module the web player depends on: the
+  // no-argument form must answer exactly what it answered before profiles
+  // existed. If this fails, the browser's fallback card has changed.
+  it("defaults to the browser profile, unchanged", () => {
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.BluRay.x264.mp4"))).toEqual([]);
+    expect(blockersFor(classifyFromName("Kepler.S02E04.1080p.WEB-DL.mkv"))).toEqual(["container"]);
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.BluRay.x265.mp4"))).toEqual(["video"]);
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.BluRay.x264.DTS.mp4"))).toEqual(["audio"]);
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.x264.AC3.mp4"), BROWSER_PROFILE)).toEqual(["audio"]);
+  });
+
+  it("blocks MKV for a Chromecast too — the device demuxes no more Matroska than a browser", () => {
+    expect(blockersFor(classifyFromName("Kepler.S02E04.1080p.WEB-DL.mkv"), CHROMECAST_PROFILE)).toEqual([
+      "container",
+    ]);
+  });
+
+  it("allows AC3 and E-AC3 on a Chromecast, which the browser refuses", () => {
+    // The recorded trade-off: this is HDMI passthrough, so a television that
+    // cannot take it plays silently. Blocking would instead REFUSE a file that
+    // would almost certainly have played, and on the torrent backend there is
+    // no transcode rung underneath to fall back to. Silence is recoverable in
+    // one keypress; a refusal is not recoverable at all.
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.x264.AC3.mp4"), CHROMECAST_PROFILE)).toEqual([]);
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.x264.DDP5.1.mp4"), CHROMECAST_PROFILE)).toEqual([]);
+  });
+
+  it("still blocks DTS and TrueHD on a Chromecast", () => {
+    expect(blockersFor(classifyFromName("Kestrel.2010.1080p.x264.DTS.mp4"), CHROMECAST_PROFILE)).toEqual(["audio"]);
+    expect(
+      blockersFor(classifyFromName("Tin.Rivers.2024.2160p.WEB-DL.DV.HDR.Atmos.7.1-GROUP.mp4"), CHROMECAST_PROFILE),
+    ).toEqual(["audio"]);
+  });
+
+  it("blocks HEVC on a Chromecast, because a model name is a guess and there is no video transcode", () => {
+    expect(blockersFor(classifyFromName("Kestrel.2010.2160p.x265.AAC.mp4"), CHROMECAST_PROFILE)).toEqual(["video"]);
+  });
+});
+
+describe("castContentType", () => {
+  it("names the container for a direct play", () => {
+    expect(castContentType("mp4", false)).toBe("video/mp4");
+    expect(castContentType("m4v", false)).toBe("video/mp4");
+    expect(castContentType("webm", false)).toBe("video/webm");
+  });
+
+  it("names HLS whenever the source is a manifest, whatever the file's own container", () => {
+    expect(castContentType("mkv", true)).toBe("application/vnd.apple.mpegurl");
+    expect(castContentType("mp4", true)).toBe("application/vnd.apple.mpegurl");
+  });
+
+  it("falls back to video/mp4 for a container it does not know, rather than an empty type", () => {
+    // An empty contentType is a LOAD_FAILED with no reason. mp4 is the honest
+    // guess: it is what a direct-play rung will have been chosen for.
+    expect(castContentType("", false)).toBe("video/mp4");
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/util/playability.test.ts`
+Expected: FAIL — `BROWSER_PROFILE` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `src/util/playability.ts`, replace the three `SAFE_*` constants and `blockersFor` with:
+
+```ts
+/**
+ * What one decoder will take.
+ *
+ * Two exist: a browser and a Chromecast. They are the same question asked of
+ * different hardware, so they live in one module — a second list somewhere else
+ * is the copy-then-drift bug this codebase has recorded four times.
+ */
+export interface PlaybackProfile {
+  containers: ReadonlySet<string>;
+  video: ReadonlySet<string>;
+  audio: ReadonlySet<string>;
+}
+
+/**
+ * Unchanged from what this module always answered.
+ *
+ * Containers short on purpose: mkv is not one in any shipping browser, and mkv
+ * is what most of the scene ships. Codecs conservative: ac3/eac3 are
+ * Safari-only and av1 is absent on older hardware, so neither is listed. Being
+ * wrong in this direction costs a fallback card; being wrong in the other costs
+ * a black rectangle.
+ */
+export const BROWSER_PROFILE: PlaybackProfile = {
+  containers: new Set(["mp4", "m4v", "webm"]),
+  video: new Set(["h264", "vp8", "vp9"]),
+  audio: new Set(["aac", "mp3", "opus", "vorbis", "flac"]),
+};
+
+/**
+ * A Chromecast, which differs from a browser in exactly one direction.
+ *
+ * Containers and video are identical: the device demuxes no Matroska, and HEVC
+ * stays out even though an Ultra or a Google TV device decodes it — the `md`
+ * TXT key names a model, a model name is a guess about both the device's
+ * decoder and the television behind it, and there is no video transcode to fall
+ * back to.
+ *
+ * Audio gains ac3 and eac3, which is passthrough and therefore depends on the
+ * HDMI link. Where that link cannot take it the result is silent video, which
+ * is bad — and still better than the alternative, which REFUSES a file that
+ * would almost certainly have played, with no transcode rung underneath it on
+ * the torrent backend. Silence is one keypress from recoverable; a refusal is
+ * not recoverable at all.
+ */
+export const CHROMECAST_PROFILE: PlaybackProfile = {
+  containers: new Set(["mp4", "m4v", "webm"]),
+  video: new Set(["h264", "vp8", "vp9"]),
+  audio: new Set(["aac", "mp3", "opus", "vorbis", "flac", "ac3", "eac3"]),
+};
+
+/**
+ * Every reason `profile`'s decoder will refuse this file.
+ *
+ * An unknown *container* blocks — that is the existing behaviour and it is
+ * right, because showing a card is honest and takes one tap to work around
+ * where a black rectangle looks like the app is broken. An unknown *codec* does
+ * not block: most release names say nothing about audio, and blocking there
+ * would send files to the card that play fine.
+ */
+export function blockersFor(facts: MediaFacts, profile: PlaybackProfile = BROWSER_PROFILE): Blocker[] {
+  const blockers: Blocker[] = [];
+  if (!profile.containers.has(facts.container)) blockers.push("container");
+  if (facts.videoCodec && !profile.video.has(facts.videoCodec)) blockers.push("video");
+  if (facts.audioCodec && !profile.audio.has(facts.audioCodec)) blockers.push("audio");
+  return blockers;
+}
+
+/**
+ * The `contentType` a `LOAD` must name.
+ *
+ * Getting it wrong is a LOAD_FAILED rather than a guess the receiver recovers
+ * from, so this is a function with tests rather than a ternary at the call site.
+ * An HLS manifest is HLS whatever the file inside it was.
+ */
+export function castContentType(container: string, hls: boolean): string {
+  if (hls) return "application/vnd.apple.mpegurl";
+  if (container === "webm") return "video/webm";
+  return "video/mp4";
+}
+```
+
+Note for the implementer: the old `SAFE_CONTAINERS`/`SAFE_VIDEO`/`SAFE_AUDIO` constants are module-private, so nothing outside this file references them. Confirm with `grep -rn "SAFE_CONTAINERS\|SAFE_VIDEO\|SAFE_AUDIO" src` before deleting them; the expected answer is hits in this file only.
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/util/playability.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run everything that consumes this module**
+
+Run: `npx vitest run src/web/stream.test.ts src/web/static/playerModel.test.ts src/core/probe.test.ts`
+Expected: PASS, unchanged. This is the point of the default-argument form; if anything here fails, the browser's behaviour has moved and the fix is in this task, not in those tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/util/playability.ts src/util/playability.test.ts
+git commit -m "feat(cast): a capability profile per decoder, with a Chromecast one"
+```
+
+---
+
+### Task 4: Talking to a device
+
+**Files:**
+- Create: `src/core/cast/connection.ts`
+- Test: `src/core/cast/connection.test.ts`
+
+**Interfaces:**
+- Consumes: `FrameReader`, `frameCastMessage`, `type CastMessage` (Task 1); `type CastDevice` (Task 2).
+- Produces:
+  ```ts
+  export const RECEIVER_APP_ID = "CC1AD845";
+  export const HEARTBEAT_MS = 5_000;
+  export interface CastSocket {
+    write(data: Buffer): void;
+    onData(cb: (chunk: Buffer) => void): void;
+    onClose(cb: () => void): void;
+    destroy(): void;
+  }
+  export type ConnectSocket = (host: string, port: number) => Promise<CastSocket>;
+  export interface CastMediaRequest {
+    url: string;
+    contentType: string;
+    title: string;
+    subtitleUrl?: string;
+    subtitleLabel?: string;
+  }
+  export type CastPlayerState = "loading" | "playing" | "paused" | "idle";
+  export interface CastStatus { state: CastPlayerState; positionSec: number; durationSec: number | null }
+  export interface ConnectionDeps {
+    connect?: ConnectSocket;
+    setInterval?: (cb: () => void, ms: number) => { unref?: () => void };
+    clearInterval?: (handle: unknown) => void;
+  }
+  export class CastError extends Error {}
+  export class CastConnection {
+    static open(device: CastDevice, deps?: ConnectionDeps): Promise<CastConnection>;
+    load(media: CastMediaRequest): Promise<void>;
+    play(): Promise<void>;
+    pause(): Promise<void>;
+    stop(): Promise<void>;
+    onStatus(cb: (status: CastStatus) => void): void;
+    onLost(cb: (message: string) => void): void;
+    close(): void;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/cast/connection.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { FrameReader, frameCastMessage, type CastMessage } from "./protocol";
+import {
+  CastConnection,
+  CastError,
+  RECEIVER_APP_ID,
+  type CastSocket,
+  type CastStatus,
+} from "./connection";
+import type { CastDevice } from "./discover";
+
+const DEVICE: CastDevice = {
+  id: "abc123",
+  name: "Living Room TV",
+  model: "Chromecast",
+  host: "192.168.0.40",
+  port: 8009,
+};
+
+/**
+ * A socket that records what was sent and lets a test answer as a receiver.
+ * The whole point of injecting the socket: every failure below is a test, not
+ * a story about a television.
+ */
+function fakeSocket() {
+  const sent: CastMessage[] = [];
+  const reader = new FrameReader();
+  let onData: (chunk: Buffer) => void = () => {};
+  let onClose: () => void = () => {};
+  const destroy = vi.fn();
+  const socket: CastSocket = {
+    write: (data) => { sent.push(...reader.push(data)); },
+    onData: (cb) => { onData = cb; },
+    onClose: (cb) => { onClose = cb; },
+    destroy,
+  };
+  return {
+    socket,
+    sent,
+    destroy,
+    /** Answer as the receiver. */
+    reply(namespace: string, payload: unknown, destinationId = "sender-torlink"): void {
+      onData(frameCastMessage({
+        sourceId: "receiver-0",
+        destinationId,
+        namespace,
+        payload: JSON.stringify(payload),
+      }));
+    },
+    drop(): void { onClose(); },
+    payloads(): Record<string, unknown>[] {
+      return sent.map((m) => JSON.parse(m.payload) as Record<string, unknown>);
+    },
+    typesSent(): string[] {
+      return this.payloads().map((p) => String(p.type));
+    },
+  };
+}
+
+const RECEIVER_NS = "urn:x-cast:com.google.cast.receiver";
+const MEDIA_NS = "urn:x-cast:com.google.cast.media";
+
+function launched(requestId: number) {
+  return {
+    type: "RECEIVER_STATUS",
+    requestId,
+    status: {
+      applications: [
+        { appId: RECEIVER_APP_ID, sessionId: "sess-1", transportId: "transport-1" },
+      ],
+    },
+  };
+}
+
+function mediaStatus(requestId: number, over: Record<string, unknown> = {}) {
+  return {
+    type: "MEDIA_STATUS",
+    requestId,
+    status: [
+      {
+        mediaSessionId: 7,
+        playerState: "PLAYING",
+        currentTime: 12.5,
+        media: { duration: 6_120 },
+        ...over,
+      },
+    ],
+  };
+}
+
+async function openWith(fake: ReturnType<typeof fakeSocket>) {
+  return CastConnection.open(DEVICE, {
+    connect: async () => fake.socket,
+    setInterval: () => ({}),
+    clearInterval: () => {},
+  });
+}
+
+describe("CastConnection.open", () => {
+  it("connects to the receiver before anything else", async () => {
+    const fake = fakeSocket();
+    await openWith(fake);
+    expect(fake.typesSent()).toEqual(["CONNECT"]);
+  });
+
+  it("is a CastError naming the device when the socket will not open", async () => {
+    await expect(
+      CastConnection.open(DEVICE, { connect: async () => { throw new Error("ECONNREFUSED"); } }),
+    ).rejects.toThrow(/Living Room TV didn't answer/);
+  });
+});
+
+describe("load", () => {
+  it("launches the default receiver, then connects to its transport, then loads", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://192.168.0.98:9161/stream/s/0?k=t", contentType: "video/mp4", title: "Kestrel 2010" });
+    // LAUNCH goes out first; answering it should produce the transport CONNECT
+    // and the LOAD.
+    expect(fake.typesSent()).toEqual(["CONNECT", "LAUNCH"]);
+    const launchId = Number(fake.payloads()[1]!.requestId);
+    fake.reply(RECEIVER_NS, launched(launchId));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    fake.reply(MEDIA_NS, mediaStatus(Number(fake.payloads().find((p) => p.type === "LOAD")!.requestId)));
+    await loading;
+
+    const load = fake.payloads().find((p) => p.type === "LOAD") as Record<string, any>;
+    expect(load.sessionId).toBe("sess-1");
+    expect(load.autoplay).toBe(true);
+    expect(load.media.contentId).toBe("http://192.168.0.98:9161/stream/s/0?k=t");
+    expect(load.media.contentType).toBe("video/mp4");
+    expect(load.media.streamType).toBe("BUFFERED");
+    expect(load.media.metadata.title).toBe("Kestrel 2010");
+    // The LOAD is addressed to the app's transport, not to receiver-0.
+    expect(fake.sent.find((m) => JSON.parse(m.payload).type === "LOAD")!.destinationId).toBe("transport-1");
+  });
+
+  it("passes a subtitle as a track and activates it", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({
+      url: "http://192.168.0.98:9161/stream/s/0?k=t",
+      contentType: "video/mp4",
+      title: "Kepler S02E04",
+      subtitleUrl: "http://192.168.0.98:9161/stream/s/1.vtt?k=t",
+      subtitleLabel: "English",
+    });
+    fake.reply(RECEIVER_NS, launched(Number(fake.payloads()[1]!.requestId)));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    const load = fake.payloads().find((p) => p.type === "LOAD") as Record<string, any>;
+    expect(load.media.tracks).toEqual([
+      {
+        trackId: 1,
+        type: "TEXT",
+        trackContentId: "http://192.168.0.98:9161/stream/s/1.vtt?k=t",
+        trackContentType: "text/vtt",
+        subtype: "SUBTITLES",
+        name: "English",
+        language: "en",
+      },
+    ]);
+    expect(load.activeTrackIds).toEqual([1]);
+    fake.reply(MEDIA_NS, mediaStatus(Number(load.requestId)));
+    await loading;
+  });
+
+  it("sends no tracks key at all when there is no subtitle", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    void conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" }).catch(() => {});
+    fake.reply(RECEIVER_NS, launched(Number(fake.payloads()[1]!.requestId)));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    const load = fake.payloads().find((p) => p.type === "LOAD") as Record<string, any>;
+    expect("tracks" in load.media).toBe(false);
+    expect("activeTrackIds" in load).toBe(false);
+  });
+
+  it("rejects with the receiver's own reason when it refuses to launch", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, { type: "LAUNCH_ERROR", requestId: Number(fake.payloads()[1]!.requestId), reason: "CANCELLED" });
+    await expect(loading).rejects.toThrow(/Living Room TV wouldn't start the player/);
+  });
+
+  it("rejects with the receiver's reason on LOAD_FAILED", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, launched(Number(fake.payloads()[1]!.requestId)));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    const load = fake.payloads().find((p) => p.type === "LOAD") as Record<string, any>;
+    fake.reply(MEDIA_NS, { type: "LOAD_FAILED", requestId: Number(load.requestId), detailedErrorCode: 905 });
+    await expect(loading).rejects.toThrow(/couldn't play this file/);
+    await expect(loading).rejects.toBeInstanceOf(CastError);
+  });
+});
+
+describe("status and commands", () => {
+  async function playing() {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const statuses: CastStatus[] = [];
+    conn.onStatus((s) => statuses.push(s));
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, launched(Number(fake.payloads()[1]!.requestId)));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    const load = fake.payloads().find((p) => p.type === "LOAD") as Record<string, any>;
+    fake.reply(MEDIA_NS, mediaStatus(Number(load.requestId)));
+    await loading;
+    return { fake, conn, statuses };
+  }
+
+  it("reports position and duration from MEDIA_STATUS, in seconds", async () => {
+    const { statuses } = await playing();
+    expect(statuses.at(-1)).toEqual({ state: "playing", positionSec: 12.5, durationSec: 6_120 });
+  });
+
+  it("reports a null duration for a live or unknown-length source rather than zero", async () => {
+    const { fake, statuses } = await playing();
+    fake.reply(MEDIA_NS, mediaStatus(99, { media: {} }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.durationSec).toBeNull());
+  });
+
+  it("maps PAUSED and IDLE", async () => {
+    const { fake, statuses } = await playing();
+    fake.reply(MEDIA_NS, mediaStatus(99, { playerState: "PAUSED" }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.state).toBe("paused"));
+    fake.reply(MEDIA_NS, mediaStatus(100, { playerState: "IDLE" }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.state).toBe("idle"));
+  });
+
+  it("addresses PAUSE and PLAY to the media session the receiver named", async () => {
+    const { fake, conn } = await playing();
+    void conn.pause();
+    void conn.play();
+    const pause = fake.payloads().find((p) => p.type === "PAUSE") as Record<string, any>;
+    const play = fake.payloads().find((p) => p.type === "PLAY") as Record<string, any>;
+    expect(pause.mediaSessionId).toBe(7);
+    expect(play.mediaSessionId).toBe(7);
+  });
+
+  it("stops by quitting the receiver app, so the TV returns to its own screen", async () => {
+    const { fake, conn } = await playing();
+    await conn.stop();
+    const stop = fake.payloads().find((p) => p.type === "STOP") as Record<string, any>;
+    expect(stop.sessionId).toBe("sess-1");
+  });
+
+  it("refuses a command before anything is loaded, rather than sending a broken one", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    await expect(conn.pause()).rejects.toThrow(/nothing is playing/);
+  });
+});
+
+describe("heartbeat and loss", () => {
+  it("pings the receiver on the heartbeat interval", async () => {
+    const fake = fakeSocket();
+    let tick: (() => void) | null = null;
+    await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: (cb) => { tick = cb; return {}; },
+      clearInterval: () => {},
+    });
+    tick!();
+    expect(fake.typesSent()).toEqual(["CONNECT", "PING"]);
+  });
+
+  it("reports the connection lost, once, when the socket drops", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const lost = vi.fn();
+    conn.onLost(lost);
+    fake.drop();
+    fake.drop();
+    expect(lost).toHaveBeenCalledOnce();
+    expect(lost).toHaveBeenCalledWith("Lost the connection to Living Room TV.");
+  });
+
+  it("destroys the socket and stops the heartbeat on close", async () => {
+    const fake = fakeSocket();
+    const cleared = vi.fn();
+    const conn = await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: () => ({ handle: 1 }),
+      clearInterval: cleared,
+    });
+    conn.close();
+    expect(fake.destroy).toHaveBeenCalledOnce();
+    expect(cleared).toHaveBeenCalledOnce();
+  });
+
+  it("reports loss rather than throwing when a frame is malformed", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const lost = vi.fn();
+    conn.onLost(lost);
+    // A length prefix past the cap: FrameReader throws, and that must surface
+    // as a lost connection rather than an unhandled error in the process.
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(0xffffffff, 0);
+    expect(() => fake.socket.onData).not.toThrow();
+    fake.reply("urn:x-cast:com.google.cast.tp.heartbeat", { type: "PONG" });
+    expect(lost).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/core/cast/connection.test.ts`
+Expected: FAIL — cannot resolve `./connection`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/core/cast/connection.ts`. The protocol facts it must encode, in order:
+
+1. `sourceId` is `"sender-torlink"` throughout.
+2. `CONNECT` (`urn:x-cast:com.google.cast.tp.connection`) to `receiver-0` immediately on open.
+3. `PING` (`urn:x-cast:com.google.cast.tp.heartbeat`) to `receiver-0` every `HEARTBEAT_MS`. A `PING` *from* the device is answered with `PONG`.
+4. `LAUNCH { appId, requestId }` on `urn:x-cast:com.google.cast.receiver`. The reply is `RECEIVER_STATUS` carrying `status.applications[]`; take the entry whose `appId` matches and keep its `sessionId` and `transportId`. `LAUNCH_ERROR` is the refusal.
+5. `CONNECT` again, this time addressed to `transportId`, before any media message.
+6. `LOAD` on `urn:x-cast:com.google.cast.media`, addressed to `transportId`. Reply is `MEDIA_STATUS` (success, carrying `mediaSessionId`) or `LOAD_FAILED` / `LOAD_CANCELLED`.
+7. `PAUSE` / `PLAY` take `{ mediaSessionId, requestId }` on the media namespace to `transportId`. `STOP` takes `{ sessionId, requestId }` on the **receiver** namespace, which quits the app and returns the TV to its own screen.
+8. Every request carries a monotonic `requestId`; replies are matched by it. `MEDIA_STATUS` also arrives *unsolicited*, with a `requestId` of 0 — those drive `onStatus` and match no pending request.
+
+```ts
+import { FrameReader, frameCastMessage, type CastMessage } from "./protocol";
+import type { CastDevice } from "./discover";
+
+export const RECEIVER_APP_ID = "CC1AD845";
+export const HEARTBEAT_MS = 5_000;
+
+const SENDER_ID = "sender-torlink";
+const NS_CONNECTION = "urn:x-cast:com.google.cast.tp.connection";
+const NS_HEARTBEAT = "urn:x-cast:com.google.cast.tp.heartbeat";
+const NS_RECEIVER = "urn:x-cast:com.google.cast.receiver";
+const NS_MEDIA = "urn:x-cast:com.google.cast.media";
+
+/**
+ * The part of a TLS socket this module uses.
+ *
+ * Injected rather than imported so the tests answer as a receiver instead of
+ * needing a television on the desk.
+ */
+export interface CastSocket {
+  write(data: Buffer): void;
+  onData(cb: (chunk: Buffer) => void): void;
+  onClose(cb: () => void): void;
+  destroy(): void;
+}
+
+export type ConnectSocket = (host: string, port: number) => Promise<CastSocket>;
+
+export interface CastMediaRequest {
+  url: string;
+  contentType: string;
+  title: string;
+  subtitleUrl?: string;
+  subtitleLabel?: string;
+}
+
+export type CastPlayerState = "loading" | "playing" | "paused" | "idle";
+
+export interface CastStatus {
+  state: CastPlayerState;
+  positionSec: number;
+  /** Null when the receiver has not said — a manifest it is still reading. */
+  durationSec: number | null;
+}
+
+export interface ConnectionDeps {
+  connect?: ConnectSocket;
+  setInterval?: (cb: () => void, ms: number) => unknown;
+  clearInterval?: (handle: unknown) => void;
+}
+
+/** A failure with a message already fit to put on screen. */
+export class CastError extends Error {}
+```
+
+Then the default socket, which is where `node:tls` is touched and nothing else:
+
+```ts
+import tls from "node:tls";
+
+const defaultConnect: ConnectSocket = (host, port) =>
+  new Promise((resolve, reject) => {
+    // rejectUnauthorized: false is load-bearing, not laziness. A Chromecast
+    // presents a device-signed certificate and there is no chain to check it
+    // against. It is acceptable because nothing secret crosses this socket:
+    // the payload is a URL already available to anything on the LAN holding the
+    // session's `?k=` token.
+    const socket = tls.connect({ host, port, rejectUnauthorized: false }, () => {
+      resolve({
+        write: (data) => socket.write(data),
+        onData: (cb) => socket.on("data", cb),
+        onClose: (cb) => { socket.on("close", cb); socket.on("error", () => cb()); },
+        destroy: () => socket.destroy(),
+      });
+    });
+    socket.once("error", reject);
+    socket.setTimeout(10_000, () => { socket.destroy(); reject(new Error("timed out")); });
+  });
+```
+
+The class itself: hold `pending: Map<number, {resolve, reject}>`, `nextRequestId`, `transportId`, `sessionId`, `mediaSessionId`, `statusCb`, `lostCb`, `lost: boolean`. Route each inbound message by namespace; a `FrameReader` throw or an unparseable payload calls `fail()` — the same path a socket close takes — so nothing escapes as an unhandled error in a TUI process, which can take the whole terminal down with it.
+
+Messages the failure table names, verbatim:
+
+```ts
+// CastConnection.open, when connect rejects:
+throw new CastError(`${device.name} didn't answer — it may be off.`);
+// LAUNCH_ERROR:
+new CastError(`${device.name} wouldn't start the player.`)
+// LOAD_FAILED / LOAD_CANCELLED:
+new CastError(`${device.name} couldn't play this file.`)
+// a command before load:
+new CastError("nothing is playing on this device.")
+// socket close, via onLost:
+`Lost the connection to ${device.name}.`
+```
+
+The `LOAD` body, with the subtitle key present only when there is one — an empty `tracks` array is not the same as no tracks, and the second test above pins that:
+
+```ts
+const media: Record<string, unknown> = {
+  contentId: req.url,
+  contentType: req.contentType,
+  streamType: "BUFFERED",
+  metadata: { type: 0, metadataType: 0, title: req.title },
+};
+if (req.subtitleUrl) {
+  media.tracks = [{
+    trackId: 1,
+    type: "TEXT",
+    trackContentId: req.subtitleUrl,
+    trackContentType: "text/vtt",
+    subtype: "SUBTITLES",
+    name: req.subtitleLabel ?? "Subtitles",
+    language: "en",
+  }];
+}
+const body: Record<string, unknown> = { type: "LOAD", requestId, sessionId, media, autoplay: true };
+if (req.subtitleUrl) body.activeTrackIds = [1];
+```
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/core/cast/connection.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/cast/connection.ts src/core/cast/connection.test.ts
+git commit -m "feat(cast): drive a Chromecast over CASTV2"
+```
+
+---
+
+### Task 5: Adopting an already-resolved stream
+
+**Files:**
+- Modify: `src/core/streamSession.ts`
+- Test: `src/core/streamSession.test.ts`
+
+**Why:** the TUI holds `StreamFile[]` it resolved itself and never registers them with the registry it constructs (`src/ui/App.tsx:265`). Casting needs a session id so the device has a URL to fetch, and re-resolving would spend the user's debrid account twice.
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  ```ts
+  export interface AdoptStreamInput {
+    infoHash: string;
+    name: string;
+    backend: StreamBackend;
+    provider?: DebridProviderId;
+    files: StreamFile[];
+  }
+  // on StreamSessionRegistry:
+  adopt(input: AdoptStreamInput): StreamSession;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/streamSession.test.ts`:
+
+```ts
+describe("adopt", () => {
+  const FILES = [
+    { url: "https://provider.example/1", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 1_400_000_000 },
+  ];
+
+  it("registers a ready session without calling either resolver", async () => {
+    const streamTorrentImpl = vi.fn();
+    const resolveDebridImpl = vi.fn();
+    const registry = new StreamSessionRegistry({
+      streamTorrentImpl: streamTorrentImpl as never,
+      resolveDebridImpl: resolveDebridImpl as never,
+    });
+    const session = registry.adopt({
+      infoHash: "abc",
+      name: "Kepler.S02.1080p.WEB-DL",
+      backend: "debrid",
+      provider: "realdebrid",
+      files: FILES,
+    });
+    expect(session.state).toBe("ready");
+    expect(session.files).toEqual(FILES);
+    expect(session.capability).toBeTruthy();
+    expect(registry.get(session.id)).toBe(session);
+    expect(streamTorrentImpl).not.toHaveBeenCalled();
+    expect(resolveDebridImpl).not.toHaveBeenCalled();
+  });
+
+  it("mints a distinct id and capability per adopted session", () => {
+    const registry = new StreamSessionRegistry();
+    const a = registry.adopt({ infoHash: "abc", name: "Kestrel.2010.1080p.BluRay.x264", backend: "torrent", files: FILES });
+    const b = registry.adopt({ infoHash: "abc", name: "Kestrel.2010.1080p.BluRay.x264", backend: "torrent", files: FILES });
+    expect(a.id).not.toBe(b.id);
+    expect(a.capability).not.toBe(b.capability);
+  });
+
+  it("stops without touching a backend it does not own", async () => {
+    const registry = new StreamSessionRegistry();
+    const session = registry.adopt({ infoHash: "abc", name: "Ashfall.1999.1080p", backend: "torrent", files: FILES });
+    // The TUI owns the WebTorrent session behind these files and stops it
+    // itself on picker cancel. Dropping the row must not reach for it.
+    await expect(registry.stop(session.id)).resolves.toBeUndefined();
+    expect(registry.get(session.id)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/core/streamSession.test.ts`
+Expected: FAIL — `registry.adopt is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/core/streamSession.ts`:
+
+```ts
+export interface AdoptStreamInput {
+  infoHash: string;
+  name: string;
+  backend: StreamBackend;
+  provider?: DebridProviderId;
+  files: StreamFile[];
+}
+```
+
+and the method on `StreamSessionRegistry`:
+
+```ts
+  /**
+   * Register files a front end has ALREADY resolved.
+   *
+   * The TUI resolves its own streams and hands the URLs straight to mpv, so its
+   * files were never in this registry. Casting needs them here, because a
+   * Chromecast can only fetch `/stream/:sid/:idx` — it cannot reach a debrid
+   * link it has no token for, nor the `localhost` WebTorrent server. Adopting
+   * is how that happens without spending a second resolve on the user's account.
+   *
+   * `backendHandle` is deliberately null: the caller still owns whatever is
+   * serving these bytes and stops it on its own terms (the picker's cancel
+   * path). So `stop()` on an adopted session drops the row and reaches for
+   * nothing — which is what the third test pins.
+   */
+  adopt(input: AdoptStreamInput): StreamSession {
+    const session: StreamSession = {
+      id: this.idFactory(),
+      capability: this.capabilityFactory(),
+      backendHandle: null,
+      backend: input.backend,
+      ...(input.provider ? { provider: input.provider } : {}),
+      infoHash: input.infoHash,
+      // No magnet: nothing will re-resolve this session, and StreamSession does
+      // not carry one anyway.
+      name: input.name,
+      state: "ready",
+      files: input.files,
+      progress: 1,
+      createdAt: this.now(),
+    };
+    this.sessions.set(session.id, session);
+    return session;
+  }
+```
+
+Note for the implementer: `stop()` already guards `backendHandle` — confirm it reads `session.backendHandle?.stop()` or equivalent before relying on the third test; if it dereferences unconditionally, add the optional call as part of this task.
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/core/streamSession.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/streamSession.ts src/core/streamSession.test.ts
+git commit -m "feat(stream): adopt already-resolved files into a session"
+```
+
+---
+
+### Task 6: The one active cast
+
+**Files:**
+- Create: `src/core/cast/session.ts`
+- Test: `src/core/cast/session.test.ts`
+- Modify: `src/daemon/runtime.ts` (add `casts` to `Runtime` and to `startRuntime`)
+
+**Interfaces:**
+- Consumes: `CastConnection`, `CastError`, `type CastStatus`, `type CastMediaRequest` (Task 4); `type CastDevice` (Task 2).
+- Produces:
+  ```ts
+  export interface ActiveCast {
+    device: CastDevice;
+    sid: string;
+    index: number;
+    title: string;
+    status: CastStatus;
+  }
+  export interface StartCastInput {
+    device: CastDevice;
+    sid: string;
+    index: number;
+    infoHash: string;
+    filename: string;
+    title: string;
+    media: CastMediaRequest;
+  }
+  export type MarkPlayed = (infoHash: string, filename: string) => Promise<void>;
+  export interface CastRegistryDeps {
+    openConnection?: (device: CastDevice) => Promise<CastConnection>;
+    markPlayed?: MarkPlayed;
+  }
+  export class CastSessionRegistry {
+    constructor(deps?: CastRegistryDeps);
+    active(): ActiveCast | null;
+    /** The message to show when the last cast ended badly, then cleared. */
+    takeNotice(): string | null;
+    start(input: StartCastInput): Promise<ActiveCast>;
+    play(): Promise<void>;
+    pause(): Promise<void>;
+    stop(): Promise<void>;
+    onChange(cb: () => void): () => void;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/cast/session.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { CastError } from "./connection";
+import { CastSessionRegistry, type StartCastInput } from "./session";
+import type { CastDevice } from "./discover";
+
+const DEVICE: CastDevice = { id: "abc", name: "Living Room TV", model: "Chromecast", host: "10.0.0.5", port: 8009 };
+const OTHER: CastDevice = { id: "k1", name: "Kitchen display", model: "Chromecast", host: "10.0.0.6", port: 8009 };
+
+function input(over: Partial<StartCastInput> = {}): StartCastInput {
+  return {
+    device: DEVICE,
+    sid: "sess",
+    index: 0,
+    infoHash: "hash",
+    filename: "Kepler.S02E04.1080p.WEB-DL.mkv",
+    title: "Kepler S02E04",
+    media: { url: "http://10.0.0.2:9161/stream/sess/0?k=t", contentType: "video/mp4", title: "Kepler S02E04" },
+    ...over,
+  };
+}
+
+function fakeConnection() {
+  let status: ((s: never) => void) | null = null;
+  let lost: ((m: string) => void) | null = null;
+  return {
+    load: vi.fn(async () => {}),
+    play: vi.fn(async () => {}),
+    pause: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    close: vi.fn(),
+    onStatus: (cb: never) => { status = cb; },
+    onLost: (cb: (m: string) => void) => { lost = cb; },
+    emitStatus(s: unknown) { (status as unknown as (v: unknown) => void)(s); },
+    emitLost(m: string) { lost!(m); },
+  };
+}
+
+describe("CastSessionRegistry", () => {
+  it("has nothing active until something is cast", () => {
+    expect(new CastSessionRegistry().active()).toBeNull();
+  });
+
+  it("loads the media and reports what is playing", async () => {
+    const conn = fakeConnection();
+    const registry = new CastSessionRegistry({ openConnection: async () => conn as never });
+    const active = await registry.start(input());
+    expect(conn.load).toHaveBeenCalledWith(input().media);
+    expect(active.device.name).toBe("Living Room TV");
+    expect(registry.active()).toMatchObject({ sid: "sess", index: 0, title: "Kepler S02E04" });
+  });
+
+  it("marks the file played on a successful load, exactly once", async () => {
+    const markPlayed = vi.fn(async () => {});
+    const registry = new CastSessionRegistry({
+      openConnection: async () => fakeConnection() as never,
+      markPlayed,
+    });
+    await registry.start(input());
+    expect(markPlayed).toHaveBeenCalledExactlyOnceWith("hash", "Kepler.S02E04.1080p.WEB-DL.mkv");
+  });
+
+  it("marks nothing when the device refuses the file", async () => {
+    const markPlayed = vi.fn(async () => {});
+    const conn = fakeConnection();
+    conn.load.mockRejectedValue(new CastError("Living Room TV couldn't play this file."));
+    const registry = new CastSessionRegistry({ openConnection: async () => conn as never, markPlayed });
+    await expect(registry.start(input())).rejects.toThrow(/couldn't play this file/);
+    expect(markPlayed).not.toHaveBeenCalled();
+    // And nothing is left behind claiming to be playing.
+    expect(registry.active()).toBeNull();
+    expect(conn.close).toHaveBeenCalledOnce();
+  });
+
+  it("never lets a history write failure fail a cast the user already started", async () => {
+    const registry = new CastSessionRegistry({
+      openConnection: async () => fakeConnection() as never,
+      markPlayed: async () => { throw new Error("disk full"); },
+    });
+    await expect(registry.start(input())).resolves.toMatchObject({ sid: "sess" });
+  });
+
+  it("replaces an existing cast, closing the first connection", async () => {
+    const first = fakeConnection();
+    const second = fakeConnection();
+    const conns = [first, second];
+    const registry = new CastSessionRegistry({ openConnection: async () => conns.shift() as never });
+    await registry.start(input());
+    await registry.start(input({ device: OTHER, sid: "sess2" }));
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(registry.active()).toMatchObject({ sid: "sess2", device: { name: "Kitchen display" } });
+  });
+
+  it("keeps the latest status and notifies subscribers", async () => {
+    const conn = fakeConnection();
+    const registry = new CastSessionRegistry({ openConnection: async () => conn as never });
+    const changed = vi.fn();
+    registry.onChange(changed);
+    await registry.start(input());
+    changed.mockClear();
+    conn.emitStatus({ state: "playing", positionSec: 30, durationSec: 6_000 });
+    expect(registry.active()!.status).toEqual({ state: "playing", positionSec: 30, durationSec: 6_000 });
+    expect(changed).toHaveBeenCalled();
+  });
+
+  it("clears the cast and leaves a notice when the connection is lost", async () => {
+    const conn = fakeConnection();
+    const registry = new CastSessionRegistry({ openConnection: async () => conn as never });
+    await registry.start(input());
+    conn.emitLost("Lost the connection to Living Room TV.");
+    expect(registry.active()).toBeNull();
+    expect(registry.takeNotice()).toBe("Lost the connection to Living Room TV.");
+    // Taken once: the front end that read it has shown it.
+    expect(registry.takeNotice()).toBeNull();
+  });
+
+  it("stop closes the connection and clears the cast, with no notice — the user asked for it", async () => {
+    const conn = fakeConnection();
+    const registry = new CastSessionRegistry({ openConnection: async () => conn as never });
+    await registry.start(input());
+    await registry.stop();
+    expect(conn.stop).toHaveBeenCalledOnce();
+    expect(conn.close).toHaveBeenCalledOnce();
+    expect(registry.active()).toBeNull();
+    expect(registry.takeNotice()).toBeNull();
+  });
+
+  it("refuses a command when nothing is casting", async () => {
+    const registry = new CastSessionRegistry();
+    await expect(registry.pause()).rejects.toThrow(/nothing is casting/i);
+    // Stop is the exception: stopping nothing is what the user wanted anyway.
+    await expect(registry.stop()).resolves.toBeUndefined();
+  });
+
+  it("unsubscribes cleanly", async () => {
+    const registry = new CastSessionRegistry({ openConnection: async () => fakeConnection() as never });
+    const changed = vi.fn();
+    registry.onChange(changed)();
+    await registry.start(input());
+    expect(changed).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/core/cast/session.test.ts`
+Expected: FAIL — cannot resolve `./session`.
+
+- [ ] **Step 3: Implement `session.ts`**
+
+The behaviours the tests pin, in prose so the implementation is not just transcribed:
+
+- `start` opens a connection, `load`s, and only then records the active cast and calls `markPlayed`. A `load` rejection closes the connection, leaves `active()` null, and propagates — a device that refuses the file must not earn a ✓, which is the rule `playFromPicker`'s `onPlayed` callback already follows in the TUI.
+- `markPlayed` failures are swallowed. A convenience list must never fail a play the user already started — the same rule `recordStreamHistory` follows in `App.tsx`.
+- A second `start` closes the first connection. One cast per process, so there is never a second thing claiming the screen.
+- `onLost` clears the cast and stores a notice `takeNotice()` hands over exactly once, because both front ends poll for it and only one should show it.
+- `stop()` with nothing casting resolves. Stopping nothing is what the caller wanted; throwing there would make a "stop" button that errors.
+
+The default `markPlayed` is the pair a local play already uses — read, change, compare by reference, write:
+
+```ts
+const defaultMarkPlayed: MarkPlayed = async (infoHash, filename) => {
+  // Read-modify-write, never a held snapshot: a `serve --web` process may be
+  // running against this same file. Same reference back means nothing moved,
+  // which is the write gate — exactly as the "watched" route does.
+  const config = await loadConfig();
+  const favourites = markWatched(config.favourites ?? [], infoHash, filename);
+  if (favourites !== (config.favourites ?? [])) await saveConfig({ ...config, favourites });
+  const history = await loadStreamHistory();
+  const advanced = recordPlayedFile(history, infoHash, filename);
+  if (advanced !== history) await saveStreamHistory(advanced);
+};
+```
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/core/cast/session.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Put the registry on `Runtime`**
+
+In `src/daemon/runtime.ts`, add to the `Runtime` interface, with a comment matching `sessions`':
+
+```ts
+  // The one active cast, shared by every front-end in this process for the same
+  // reason `sessions` is. Note the limit, which is honest rather than hidden:
+  // the TUI and `serve --web` are separate processes, so a cast started in one
+  // is invisible to the other unless the TUI is hosting the web UI itself.
+  casts: CastSessionRegistry;
+```
+
+and in `startRuntime`, `casts: new CastSessionRegistry()`.
+
+- [ ] **Step 6: Fix every other place that builds a `Runtime`**
+
+Run: `grep -rn "Runtime = {\|: Runtime = \|runtime: {" src scripts | grep -v "\.test\." | cut -c1-120`
+
+Then the tests: `grep -rln "Runtime" src --include="*.test.ts*"`. Every literal needs `casts`. Prefer a shared helper if the test files already have one (`src/daemon/testHarness.ts`); otherwise add the field.
+
+- [ ] **Step 7: Typecheck and run the affected suites**
+
+Run: `npm run typecheck && npx vitest run src/daemon src/web/routes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/cast/session.ts src/core/cast/session.test.ts src/daemon/runtime.ts
+git add -u
+git commit -m "feat(cast): one active cast per process, on Runtime"
+```
+
+---
+
+### Task 7: What the page and the device need to know about a file
+
+**Files:**
+- Modify: `src/web/stream.ts` (the `.info` body; the `.vtt` headers)
+- Modify: `src/web/wire.ts` (`StreamInfoResponse.castBlockers`)
+- Test: `src/web/stream.test.ts`
+
+**Interfaces:**
+- Consumes: `CHROMECAST_PROFILE`, `blockersFor` (Task 3).
+- Produces: `StreamInfoResponse.castBlockers: Blocker[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/web/stream.test.ts`, following the existing `.info` and `.vtt` tests' setup:
+
+```ts
+it("reports cast blockers beside the browser's, because the two decoders differ", async () => {
+  // An MP4 carrying AC3: the browser refuses the audio, a Chromecast takes it.
+  // This is the pair that lets the fallback card offer to cast.
+  const body = await infoFor("Kestrel.2010.1080p.BluRay.x264.AC3.mp4");
+  expect(body.blockers).toEqual(["audio"]);
+  expect(body.castBlockers).toEqual([]);
+});
+
+it("reports a container blocker for both, for an mkv", async () => {
+  const body = await infoFor("Kepler.S02E04.1080p.WEB-DL.mkv");
+  expect(body.blockers).toEqual(["container"]);
+  expect(body.castBlockers).toEqual(["container"]);
+});
+
+it("serves a subtitle with CORS, because a Chromecast fetches tracks cross-origin", async () => {
+  // Without this the device drops the track SILENTLY, which reads as "casting
+  // ignores subtitles". Safe here because the request was already authorised by
+  // the session capability in `?k=` — the header widens who may read the
+  // response, not who may ask for it.
+  const res = await getStream(`/stream/${sid}/1.vtt?k=${capability}`);
+  expect(res.headers["access-control-allow-origin"]).toBe("*");
+  expect(res.headers["content-type"]).toBe("text/vtt; charset=utf-8");
+});
+
+it("does NOT put CORS on the media itself", async () => {
+  // The media is a range-proxied video, or a redirect to a debrid link. Nothing
+  // cross-origin reads it, and widening it would let any page on the LAN read
+  // the user's stream once it guessed a handle.
+  const res = await getStream(`/stream/${sid}/0?k=${capability}`);
+  expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `npx vitest run src/web/stream.test.ts`
+Expected: FAIL — `castBlockers` undefined; no CORS header.
+
+- [ ] **Step 3: Implement**
+
+In `src/web/wire.ts`, on `StreamInfoResponse`, after `blockers`:
+
+```ts
+  /**
+   * Empty means a Chromecast should be able to play this file as it is.
+   *
+   * Separate from `blockers` because the two decoders genuinely differ: a
+   * Chromecast passes AC3 and E-AC3 through to the television, which no browser
+   * will decode. See `CHROMECAST_PROFILE` (src/util/playability.ts) for the
+   * trade-off that allows, which is silence on a TV whose HDMI link cannot take
+   * passthrough.
+   */
+  castBlockers: Blocker[];
+```
+
+In `src/web/stream.ts`, the `.info` body:
+
+```ts
+    const body: StreamInfoResponse = {
+      facts,
+      blockers: blockersFor(facts),
+      castBlockers: blockersFor(facts, CHROMECAST_PROFILE),
+      hls,
+      subtitles: { ... },
+    };
+```
+
+and in the `rep === "subtitle"` branch's `res.writeHead`, add the header with the reason beside it:
+
+```ts
+      // A Chromecast's receiver runs on an HTTPS origin of Google's and fetches
+      // sidecar tracks cross-origin; without this it drops the track SILENTLY,
+      // which reads to the user as "casting ignores subtitles". Only this
+      // representation gets it — the media handle must not, and a test pins
+      // that. It is safe here because `?k=` already authorised the request; the
+      // header widens who may READ the response, not who may make it.
+      "Access-Control-Allow-Origin": "*",
+```
+
+- [ ] **Step 4: Run and confirm they pass**
+
+Run: `npx vitest run src/web/stream.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/stream.ts src/web/wire.ts src/web/stream.test.ts
+git commit -m "feat(cast): report cast blockers, and let a device fetch the subtitle"
+```
+
+---
+
+### Task 8: The origin a television can fetch from
+
+**Files:**
+- Create: `src/web/castOrigin.ts`
+- Test: `src/web/castOrigin.test.ts`
+
+**Interfaces:**
+- Consumes: `displayHosts`, `type NetInterfaces` (`src/web/links.ts`).
+- Produces:
+  ```ts
+  export function castOrigin(
+    host: string,
+    port: number,
+    interfaces: NetInterfaces,
+  ): string | null;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web/castOrigin.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { castOrigin } from "./castOrigin";
+import type { NetInterfaces } from "./links";
+
+const IFACES: NetInterfaces = {
+  lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+  en0: [{ address: "192.168.0.98", family: "IPv4", internal: false }],
+};
+
+describe("castOrigin", () => {
+  it("names a LAN address, never loopback, even when the server is bound to a wildcard", () => {
+    expect(castOrigin("0.0.0.0", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+  });
+
+  it("names the LAN address when the user is browsing localhost", () => {
+    // THE failure this module exists to prevent: the request's Host header says
+    // `localhost`, and handing a television `http://localhost:9161` points it
+    // at itself. Every other absolute URL in this app is built from Host
+    // (`requestOrigin`), and this one must not be.
+    expect(castOrigin("localhost", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+  });
+
+  it("uses an explicit non-loopback bind address as given", () => {
+    expect(castOrigin("192.168.0.98", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+  });
+
+  it("is null when the machine has no non-loopback address, rather than naming loopback", () => {
+    // A caller turns this into "this machine has no network a TV could reach
+    // it on". A URL that cannot work is worse than no button.
+    expect(castOrigin("0.0.0.0", 9161, { lo0: IFACES.lo0 })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/web/castOrigin.test.ts`
+Expected: FAIL — cannot resolve `./castOrigin`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/web/castOrigin.ts`. Read `displayHosts` first (`src/web/links.ts:45`) and use its `lan` result rather than enumerating interfaces again — this module's whole job is to pick which of its two answers a device needs.
+
+```ts
+import { displayHosts, type NetInterfaces } from "./links";
+
+/**
+ * The origin a Chromecast must fetch media from.
+ *
+ * Deliberately NOT `requestOrigin` (src/web/stream.ts), which every other
+ * absolute URL in this app comes from. That reads the request's `Host`, which
+ * is right for a playlist the user's own machine opens and wrong for a
+ * television: a user browsing `http://localhost:9161` would hand the device a
+ * URL pointing at the device itself, and a user on a second interface would
+ * hand it one it cannot route to.
+ *
+ * Null when there is no non-loopback address at all. A caller turns that into a
+ * message; it must not fall back to loopback, because a URL that cannot work is
+ * worse than no button.
+ */
+export function castOrigin(host: string, port: number, interfaces: NetInterfaces): string | null {
+  const { lan } = displayHosts(host, interfaces);
+  if (!lan) return null;
+  return `http://${lan}:${port}`;
+}
+```
+
+Note for the implementer: check what `displayHosts` returns for `lan` when the bind host is already a specific LAN address, and when there is none — the third and fourth tests pin both. If its shape does not fit (for instance `lan` is only populated for a wildcard bind), keep the signature and handle the cases here rather than changing `displayHosts`, which the TUI's splash line and `daemon/files.ts` also use.
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/web/castOrigin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/castOrigin.ts src/web/castOrigin.test.ts
+git commit -m "feat(cast): the LAN origin a device fetches from"
+```
+
+---
+
+### Task 9: The cast routes
+
+**Files:**
+- Modify: `src/web/routes.ts`, `src/web/wire.ts`, `src/web/server.ts` (pass the bound host/port and interfaces into `WebDeps`)
+- Test: `src/web/routes.test.ts`
+
+**Interfaces:**
+- Consumes: `discover`, `parseManualDevice`, `type CastDevice` (Task 2); `CastSessionRegistry` on `Runtime` (Task 6); `castOrigin` (Task 8); `castContentType`, `CHROMECAST_PROFILE`, `blockersFor` (Task 3); `playlistTitle` (`src/util/playlistTitle.ts`).
+- Produces, in `src/web/wire.ts`:
+  ```ts
+  export interface PublicCastDevice { id: string; name: string; model: string }
+  export interface CastDevicesResponse { devices: PublicCastDevice[]; castable: boolean; reason: string | null }
+  export interface CastStatusResponse {
+    casting: null | {
+      deviceName: string;
+      title: string;
+      state: "loading" | "playing" | "paused" | "idle";
+      positionSec: number;
+      durationSec: number | null;
+    };
+    notice: string | null;
+  }
+  ```
+  and in `WebDeps`: `discoverCastImpl?: () => Promise<CastDevice[]>`, `castOriginImpl?: () => string | null`.
+
+  Note what `PublicCastDevice` omits: `host` and `port`. The browser picks a device by `id`; the address stays server-side, because a page has no use for it and publishing the LAN topology of the user's house to any tab is gratuitous.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/web/routes.test.ts`, using the file's existing `deps` builder:
+
+```ts
+describe("GET /api/cast/devices", () => {
+  it("lists discovered devices without their addresses", async () => {
+    const res = await handleWebApi(
+      deps({ discoverCastImpl: async () => [
+        { id: "abc", name: "Living Room TV", model: "Chromecast", host: "10.0.0.5", port: 8009 },
+      ] }),
+      "GET", "/api/cast/devices", new URLSearchParams(), auth, "",
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({
+      devices: [{ id: "abc", name: "Living Room TV", model: "Chromecast" }],
+      castable: true,
+      reason: null,
+    });
+  });
+
+  it("includes the configured address whether discovery saw anything or not", async () => {
+    const res = await handleWebApi(
+      deps({
+        discoverCastImpl: async () => [],
+        loadConfigImpl: async () => ({ ...baseConfig, castDevice: "192.168.0.40" }),
+      }),
+      "GET", "/api/cast/devices", new URLSearchParams(), auth, "",
+    );
+    expect((res.json as CastDevicesResponse).devices).toEqual([
+      { id: "manual:192.168.0.40:8009", name: "192.168.0.40", model: "" },
+    ]);
+  });
+
+  it("says why casting is unavailable when nothing answered", async () => {
+    const res = await handleWebApi(
+      deps({ discoverCastImpl: async () => [] }),
+      "GET", "/api/cast/devices", new URLSearchParams(), auth, "",
+    );
+    expect(res.json).toMatchObject({ devices: [], castable: false });
+    expect((res.json as CastDevicesResponse).reason).toMatch(/No Chromecast found/);
+  });
+
+  it("says why casting is unavailable when this machine has no LAN address", async () => {
+    const res = await handleWebApi(
+      deps({
+        discoverCastImpl: async () => [{ id: "abc", name: "Living Room TV", model: "", host: "10.0.0.5", port: 8009 }],
+        castOriginImpl: () => null,
+      }),
+      "GET", "/api/cast/devices", new URLSearchParams(), auth, "",
+    );
+    expect(res.json).toMatchObject({ castable: false });
+    expect((res.json as CastDevicesResponse).reason).toMatch(/no network address/i);
+  });
+
+  it("needs the token", async () => {
+    const res = await handleWebApi(deps(), "GET", "/api/cast/devices", new URLSearchParams(), undefined, "");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/cast/start", () => {
+  it("casts the stream handle built from the LAN origin, not from Host", async () => {
+    const runtime = runtimeWithSession(); // a ready session over Kestrel.2010…AC3.mp4
+    const start = vi.spyOn(runtime.casts, "start");
+    const res = await handleWebApi(
+      deps({
+        runtime,
+        discoverCastImpl: async () => [{ id: "abc", name: "Living Room TV", model: "", host: "10.0.0.5", port: 8009 }],
+        castOriginImpl: () => "http://192.168.0.98:9161",
+      }),
+      "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "abc", sid: runtime.sessionId, index: 0 }),
+    );
+    expect(res.status).toBe(200);
+    const arg = start.mock.calls[0]![0];
+    expect(arg.media.url).toBe(`http://192.168.0.98:9161/stream/${runtime.sessionId}/0?k=${runtime.capability}`);
+    expect(arg.media.contentType).toBe("video/mp4");
+    expect(arg.media.title).toBe("Kestrel 2010");
+  });
+
+  it("casts an HLS manifest with the HLS content type when the direct file is blocked", async () => {
+    // The debrid provider's transcode: the only rung above direct play today.
+    const runtime = runtimeWithSession({ filename: "Kepler.S02E04.1080p.WEB-DL.mkv", hls: "https://provider.example/m.m3u8" });
+    const start = vi.spyOn(runtime.casts, "start");
+    await handleWebApi(
+      deps({ runtime, discoverCastImpl: async () => [DISCOVERED], castOriginImpl: () => "http://192.168.0.98:9161" }),
+      "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "abc", sid: runtime.sessionId, index: 0 }),
+    );
+    expect(start.mock.calls[0]![0].media.contentType).toBe("application/vnd.apple.mpegurl");
+  });
+
+  it("refuses a file no Chromecast can play, naming the reason", async () => {
+    const runtime = runtimeWithSession({ filename: "Kepler.S02E04.1080p.WEB-DL.mkv" }); // torrent backend, no hls
+    const res = await handleWebApi(
+      deps({ runtime, discoverCastImpl: async () => [DISCOVERED], castOriginImpl: () => "http://192.168.0.98:9161" }),
+      "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "abc", sid: runtime.sessionId, index: 0 }),
+    );
+    expect(res.status).toBe(409);
+    expect((res.json as { error: string }).error).toMatch(/can't play this one/);
+  });
+
+  it("passes the chosen subtitle as a vtt handle on the same origin", async () => {
+    const runtime = runtimeWithSession({ subtitleIndex: 1 });
+    const start = vi.spyOn(runtime.casts, "start");
+    await handleWebApi(
+      deps({ runtime, discoverCastImpl: async () => [DISCOVERED], castOriginImpl: () => "http://192.168.0.98:9161" }),
+      "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "abc", sid: runtime.sessionId, index: 0, subtitleIndex: 1 }),
+    );
+    expect(start.mock.calls[0]![0].media.subtitleUrl).toBe(
+      `http://192.168.0.98:9161/stream/${runtime.sessionId}/1.vtt?k=${runtime.capability}`,
+    );
+  });
+
+  it("404s an unknown session and 404s an unknown device", async () => {
+    const runtime = runtimeWithSession();
+    const base = deps({ runtime, discoverCastImpl: async () => [DISCOVERED], castOriginImpl: () => "http://h:1" });
+    const noSession = await handleWebApi(base, "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "abc", sid: "nope", index: 0 }));
+    expect(noSession.status).toBe(404);
+    const noDevice = await handleWebApi(base, "POST", "/api/cast/start", new URLSearchParams(), auth,
+      JSON.stringify({ deviceId: "nope", sid: runtime.sessionId, index: 0 }));
+    expect(noDevice.status).toBe(404);
+  });
+
+  it("400s a body missing a field, rather than casting something undefined", async () => {
+    const res = await handleWebApi(deps(), "POST", "/api/cast/start", new URLSearchParams(), auth, "{}");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/cast/command", () => {
+  it("pauses, plays and stops the active cast", async () => {
+    const runtime = runtimeWithSession();
+    const pause = vi.spyOn(runtime.casts, "pause").mockResolvedValue(undefined);
+    const res = await handleWebApi(deps({ runtime }), "POST", "/api/cast/command",
+      new URLSearchParams(), auth, JSON.stringify({ action: "pause" }));
+    expect(res.status).toBe(200);
+    expect(pause).toHaveBeenCalledOnce();
+  });
+
+  it("is a clean 409 when nothing is casting, not a crash", async () => {
+    const runtime = runtimeWithSession();
+    const res = await handleWebApi(deps({ runtime }), "POST", "/api/cast/command",
+      new URLSearchParams(), auth, JSON.stringify({ action: "pause" }));
+    expect(res.status).toBe(409);
+  });
+
+  it("400s an action it does not know", async () => {
+    const res = await handleWebApi(deps(), "POST", "/api/cast/command",
+      new URLSearchParams(), auth, JSON.stringify({ action: "seek" }));
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: FAIL — the routes 404.
+
+- [ ] **Step 3: Add the wire types**
+
+In `src/web/wire.ts`, add `PublicCastDevice`, `CastDevicesResponse` and `CastStatusResponse` as given in the Interfaces block, each with a comment saying what it is for and, for `PublicCastDevice`, why the address is omitted.
+
+- [ ] **Step 4: Implement the routes**
+
+In `src/web/routes.ts`, below the streaming section's comment about the token gate, add three handlers and their dispatch lines, following the shape of `libraryAction` / `startStream`:
+
+- `castDevices(deps)` — `discover()` plus `parseManualDevice(config.castDevice)`, de-duplicated by `id` with the configured entry last; `castable` is false with a reason when the list is empty (`No Chromecast found on this network.`) or when `castOriginImpl()` is null (`This machine has no network address a Chromecast could reach it on.`).
+- `startCast(deps, bodyText)` — parse `{ deviceId, sid, index, subtitleIndex? }`; 400 on a missing field; 404 for an unknown session or device; compute facts the way `.info` does and refuse with 409 when `blockersFor(facts, CHROMECAST_PROFILE)` is non-empty *and* no HLS manifest is available; otherwise build the URL from `castOriginImpl()` and the session's `capability`, the content type from `castContentType`, and the title from `playlistTitle(file.filename)`; then `runtime.casts.start(...)`.
+- `castCommand(deps, bodyText)` — `play` / `pause` / `stop` only; 400 otherwise; 409 when the registry says nothing is casting.
+
+Reuse, don't reimplement: the `?k=` handle and `.vtt` suffix already have builders on the browser side (`streamPath`, `subtitlePath` in `playerModel.ts`) but those are in `src/web/static` and cannot be imported by the server. Build the two paths with a small local helper in `routes.ts` and note in a comment that a third consumer means moving one into `src/util/`.
+
+- [ ] **Step 5: Pass the origin in from the server**
+
+In `src/web/server.ts`, where `WebDeps` is assembled, default `castOriginImpl` to `() => castOrigin(host, boundPort, os.networkInterfaces())` — the *bound* port, read back from the handle the way the TUI's notice does (`src/ui/App.tsx:614`), never the requested one, because `port: 0` is in play.
+
+- [ ] **Step 6: Run and confirm they pass**
+
+Run: `npx vitest run src/web/routes.test.ts src/web/server.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/routes.ts src/web/wire.ts src/web/server.ts src/web/routes.test.ts
+git commit -m "feat(cast): device list, start and command routes"
+```
+
+---
+
+### Task 10: Cast status on the event stream
+
+**Files:**
+- Modify: `src/web/sse.ts`, `src/web/routes.ts` (or wherever the SSE endpoint is mounted)
+- Test: `src/web/sse.test.ts`
+
+**Interfaces:**
+- Consumes: `CastSessionRegistry.onChange` (Task 6); `CastStatusResponse` (Task 9).
+- Produces: `export function subscribeToCasts(channel: SseChannel, casts: CastSessionRegistry): () => void;` emitting a `cast` event whose data is a `CastStatusResponse`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/web/sse.test.ts`, mirroring `subscribeToQueue`'s tests:
+
+```ts
+describe("subscribeToCasts", () => {
+  it("sends the current cast state on subscribe, so a page that arrives mid-cast is not blank", () => {
+    const written: string[] = [];
+    const channel = openSseChannel((c) => written.push(c));
+    const casts = new CastSessionRegistry();
+    subscribeToCasts(channel, casts);
+    expect(written.join("")).toContain("event: cast");
+    expect(written.join("")).toContain('"casting":null');
+  });
+
+  it("sends an update whenever the cast changes", async () => { /* start a cast on a fake connection, assert a second frame naming the device */ });
+
+  it("unsubscribes on close, so a closed page's socket is not written to", () => { /* assert the returned function detaches */ });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/web/sse.test.ts`
+Expected: FAIL — `subscribeToCasts` is not exported.
+
+- [ ] **Step 3: Implement, and mount it beside `subscribeToQueue`**
+
+The `cast` event carries the same `CastStatusResponse` shape the routes return, so the browser has one parser for both. Include `notice` and take it from the registry, so a lost connection reaches an open page without it polling.
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/web/sse.test.ts src/web/routes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/sse.ts src/web/sse.test.ts src/web/routes.ts
+git commit -m "feat(cast): push cast status over SSE"
+```
+
+---
+
+### Task 11: Every browser-side decision
+
+**Files:**
+- Create: `src/web/static/castModel.ts`
+- Test: `src/web/static/castModel.test.ts`
+
+**Interfaces:**
+- Consumes: `CastDevicesResponse`, `CastStatusResponse` (Task 9); `type Blocker` (`src/util/playability.ts`).
+- Produces:
+  ```ts
+  export type CastButtonState = "hidden" | "ready" | "finding" | "disabled" | "casting";
+  export interface CastButtonView { state: CastButtonState; label: string; disabledReason: string | null }
+  export function castButtonView(input: {
+    devices: CastDevicesResponse | null;
+    status: CastStatusResponse | null;
+    castBlockers: Blocker[];
+    hasHls: boolean;
+  }): CastButtonView;
+  export function castStatusLine(status: CastStatusResponse): string | null;
+  export function castControls(status: CastStatusResponse): ("play" | "pause" | "stop")[];
+  export function formatCastTime(seconds: number): string;
+  export function castBlockerReason(blockers: Blocker[]): string;
+  ```
+  Nothing here imports `node:*` — Task 14's `npm run build` is the only thing that proves it, because this module is bundled for the browser.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web/static/castModel.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  castBlockerReason,
+  castButtonView,
+  castControls,
+  castStatusLine,
+  formatCastTime,
+} from "./castModel";
+import type { CastDevicesResponse, CastStatusResponse } from "../wire";
+
+const ONE_DEVICE: CastDevicesResponse = {
+  devices: [{ id: "abc", name: "Living Room TV", model: "Chromecast" }],
+  castable: true,
+  reason: null,
+};
+const NONE: CastDevicesResponse = { devices: [], castable: false, reason: "No Chromecast found on this network." };
+const IDLE: CastStatusResponse = { casting: null, notice: null };
+
+describe("castButtonView", () => {
+  it("is hidden until the device list has been fetched, so nothing flickers", () => {
+    expect(castButtonView({ devices: null, status: null, castBlockers: [], hasHls: false })).toEqual({
+      state: "hidden", label: "", disabledReason: null,
+    });
+  });
+
+  it("offers casting when a device answered and the file is playable", () => {
+    expect(castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: [], hasHls: false })).toEqual({
+      state: "ready", label: "Cast to TV", disabledReason: null,
+    });
+  });
+
+  it("is disabled with the network reason when nothing answered", () => {
+    expect(castButtonView({ devices: NONE, status: IDLE, castBlockers: [], hasHls: false })).toEqual({
+      state: "disabled", label: "Cast to TV", disabledReason: "No Chromecast found on this network.",
+    });
+  });
+
+  it("is disabled with the file's reason when no Chromecast can play it", () => {
+    expect(castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: ["container"], hasHls: false })).toEqual({
+      state: "disabled",
+      label: "Cast to TV",
+      disabledReason: "A Chromecast can't play this one — it's a container it won't demux.",
+    });
+  });
+
+  it("offers casting for a blocked file that has an HLS manifest, which is the rung above it", () => {
+    expect(
+      castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: ["container"], hasHls: true }),
+    ).toMatchObject({ state: "ready" });
+  });
+
+  it("names the device once something is casting", () => {
+    const status: CastStatusResponse = {
+      casting: { deviceName: "Living Room TV", title: "Kepler S02E04", state: "playing", positionSec: 0, durationSec: 60 },
+      notice: null,
+    };
+    expect(castButtonView({ devices: ONE_DEVICE, status, castBlockers: [], hasHls: false })).toEqual({
+      state: "casting", label: "Playing on Living Room TV", disabledReason: null,
+    });
+  });
+
+  it("says it is finding devices while the file is playable and the list is still empty-but-loading", () => {
+    expect(
+      castButtonView({ devices: { devices: [], castable: false, reason: null }, status: IDLE, castBlockers: [], hasHls: false }),
+    ).toEqual({ state: "finding", label: "Finding devices…", disabledReason: null });
+  });
+});
+
+describe("castStatusLine", () => {
+  it("reads position over duration", () => {
+    expect(castStatusLine({
+      casting: { deviceName: "Living Room TV", title: "Kestrel 2010", state: "playing", positionSec: 724, durationSec: 6_512 },
+      notice: null,
+    })).toBe("0:12:04 / 1:48:32");
+  });
+
+  it("shows position alone when the duration is unknown, rather than inventing 0:00:00", () => {
+    expect(castStatusLine({
+      casting: { deviceName: "T", title: "Kestrel 2010", state: "playing", positionSec: 5, durationSec: null },
+      notice: null,
+    })).toBe("0:00:05");
+  });
+
+  it("says what it is doing when it is not playing", () => {
+    expect(castStatusLine({
+      casting: { deviceName: "T", title: "Kestrel 2010", state: "loading", positionSec: 0, durationSec: null },
+      notice: null,
+    })).toBe("Loading on the TV…");
+    expect(castStatusLine({
+      casting: { deviceName: "T", title: "Kestrel 2010", state: "paused", positionSec: 61, durationSec: 600 },
+      notice: null,
+    })).toBe("Paused · 0:01:01 / 0:10:00");
+  });
+
+  it("is null when nothing is casting", () => {
+    expect(castStatusLine(IDLE)).toBeNull();
+  });
+});
+
+describe("formatCastTime", () => {
+  it("is h:mm:ss, zero-padded past the hours", () => {
+    expect(formatCastTime(0)).toBe("0:00:00");
+    expect(formatCastTime(61)).toBe("0:01:01");
+    expect(formatCastTime(3_661)).toBe("1:01:01");
+  });
+
+  it("floors a fractional position and clamps a negative one", () => {
+    expect(formatCastTime(12.9)).toBe("0:00:12");
+    expect(formatCastTime(-5)).toBe("0:00:00");
+  });
+});
+
+describe("castControls", () => {
+  it("offers pause and stop while playing, play and stop while paused", () => {
+    const at = (state: "playing" | "paused" | "loading" | "idle"): CastStatusResponse => ({
+      casting: { deviceName: "T", title: "Kestrel 2010", state, positionSec: 0, durationSec: null },
+      notice: null,
+    });
+    expect(castControls(at("playing"))).toEqual(["pause", "stop"]);
+    expect(castControls(at("paused"))).toEqual(["play", "stop"]);
+    // Loading: only stop, because pausing something that has not started is a
+    // button that appears to do nothing.
+    expect(castControls(at("loading"))).toEqual(["stop"]);
+    expect(castControls(at("idle"))).toEqual(["stop"]);
+    expect(castControls(IDLE)).toEqual([]);
+  });
+});
+
+describe("castBlockerReason", () => {
+  it("names the container first, because it is the one a user can recognise", () => {
+    expect(castBlockerReason(["container", "audio"])).toContain("container");
+    expect(castBlockerReason(["video"])).toContain("video");
+    expect(castBlockerReason(["audio"])).toContain("audio");
+  });
+
+  it("never returns an empty string, so a disabled button always says why", () => {
+    expect(castBlockerReason([])).not.toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm it fails**
+
+Run: `npx vitest run src/web/static/castModel.test.ts`
+Expected: FAIL — cannot resolve `./castModel`.
+
+- [ ] **Step 3: Implement**
+
+Write `castModel.ts` to satisfy exactly the above. Keep the doc comment at the top explaining why this module exists: `player.ts` is DOM wiring only, has no test reachable without jsdom, and this codebase has twice caught a decision that belonged here sitting in the wiring.
+
+- [ ] **Step 4: Run and confirm it passes**
+
+Run: `npx vitest run src/web/static/castModel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/static/castModel.ts src/web/static/castModel.test.ts
+git commit -m "feat(cast): the browser's cast decisions, as a pure module"
+```
+
+---
+
+### Task 12: The cast button on the player page
+
+**Files:**
+- Modify: `src/web/static/player.ts`, `src/web/static/styles.css`
+- Read first: `src/web/static/player.ts:56` (`actions`), `:428` (`actions.replaceChildren`), `:453` (`linkButton`), and the fallback-card renderer
+
+**Interfaces:**
+- Consumes: everything from Task 11; the routes from Task 9; the `cast` SSE event from Task 10.
+- Produces: no new exports. This task adds no conditionals — `player.ts` reads `castButtonView`, `castStatusLine` and `castControls` and renders what they say.
+
+There is no unit test here, deliberately: nothing in `player.ts` is reachable without jsdom, and this repo has none. Verification is running it.
+
+- [ ] **Step 1: Fetch the device list and subscribe to status**
+
+On page load, after `.info` resolves, `GET /api/cast/devices` and hold the response; subscribe to the `cast` SSE event and hold the latest `CastStatusResponse`. Re-render the action row on either changing. Both start null, which `castButtonView` reports as `hidden` — that is why it has that state.
+
+- [ ] **Step 2: Render the button in the hand-off row**
+
+In the same `actions` container as copy-URL, `.m3u` and the mobile VLC link, because casting *is* a hand-off. `createElement` + `textContent` only. A `disabled` state renders as a disabled `<button>` with its reason as adjacent text — not a `title` attribute, which a phone cannot show.
+
+- [ ] **Step 3: The device picker**
+
+Clicking `Cast to TV` with one device casts to it. With more than one, reveal a list of buttons, one per device, labelled `name` with `model` as secondary text. `POST /api/cast/start` with `{ deviceId, sid, index, subtitleIndex }`, taking the subtitle index from whatever the page's subtitle picker currently has selected.
+
+- [ ] **Step 4: Swap the controls while casting**
+
+On a `casting` state: pause the local `<video>` (`video.pause()`), show `castStatusLine`'s text, and render one button per `castControls` entry, each `POST /api/cast/command`. On `stop`, or on a `notice` arriving, restore the page's own controls and show the notice in the existing `notice` element.
+
+- [ ] **Step 5: The fallback card gets a cast button**
+
+Where the card renders (`fallbackMessage`), also render the cast button. `castButtonView` already returns `ready` for a file the browser refuses but a Chromecast takes — an MP4 carrying AC3 — which is the point of having two profiles. Nothing new decides this; pass the same inputs.
+
+- [ ] **Step 6: Style it**
+
+Add a `.cast-*` block to `styles.css` following the calm theme already there. No new colours.
+
+- [ ] **Step 7: Verify by running it**
+
+```bash
+npm run build && npm run dev -- serve --web
+```
+
+Then, against a real Chromecast on the LAN, confirm each in turn and write the result into the commit body:
+1. The button appears, and names a real device.
+2. An MP4 casts and plays on the television.
+3. Pause, resume and stop each work, and the position line advances.
+4. Stopping restores the page's own player.
+5. A file with a subtitle selected shows that subtitle on the television.
+6. With no Chromecast on the network, the button is disabled and says so.
+7. An MKV from a torrent is disabled with the container reason; the same MKV on the debrid backend casts.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/web/static/player.ts src/web/static/styles.css
+git commit -m "feat(web): cast a stream to a Chromecast from the player page"
+```
+
+---
+
+### Task 13: The device list in the terminal
+
+**Files:**
+- Create: `src/ui/components/CastPrompt.tsx`, `src/ui/components/CastPrompt.test.tsx`
+- Modify: `src/config/config.ts` (add `castDevice`), `src/ui/keymap.ts`, `src/ui/keymap.test.ts`, `src/ui/components/StreamFilePrompt.tsx`, `src/ui/components/StreamFilePrompt.test.tsx`
+- Modify: `src/ui/store.ts`, `src/ui/testHarness.ts`, `scripts/render-previews-impl.tsx`
+
+**Interfaces:**
+- Consumes: `type CastDevice` (Task 2).
+- Produces:
+  ```ts
+  // CastPrompt.tsx
+  interface CastPromptProps {
+    width: number;
+    devices: CastDevice[];
+    /** True while discovery is still running. */
+    finding: boolean;
+    /** The configured address, prefilled into the field. */
+    configured?: string;
+    onSelect: (device: CastDevice) => void;
+    /** Saves the typed address to config and casts to it. */
+    onAddress: (address: string) => void;
+    onCancel: () => void;
+  }
+  // StreamFilePrompt gains:
+  onCast?: (file: StreamFile) => void;
+  // Store gains:
+  castStatus: { deviceName: string; title: string; state: string; positionSec: number; durationSec: number | null } | null;
+  ```
+
+**Why the address field lives in this prompt rather than behind a new key:** the letters in the Search section are used up, and a config screen for one field the user needs *exactly* when the list is empty is the wrong place for it. The empty list is the moment to offer it.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/ui/components/CastPrompt.test.tsx`, following `SourcesPrompt.test.tsx`'s use of `ink-testing-library`:
+
+```tsx
+import { describe, expect, it, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { CastPrompt } from "./CastPrompt";
+import type { CastDevice } from "../../core/cast/discover";
+
+const DEVICES: CastDevice[] = [
+  { id: "abc", name: "Living Room TV", model: "Chromecast", host: "10.0.0.5", port: 8009 },
+  { id: "k1", name: "Kitchen display", model: "Google TV Streamer", host: "10.0.0.6", port: 8009 },
+];
+
+describe("CastPrompt", () => {
+  it("lists devices with their models", () => {
+    const { lastFrame } = render(
+      <CastPrompt width={80} devices={DEVICES} finding={false} onSelect={() => {}} onAddress={() => {}} onCancel={() => {}} />,
+    );
+    expect(lastFrame()).toContain("Living Room TV");
+    expect(lastFrame()).toContain("Google TV Streamer");
+  });
+
+  it("selects the highlighted device on enter", () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <CastPrompt width={80} devices={DEVICES} finding={false} onSelect={onSelect} onAddress={() => {}} onCancel={() => {}} />,
+    );
+    stdin.write("[B"); // down
+    stdin.write("\r");
+    expect(onSelect).toHaveBeenCalledWith(DEVICES[1]);
+  });
+
+  it("says it is looking while discovery runs", () => {
+    const { lastFrame } = render(
+      <CastPrompt width={80} devices={[]} finding onSelect={() => {}} onAddress={() => {}} onCancel={() => {}} />,
+    );
+    expect(lastFrame()).toMatch(/Looking for/i);
+  });
+
+  it("explains mDNS when nothing was found, and offers the address field", () => {
+    const { lastFrame } = render(
+      <CastPrompt width={80} devices={[]} finding={false} onSelect={() => {}} onAddress={() => {}} onCancel={() => {}} />,
+    );
+    // The Docker / VLAN case: without this the feature looks broken rather
+    // than blocked.
+    expect(lastFrame()).toMatch(/No Chromecast found/i);
+    expect(lastFrame()).toMatch(/Docker|VLAN|address/i);
+  });
+
+  it("submits a typed address", () => {
+    const onAddress = vi.fn();
+    const { stdin } = render(
+      <CastPrompt width={80} devices={[]} finding={false} onSelect={() => {}} onAddress={onAddress} onCancel={() => {}} />,
+    );
+    stdin.write("192.168.0.40");
+    stdin.write("\r");
+    expect(onAddress).toHaveBeenCalledWith("192.168.0.40");
+  });
+
+  it("cancels on escape", () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <CastPrompt width={80} devices={DEVICES} finding={false} onSelect={() => {}} onAddress={() => {}} onCancel={onCancel} />,
+    );
+    stdin.write("");
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Write the failing keymap and picker tests**
+
+In `src/ui/keymap.test.ts`:
+
+```ts
+it("advertises the cast key in both halves, so the help overlay and the footer agree", () => {
+  const search = HELP_GROUPS.find((g) => g.title === "Search")!;
+  expect(search.hints.some((h) => h.keys === "c" && /cast/i.test(h.label))).toBe(true);
+  const footer = footerHints("content", "search");
+  expect(footer.some((h) => h.keys === "c" && /cast/i.test(h.label))).toBe(true);
+});
+```
+
+In `src/ui/components/StreamFilePrompt.test.tsx`:
+
+```ts
+it("casts the highlighted file on c, without also playing it locally", () => {
+  const onCast = vi.fn();
+  const onSelect = vi.fn();
+  const { stdin } = render(<StreamFilePrompt width={80} files={FILES} onSelect={onSelect} onCast={onCast} onCancel={() => {}} />);
+  stdin.write("c");
+  expect(onCast).toHaveBeenCalledWith(FILES[0]);
+  expect(onSelect).not.toHaveBeenCalled();
+});
+
+it("ignores c when no cast handler was given, rather than swallowing the key", () => {
+  const onSelect = vi.fn();
+  const { stdin } = render(<StreamFilePrompt width={80} files={FILES} onSelect={onSelect} onCancel={() => {}} />);
+  stdin.write("c");
+  expect(onSelect).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run all three and confirm they fail**
+
+Run: `npx vitest run src/ui/components/CastPrompt.test.tsx src/ui/keymap.test.ts src/ui/components/StreamFilePrompt.test.tsx`
+Expected: FAIL on each.
+
+- [ ] **Step 4: Add `castDevice` to the config**
+
+In `src/config/config.ts`, add to the `Config` interface with a comment saying why it exists (mDNS does not cross a Docker bridge or a VLAN) and that it is TUI-only by the rule in `CLAUDE.md`. Follow the file's existing optional-string handling in load and save, and add a `config.test.ts` case that a saved address round-trips and that an absent one stays absent.
+
+- [ ] **Step 5: Write `CastPrompt.tsx`**
+
+Follow `SourcesPrompt.tsx` for the list and `TokenPrompt.tsx` for the text field. `useInput` handles up/down/enter/escape; the field is `TextField`. The empty state carries the mDNS sentence.
+
+- [ ] **Step 6: Add `c` to `StreamFilePrompt` and both halves of the keymap**
+
+`HELP_GROUPS` Search section: `{ keys: "c", label: "Cast to a TV (Chromecast)" }`. `footerHints`: a terse `{ keys: "c", label: "Cast" }` in the row the picker shows. `StreamFilePrompt`'s `useInput` gains the `c` branch, guarded on `onCast` being present.
+
+- [ ] **Step 7: Add `castStatus` to the store and BOTH harnesses**
+
+`src/ui/store.ts`, then `makeTestStore` in `src/ui/testHarness.ts` (or `npm run typecheck` breaks) and `makeStore` in `scripts/render-previews-impl.tsx` (or `npm run previews` breaks). Both, per `CLAUDE.md`'s table.
+
+- [ ] **Step 8: Run and confirm they pass**
+
+Run: `npx vitest run src/ui src/config/config.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui src/config/config.ts src/config/config.test.ts scripts/render-previews-impl.tsx
+git commit -m "feat(tui): a cast key and a device list"
+```
+
+---
+
+### Task 14: Casting from the terminal
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+- Test: `src/ui/App.web.test.tsx` (the existing harness for App-level behaviour)
+
+**Interfaces:**
+- Consumes: `discover`, `parseManualDevice` (Task 2); `CastSessionRegistry` (Task 6); `StreamSessionRegistry.adopt` (Task 5); `castOrigin` (Task 8); `castContentType`, `CHROMECAST_PROFILE`, `blockersFor` (Task 3); `CastPrompt` (Task 13).
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/ui/App.web.test.tsx`, add cases for the flow's two decisions — remembering that the point of testing here is the *sequence*, since the pieces each have their own tests:
+
+```tsx
+it("starts the web UI when casting and it is not already running, and says so", async () => {
+  // The TUI's own stream server binds localhost on an ephemeral port
+  // (src/integrations/torrentStream.ts:73), so a television cannot fetch from
+  // it. The web server is the only LAN-reachable, token-authed origin torlink
+  // has — so casting brings it up, and announces that rather than starting a
+  // server behind the user's back.
+});
+
+it("reuses the running web server when there is one", async () => {});
+
+it("adopts the resolved files rather than resolving a second time", async () => {
+  // Casting from the picker must not spend the user's debrid account twice.
+});
+
+it("refuses to cast a file no Chromecast can play, with the reason, and does not open the device list", async () => {});
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `npx vitest run src/ui/App.web.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the flow**
+
+Add `castFromPicker`, beside `playFromPicker` (`src/ui/App.tsx:1429`) and shaped like it:
+
+1. Compute `blockersFor(classifyFromName(file.filename, streamSource?.name), CHROMECAST_PROFILE)`. Non-empty with no HLS available → `setNotice("A Chromecast can't play this one — …")` and stop. No prompt appears for something that cannot work.
+2. Ensure the web server is up. If the existing mount has no handle, start it the same way the shift+w path does, reusing that code rather than a second copy, and set a notice naming the URL — `withoutToken`, as the existing notice does, because terminal scrollback is kept alive by `torlnk attach`.
+3. `sessions.adopt({ infoHash, name, backend, provider, files })`.
+4. `discover()` plus `parseManualDevice(config.castDevice)`; open `CastPrompt` with the result.
+5. On selection, build the URL from `castOrigin(host, boundPort, os.networkInterfaces())` and the adopted session's `capability`, and call `casts.start(...)`. On rejection, `setNotice(e.message)` — the messages from Task 4 are already fit for the screen.
+6. On `onAddress`, read-modify-write the config with the address (`loadConfig()` → set `castDevice` → `saveConfig()`), then cast to `parseManualDevice`'s device.
+7. Subscribe to `casts.onChange` to keep `castStatus` in the store, and render a cast row in the stream pane: device, title, position. `p` pauses and resumes; `x` stops — which is already "stop active stream" in all three list panes, so the key that stops a stream stops a cast.
+
+- [ ] **Step 4: Run and confirm they pass**
+
+Run: `npx vitest run src/ui && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Verify by running it**
+
+```bash
+npm run dev
+```
+
+Search, stream a torrent, press `c` in the picker, and confirm: the web UI starts and is announced; the device list names a real Chromecast; the file plays on the television; the cast row shows an advancing position; `p` pauses and resumes; `x` stops and the television returns to its own screen. Then repeat with the web UI already running (shift+w first) and confirm nothing is started twice. Write the results into the commit body.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/App.tsx src/ui/App.web.test.tsx
+git commit -m "feat(tui): cast a stream to a Chromecast from the file picker"
+```
+
+---
+
+### Task 15: Documentation and the full gate
+
+**Files:**
+- Modify: `README.md`
+- Verify: everything
+
+- [ ] **Step 1: README**
+
+Add casting to the streaming section, and be exact about the limits rather than selling past them:
+
+- It finds devices over mDNS, which does not cross a Docker bridge or a VLAN — hence the address you can type into the device list, which is remembered.
+- An MP4 or WebM carrying H.264 casts. An MKV casts **only** on the debrid backend, via the provider's transcode; from a torrent it does not, and the button says so. HEVC casts on neither.
+- AC3 and E-AC3 are passed through to the television. On a TV or receiver that cannot take them the picture plays silently — stop the cast and play it locally.
+- Pause, resume, stop and a position, from either front end. Seeking and volume are the TV's remote.
+- A cast started in the terminal is not visible to a separate `serve --web` process, and vice versa.
+
+Then re-read the web UI's own limitations list and confirm the "needs a real player" wording is still true now that the fallback card can cast. Correct it if not.
+
+- [ ] **Step 2: The full gate**
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+All four must pass. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) is expected — leave it. `npm run build` is the only thing that proves `castModel.ts` pulled no `node:*` into the browser bundle; if it fails there, the fix is in `castModel.ts`, not in the build config.
+
+- [ ] **Step 3: Confirm the fixture rule held**
+
+```bash
+grep -rniE "\b(inception|breaking bad|the bear|big buck)" src README.md | grep -v "preview/" | cut -c1-120
+```
+
+Expected: no hits outside `preview/` screenshots, which are the documented exception.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: casting to a Chromecast, and what it will not do"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of the design maps to a task: `protocol.ts` → 1; `discover.ts` and the configured address → 2 and 13 (config) and 9 (the route that returns it); the capability profile and `castContentType` → 3; `connection.ts` and every row of the failure table → 4; `adopt` → 5; `session.ts`, `Runtime.casts`, the played-file write and the per-process limit → 6; `castBlockers` and the `.vtt` CORS header → 7; the LAN-origin rule → 8; the three routes → 9; SSE → 10; `castModel.ts` → 11; the player page and the fallback card's cast button → 12; the TUI's key, prompt, keymap halves and store fields → 13; the TUI flow including "ensure the web server" → 14; docs and the gate → 15.
+
+**Gaps accepted, and why.** Task 12 and Task 14 have no unit tests for their DOM and Ink wiring beyond what Task 13's component tests cover — that is the repo's stated position (no jsdom, wiring is verified by running it), which is why both tasks end with a numbered manual checklist whose results go in the commit body. Task 10's test bodies are sketched rather than written out, because their setup depends on the exact shape of `openSseChannel`'s existing test helpers; the implementer should follow `subscribeToQueue`'s tests in the same file.
+
+**Type consistency.** `CastDevice` (Task 2) is used unchanged through Tasks 4, 6, 9, 13, 14. `CastStatus` (Task 4) is the core shape; `CastStatusResponse` (Task 9) is the wire shape, and Task 11 consumes only the wire one — the browser never sees the core type, which is what the layering rule requires. `blockersFor(facts, profile?)` keeps its one-argument form for the two existing call sites. `CastMediaRequest` is built in Task 9 (web) and Task 14 (TUI) and consumed in Task 4 — the same fields in both, which is what the third test in Task 9 and the manual check in Task 14 confirm.

--- a/docs/superpowers/specs/2026-08-01-chromecast-design.md
+++ b/docs/superpowers/specs/2026-08-01-chromecast-design.md
@@ -1,0 +1,297 @@
+# Casting a stream to a Chromecast, from either front end
+
+Date: 2026-08-01
+Status: design, approved for planning
+
+## The problem
+
+Both front ends can play a torrent and both can hand it to something else — the terminal spawns
+mpv, IINA or VLC; the browser plays it inline, or hands out a URL, a `.m3u` and a mobile VLC
+link. Neither can put it on the television, which for a great deal of what this app is used for
+is the only screen that matters. The user's route today is to download the `.m3u`, open it in a
+desktop app and cast that app's window, which re-encodes the whole film through the laptop to
+show it on a device that could have fetched the bytes itself.
+
+## The constraint that decides the architecture
+
+`serve --web` is plain HTTP (`src/web/server.ts:389`) and the normal way in is
+`http://192.168.x.x:9161`. Google's Cast Web Sender SDK is secure-context-only: on a LAN IP
+`chrome.cast` never initialises. A cast button built on the SDK is therefore a button that works
+only for whoever is browsing `localhost` — which is the dead-button failure this repo has already
+refused once, when `vlcLinks` was made to return `[]` on macOS because "a button there would be a
+button that does nothing".
+
+So torlink does the casting itself: it discovers Chromecasts on the LAN over mDNS and drives them
+over the CASTV2 protocol, the way `catt` and `castnow` do. That choice pays for itself twice —
+it works over plain HTTP and from a phone, and it puts the casting in `src/core`, where both
+front ends are clients of one implementation rather than two.
+
+## Scope
+
+**In scope.** Discovering Chromecast devices; casting one file to one of them from either front
+end; pause, resume, stop, and a live position; the subtitle the user already picked; and
+remembering the resume point, so a cast play lands in Continue watching like any other.
+
+**Out of scope, deliberately.** Seeking and volume from torlink — the TV's own remote and the
+Google Home app do those, and each control added here is another failure mode over a flaky LAN
+socket. Casting to anything that is not a Chromecast (AirPlay, DLNA). Multi-device groups.
+Queueing a season onto the device. Video-level transcoding, for exactly the reason the
+hard-containers design gives: HEVC and AV1 need a full re-encode, which needs per-platform
+hardware acceleration, which is its own project.
+
+## Where the code lives
+
+```
+src/core/cast/protocol.ts     pure: CastMessage codec + length framing
+src/core/cast/discover.ts     mDNS query → CastDevice[]
+src/core/cast/connection.ts   TLS socket, heartbeat, channels, LAUNCH/LOAD/commands
+src/core/cast/session.ts      the one active cast, its status, its history writes
+src/util/playability.ts       gains a capability profile (existing module)
+src/web/routes.ts             three routes; types in src/web/wire.ts
+src/web/static/castModel.ts   pure: every browser-side decision
+src/ui/                       the picker's `c`, the cast row, keymap, store
+```
+
+`src/core/cast` imports nothing from `src/ui` or `src/web`, per the layering rule. In particular
+it never builds a URL — the caller passes one in. That is what keeps it from reaching for
+`src/web/links.ts`, and it is also what makes it testable without a server.
+
+### `protocol.ts`
+
+A `CastMessage` has six fields and its shape never varies: `protocol_version` (enum),
+`source_id`, `destination_id`, `namespace` (strings), `payload_type` (enum) and `payload_utf8`
+(string). Everything torlink sends or reads is JSON in `payload_utf8`; the binary payload field
+is never used. Encoding that by hand is around sixty lines, so `protobufjs` — roughly a megabyte
+into the bundled CLI, whose whole runtime dependency list is ten packages — is not warranted.
+
+Framing is a 4-byte big-endian length followed by the message. The frame *reader* is a named
+function with its own tests rather than inline socket code, because a length prefix split across
+two TCP reads is the bug every hand-rolled framer has on its first day, and a reader that also
+refuses an absurd claimed length cannot be made to buffer without bound by a hostile answer on
+port 8009.
+
+### `discover.ts`
+
+`discover(deps, timeoutMs)` sends a PTR query for `_googlecast._tcp.local` through
+`multicast-dns` and assembles `CastDevice { id, name, model, host, port }` from the SRV record
+(host and port), the A record (address) and the TXT keys `id`, `fn` (friendly name) and `md`
+(model).
+
+`multicast-dns` is the one new dependency, and it is the half worth taking: DNS name compression,
+several interfaces answering at once and multicast group membership are real edge cases, where
+the protocol above is a fixed six-field message. The mdns factory is injected, so the tests feed
+canned records and never open a socket.
+
+A response missing an SRV record is dropped rather than half-built — a device with no port is not
+a device. Two interfaces answering for the same TV collapse by `id`. Results are cached briefly
+and refreshed on request, because "the TV was off ten seconds ago" is the normal case, not an
+error.
+
+### `connection.ts`
+
+A TLS socket to `<host>:8009` with `rejectUnauthorized: false`. The certificate is device-signed
+and there is no chain to check it against; the reason this is acceptable rather than merely
+convenient is that nothing secret goes over it — the payload is a URL that is already available
+to anyone holding the `?k=` token on the LAN.
+
+On top of that: `urn:x-cast:com.google.cast.tp.heartbeat` PING every 5 seconds, namespace-routed
+virtual channels, `LAUNCH` of the default media receiver `CC1AD845`, then `LOAD` on
+`urn:x-cast:com.google.cast.media`, and `PAUSE` / `PLAY` / `STOP` plus `MEDIA_STATUS` after that.
+The socket factory is injected, so every failure row in the table below is a test against a fake
+socket rather than a story about a television.
+
+The `LOAD` request must name a `contentType` the default receiver recognises, and it differs per
+rung: `video/mp4` or `video/webm` for direct play, `application/vnd.apple.mpegurl` with
+`streamType: "BUFFERED"` for either HLS rung. Getting it wrong is a `LOAD_FAILED` rather than a
+guess, so the mapping is a pure function beside the profile it belongs to and has its own test.
+
+### `session.ts`
+
+`CastSessionRegistry` holds at most one active cast per process: the device, what is playing, and
+the last `MEDIA_STATUS`. Position updates feed the existing `streamHistory` resume-point writer,
+so a cast play is remembered exactly like a local one — and, specifically, the last known
+position is still written when the socket drops, because a failure that loses the resume point is
+the shape of bug this repo has already recorded against the web player.
+
+## Chromecast is a second capability profile, not a second list
+
+`src/util/playability.ts` currently hard-codes one set of answers —
+`SAFE_CONTAINERS`/`SAFE_VIDEO`/`SAFE_AUDIO` — for the question "will a browser play this".
+`blockersFor(facts)` becomes `blockersFor(facts, profile = BROWSER)` and a `CHROMECAST` profile
+joins it. Same module, because it is the same question asked of a different decoder, and a second
+list somewhere else is the copy-then-drift bug this codebase has recorded four times.
+
+| | Browser (unchanged) | Chromecast |
+| --- | --- | --- |
+| Containers | `mp4`, `m4v`, `webm` | same — MKV is not one, on either |
+| Video | `h264`, `vp8`, `vp9` | same |
+| Audio | `aac`, `mp3`, `opus`, `vorbis`, `flac` | those **plus `ac3` and `eac3`** |
+
+Two calls in that table are deliberate and each has a cost:
+
+- **HEVC and AV1 stay blocked**, even though a Chromecast Ultra or a Google TV device decodes
+  HEVC. The `md` TXT key names a model, but a model name is a guess about a device's decoder and
+  about the television behind it, and there is no video transcode to fall back to. The refusal a
+  user gets is the same one the browser gives, for the same honest reason.
+- **AC3 and E-AC3 are allowed**, which is passthrough and therefore depends on the television or
+  receiver on the other side of the HDMI cable. Where that link cannot take it the result is
+  silent video, which is a bad failure. It is still the right call: every Chromecast generation
+  lists AC-3 and E-AC-3, the alternative burns CPU on a local transcode for every AC3 file, and
+  where `ffmpeg` is absent the alternative *refuses a file that would have played*. Silence is
+  recoverable in one keypress; a refusal is not recoverable at all. A test pins the choice so it
+  cannot be reversed by accident.
+
+This is also what makes a small feature possible on the other side: a file the browser refuses
+but the device accepts — an MP4 carrying AC3 — currently ends at the "this one needs a real
+player" card. With two profiles that card can offer to cast it, which is the point of having
+profiles rather than one list.
+
+## One URL shape, both front ends
+
+The cast target is always `/stream/<sid>/<idx>?k=…` on torlink's own web server, chosen by the
+same source ladder the browser player walks — direct play, then the provider's HLS transcode,
+then local `ffmpeg` HLS, then an honest refusal — with `CHROMECAST` in place of `BROWSER`.
+Consequences:
+
+- The browser's cast button reuses the stream session the page already has.
+- The TUI's cast ensures the in-process web server is up, opens a session, and casts the same
+  URL. It announces that ("Started the web UI on … so the TV can reach the file") rather than
+  starting a server behind the user's back.
+- MKV casts, by the rung that already exists. HEVC says why it cannot.
+- There is one auth story: the `?k=` token, which the device carries in the query string.
+
+**The origin comes from `displayHosts(...).lan`, never from the request's `Host` header.** A user
+browsing `http://localhost:9161` would otherwise hand the television a `localhost` URL. The last
+spec in this directory investigated a `127.0.0.1` playlist report and found it was a second
+server on another port; this is the same failure arriving for real, and the guard against it is a
+test that pins the LAN address even when `Host` says `localhost`.
+
+### Why the TUI cannot cast its own stream server
+
+`src/integrations/torrentStream.ts:73` binds the WebTorrent HTTP server to `localhost` on an
+ephemeral port, so a Chromecast cannot fetch from it. The alternative to routing through the web
+server would be binding that one to `0.0.0.0`, which exposes the file to everything on the
+network with no auth at all, and which has none of the HLS rungs — so MKV would cast from the
+browser and not from the terminal. Rejected on both counts.
+
+## Subtitles
+
+The subtitle the user has already picked is passed as a `tracks` entry in the `LOAD` request,
+pointing at the existing `.vtt` representation of the stream route (`splitRepresentation`,
+`src/web/stream.ts:184`), which `srtToVtt` already produces.
+
+That representation gains `Access-Control-Allow-Origin: *`. The receiver fetches tracks
+cross-origin and drops them **silently** without it, which would read as "casting ignores
+subtitles". The header goes on the subtitle representation only, and the media representation
+must keep not having it — a test asserts both halves. It is acceptable there because the
+subtitle is already gated by the same `?k=` token as the media, so the header widens who may
+*read the response* for a request that was already authorised, not who may make it.
+
+Track choice is fixed at cast time. Changing it re-loads on the device, which is a visible
+half-second and simpler than a second control surface.
+
+## When mDNS is blocked
+
+mDNS does not cross a Docker bridge or a VLAN, and torlink gets run behind both. Without a
+fallback the feature is dead there, behind a message that reads like a bug.
+
+So one TUI-only config field holds a device address — a host, optionally `host:port`, defaulting
+to 8009 — and `/api/cast/devices` returns it in the list whether discovery saw it or not.
+Configuration is TUI-only by the existing rule, and the browser needs no new capability flag,
+because an empty device list is already the signal it needs.
+
+## The browser
+
+Every decision lives in `src/web/static/castModel.ts`; `player.ts` renders what it is handed and
+decides nothing, per the rule that has been caught in review twice. The module answers:
+
+- the button's state and label — `Cast to TV`, `Finding devices…`, `Playing on <name>`
+- the disabled reason where there is one — `No Chromecast found on this network`, or
+  `HEVC can't be cast`
+- the status line for a `MEDIA_STATUS` — `0:12:04 / 1:48:22`, buffering, paused
+- which of play, pause and stop to offer
+
+Placement is the existing hand-off row, beside copy-URL, `.m3u` and the mobile VLC link:
+casting *is* a hand-off, and that row is already where "play this somewhere else" lives. Starting
+a cast pauses the local `<video>` and swaps the controls for the cast status; stopping hands
+playback back to the page at the device's position.
+
+Routes in `src/web/routes.ts`, types in `src/web/wire.ts`:
+
+| Route | Body |
+| --- | --- |
+| `GET /api/cast/devices` | discovered devices plus the configured one |
+| `POST /api/cast/start` | `{ sid, index, subtitle? }` |
+| `POST /api/cast/command` | `{ action: "play" \| "pause" \| "stop" }` |
+
+Status rides the existing SSE stream (`src/web/sse.ts`) rather than a poll, so a cast started
+from a laptop appears on a phone pointed at the same server.
+
+## The terminal
+
+`c` in the stream file picker — free in that section of `src/ui/keymap.ts` today, and the
+mnemonic. It opens a device list in the same overlay shape as "Choose sources". On selection the
+stream pane becomes a cast row: device name, title, position, `p` to pause, `x` to stop. `x`
+already means "stop active stream" in all three list panes, so a cast stops with the key that
+already stops a stream.
+
+Per the table in `CLAUDE.md`, that means:
+
+- **both** halves of `src/ui/keymap.ts` — `HELP_GROUPS` and `footerHints`
+- the new `Store` fields in **both** `makeStore` (`scripts/render-previews-impl.tsx`) and
+  `makeTestStore` (`src/ui/testHarness.ts`)
+
+## The per-process consequence, named rather than hidden
+
+The TUI and `serve --web` are separate processes, so the registry is per-process: a cast started
+in the terminal is not visible to a browser talking to a standalone `serve --web`, and the
+reverse. Where the TUI hosts the web UI itself (shift+w) it is one process and both surfaces see
+the one cast.
+
+Sharing it across processes means a TUI↔daemon RPC that does not exist today — out of scope. What
+this design owes the user is that the screen says "not casting" rather than implying it knows
+about a cast it cannot see.
+
+## Failures, each with its own message
+
+| What happens | What the user sees |
+| --- | --- |
+| No devices answer | `No Chromecast found on this network.` — and in the TUI, that mDNS may not cross their network's boundaries |
+| TLS connect refused or timed out | `<name> didn't answer — it may be off.` The device stays in the list |
+| Receiver refuses `LAUNCH` | `<name> wouldn't start the player.` |
+| `LOAD_FAILED` / `LOAD_CANCELLED` | `<name> couldn't play this file.` — with the receiver's own reason where it gives one |
+| Socket drops mid-play | one reconnect attempt, then `Lost the connection to <name>.`, and the last known position is written to history regardless |
+| `ffmpeg` absent and the file needs rung 3 | the existing missing-ffmpeg message, unchanged |
+
+## Testing
+
+Every row is a test written before the change it covers.
+
+| Test | What it pins |
+| --- | --- |
+| `src/core/cast/protocol.test.ts` | a `CastMessage` round-trips; a frame whose length prefix arrives split across two chunks yields exactly one message; two messages in one chunk yield two; a frame claiming an absurd length is rejected rather than buffered |
+| `src/core/cast/discover.test.ts` | canned SRV/A/TXT records → devices with name and model; a response missing SRV is dropped; duplicates from two interfaces collapse by `id`; the configured manual entry appears with no discovery at all; the timeout resolves with what arrived rather than throwing |
+| `src/core/cast/connection.test.ts` | against a fake socket: heartbeat cadence; `LAUNCH` precedes `LOAD`; each failure row above; one reconnect then give up |
+| `src/core/cast/session.test.ts` | a second start replaces the first; `MEDIA_STATUS` positions reach `streamHistory`; a dropped socket still writes the last position |
+| `src/util/playability.test.ts` | **the browser profile's verdicts are exactly what they are today** — the regression guard for touching a shared module — then MKV blocked for Chromecast, AC3 and E-AC3 allowed (the recorded trade-off), HEVC and DTS blocked |
+| `src/web/static/castModel.test.ts` | every button state and disabled reason; the status line's formatting including a stream with no known duration; the fallback card offers casting only where the Chromecast profile has no blockers |
+| `src/web/routes.test.ts` | the three routes and their authorisation; the cast URL is built from the LAN address even when `Host` is `localhost`; `POST /api/cast/command` with nothing casting is a clean refusal, not a crash |
+| `src/web/stream.test.ts` | the `.vtt` representation carries `Access-Control-Allow-Origin`, and the media representation still does **not** |
+| `src/ui/keymap.test.ts` | `c` appears in both `HELP_GROUPS` and `footerHints` for the picker |
+
+Fixtures use the repo's cast — `Kepler`, `Harrowgate`, `Kestrel`, `Tin.Rivers` — and device names
+are invented too (`Living Room TV`, `Kitchen display`). Note the trap `CLAUDE.md` records: the
+playability tests assert on substrings of fixture names, so a later rename must re-check them.
+
+Then `npm test`, `npm run typecheck`, `npm run lint`, `npm run build` — the last being the only
+thing that proves `castModel.ts` pulled no `node:*` into the browser bundle.
+
+## Documentation
+
+- `README.md`: casting joins the streaming section, naming the MKV path (it transcodes) and the
+  HEVC refusal (it does not), and the fact that discovery needs mDNS with the configured-address
+  fallback for Docker and VLANs.
+- The web UI's limitations list: re-read to confirm the "needs a real player" wording is still
+  true now that the fallback card can cast. Casting itself is not a limitation and adds no entry.
+- `package.json` gains one runtime dependency, `multicast-dns`, taking the list from ten to
+  eleven.

--- a/docs/superpowers/specs/2026-08-01-chromecast-design.md
+++ b/docs/superpowers/specs/2026-08-01-chromecast-design.md
@@ -29,8 +29,8 @@ front ends are clients of one implementation rather than two.
 ## Scope
 
 **In scope.** Discovering Chromecast devices; casting one file to one of them from either front
-end; pause, resume, stop, and a live position; the subtitle the user already picked; and
-remembering the resume point, so a cast play lands in Continue watching like any other.
+end; pause, resume, stop, and a live position on screen; the subtitle the user already picked;
+and marking the file played, so a cast lands in Continue watching exactly as a local play does.
 
 **Out of scope, deliberately.** Seeking and volume from torlink — the TV's own remote and the
 Google Home app do those, and each control added here is another failure mode over a flaky LAN
@@ -38,6 +38,24 @@ socket. Casting to anything that is not a Chromecast (AirPlay, DLNA). Multi-devi
 Queueing a season onto the device. Video-level transcoding, for exactly the reason the
 hard-containers design gives: HEVC and AV1 need a full re-encode, which needs per-platform
 hardware acceleration, which is its own project.
+
+**Two things this design does not build on, because they do not exist in the tree.** Both were
+checked rather than assumed, and each removes something an earlier draft of this document
+promised:
+
+- **There is no persisted time position anywhere in torlink.** `StreamHistoryItem`
+  (`src/core/streamHistory.ts:24`) carries a season and an episode and no seconds, and neither
+  front end tracks `currentTime` for resume — `recordPlayedFile` advances progress at *episode*
+  granularity. So the position a cast reports is **displayed and not stored**, and casting marks
+  the file played through the same hook a local play uses. A real resume point is a feature for
+  both front ends and both players, and it is not this one.
+- **The source ladder's local-`ffmpeg` rung was never implemented.** `src/util/ffmpegBin.ts`
+  exists but its only consumer is `findFfprobe` in `src/core/probe.ts`; nothing spawns a
+  transcode. The rungs that exist are direct play and the debrid provider's HLS
+  (`chooseSource`, `src/web/static/playerModel.ts:169`). Casting therefore covers exactly what
+  the browser covers: **an MKV on the debrid backend casts via the provider's transcode; an MKV
+  from a torrent cannot cast**, and says so. It starts working the day rung 3 lands, with no
+  change here, because casting asks the same ladder.
 
 ## Where the code lives
 
@@ -102,16 +120,20 @@ socket rather than a story about a television.
 
 The `LOAD` request must name a `contentType` the default receiver recognises, and it differs per
 rung: `video/mp4` or `video/webm` for direct play, `application/vnd.apple.mpegurl` with
-`streamType: "BUFFERED"` for either HLS rung. Getting it wrong is a `LOAD_FAILED` rather than a
-guess, so the mapping is a pure function beside the profile it belongs to and has its own test.
+`streamType: "BUFFERED"` for the provider HLS rung. Getting it wrong is a `LOAD_FAILED` rather
+than a guess, so the mapping is a pure function beside the profile it belongs to and has its own
+test.
 
 ### `session.ts`
 
 `CastSessionRegistry` holds at most one active cast per process: the device, what is playing, and
-the last `MEDIA_STATUS`. Position updates feed the existing `streamHistory` resume-point writer,
-so a cast play is remembered exactly like a local one — and, specifically, the last known
-position is still written when the socket drops, because a failure that loses the resume point is
-the shape of bug this repo has already recorded against the web player.
+the last `MEDIA_STATUS`. The position in that status is state, not a store — it drives the line
+on screen and nothing writes it to disk, because there is nowhere to write it to (see Scope).
+
+What *is* persisted is the same thing a local play persists: on a successful `LOAD`, the file is
+marked played through `markWatched` and `recordPlayedFile`, so a cast advances Continue watching
+like anything else. On `LOAD`, not on cast start — a device that refuses the file must not earn
+a ✓, which is the rule `playFromPicker`'s `onPlayed` callback already follows in the TUI.
 
 ## Chromecast is a second capability profile, not a second list
 
@@ -135,11 +157,12 @@ Two calls in that table are deliberate and each has a cost:
   user gets is the same one the browser gives, for the same honest reason.
 - **AC3 and E-AC3 are allowed**, which is passthrough and therefore depends on the television or
   receiver on the other side of the HDMI cable. Where that link cannot take it the result is
-  silent video, which is a bad failure. It is still the right call: every Chromecast generation
-  lists AC-3 and E-AC-3, the alternative burns CPU on a local transcode for every AC3 file, and
-  where `ffmpeg` is absent the alternative *refuses a file that would have played*. Silence is
-  recoverable in one keypress; a refusal is not recoverable at all. A test pins the choice so it
-  cannot be reversed by accident.
+  silent video, which is a bad failure. It is still the right call, and more clearly so now that
+  there is no local transcode to fall back to: every Chromecast generation lists AC-3 and E-AC-3,
+  and blocking them would simply *refuse a file that would almost certainly have played* — on the
+  torrent backend it would refuse it outright, with no rung underneath. Silence is recoverable in
+  one keypress; a refusal is not recoverable at all. A test pins the choice so it cannot be
+  reversed by accident.
 
 This is also what makes a small feature possible on the other side: a file the browser refuses
 but the device accepts — an MP4 carrying AC3 — currently ends at the "this one needs a real
@@ -150,14 +173,14 @@ profiles rather than one list.
 
 The cast target is always `/stream/<sid>/<idx>?k=…` on torlink's own web server, chosen by the
 same source ladder the browser player walks — direct play, then the provider's HLS transcode,
-then local `ffmpeg` HLS, then an honest refusal — with `CHROMECAST` in place of `BROWSER`.
-Consequences:
+then an honest refusal — with `CHROMECAST` in place of `BROWSER`. Consequences:
 
 - The browser's cast button reuses the stream session the page already has.
 - The TUI's cast ensures the in-process web server is up, opens a session, and casts the same
   URL. It announces that ("Started the web UI on … so the TV can reach the file") rather than
   starting a server behind the user's back.
-- MKV casts, by the rung that already exists. HEVC says why it cannot.
+- An MKV on the debrid backend casts, by the provider's transcode. An MKV from a torrent does
+  not, and says which of the two it is. HEVC says why it cannot, on either backend.
 - There is one auth story: the `?k=` token, which the device carries in the query string.
 
 **The origin comes from `displayHosts(...).lan`, never from the request's `Host` header.** A user
@@ -171,8 +194,14 @@ test that pins the LAN address even when `Host` says `localhost`.
 `src/integrations/torrentStream.ts:73` binds the WebTorrent HTTP server to `localhost` on an
 ephemeral port, so a Chromecast cannot fetch from it. The alternative to routing through the web
 server would be binding that one to `0.0.0.0`, which exposes the file to everything on the
-network with no auth at all, and which has none of the HLS rungs — so MKV would cast from the
-browser and not from the terminal. Rejected on both counts.
+network with no auth at all, and which has no ladder above it at all — so a debrid MKV would cast
+from the browser and not from the terminal. Rejected on both counts.
+
+A second reason, which is the one that makes this cheap: the TUI holds resolved files and never
+registers them with `Runtime.sessions` (nothing in `src/ui/App.tsx` calls into the registry it
+constructs at line 265). Casting needs a session id either way, so `StreamSessionRegistry` gains
+an `adopt` method for already-resolved files — one small, tested addition instead of a second
+resolve.
 
 ## Subtitles
 
@@ -260,8 +289,8 @@ about a cast it cannot see.
 | TLS connect refused or timed out | `<name> didn't answer — it may be off.` The device stays in the list |
 | Receiver refuses `LAUNCH` | `<name> wouldn't start the player.` |
 | `LOAD_FAILED` / `LOAD_CANCELLED` | `<name> couldn't play this file.` — with the receiver's own reason where it gives one |
-| Socket drops mid-play | one reconnect attempt, then `Lost the connection to <name>.`, and the last known position is written to history regardless |
-| `ffmpeg` absent and the file needs rung 3 | the existing missing-ffmpeg message, unchanged |
+| Socket drops mid-play | one reconnect attempt, then `Lost the connection to <name>.` — and the ✓ already written on `LOAD` stays, because the file was played |
+| The file has a blocker and no rung above it | `A Chromecast can't play this one — <reason>.` The button is disabled with that reason rather than absent, so it is clear the device is the limit and not the network |
 
 ## Testing
 
@@ -272,7 +301,8 @@ Every row is a test written before the change it covers.
 | `src/core/cast/protocol.test.ts` | a `CastMessage` round-trips; a frame whose length prefix arrives split across two chunks yields exactly one message; two messages in one chunk yield two; a frame claiming an absurd length is rejected rather than buffered |
 | `src/core/cast/discover.test.ts` | canned SRV/A/TXT records → devices with name and model; a response missing SRV is dropped; duplicates from two interfaces collapse by `id`; the configured manual entry appears with no discovery at all; the timeout resolves with what arrived rather than throwing |
 | `src/core/cast/connection.test.ts` | against a fake socket: heartbeat cadence; `LAUNCH` precedes `LOAD`; each failure row above; one reconnect then give up |
-| `src/core/cast/session.test.ts` | a second start replaces the first; `MEDIA_STATUS` positions reach `streamHistory`; a dropped socket still writes the last position |
+| `src/core/cast/session.test.ts` | a second start replaces the first; a successful `LOAD` marks the file played exactly once; a `LOAD_FAILED` marks nothing; `MEDIA_STATUS` positions reach the status the front ends read and are never written to disk |
+| `src/core/streamSession.test.ts` | `adopt` yields a `ready` session with a fresh id and capability, without calling either resolve impl; stopping an adopted session does not touch a backend it does not own |
 | `src/util/playability.test.ts` | **the browser profile's verdicts are exactly what they are today** — the regression guard for touching a shared module — then MKV blocked for Chromecast, AC3 and E-AC3 allowed (the recorded trade-off), HEVC and DTS blocked |
 | `src/web/static/castModel.test.ts` | every button state and disabled reason; the status line's formatting including a stream with no known duration; the fallback card offers casting only where the Chromecast profile has no blockers |
 | `src/web/routes.test.ts` | the three routes and their authorisation; the cast URL is built from the LAN address even when `Host` is `localhost`; `POST /api/cast/command` with nothing casting is a clean refusal, not a crash |
@@ -288,9 +318,9 @@ thing that proves `castModel.ts` pulled no `node:*` into the browser bundle.
 
 ## Documentation
 
-- `README.md`: casting joins the streaming section, naming the MKV path (it transcodes) and the
-  HEVC refusal (it does not), and the fact that discovery needs mDNS with the configured-address
-  fallback for Docker and VLANs.
+- `README.md`: casting joins the streaming section, naming what a Chromecast will and will not
+  take — an MKV casts on the debrid backend and not from a torrent, HEVC casts on neither — and
+  the fact that discovery needs mDNS, with the configured-address fallback for Docker and VLANs.
 - The web UI's limitations list: re-read to confirm the "needs a real player" wording is still
   true now that the fallback card can cast. Casting itself is not a limitation and adds no entry.
 - `package.json` gains one runtime dependency, `multicast-dns`, taking the list from ten to

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "hls.js": "^1.6.16",
         "ink": "^7.0.5",
         "jpeg-js": "^0.4.4",
+        "multicast-dns": "^7.2.5",
         "parse-torrent": "^11.0.21",
         "parse-torrent-title": "^3.0.1",
         "react": "^19.2.7",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/multicast-dns": "^7.2.4",
         "@types/node": "^25.9.2",
         "@types/react": "^19.2.17",
         "eslint": "^10.6.0",
@@ -1035,6 +1037,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1791,6 +1799,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1811,6 +1829,17 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "25.9.4",
@@ -3285,6 +3314,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5023,6 +5064,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "hls.js": "^1.6.16",
     "ink": "^7.0.5",
     "jpeg-js": "^0.4.4",
+    "multicast-dns": "^7.2.5",
     "parse-torrent": "^11.0.21",
     "parse-torrent-title": "^3.0.1",
     "react": "^19.2.7",
@@ -89,6 +90,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/multicast-dns": "^7.2.4",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
     "eslint": "^10.6.0",

--- a/preview/help.svg
+++ b/preview/help.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="832" height="2190" viewBox="0 0 832 2190" style="max-width: 832px; width: 100%; height: auto;" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="832" height="2212" viewBox="0 0 832 2212" style="max-width: 832px; width: 100%; height: auto;" role="img">
   <rect width="100%" height="100%" rx="14" fill="#0a0810"/>
-  <rect x="0.5" y="0.5" width="831" height="2189" rx="14" fill="none" stroke="#2d2b31" stroke-width="1"/>
+  <rect x="0.5" y="0.5" width="831" height="2211" rx="14" fill="none" stroke="#2d2b31" stroke-width="1"/>
   <text x="416" y="23" text-anchor="middle" font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="13" fill="#8a8a8a">torlink</text>
   <g font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="16" fill="#ddd8ea">
     <text x="99.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#5ae87a" font-weight="600">𐓏</text>
@@ -230,150 +230,154 @@
     <text x="195.2" y="1228" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Stream</text>
     <rect x="784.9" y="1212" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1234" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">b</text>
-    <text x="195.2" y="1250" textLength="451.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Favourite a video (detail view / stream picker)</text>
+    <text x="70.4" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">c</text>
+    <text x="195.2" y="1250" textLength="508.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cast to a TV (Chromecast) — in the stream file picker</text>
     <rect x="784.9" y="1234" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1256" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1272" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">y</text>
-    <text x="195.2" y="1272" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Copy magnet</text>
+    <text x="70.4" y="1272" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">b</text>
+    <text x="195.2" y="1272" textLength="451.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Favourite a video (detail view / stream picker)</text>
     <rect x="784.9" y="1256" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1278" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1294" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">m</text>
-    <text x="195.2" y="1294" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Paste magnet</text>
+    <text x="70.4" y="1294" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">y</text>
+    <text x="195.2" y="1294" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Copy magnet</text>
     <rect x="784.9" y="1278" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1300" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">x</text>
-    <text x="195.2" y="1316" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Stop active stream</text>
+    <text x="70.4" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">m</text>
+    <text x="195.2" y="1316" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Paste magnet</text>
     <rect x="784.9" y="1300" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1322" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="1338" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">x</text>
+    <text x="195.2" y="1338" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Stop active stream</text>
     <rect x="784.9" y="1322" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1344" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1360" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">For You</text>
     <rect x="784.9" y="1344" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1366" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1382" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑ ↓</text>
-    <text x="195.2" y="1382" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move between picks</text>
+    <text x="70.4" y="1382" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">For You</text>
     <rect x="784.9" y="1366" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1388" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1404" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
-    <text x="195.2" y="1404" textLength="556.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Play the best release (confirmed films) / otherwise search</text>
+    <text x="70.4" y="1404" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑ ↓</text>
+    <text x="195.2" y="1404" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move between picks</text>
     <rect x="784.9" y="1388" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1410" width="1.4" height="22" fill="#8676b2"/>
-    <text x="195.2" y="1426" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">the title</text>
+    <text x="70.4" y="1426" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
+    <text x="195.2" y="1426" textLength="556.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Play the best release (confirmed films) / otherwise search</text>
     <rect x="784.9" y="1410" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1432" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1448" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
-    <text x="195.2" y="1448" textLength="374.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search this title instead of playing it</text>
+    <text x="195.2" y="1448" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">the title</text>
     <rect x="784.9" y="1432" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1454" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1470" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">i</text>
-    <text x="195.2" y="1470" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Open the IMDb page</text>
+    <text x="70.4" y="1470" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
+    <text x="195.2" y="1470" textLength="374.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search this title instead of playing it</text>
     <rect x="784.9" y="1454" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1476" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1492" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
-    <text x="195.2" y="1492" textLength="432" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Toggle poster / plot preview (needs OMDb key)</text>
+    <text x="70.4" y="1492" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">i</text>
+    <text x="195.2" y="1492" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Open the IMDb page</text>
     <rect x="784.9" y="1476" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1498" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1514" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">t</text>
-    <text x="195.2" y="1514" textLength="211.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cycle movie / TV / all</text>
+    <text x="70.4" y="1514" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
+    <text x="195.2" y="1514" textLength="432" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Toggle poster / plot preview (needs OMDb key)</text>
     <rect x="784.9" y="1498" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1520" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1536" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">g</text>
-    <text x="195.2" y="1536" textLength="144" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Filter by genre</text>
+    <text x="70.4" y="1536" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">t</text>
+    <text x="195.2" y="1536" textLength="211.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cycle movie / TV / all</text>
     <rect x="784.9" y="1520" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1542" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1558" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">e</text>
-    <text x="195.2" y="1558" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Toggle explore mode</text>
+    <text x="70.4" y="1558" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">g</text>
+    <text x="195.2" y="1558" textLength="144" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Filter by genre</text>
     <rect x="784.9" y="1542" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1564" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1580" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">b</text>
-    <text x="195.2" y="1580" textLength="278.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Show / hide the 'why' reasons</text>
+    <text x="70.4" y="1580" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">e</text>
+    <text x="195.2" y="1580" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Toggle explore mode</text>
     <rect x="784.9" y="1564" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1586" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1602" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">f</text>
-    <text x="195.2" y="1602" textLength="297.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Rate — watched / like / dislike</text>
+    <text x="70.4" y="1602" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">b</text>
+    <text x="195.2" y="1602" textLength="278.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Show / hide the 'why' reasons</text>
     <rect x="784.9" y="1586" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1608" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1624" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">w</text>
-    <text x="195.2" y="1624" textLength="259.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Save this title as a search</text>
+    <text x="70.4" y="1624" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">f</text>
+    <text x="195.2" y="1624" textLength="297.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Rate — watched / like / dislike</text>
     <rect x="784.9" y="1608" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1630" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1646" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">r</text>
-    <text x="195.2" y="1646" textLength="220.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Refresh recommendations</text>
+    <text x="70.4" y="1646" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">w</text>
+    <text x="195.2" y="1646" textLength="259.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Save this title as a search</text>
     <rect x="784.9" y="1630" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1652" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="1668" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">r</text>
+    <text x="195.2" y="1668" textLength="220.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Refresh recommendations</text>
     <rect x="784.9" y="1652" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1674" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1690" textLength="163.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Continue watching</text>
     <rect x="784.9" y="1674" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1696" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1712" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑ ↓</text>
-    <text x="195.2" y="1712" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move between titles</text>
+    <text x="70.4" y="1712" textLength="163.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Continue watching</text>
     <rect x="784.9" y="1696" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1718" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1734" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
-    <text x="195.2" y="1734" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Play the next episode, or resume where there is none</text>
+    <text x="70.4" y="1734" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑ ↓</text>
+    <text x="195.2" y="1734" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move between titles</text>
     <rect x="784.9" y="1718" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1740" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1756" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">r</text>
-    <text x="195.2" y="1756" textLength="278.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Resume the remembered torrent</text>
+    <text x="70.4" y="1756" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
+    <text x="195.2" y="1756" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Play the next episode, or resume where there is none</text>
     <rect x="784.9" y="1740" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1762" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1778" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
-    <text x="195.2" y="1778" textLength="374.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search this title instead of playing it</text>
+    <text x="70.4" y="1778" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">r</text>
+    <text x="195.2" y="1778" textLength="278.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Resume the remembered torrent</text>
     <rect x="784.9" y="1762" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1784" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1800" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">x</text>
-    <text x="195.2" y="1800" textLength="192" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Remove from the list</text>
+    <text x="70.4" y="1800" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
+    <text x="195.2" y="1800" textLength="374.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search this title instead of playing it</text>
     <rect x="784.9" y="1784" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1806" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="1822" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">x</text>
+    <text x="195.2" y="1822" textLength="192" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Remove from the list</text>
     <rect x="784.9" y="1806" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1828" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1844" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Downloads</text>
     <rect x="784.9" y="1828" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1850" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1866" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
-    <text x="195.2" y="1866" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause/resume</text>
+    <text x="70.4" y="1866" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Downloads</text>
     <rect x="784.9" y="1850" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1872" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1888" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">c</text>
-    <text x="195.2" y="1888" textLength="297.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cancel or remove (shift+c: all)</text>
+    <text x="70.4" y="1888" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
+    <text x="195.2" y="1888" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause/resume</text>
     <rect x="784.9" y="1872" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1894" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1910" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">f</text>
-    <text x="195.2" y="1910" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Retry failed</text>
+    <text x="70.4" y="1910" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">c</text>
+    <text x="195.2" y="1910" textLength="297.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cancel or remove (shift+c: all)</text>
     <rect x="784.9" y="1894" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1916" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1932" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">d</text>
-    <text x="195.2" y="1932" textLength="134.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Download again</text>
+    <text x="70.4" y="1932" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">f</text>
+    <text x="195.2" y="1932" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Retry failed</text>
     <rect x="784.9" y="1916" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1938" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1954" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">e</text>
-    <text x="195.2" y="1954" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Open folder</text>
+    <text x="70.4" y="1954" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">d</text>
+    <text x="195.2" y="1954" textLength="134.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Download again</text>
     <rect x="784.9" y="1938" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1960" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="1976" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
-    <text x="195.2" y="1976" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Export torrent file</text>
+    <text x="70.4" y="1976" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">e</text>
+    <text x="195.2" y="1976" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Open folder</text>
     <rect x="784.9" y="1960" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="1982" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="1998" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
+    <text x="195.2" y="1998" textLength="182.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Export torrent file</text>
     <rect x="784.9" y="1982" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2004" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="2020" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Seeding</text>
     <rect x="784.9" y="2004" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2026" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="2042" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
-    <text x="195.2" y="2042" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause/resume</text>
+    <text x="70.4" y="2042" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">Seeding</text>
     <rect x="784.9" y="2026" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2048" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="2064" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
+    <text x="195.2" y="2064" textLength="115.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause/resume</text>
     <rect x="784.9" y="2048" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2070" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="2086" textLength="403.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Your downloaded files always stay on disk.</text>
     <rect x="784.9" y="2070" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2092" width="1.4" height="22" fill="#8676b2"/>
-    <text x="70.4" y="2108" textLength="220.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Press ? or esc to close</text>
+    <text x="70.4" y="2108" textLength="403.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Your downloaded files always stay on disk.</text>
     <rect x="784.9" y="2092" width="1.4" height="22" fill="#8676b2"/>
     <rect x="45.7" y="2114" width="1.4" height="22" fill="#8676b2"/>
+    <text x="70.4" y="2130" textLength="220.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Press ? or esc to close</text>
     <rect x="784.9" y="2114" width="1.4" height="22" fill="#8676b2"/>
-    <text x="41.6" y="2152" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#8676b2">╰────────────────────────────────────────────────────────────────────────────╯</text>
+    <rect x="45.7" y="2136" width="1.4" height="22" fill="#8676b2"/>
+    <rect x="784.9" y="2136" width="1.4" height="22" fill="#8676b2"/>
+    <text x="41.6" y="2174" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#8676b2">╰────────────────────────────────────────────────────────────────────────────╯</text>
   </g>
 </svg>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -155,6 +155,7 @@ function makeStore(
     omdbApiKey: "",
     adultEnabled: false,
     streamActive: false,
+    castStatus: null,
     debridStatus: null,
     cachedHashes: new Set(),
     refreshCachedHashes: noop,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -200,6 +200,18 @@ describe("config vpnInterface", () => {
   });
 });
 
+describe("config castDevice", () => {
+  it("round-trips a configured Chromecast address", async () => {
+    await saveConfig({ downloadDir: "/tmp/dl", trackers: [], castDevice: "192.168.0.40:8009" });
+    expect((await loadConfig()).castDevice).toBe("192.168.0.40:8009");
+  });
+
+  it("stays absent when nothing was set, so the device list is discovery-only", async () => {
+    await saveConfig({ downloadDir: "/tmp/dl", trackers: [] });
+    expect((await loadConfig()).castDevice).toBeUndefined();
+  });
+});
+
 describe("config favourites", () => {
   it("round-trips favourites with watched episodes", async () => {
     await saveConfig({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -123,6 +123,15 @@ export interface Config {
   seedMinutes?: number;
   // Fail-closed P2P guard: this interface must exist and own the default route.
   vpnInterface?: string;
+  /**
+   * A Chromecast to offer alongside the ones mDNS finds — a host, or `host:port`.
+   *
+   * It exists because mDNS does not cross a Docker bridge or a VLAN, and torlink
+   * is run behind both: without it, casting on those networks is dead behind a
+   * message that reads like a bug. TUI-only, like every other setting — the web
+   * UI is a client of this config and reads the resulting device list.
+   */
+  castDevice?: string;
 }
 
 export const defaultConfig: Config = {

--- a/src/core/cast/connection.test.ts
+++ b/src/core/cast/connection.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { FrameReader, frameCastMessage, type CastMessage } from "./protocol";
-import { CastConnection, CastError, RECEIVER_APP_ID, type CastSocket } from "./connection";
+import {
+  CastConnection,
+  CastError,
+  HEARTBEAT_MS,
+  RECEIVER_APP_ID,
+  type CastSocket,
+} from "./connection";
 import type { CastDevice } from "./discover";
 
 const DEVICE: CastDevice = {
@@ -290,16 +296,19 @@ describe("status and commands", () => {
 describe("heartbeat and loss", () => {
   it("pings the receiver on the heartbeat interval", async () => {
     const fake = fakeSocket();
-    let tick: (() => void) | null = null;
+    // Two timers now — the heartbeat and the position poll — so every tick is
+    // captured rather than the last one registered.
+    const ticks: (() => void)[] = [];
     await CastConnection.open(DEVICE, {
       connect: async () => fake.socket,
-      setInterval: (cb) => {
-        tick = cb;
+      setInterval: (cb, ms) => {
+        if (ms === HEARTBEAT_MS) ticks.push(cb);
         return {};
       },
       clearInterval: () => {},
     });
-    tick!();
+    expect(ticks).toHaveLength(1);
+    ticks[0]!();
     expect(fake.typesSent()).toEqual(["CONNECT", "PING"]);
   });
 
@@ -329,17 +338,20 @@ describe("heartbeat and loss", () => {
     await expect(loading).rejects.toThrow(/Lost the connection to Living Room TV/);
   });
 
-  it("destroys the socket and stops the heartbeat on close", async () => {
+  it("destroys the socket and stops every timer on close", async () => {
     const fake = fakeSocket();
     const cleared = vi.fn();
+    let started = 0;
     const conn = await CastConnection.open(DEVICE, {
       connect: async () => fake.socket,
-      setInterval: () => ({ handle: 1 }),
+      setInterval: () => ({ handle: (started += 1) }),
       clearInterval: cleared,
     });
     conn.close();
     expect(fake.destroy).toHaveBeenCalledOnce();
-    expect(cleared).toHaveBeenCalledOnce();
+    // Every one, not just the heartbeat: a poll left running against a destroyed
+    // socket writes to nothing every two seconds, forever.
+    expect(cleared).toHaveBeenCalledTimes(started);
   });
 
   it("reports loss rather than throwing when a frame is malformed", async () => {
@@ -354,5 +366,64 @@ describe("heartbeat and loss", () => {
     header.writeUInt32BE(0xffffffff, 0);
     expect(() => fake.raw(header)).not.toThrow();
     expect(lost).toHaveBeenCalledOnce();
+  });
+});
+
+describe("position polling", () => {
+  it("asks the receiver for a status on a tick, so the position advances between state changes", async () => {
+    // THE BUG THIS EXISTS FOR, found against a real device: a receiver sends
+    // MEDIA_STATUS only when the state CHANGES, so a film played for thirty
+    // seconds still reported 0.3s. Pausing it produced 47.1s — the position was
+    // always right, it simply was not being asked for.
+    const fake = fakeSocket();
+    const ticks: (() => void)[] = [];
+    const conn = await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: (cb) => {
+        ticks.push(cb);
+        return {};
+      },
+      clearInterval: () => {},
+    });
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, launched(fake.requestId("LAUNCH")));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    fake.reply(MEDIA_NS, mediaStatus(fake.requestId("LOAD")));
+    await loading;
+
+    for (const tick of ticks) tick();
+    const status = fake.payload("GET_STATUS");
+    expect(status.mediaSessionId).toBe(7);
+    expect(fake.message("GET_STATUS").destinationId).toBe("transport-1");
+  });
+
+  it("asks for nothing before anything is loaded", async () => {
+    const fake = fakeSocket();
+    const ticks: (() => void)[] = [];
+    await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: (cb) => {
+        ticks.push(cb);
+        return {};
+      },
+      clearInterval: () => {},
+    });
+    for (const tick of ticks) tick();
+    expect(fake.typesSent()).not.toContain("GET_STATUS");
+  });
+
+  it("clears every timer on close, not just the heartbeat", async () => {
+    const fake = fakeSocket();
+    const cleared: unknown[] = [];
+    let n = 0;
+    const conn = await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: () => ({ id: (n += 1) }),
+      clearInterval: (h) => cleared.push(h),
+    });
+    conn.close();
+    // One per timer this connection started. A poll left running against a
+    // destroyed socket is a write to nothing, every two seconds, forever.
+    expect(cleared).toHaveLength(n);
   });
 });

--- a/src/core/cast/connection.test.ts
+++ b/src/core/cast/connection.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from "vitest";
+import { FrameReader, frameCastMessage, type CastMessage } from "./protocol";
+import { CastConnection, CastError, RECEIVER_APP_ID, type CastSocket } from "./connection";
+import type { CastDevice } from "./discover";
+
+const DEVICE: CastDevice = {
+  id: "abc123",
+  name: "Living Room TV",
+  model: "Chromecast",
+  host: "192.168.0.40",
+  port: 8009,
+};
+
+const RECEIVER_NS = "urn:x-cast:com.google.cast.receiver";
+const MEDIA_NS = "urn:x-cast:com.google.cast.media";
+const HEARTBEAT_NS = "urn:x-cast:com.google.cast.tp.heartbeat";
+
+/**
+ * A socket that records what was sent and lets a test answer as a receiver.
+ * The whole point of injecting the socket: every failure below is a test, not
+ * a story about a television.
+ */
+function fakeSocket() {
+  const sent: CastMessage[] = [];
+  const reader = new FrameReader();
+  let dataCb: (chunk: Buffer) => void = () => {};
+  let closeCb: () => void = () => {};
+  const destroy = vi.fn();
+  const socket: CastSocket = {
+    write: (data) => {
+      sent.push(...reader.push(data));
+    },
+    onData: (cb) => {
+      dataCb = cb;
+    },
+    onClose: (cb) => {
+      closeCb = cb;
+    },
+    destroy,
+  };
+  return {
+    socket,
+    sent,
+    destroy,
+    /** Answer as the receiver. */
+    reply(namespace: string, payload: unknown): void {
+      dataCb(
+        frameCastMessage({
+          sourceId: "receiver-0",
+          destinationId: "sender-torlink",
+          namespace,
+          payload: JSON.stringify(payload),
+        }),
+      );
+    },
+    /** Deliver a raw chunk, for the malformed-frame case. */
+    raw(chunk: Buffer): void {
+      dataCb(chunk);
+    },
+    drop(): void {
+      closeCb();
+    },
+    payloads(): Record<string, unknown>[] {
+      return sent.map((m) => JSON.parse(m.payload) as Record<string, unknown>);
+    },
+    typesSent(): string[] {
+      return this.payloads().map((p) => String(p.type));
+    },
+    /** The request id of the first message of this type. */
+    requestId(type: string): number {
+      return Number(this.payloads().find((p) => p.type === type)!.requestId);
+    },
+    payload(type: string): Record<string, unknown> {
+      return this.payloads().find((p) => p.type === type)!;
+    },
+    message(type: string): CastMessage {
+      return this.sent.find((m) => (JSON.parse(m.payload) as { type?: string }).type === type)!;
+    },
+  };
+}
+
+function launched(requestId: number) {
+  return {
+    type: "RECEIVER_STATUS",
+    requestId,
+    status: {
+      applications: [{ appId: RECEIVER_APP_ID, sessionId: "sess-1", transportId: "transport-1" }],
+    },
+  };
+}
+
+function mediaStatus(requestId: number, over: Record<string, unknown> = {}) {
+  return {
+    type: "MEDIA_STATUS",
+    requestId,
+    status: [
+      {
+        mediaSessionId: 7,
+        playerState: "PLAYING",
+        currentTime: 12.5,
+        media: { duration: 6_120 },
+        ...over,
+      },
+    ],
+  };
+}
+
+async function openWith(fake: ReturnType<typeof fakeSocket>) {
+  return CastConnection.open(DEVICE, {
+    connect: async () => fake.socket,
+    setInterval: () => ({}),
+    clearInterval: () => {},
+  });
+}
+
+/** Open, launch and load, answering as a receiver would. */
+async function playing() {
+  const fake = fakeSocket();
+  const conn = await openWith(fake);
+  const statuses: { state: string; positionSec: number; durationSec: number | null }[] = [];
+  conn.onStatus((s) => statuses.push(s));
+  const loading = conn.load({
+    url: "http://192.168.0.98:9161/stream/s/0?k=t",
+    contentType: "video/mp4",
+    title: "Kestrel 2010",
+  });
+  fake.reply(RECEIVER_NS, launched(fake.requestId("LAUNCH")));
+  await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+  fake.reply(MEDIA_NS, mediaStatus(fake.requestId("LOAD")));
+  await loading;
+  return { fake, conn, statuses };
+}
+
+describe("CastConnection.open", () => {
+  it("connects to the receiver before anything else", async () => {
+    const fake = fakeSocket();
+    await openWith(fake);
+    expect(fake.typesSent()).toEqual(["CONNECT"]);
+  });
+
+  it("is a CastError naming the device when the socket will not open", async () => {
+    await expect(
+      CastConnection.open(DEVICE, {
+        connect: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+      }),
+    ).rejects.toThrow(/Living Room TV didn't answer/);
+  });
+});
+
+describe("load", () => {
+  it("launches the default receiver, then connects to its transport, then loads", async () => {
+    const { fake } = await playing();
+    expect(fake.typesSent()).toEqual(["CONNECT", "LAUNCH", "CONNECT", "LOAD"]);
+    const load = fake.payload("LOAD");
+    expect(load.sessionId).toBe("sess-1");
+    expect(load.autoplay).toBe(true);
+    const media = load.media as Record<string, unknown>;
+    expect(media.contentId).toBe("http://192.168.0.98:9161/stream/s/0?k=t");
+    expect(media.contentType).toBe("video/mp4");
+    expect(media.streamType).toBe("BUFFERED");
+    expect((media.metadata as { title: string }).title).toBe("Kestrel 2010");
+    // The LOAD is addressed to the app's transport, not to receiver-0.
+    expect(fake.message("LOAD").destinationId).toBe("transport-1");
+  });
+
+  it("passes a subtitle as a track and activates it", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({
+      url: "http://192.168.0.98:9161/stream/s/0?k=t",
+      contentType: "video/mp4",
+      title: "Kepler S02E04",
+      subtitleUrl: "http://192.168.0.98:9161/stream/s/1.vtt?k=t",
+      subtitleLabel: "English",
+    });
+    fake.reply(RECEIVER_NS, launched(fake.requestId("LAUNCH")));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    const load = fake.payload("LOAD");
+    expect((load.media as Record<string, unknown>).tracks).toEqual([
+      {
+        trackId: 1,
+        type: "TEXT",
+        trackContentId: "http://192.168.0.98:9161/stream/s/1.vtt?k=t",
+        trackContentType: "text/vtt",
+        subtype: "SUBTITLES",
+        name: "English",
+        language: "en",
+      },
+    ]);
+    expect(load.activeTrackIds).toEqual([1]);
+    fake.reply(MEDIA_NS, mediaStatus(fake.requestId("LOAD")));
+    await loading;
+  });
+
+  it("sends no tracks key at all when there is no subtitle", async () => {
+    const { fake } = await playing();
+    const media = fake.payload("LOAD").media as Record<string, unknown>;
+    // An empty tracks array is not the same as no tracks: the receiver reads it
+    // as "this file has no text tracks", which is a different claim.
+    expect("tracks" in media).toBe(false);
+    expect("activeTrackIds" in fake.payload("LOAD")).toBe(false);
+  });
+
+  it("rejects with a message fit for the screen when the receiver will not launch", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, {
+      type: "LAUNCH_ERROR",
+      requestId: fake.requestId("LAUNCH"),
+      reason: "CANCELLED",
+    });
+    await expect(loading).rejects.toThrow(/Living Room TV wouldn't start the player/);
+  });
+
+  it("rejects on LOAD_FAILED, as a CastError", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, launched(fake.requestId("LAUNCH")));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    fake.reply(MEDIA_NS, {
+      type: "LOAD_FAILED",
+      requestId: fake.requestId("LOAD"),
+      detailedErrorCode: 905,
+    });
+    await expect(loading).rejects.toBeInstanceOf(CastError);
+    await expect(loading).rejects.toThrow(/couldn't play this file/);
+  });
+
+  it("rejects on LOAD_CANCELLED too", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.reply(RECEIVER_NS, launched(fake.requestId("LAUNCH")));
+    await vi.waitFor(() => expect(fake.typesSent()).toContain("LOAD"));
+    fake.reply(MEDIA_NS, { type: "LOAD_CANCELLED", requestId: fake.requestId("LOAD") });
+    await expect(loading).rejects.toThrow(/couldn't play this file/);
+  });
+});
+
+describe("status and commands", () => {
+  it("reports position and duration from MEDIA_STATUS, in seconds", async () => {
+    const { statuses } = await playing();
+    expect(statuses.at(-1)).toEqual({ state: "playing", positionSec: 12.5, durationSec: 6_120 });
+  });
+
+  it("reports a null duration for an unknown-length source rather than zero", async () => {
+    const { fake, statuses } = await playing();
+    fake.reply(MEDIA_NS, mediaStatus(0, { media: {} }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.durationSec).toBeNull());
+  });
+
+  it("maps PAUSED, BUFFERING and IDLE", async () => {
+    const { fake, statuses } = await playing();
+    fake.reply(MEDIA_NS, mediaStatus(0, { playerState: "PAUSED" }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.state).toBe("paused"));
+    fake.reply(MEDIA_NS, mediaStatus(0, { playerState: "BUFFERING" }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.state).toBe("loading"));
+    fake.reply(MEDIA_NS, mediaStatus(0, { playerState: "IDLE" }));
+    await vi.waitFor(() => expect(statuses.at(-1)!.state).toBe("idle"));
+  });
+
+  it("addresses PAUSE and PLAY to the media session the receiver named", async () => {
+    const { fake, conn } = await playing();
+    void conn.pause();
+    void conn.play();
+    expect(fake.payload("PAUSE").mediaSessionId).toBe(7);
+    expect(fake.payload("PLAY").mediaSessionId).toBe(7);
+    expect(fake.message("PAUSE").destinationId).toBe("transport-1");
+  });
+
+  it("stops by quitting the receiver app, so the TV returns to its own screen", async () => {
+    const { fake, conn } = await playing();
+    await conn.stop();
+    expect(fake.payload("STOP").sessionId).toBe("sess-1");
+    expect(fake.message("STOP").namespace).toBe(RECEIVER_NS);
+  });
+
+  it("refuses a command before anything is loaded, rather than sending a broken one", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    await expect(conn.pause()).rejects.toThrow(/nothing is playing/);
+    await expect(conn.play()).rejects.toThrow(/nothing is playing/);
+  });
+});
+
+describe("heartbeat and loss", () => {
+  it("pings the receiver on the heartbeat interval", async () => {
+    const fake = fakeSocket();
+    let tick: (() => void) | null = null;
+    await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: (cb) => {
+        tick = cb;
+        return {};
+      },
+      clearInterval: () => {},
+    });
+    tick!();
+    expect(fake.typesSent()).toEqual(["CONNECT", "PING"]);
+  });
+
+  it("answers the device's own PING with a PONG", async () => {
+    const fake = fakeSocket();
+    await openWith(fake);
+    fake.reply(HEARTBEAT_NS, { type: "PING" });
+    expect(fake.typesSent()).toEqual(["CONNECT", "PONG"]);
+  });
+
+  it("reports the connection lost, once, when the socket drops", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const lost = vi.fn();
+    conn.onLost(lost);
+    fake.drop();
+    fake.drop();
+    expect(lost).toHaveBeenCalledOnce();
+    expect(lost).toHaveBeenCalledWith("Lost the connection to Living Room TV.");
+  });
+
+  it("rejects a pending request when the socket drops, rather than hanging forever", async () => {
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const loading = conn.load({ url: "http://h/s", contentType: "video/mp4", title: "Kestrel 2010" });
+    fake.drop();
+    await expect(loading).rejects.toThrow(/Lost the connection to Living Room TV/);
+  });
+
+  it("destroys the socket and stops the heartbeat on close", async () => {
+    const fake = fakeSocket();
+    const cleared = vi.fn();
+    const conn = await CastConnection.open(DEVICE, {
+      connect: async () => fake.socket,
+      setInterval: () => ({ handle: 1 }),
+      clearInterval: cleared,
+    });
+    conn.close();
+    expect(fake.destroy).toHaveBeenCalledOnce();
+    expect(cleared).toHaveBeenCalledOnce();
+  });
+
+  it("reports loss rather than throwing when a frame is malformed", async () => {
+    // FrameReader throws on a length past its cap. In a TUI process an
+    // unhandled error can take the whole terminal down, so this must surface as
+    // a lost connection like any other.
+    const fake = fakeSocket();
+    const conn = await openWith(fake);
+    const lost = vi.fn();
+    conn.onLost(lost);
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(0xffffffff, 0);
+    expect(() => fake.raw(header)).not.toThrow();
+    expect(lost).toHaveBeenCalledOnce();
+  });
+});

--- a/src/core/cast/connection.ts
+++ b/src/core/cast/connection.ts
@@ -27,6 +27,18 @@ export const RECEIVER_APP_ID = "CC1AD845";
  */
 export const HEARTBEAT_MS = 5_000;
 
+/**
+ * How often to ask the receiver where it is.
+ *
+ * IT HAS TO BE ASKED. A receiver pushes `MEDIA_STATUS` when the state CHANGES and
+ * not while it plays, so without this the position line sits at whatever the LOAD
+ * reported — measured against a real device, 0.3s for a film that had been running
+ * for thirty seconds, jumping to 47.1s the moment it was paused. Two seconds is
+ * fine for a clock that reads in seconds and is nothing on the wire: the reply is
+ * a small JSON object over a socket that is already open.
+ */
+export const STATUS_POLL_MS = 2_000;
+
 const SENDER_ID = "sender-torlink";
 const RECEIVER_ID = "receiver-0";
 const NS_CONNECTION = "urn:x-cast:com.google.cast.tp.connection";
@@ -144,8 +156,9 @@ export class CastConnection {
   private constructor(
     private readonly device: CastDevice,
     private readonly socket: CastSocket,
-    private readonly heartbeat: unknown,
-    private readonly clearHeartbeat: (handle: unknown) => void,
+    /** Every timer this connection started, so `close` and `fail` clear them all. */
+    private readonly timers: readonly unknown[],
+    private readonly clearTimer: (handle: unknown) => void,
   ) {}
 
   static async open(device: CastDevice, deps: ConnectionDeps = {}): Promise<CastConnection> {
@@ -161,8 +174,11 @@ export class CastConnection {
       throw new CastError(`${device.name} didn't answer — it may be off.`);
     }
     let conn: CastConnection | null = null;
-    const timer = setTimer(() => conn?.ping(), HEARTBEAT_MS);
-    conn = new CastConnection(device, socket, timer, clearTimer);
+    const timers = [
+      setTimer(() => conn?.ping(), HEARTBEAT_MS),
+      setTimer(() => conn?.pollStatus(), STATUS_POLL_MS),
+    ];
+    conn = new CastConnection(device, socket, timers, clearTimer);
     socket.onData((chunk) => conn!.receive(chunk));
     socket.onClose(() => conn!.fail(`Lost the connection to ${device.name}.`));
     conn.send(NS_CONNECTION, RECEIVER_ID, { type: "CONNECT" });
@@ -178,8 +194,12 @@ export class CastConnection {
   }
 
   close(): void {
-    this.clearHeartbeat(this.heartbeat);
+    this.stopTimers();
     this.socket.destroy();
+  }
+
+  private stopTimers(): void {
+    for (const timer of this.timers) this.clearTimer(timer);
   }
 
   async load(req: CastMediaRequest): Promise<void> {
@@ -287,6 +307,22 @@ export class CastConnection {
     this.send(NS_HEARTBEAT, RECEIVER_ID, { type: "PING" });
   }
 
+  /**
+   * Ask where the receiver is up to.
+   *
+   * Silent before a load: there is no media session to ask about, and a
+   * GET_STATUS without one answers with the receiver's volume rather than a
+   * position, which would overwrite a good status with an empty one.
+   */
+  private pollStatus(): void {
+    if (this.lost || this.mediaSessionId === null || !this.transportId) return;
+    this.send(NS_MEDIA, this.transportId, {
+      type: "GET_STATUS",
+      requestId: this.nextRequestId++,
+      mediaSessionId: this.mediaSessionId,
+    });
+  }
+
   private send(namespace: string, destinationId: string, payload: unknown): void {
     const message: CastMessage = {
       sourceId: SENDER_ID,
@@ -386,7 +422,7 @@ export class CastConnection {
   private fail(message: string): void {
     if (this.lost) return;
     this.lost = true;
-    this.clearHeartbeat(this.heartbeat);
+    this.stopTimers();
     for (const [id, waiting] of this.pending) {
       this.pending.delete(id);
       waiting.reject(new CastError(message));

--- a/src/core/cast/connection.ts
+++ b/src/core/cast/connection.ts
@@ -1,0 +1,396 @@
+import tls from "node:tls";
+import { FrameReader, frameCastMessage, type CastMessage } from "./protocol";
+import type { CastDevice } from "./discover";
+
+/**
+ * One conversation with one Chromecast.
+ *
+ * The protocol, in the order it happens: CONNECT to `receiver-0`; LAUNCH the
+ * default media receiver; read the app's `sessionId` and `transportId` out of
+ * the RECEIVER_STATUS that answers; CONNECT again to that transport; LOAD on the
+ * media namespace. PAUSE and PLAY are addressed to the transport thereafter, and
+ * STOP goes back to the receiver namespace because it quits the app rather than
+ * pausing the file.
+ *
+ * Every message carries a monotonic `requestId` and replies are matched by it.
+ * MEDIA_STATUS also arrives UNSOLICITED, with a requestId of 0 — those are the
+ * position updates, and they match no pending request.
+ */
+
+export const RECEIVER_APP_ID = "CC1AD845";
+
+/**
+ * How often to PING.
+ *
+ * A receiver drops a sender that goes quiet for about eight seconds, so this has
+ * to be comfortably under that. Five is what every other sender uses.
+ */
+export const HEARTBEAT_MS = 5_000;
+
+const SENDER_ID = "sender-torlink";
+const RECEIVER_ID = "receiver-0";
+const NS_CONNECTION = "urn:x-cast:com.google.cast.tp.connection";
+const NS_HEARTBEAT = "urn:x-cast:com.google.cast.tp.heartbeat";
+const NS_RECEIVER = "urn:x-cast:com.google.cast.receiver";
+const NS_MEDIA = "urn:x-cast:com.google.cast.media";
+
+/** How long to wait for a socket, and for a reply to a request. */
+const CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * The part of a TLS socket this module uses.
+ *
+ * Injected rather than imported so the tests answer as a receiver instead of
+ * needing a television on the desk.
+ */
+export interface CastSocket {
+  write(data: Buffer): void;
+  onData(cb: (chunk: Buffer) => void): void;
+  onClose(cb: () => void): void;
+  destroy(): void;
+}
+
+export type ConnectSocket = (host: string, port: number) => Promise<CastSocket>;
+
+export interface CastMediaRequest {
+  url: string;
+  contentType: string;
+  title: string;
+  subtitleUrl?: string;
+  subtitleLabel?: string;
+}
+
+export type CastPlayerState = "loading" | "playing" | "paused" | "idle";
+
+export interface CastStatus {
+  state: CastPlayerState;
+  positionSec: number;
+  /** Null when the receiver has not said — a manifest it is still reading. */
+  durationSec: number | null;
+}
+
+export interface ConnectionDeps {
+  connect?: ConnectSocket;
+  setInterval?: (cb: () => void, ms: number) => unknown;
+  clearInterval?: (handle: unknown) => void;
+}
+
+/** A failure with a message already fit to put on screen. */
+export class CastError extends Error {}
+
+const defaultConnect: ConnectSocket = (host, port) =>
+  new Promise((resolve, reject) => {
+    // rejectUnauthorized: false is load-bearing, not laziness. A Chromecast
+    // presents a device-signed certificate and there is no chain to check it
+    // against. It is acceptable because nothing secret crosses this socket: the
+    // payload is a URL already available to anything on the LAN holding the
+    // session's `?k=` token.
+    const socket = tls.connect({ host, port, rejectUnauthorized: false }, () => {
+      socket.setTimeout(0);
+      resolve({
+        write: (data) => void socket.write(data),
+        onData: (cb) => void socket.on("data", cb),
+        onClose: (cb) => {
+          socket.on("close", cb);
+          // An error is a close as far as this module is concerned, and an
+          // unhandled "error" event on a socket is a thrown exception in the
+          // process — which in the TUI takes the terminal down with it.
+          socket.on("error", () => cb());
+        },
+        destroy: () => void socket.destroy(),
+      });
+    });
+    socket.once("error", reject);
+    socket.setTimeout(CONNECT_TIMEOUT_MS, () => {
+      socket.destroy();
+      reject(new Error("timed out"));
+    });
+  });
+
+interface Pending {
+  resolve: (payload: Record<string, unknown>) => void;
+  reject: (err: Error) => void;
+  /** Reply types that settle this request, beyond the expected one. */
+  failures: string[];
+  expect: string;
+}
+
+function playerState(raw: unknown): CastPlayerState {
+  switch (String(raw)) {
+    case "PLAYING":
+      return "playing";
+    case "PAUSED":
+      return "paused";
+    case "IDLE":
+      return "idle";
+    // BUFFERING and anything else the receiver invents read as "not showing you
+    // a frame yet", which is what "loading" says on screen.
+    default:
+      return "loading";
+  }
+}
+
+export class CastConnection {
+  private readonly pending = new Map<number, Pending>();
+  private nextRequestId = 1;
+  private transportId: string | null = null;
+  private sessionId: string | null = null;
+  private mediaSessionId: number | null = null;
+  private statusCb: ((status: CastStatus) => void) | null = null;
+  private lostCb: ((message: string) => void) | null = null;
+  private lost = false;
+  private readonly reader = new FrameReader();
+
+  private constructor(
+    private readonly device: CastDevice,
+    private readonly socket: CastSocket,
+    private readonly heartbeat: unknown,
+    private readonly clearHeartbeat: (handle: unknown) => void,
+  ) {}
+
+  static async open(device: CastDevice, deps: ConnectionDeps = {}): Promise<CastConnection> {
+    const connect = deps.connect ?? defaultConnect;
+    const setTimer = deps.setInterval ?? ((cb, ms) => setInterval(cb, ms));
+    const clearTimer = deps.clearInterval ?? ((handle) => clearInterval(handle as never));
+    let socket: CastSocket;
+    try {
+      socket = await connect(device.host, device.port);
+    } catch {
+      // The reason is never shown: ECONNREFUSED, EHOSTUNREACH and a timeout all
+      // mean the same thing to someone holding a remote control.
+      throw new CastError(`${device.name} didn't answer — it may be off.`);
+    }
+    let conn: CastConnection | null = null;
+    const timer = setTimer(() => conn?.ping(), HEARTBEAT_MS);
+    conn = new CastConnection(device, socket, timer, clearTimer);
+    socket.onData((chunk) => conn!.receive(chunk));
+    socket.onClose(() => conn!.fail(`Lost the connection to ${device.name}.`));
+    conn.send(NS_CONNECTION, RECEIVER_ID, { type: "CONNECT" });
+    return conn;
+  }
+
+  onStatus(cb: (status: CastStatus) => void): void {
+    this.statusCb = cb;
+  }
+
+  onLost(cb: (message: string) => void): void {
+    this.lostCb = cb;
+  }
+
+  close(): void {
+    this.clearHeartbeat(this.heartbeat);
+    this.socket.destroy();
+  }
+
+  async load(req: CastMediaRequest): Promise<void> {
+    const launch = await this.request(NS_RECEIVER, RECEIVER_ID, "RECEIVER_STATUS", ["LAUNCH_ERROR"], (requestId) => ({
+      type: "LAUNCH",
+      requestId,
+      appId: RECEIVER_APP_ID,
+    })).catch((e: unknown) => {
+      if (e instanceof CastError) throw e;
+      throw new CastError(`${this.device.name} wouldn't start the player.`);
+    });
+    const app = ((launch.status as { applications?: Record<string, unknown>[] } | undefined)
+      ?.applications ?? []).find((a) => a.appId === RECEIVER_APP_ID);
+    const transportId = typeof app?.transportId === "string" ? app.transportId : null;
+    const sessionId = typeof app?.sessionId === "string" ? app.sessionId : null;
+    if (!transportId || !sessionId) {
+      throw new CastError(`${this.device.name} wouldn't start the player.`);
+    }
+    this.transportId = transportId;
+    this.sessionId = sessionId;
+    // A media message to an app we have not joined is dropped silently, which
+    // presents as a LOAD that never answers.
+    this.send(NS_CONNECTION, transportId, { type: "CONNECT" });
+
+    const media: Record<string, unknown> = {
+      contentId: req.url,
+      contentType: req.contentType,
+      streamType: "BUFFERED",
+      metadata: { metadataType: 0, title: req.title },
+    };
+    if (req.subtitleUrl) {
+      media.tracks = [
+        {
+          trackId: 1,
+          type: "TEXT",
+          trackContentId: req.subtitleUrl,
+          trackContentType: "text/vtt",
+          subtype: "SUBTITLES",
+          name: req.subtitleLabel ?? "Subtitles",
+          language: "en",
+        },
+      ];
+    }
+    const status = await this.request(
+      NS_MEDIA,
+      transportId,
+      "MEDIA_STATUS",
+      ["LOAD_FAILED", "LOAD_CANCELLED"],
+      (requestId) => {
+        const body: Record<string, unknown> = {
+          type: "LOAD",
+          requestId,
+          sessionId,
+          media,
+          autoplay: true,
+        };
+        if (req.subtitleUrl) body.activeTrackIds = [1];
+        return body;
+      },
+    ).catch((e: unknown) => {
+      if (e instanceof CastError) throw e;
+      throw new CastError(`${this.device.name} couldn't play this file.`);
+    });
+    this.absorbMediaStatus(status);
+  }
+
+  async play(): Promise<void> {
+    await this.mediaCommand("PLAY");
+  }
+
+  async pause(): Promise<void> {
+    await this.mediaCommand("PAUSE");
+  }
+
+  /**
+   * Quit the receiver app.
+   *
+   * Not a media STOP: quitting hands the television back to its own screen,
+   * which is what "stop casting" means to the person who pressed it. Tolerant of
+   * having nothing to stop, because a stop button that errors is worse than one
+   * that does nothing.
+   */
+  async stop(): Promise<void> {
+    if (!this.sessionId) return;
+    this.send(NS_RECEIVER, RECEIVER_ID, {
+      type: "STOP",
+      requestId: this.nextRequestId++,
+      sessionId: this.sessionId,
+    });
+  }
+
+  private async mediaCommand(type: "PLAY" | "PAUSE"): Promise<void> {
+    if (this.mediaSessionId === null || !this.transportId) {
+      throw new CastError("nothing is playing on this device.");
+    }
+    this.send(NS_MEDIA, this.transportId, {
+      type,
+      requestId: this.nextRequestId++,
+      mediaSessionId: this.mediaSessionId,
+    });
+  }
+
+  private ping(): void {
+    if (this.lost) return;
+    this.send(NS_HEARTBEAT, RECEIVER_ID, { type: "PING" });
+  }
+
+  private send(namespace: string, destinationId: string, payload: unknown): void {
+    const message: CastMessage = {
+      sourceId: SENDER_ID,
+      destinationId,
+      namespace,
+      payload: JSON.stringify(payload),
+    };
+    try {
+      this.socket.write(frameCastMessage(message));
+    } catch {
+      this.fail(`Lost the connection to ${this.device.name}.`);
+    }
+  }
+
+  private request(
+    namespace: string,
+    destinationId: string,
+    expect: string,
+    failures: string[],
+    build: (requestId: number) => Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const requestId = this.nextRequestId++;
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.pending.set(requestId, { resolve, reject, expect, failures });
+      this.send(namespace, destinationId, build(requestId));
+    });
+  }
+
+  private receive(chunk: Buffer): void {
+    let messages: CastMessage[];
+    try {
+      messages = this.reader.push(chunk);
+    } catch {
+      // A malformed frame is a connection we can no longer follow. Reported, not
+      // thrown: in the TUI an unhandled error takes the terminal with it.
+      this.fail(`Lost the connection to ${this.device.name}.`);
+      return;
+    }
+    for (const message of messages) {
+      let payload: Record<string, unknown>;
+      try {
+        payload = JSON.parse(message.payload) as Record<string, unknown>;
+      } catch {
+        continue; // Not JSON, so not something this sender speaks.
+      }
+      this.dispatch(message.namespace, payload);
+    }
+  }
+
+  private dispatch(namespace: string, payload: Record<string, unknown>): void {
+    const type = String(payload.type ?? "");
+    if (namespace === NS_HEARTBEAT) {
+      if (type === "PING") this.send(NS_HEARTBEAT, RECEIVER_ID, { type: "PONG" });
+      return;
+    }
+    if (namespace === NS_MEDIA && type === "MEDIA_STATUS") {
+      // Absorbed before the pending lookup so an UNSOLICITED status (requestId
+      // 0) still updates position — that is what most of them are.
+      this.absorbMediaStatus(payload);
+    }
+    const requestId = Number(payload.requestId ?? 0);
+    const waiting = this.pending.get(requestId);
+    if (!waiting) return;
+    if (waiting.expect === type) {
+      this.pending.delete(requestId);
+      waiting.resolve(payload);
+      return;
+    }
+    if (waiting.failures.includes(type)) {
+      this.pending.delete(requestId);
+      // A plain Error, deliberately: `CastError` means "this message is already
+      // fit for the screen", and a receiver's reply type is not. The caller maps
+      // it, and passes a real CastError — a lost connection — straight through.
+      waiting.reject(new Error(type));
+    }
+  }
+
+  private absorbMediaStatus(payload: Record<string, unknown>): void {
+    const entry = (payload.status as Record<string, unknown>[] | undefined)?.[0];
+    if (!entry) return;
+    if (typeof entry.mediaSessionId === "number") this.mediaSessionId = entry.mediaSessionId;
+    const duration = (entry.media as { duration?: unknown } | undefined)?.duration;
+    this.statusCb?.({
+      state: playerState(entry.playerState),
+      positionSec: typeof entry.currentTime === "number" ? entry.currentTime : 0,
+      durationSec: typeof duration === "number" ? duration : null,
+    });
+  }
+
+  /**
+   * The one exit for every way this connection can end badly.
+   *
+   * Idempotent: a socket reports `error` and then `close`, and the user must not
+   * be told twice. Pending requests are rejected here rather than left to time
+   * out, because a LOAD that never settles is a spinner that never stops.
+   */
+  private fail(message: string): void {
+    if (this.lost) return;
+    this.lost = true;
+    this.clearHeartbeat(this.heartbeat);
+    for (const [id, waiting] of this.pending) {
+      this.pending.delete(id);
+      waiting.reject(new CastError(message));
+    }
+    this.lostCb?.(message);
+  }
+}

--- a/src/core/cast/discover.test.ts
+++ b/src/core/cast/discover.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CAST_PORT,
+  devicesFromPackets,
+  discover,
+  parseManualDevice,
+  type MdnsLike,
+  type MdnsPacket,
+} from "./discover";
+
+// One device's answer, as multicast-dns reports it: a PTR naming the instance,
+// an SRV with host and port, TXT key=value pairs as Buffers, and an A record.
+function packetFor(opts: {
+  instance: string;
+  target: string;
+  ip: string;
+  port?: number;
+  txt?: string[];
+  withSrv?: boolean;
+}): MdnsPacket {
+  const records = [
+    { name: "_googlecast._tcp.local", type: "PTR", data: opts.instance },
+    ...(opts.withSrv === false
+      ? []
+      : [
+          {
+            name: opts.instance,
+            type: "SRV",
+            data: { port: opts.port ?? DEFAULT_CAST_PORT, target: opts.target },
+          },
+        ]),
+    {
+      name: opts.instance,
+      type: "TXT",
+      data: (opts.txt ?? ["id=abc123", "fn=Living Room TV", "md=Chromecast"]).map((s) =>
+        Buffer.from(s),
+      ),
+    },
+    { name: opts.target, type: "A", data: opts.ip },
+  ];
+  return { answers: records, additionals: [] };
+}
+
+describe("devicesFromPackets", () => {
+  it("builds a device from SRV, A and TXT", () => {
+    const devices = devicesFromPackets([
+      packetFor({ instance: "abc._googlecast._tcp.local", target: "abc.local", ip: "192.168.0.40" }),
+    ]);
+    expect(devices).toEqual([
+      { id: "abc123", name: "Living Room TV", model: "Chromecast", host: "192.168.0.40", port: 8009 },
+    ]);
+  });
+
+  it("drops an answer with no SRV rather than half-building a device with no port", () => {
+    const devices = devicesFromPackets([
+      packetFor({
+        instance: "abc._googlecast._tcp.local",
+        target: "abc.local",
+        ip: "192.168.0.40",
+        withSrv: false,
+      }),
+    ]);
+    expect(devices).toEqual([]);
+  });
+
+  it("collapses the same device answering on two interfaces, by id", () => {
+    const one = packetFor({
+      instance: "abc._googlecast._tcp.local",
+      target: "abc.local",
+      ip: "192.168.0.40",
+    });
+    const again = packetFor({
+      instance: "abc._googlecast._tcp.local",
+      target: "abc.local",
+      ip: "10.8.0.4",
+    });
+    expect(devicesFromPackets([one, again]).map((d) => d.id)).toEqual(["abc123"]);
+  });
+
+  it("falls back to the instance name when TXT carries no fn, so a device is never nameless", () => {
+    const devices = devicesFromPackets([
+      packetFor({
+        instance: "kitchen-display._googlecast._tcp.local",
+        target: "k.local",
+        ip: "192.168.0.41",
+        txt: ["id=k1"],
+      }),
+    ]);
+    expect(devices[0]).toMatchObject({ id: "k1", name: "kitchen-display", model: "" });
+  });
+
+  it("keeps two genuinely different devices", () => {
+    const devices = devicesFromPackets([
+      packetFor({ instance: "a._googlecast._tcp.local", target: "a.local", ip: "192.168.0.40" }),
+      packetFor({
+        instance: "b._googlecast._tcp.local",
+        target: "b.local",
+        ip: "192.168.0.41",
+        txt: ["id=k1", "fn=Kitchen display", "md=Google TV Streamer"],
+      }),
+    ]);
+    expect(devices.map((d) => d.name)).toEqual(["Living Room TV", "Kitchen display"]);
+  });
+});
+
+describe("parseManualDevice", () => {
+  it("takes a bare host and defaults the port", () => {
+    expect(parseManualDevice("192.168.0.40")).toEqual({
+      id: "manual:192.168.0.40:8009",
+      name: "192.168.0.40",
+      model: "",
+      host: "192.168.0.40",
+      port: 8009,
+    });
+  });
+
+  it("takes host:port", () => {
+    expect(parseManualDevice("tv.local:8010")).toMatchObject({ host: "tv.local", port: 8010 });
+  });
+
+  it("is null for absent, blank, or an unusable port", () => {
+    expect(parseManualDevice(undefined)).toBeNull();
+    expect(parseManualDevice("   ")).toBeNull();
+    expect(parseManualDevice("tv.local:not-a-port")).toBeNull();
+    expect(parseManualDevice("tv.local:0")).toBeNull();
+  });
+});
+
+describe("discover", () => {
+  it("queries the cast service, collects what answers within the window, and destroys the socket", async () => {
+    const handlers: ((p: MdnsPacket) => void)[] = [];
+    const query = vi.fn();
+    const destroy = vi.fn();
+    const mdns: MdnsLike = {
+      on: (_event, cb) => {
+        handlers.push(cb);
+      },
+      query,
+      destroy,
+    };
+    const devices = await discover({
+      mdnsFactory: () => mdns,
+      timeoutMs: 1,
+      sleep: async () => {
+        handlers[0]!(
+          packetFor({
+            instance: "abc._googlecast._tcp.local",
+            target: "abc.local",
+            ip: "192.168.0.40",
+          }),
+        );
+      },
+    });
+    expect(query).toHaveBeenCalledWith({
+      questions: [{ name: "_googlecast._tcp.local", type: "PTR" }],
+    });
+    expect(devices.map((d) => d.name)).toEqual(["Living Room TV"]);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it("resolves empty when nothing answers, rather than throwing or hanging", async () => {
+    const mdns: MdnsLike = { on: () => {}, query: () => {}, destroy: () => {} };
+    await expect(
+      discover({ mdnsFactory: () => mdns, timeoutMs: 1, sleep: async () => {} }),
+    ).resolves.toEqual([]);
+  });
+
+  it("destroys the socket even when the query itself throws", async () => {
+    const destroy = vi.fn();
+    const mdns: MdnsLike = {
+      on: () => {},
+      query: () => {
+        throw new Error("no multicast route");
+      },
+      destroy,
+    };
+    await expect(
+      discover({ mdnsFactory: () => mdns, timeoutMs: 1, sleep: async () => {} }),
+    ).resolves.toEqual([]);
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/core/cast/discover.ts
+++ b/src/core/cast/discover.ts
@@ -1,0 +1,157 @@
+import makeMdns from "multicast-dns";
+
+/**
+ * Finding Chromecasts on the LAN.
+ *
+ * `multicast-dns` is the one dependency this feature takes, and it is the half
+ * worth taking: DNS name compression, several interfaces answering at once and
+ * multicast group membership are real edge cases, where the protocol on top
+ * (see ./protocol.ts) is a fixed six-field message. The factory is injected so
+ * the tests feed canned records and never open a socket.
+ */
+
+export interface CastDevice {
+  /** The device's own id from TXT, or a synthetic one for a configured address. */
+  id: string;
+  name: string;
+  /** TXT `md`, e.g. "Chromecast". Empty when the device did not say. */
+  model: string;
+  host: string;
+  port: number;
+}
+
+export const CAST_SERVICE = "_googlecast._tcp.local";
+export const DEFAULT_CAST_PORT = 8009;
+
+/**
+ * How long to listen for answers.
+ *
+ * A device on the same segment answers in tens of milliseconds; two seconds is
+ * generous for a busy access point and short enough that the device list does
+ * not feel broken. Nothing waits for a *complete* answer set, because there is
+ * no such thing — a television that is off answers never.
+ */
+export const DISCOVER_TIMEOUT_MS = 2_000;
+
+export interface MdnsRecord {
+  name: string;
+  type: string;
+  data: unknown;
+}
+
+export interface MdnsPacket {
+  answers?: MdnsRecord[];
+  additionals?: MdnsRecord[];
+}
+
+/** The part of multicast-dns's surface this module uses. */
+export interface MdnsLike {
+  on(event: "response", cb: (packet: MdnsPacket) => void): void;
+  query(q: { questions: { name: string; type: "PTR" }[] }): void;
+  destroy(): void;
+}
+
+export interface DiscoverDeps {
+  mdnsFactory?: () => MdnsLike;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function txtPairs(data: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!Array.isArray(data)) return out;
+  for (const entry of data) {
+    const text = Buffer.isBuffer(entry) ? entry.toString("utf8") : String(entry);
+    const eq = text.indexOf("=");
+    if (eq > 0) out.set(text.slice(0, eq), text.slice(eq + 1));
+  }
+  return out;
+}
+
+/**
+ * Assemble devices from whatever answered.
+ *
+ * Pure, and separate from the socket for that reason. An answer with no SRV is
+ * dropped: a device with no port is not a device, and inventing 8009 for it
+ * would put a row on screen that cannot be cast to.
+ */
+export function devicesFromPackets(packets: readonly MdnsPacket[]): CastDevice[] {
+  const byId = new Map<string, CastDevice>();
+  for (const packet of packets) {
+    const records = [...(packet.answers ?? []), ...(packet.additionals ?? [])];
+    const srv = records.find((r) => r.type === "SRV");
+    if (!srv || typeof srv.data !== "object" || srv.data === null) continue;
+    const { port, target } = srv.data as { port?: number; target?: string };
+    if (!port || !target) continue;
+    const addressed = records.find(
+      (r) => (r.type === "A" || r.type === "AAAA") && r.name === target,
+    );
+    const host = typeof addressed?.data === "string" ? addressed.data : target;
+    const txt = txtPairs(records.find((r) => r.type === "TXT")?.data);
+    // The instance name is the fallback because a nameless row cannot be
+    // chosen: "abc._googlecast._tcp.local" reads as "abc", which is at least
+    // something the user can tell apart from the other row.
+    const instance = srv.name.replace(`.${CAST_SERVICE}`, "");
+    const id = txt.get("id") ?? `${host}:${port}`;
+    if (byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      name: txt.get("fn") ?? instance,
+      model: txt.get("md") ?? "",
+      host,
+      port,
+    });
+  }
+  return [...byId.values()];
+}
+
+/**
+ * A device from the configured address, for networks mDNS cannot cross.
+ *
+ * mDNS does not traverse a Docker bridge or a VLAN, and torlink is run behind
+ * both — without this the feature is dead there, behind a message that reads
+ * like a bug. The id is prefixed so nothing can confuse it with a discovered
+ * device's own id.
+ */
+export function parseManualDevice(raw: string | undefined): CastDevice | null {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return null;
+  const colon = trimmed.lastIndexOf(":");
+  let host = trimmed;
+  let port = DEFAULT_CAST_PORT;
+  if (colon > 0) {
+    const tail = trimmed.slice(colon + 1);
+    if (!/^\d+$/.test(tail)) return null;
+    port = Number(tail);
+    if (port < 1 || port > 65_535) return null;
+    host = trimmed.slice(0, colon);
+  }
+  if (!host) return null;
+  return { id: `manual:${host}:${port}`, name: host, model: "", host, port };
+}
+
+export async function discover(deps: DiscoverDeps = {}): Promise<CastDevice[]> {
+  const factory = deps.mdnsFactory ?? (() => makeMdns() as unknown as MdnsLike);
+  const timeoutMs = deps.timeoutMs ?? DISCOVER_TIMEOUT_MS;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const packets: MdnsPacket[] = [];
+  const mdns = factory();
+  try {
+    mdns.on("response", (packet) => {
+      packets.push(packet);
+    });
+    mdns.query({ questions: [{ name: CAST_SERVICE, type: "PTR" }] });
+    await sleep(timeoutMs);
+  } catch {
+    // No multicast route, a firewall, a container with no host network: an
+    // empty list and a message the caller can explain, never a thrown error
+    // in the middle of someone pressing a button.
+  } finally {
+    try {
+      mdns.destroy();
+    } catch {
+      // Already gone. Nothing to reclaim.
+    }
+  }
+  return devicesFromPackets(packets);
+}

--- a/src/core/cast/protocol.test.ts
+++ b/src/core/cast/protocol.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  FrameReader,
+  MAX_FRAME_BYTES,
+  decodeCastMessage,
+  encodeCastMessage,
+  frameCastMessage,
+  type CastMessage,
+} from "./protocol";
+
+const MSG: CastMessage = {
+  sourceId: "sender-torlink",
+  destinationId: "receiver-0",
+  namespace: "urn:x-cast:com.google.cast.receiver",
+  payload: JSON.stringify({ type: "LAUNCH", appId: "CC1AD845", requestId: 1 }),
+};
+
+describe("encodeCastMessage / decodeCastMessage", () => {
+  it("round-trips every field", () => {
+    expect(decodeCastMessage(encodeCastMessage(MSG))).toEqual(MSG);
+  });
+
+  it("round-trips a payload carrying non-ASCII, so the length prefix is bytes and not characters", () => {
+    const msg = { ...MSG, payload: JSON.stringify({ title: "Kestrel — 2010" }) };
+    expect(decodeCastMessage(encodeCastMessage(msg))).toEqual(msg);
+  });
+
+  it("ignores a field it does not know rather than throwing", () => {
+    // field 7, wire type 0 (varint), value 3 — appended to a valid body.
+    const extended = Buffer.concat([encodeCastMessage(MSG), Buffer.from([0x38, 0x03])]);
+    expect(decodeCastMessage(extended)).toEqual(MSG);
+  });
+});
+
+describe("FrameReader", () => {
+  it("yields one message from a whole frame", () => {
+    const reader = new FrameReader();
+    expect(reader.push(frameCastMessage(MSG))).toEqual([MSG]);
+  });
+
+  it("yields nothing until a frame whose length prefix is split across chunks completes", () => {
+    const reader = new FrameReader();
+    const framed = frameCastMessage(MSG);
+    // Two bytes of the four-byte length: the failure mode every hand-rolled
+    // framer has on its first day.
+    expect(reader.push(framed.subarray(0, 2))).toEqual([]);
+    expect(reader.push(framed.subarray(2, 9))).toEqual([]);
+    expect(reader.push(framed.subarray(9))).toEqual([MSG]);
+  });
+
+  it("yields two messages from one chunk carrying both", () => {
+    const reader = new FrameReader();
+    const second = { ...MSG, payload: JSON.stringify({ type: "PONG" }) };
+    const chunk = Buffer.concat([frameCastMessage(MSG), frameCastMessage(second)]);
+    expect(reader.push(chunk)).toEqual([MSG, second]);
+  });
+
+  it("refuses a frame claiming an absurd length instead of buffering for it", () => {
+    const reader = new FrameReader();
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(MAX_FRAME_BYTES + 1, 0);
+    expect(() => reader.push(header)).toThrow(/refused/);
+  });
+});

--- a/src/core/cast/protocol.ts
+++ b/src/core/cast/protocol.ts
@@ -1,0 +1,154 @@
+/**
+ * The CASTV2 wire format, by hand.
+ *
+ * A `CastMessage` is a protobuf with six fields and its shape never varies:
+ * protocol_version (1, varint), source_id (2), destination_id (3), namespace
+ * (4), payload_type (5, varint) and payload_utf8 (6). Everything torlink sends
+ * or reads is JSON in field 6; the binary payload field is never used.
+ *
+ * Sixty lines of encoder is why `protobufjs` is not a dependency here: it is
+ * roughly a megabyte into the bundled CLI, whose whole runtime dependency list
+ * is eleven packages, to encode a message with no variability at all.
+ */
+
+export interface CastMessage {
+  sourceId: string;
+  destinationId: string;
+  namespace: string;
+  /** The JSON body. Field 6, `payload_utf8`. */
+  payload: string;
+}
+
+/**
+ * The largest frame we will assemble.
+ *
+ * A cast reply is a small JSON object; the biggest thing a receiver sends is a
+ * MEDIA_STATUS with track metadata, orders of magnitude under this. The cap
+ * exists because the length prefix arrives from the network: without it, four
+ * bytes from anything listening on port 8009 can make this buffer without
+ * bound.
+ */
+export const MAX_FRAME_BYTES = 1 << 20;
+
+function varint(value: number): Buffer {
+  const out: number[] = [];
+  let v = value;
+  do {
+    let byte = v & 0x7f;
+    v = Math.floor(v / 128);
+    if (v > 0) byte |= 0x80;
+    out.push(byte);
+  } while (v > 0);
+  return Buffer.from(out);
+}
+
+// Wire type 0 is a varint, 2 is length-delimited. Those are the only two here.
+function key(field: number, wire: 0 | 2): Buffer {
+  return varint((field << 3) | wire);
+}
+
+function stringField(field: number, value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  return Buffer.concat([key(field, 2), varint(bytes.length), bytes]);
+}
+
+export function encodeCastMessage(m: CastMessage): Buffer {
+  return Buffer.concat([
+    key(1, 0),
+    varint(0), // protocol_version = CASTV2_1_0
+    stringField(2, m.sourceId),
+    stringField(3, m.destinationId),
+    stringField(4, m.namespace),
+    key(5, 0),
+    varint(0), // payload_type = STRING
+    stringField(6, m.payload),
+  ]);
+}
+
+function readVarint(buf: Buffer, at: number): { value: number; next: number } {
+  let value = 0;
+  // Multiplication rather than `<<`, which is a 32-bit operation in JS and
+  // would silently wrap on a five-byte varint.
+  let shift = 1;
+  let i = at;
+  for (;;) {
+    if (i >= buf.length) throw new Error("cast frame: truncated varint");
+    const byte = buf[i]!;
+    i += 1;
+    value += (byte & 0x7f) * shift;
+    if ((byte & 0x80) === 0) break;
+    shift *= 128;
+    if (shift > 2 ** 42) throw new Error("cast frame: varint too long");
+  }
+  return { value, next: i };
+}
+
+/**
+ * Read a body into the four fields that matter.
+ *
+ * Unknown fields are skipped rather than rejected: a future receiver adding one
+ * must not stop playback, and the two enum fields we write are skipped by this
+ * same path on the way back in.
+ */
+export function decodeCastMessage(body: Buffer): CastMessage {
+  const out: CastMessage = { sourceId: "", destinationId: "", namespace: "", payload: "" };
+  let at = 0;
+  while (at < body.length) {
+    const k = readVarint(body, at);
+    at = k.next;
+    const field = Math.floor(k.value / 8);
+    const wire = k.value % 8;
+    if (wire === 0) {
+      at = readVarint(body, at).next;
+      continue;
+    }
+    if (wire !== 2) throw new Error(`cast frame: unsupported wire type ${wire}`);
+    const len = readVarint(body, at);
+    at = len.next;
+    const end = at + len.value;
+    if (end > body.length) throw new Error("cast frame: truncated field");
+    const text = body.subarray(at, end).toString("utf8");
+    at = end;
+    if (field === 2) out.sourceId = text;
+    else if (field === 3) out.destinationId = text;
+    else if (field === 4) out.namespace = text;
+    else if (field === 6) out.payload = text;
+  }
+  return out;
+}
+
+export function frameCastMessage(m: CastMessage): Buffer {
+  const body = encodeCastMessage(m);
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+/**
+ * Reassemble frames from a TCP stream.
+ *
+ * Stateful on purpose: a socket hands over arbitrary chunk boundaries, so a
+ * length prefix split across two reads is normal traffic and not an error.
+ */
+export class FrameReader {
+  // `ArrayBufferLike` rather than the narrower default: `subarray` returns a
+  // view whose backing buffer type is unconstrained, and this field is
+  // reassigned from one on every complete frame.
+  private buffered: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+  push(chunk: Buffer): CastMessage[] {
+    this.buffered = this.buffered.length === 0 ? chunk : Buffer.concat([this.buffered, chunk]);
+    const out: CastMessage[] = [];
+    for (;;) {
+      if (this.buffered.length < 4) break;
+      const length = this.buffered.readUInt32BE(0);
+      if (length > MAX_FRAME_BYTES) {
+        throw new Error(`cast frame of ${length} bytes refused`);
+      }
+      if (this.buffered.length < 4 + length) break;
+      out.push(decodeCastMessage(this.buffered.subarray(4, 4 + length)));
+      this.buffered = this.buffered.subarray(4 + length);
+    }
+    return out;
+  }
+}

--- a/src/core/cast/session.test.ts
+++ b/src/core/cast/session.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { CastError } from "./connection";
+import { CastSessionRegistry, type StartCastInput } from "./session";
+import type { CastDevice } from "./discover";
+
+const DEVICE: CastDevice = {
+  id: "abc",
+  name: "Living Room TV",
+  model: "Chromecast",
+  host: "10.0.0.5",
+  port: 8009,
+};
+const OTHER: CastDevice = {
+  id: "k1",
+  name: "Kitchen display",
+  model: "Chromecast",
+  host: "10.0.0.6",
+  port: 8009,
+};
+
+function input(over: Partial<StartCastInput> = {}): StartCastInput {
+  return {
+    device: DEVICE,
+    sid: "sess",
+    index: 0,
+    infoHash: "hash",
+    filename: "Kepler.S02E04.1080p.WEB-DL.mkv",
+    title: "Kepler S02E04",
+    media: {
+      url: "http://10.0.0.2:9161/stream/sess/0?k=t",
+      contentType: "video/mp4",
+      title: "Kepler S02E04",
+    },
+    ...over,
+  };
+}
+
+function fakeConnection() {
+  let statusCb: ((s: never) => void) | null = null;
+  let lostCb: ((m: string) => void) | null = null;
+  return {
+    load: vi.fn(async () => {}),
+    play: vi.fn(async () => {}),
+    pause: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    close: vi.fn(),
+    onStatus(cb: never) {
+      statusCb = cb;
+    },
+    onLost(cb: (m: string) => void) {
+      lostCb = cb;
+    },
+    emitStatus(s: unknown) {
+      (statusCb as unknown as (v: unknown) => void)(s);
+    },
+    emitLost(m: string) {
+      lostCb!(m);
+    },
+  };
+}
+
+/** No default markPlayed: the real one writes the developer's own data dir. */
+function registryWith(conn: ReturnType<typeof fakeConnection>) {
+  return new CastSessionRegistry({
+    openConnection: async () => conn as never,
+    markPlayed: async () => {},
+  });
+}
+
+describe("CastSessionRegistry", () => {
+  it("has nothing active until something is cast", () => {
+    expect(new CastSessionRegistry({ markPlayed: async () => {} }).active()).toBeNull();
+  });
+
+  it("loads the media and reports what is playing", async () => {
+    const conn = fakeConnection();
+    const active = await registryWith(conn).start(input());
+    expect(conn.load).toHaveBeenCalledWith(input().media);
+    expect(active.device.name).toBe("Living Room TV");
+    expect(active).toMatchObject({ sid: "sess", index: 0, title: "Kepler S02E04" });
+  });
+
+  it("marks the file played on a successful load, exactly once", async () => {
+    const markPlayed = vi.fn(async () => {});
+    const registry = new CastSessionRegistry({
+      openConnection: async () => fakeConnection() as never,
+      markPlayed,
+    });
+    await registry.start(input());
+    expect(markPlayed).toHaveBeenCalledExactlyOnceWith("hash", "Kepler.S02E04.1080p.WEB-DL.mkv");
+  });
+
+  it("marks nothing when the device refuses the file", async () => {
+    const markPlayed = vi.fn(async () => {});
+    const conn = fakeConnection();
+    conn.load.mockRejectedValue(new CastError("Living Room TV couldn't play this file."));
+    const registry = new CastSessionRegistry({
+      openConnection: async () => conn as never,
+      markPlayed,
+    });
+    await expect(registry.start(input())).rejects.toThrow(/couldn't play this file/);
+    // A device that refused the file must not earn a ✓ — the rule the TUI's
+    // onPlayed callback already follows.
+    expect(markPlayed).not.toHaveBeenCalled();
+    expect(registry.active()).toBeNull();
+    expect(conn.close).toHaveBeenCalledOnce();
+  });
+
+  it("never lets a history write failure fail a cast the user already started", async () => {
+    const registry = new CastSessionRegistry({
+      openConnection: async () => fakeConnection() as never,
+      markPlayed: async () => {
+        throw new Error("disk full");
+      },
+    });
+    await expect(registry.start(input())).resolves.toMatchObject({ sid: "sess" });
+  });
+
+  it("replaces an existing cast, closing the first connection", async () => {
+    const first = fakeConnection();
+    const second = fakeConnection();
+    const conns = [first, second];
+    const registry = new CastSessionRegistry({
+      openConnection: async () => conns.shift() as never,
+      markPlayed: async () => {},
+    });
+    await registry.start(input());
+    await registry.start(input({ device: OTHER, sid: "sess2" }));
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(registry.active()).toMatchObject({ sid: "sess2", device: { name: "Kitchen display" } });
+  });
+
+  it("keeps the latest status and notifies subscribers", async () => {
+    const conn = fakeConnection();
+    const registry = registryWith(conn);
+    const changed = vi.fn();
+    registry.onChange(changed);
+    await registry.start(input());
+    changed.mockClear();
+    conn.emitStatus({ state: "playing", positionSec: 30, durationSec: 6_000 });
+    expect(registry.active()!.status).toEqual({
+      state: "playing",
+      positionSec: 30,
+      durationSec: 6_000,
+    });
+    expect(changed).toHaveBeenCalled();
+  });
+
+  it("starts at loading with no position, so nothing claims 0:00 of a file it has not read", async () => {
+    const registry = registryWith(fakeConnection());
+    const active = await registry.start(input());
+    expect(active.status).toEqual({ state: "loading", positionSec: 0, durationSec: null });
+  });
+
+  it("clears the cast and leaves a notice when the connection is lost", async () => {
+    const conn = fakeConnection();
+    const registry = registryWith(conn);
+    await registry.start(input());
+    conn.emitLost("Lost the connection to Living Room TV.");
+    expect(registry.active()).toBeNull();
+    expect(registry.takeNotice()).toBe("Lost the connection to Living Room TV.");
+    // Taken once: the front end that read it has shown it.
+    expect(registry.takeNotice()).toBeNull();
+  });
+
+  it("ignores a lost report from a connection that has already been replaced", async () => {
+    const first = fakeConnection();
+    const second = fakeConnection();
+    const conns = [first, second];
+    const registry = new CastSessionRegistry({
+      openConnection: async () => conns.shift() as never,
+      markPlayed: async () => {},
+    });
+    await registry.start(input());
+    await registry.start(input({ sid: "sess2" }));
+    // The first socket closing is the expected consequence of replacing it, and
+    // must not tear down the cast that replaced it.
+    first.emitLost("Lost the connection to Living Room TV.");
+    expect(registry.active()).toMatchObject({ sid: "sess2" });
+    expect(registry.takeNotice()).toBeNull();
+  });
+
+  it("stop closes the connection and clears the cast, with no notice — the user asked for it", async () => {
+    const conn = fakeConnection();
+    const registry = registryWith(conn);
+    await registry.start(input());
+    await registry.stop();
+    expect(conn.stop).toHaveBeenCalledOnce();
+    expect(conn.close).toHaveBeenCalledOnce();
+    expect(registry.active()).toBeNull();
+    expect(registry.takeNotice()).toBeNull();
+  });
+
+  it("passes play and pause through", async () => {
+    const conn = fakeConnection();
+    const registry = registryWith(conn);
+    await registry.start(input());
+    await registry.pause();
+    await registry.play();
+    expect(conn.pause).toHaveBeenCalledOnce();
+    expect(conn.play).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a command when nothing is casting", async () => {
+    const registry = new CastSessionRegistry({ markPlayed: async () => {} });
+    await expect(registry.pause()).rejects.toThrow(/nothing is casting/i);
+    await expect(registry.play()).rejects.toThrow(/nothing is casting/i);
+    // Stop is the exception: stopping nothing is what the caller wanted anyway.
+    await expect(registry.stop()).resolves.toBeUndefined();
+  });
+
+  it("unsubscribes cleanly", async () => {
+    const registry = new CastSessionRegistry({
+      openConnection: async () => fakeConnection() as never,
+      markPlayed: async () => {},
+    });
+    const changed = vi.fn();
+    registry.onChange(changed)();
+    await registry.start(input());
+    expect(changed).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/cast/session.ts
+++ b/src/core/cast/session.ts
@@ -1,0 +1,185 @@
+import { loadConfig, saveConfig } from "../../config/config";
+import { markWatched } from "../../util/favouriteList";
+import { loadStreamHistory, recordPlayedFile, saveStreamHistory } from "../streamHistory";
+import { CastConnection, type CastMediaRequest, type CastStatus } from "./connection";
+import type { CastDevice } from "./discover";
+
+/**
+ * The one active cast in this process.
+ *
+ * One, deliberately: a second would be a second thing claiming the same screen,
+ * and there is nowhere on either front end to show two.
+ *
+ * NOTE THE PER-PROCESS LIMIT, which is honest rather than hidden. The TUI and
+ * `serve --web` are separate processes, so a cast started in one is invisible to
+ * the other — except where the TUI is hosting the web UI itself (shift+w), which
+ * is one process and therefore one registry. Sharing it across processes needs a
+ * TUI↔daemon RPC that does not exist.
+ */
+
+export interface ActiveCast {
+  device: CastDevice;
+  sid: string;
+  index: number;
+  title: string;
+  status: CastStatus;
+}
+
+export interface StartCastInput {
+  device: CastDevice;
+  sid: string;
+  index: number;
+  /** For the played-file write — the key every store in the app is written under. */
+  infoHash: string;
+  filename: string;
+  /** What to show on screen and on the television. */
+  title: string;
+  media: CastMediaRequest;
+}
+
+export type MarkPlayed = (infoHash: string, filename: string) => Promise<void>;
+
+export interface CastRegistryDeps {
+  openConnection?: (device: CastDevice) => Promise<CastConnection>;
+  markPlayed?: MarkPlayed;
+}
+
+/**
+ * Advance the same two stores a local play advances.
+ *
+ * Read-modify-write, never a held snapshot: a `serve --web` process may be
+ * running against this same file. Same reference back means nothing moved, which
+ * is the write gate — exactly what the browser's "watched" route does, and for
+ * the same reason (this fires on every play, and churning config.json on every
+ * re-watch is what the check avoids).
+ */
+const defaultMarkPlayed: MarkPlayed = async (infoHash, filename) => {
+  const config = await loadConfig();
+  const current = config.favourites ?? [];
+  const favourites = markWatched(current, infoHash, filename);
+  if (favourites !== current) await saveConfig({ ...config, favourites });
+  const history = await loadStreamHistory();
+  const advanced = recordPlayedFile(history, infoHash, filename);
+  if (advanced !== history) await saveStreamHistory(advanced);
+};
+
+/** Nothing has been read off the file yet, so nothing claims a position. */
+const INITIAL_STATUS: CastStatus = { state: "loading", positionSec: 0, durationSec: null };
+
+export class CastSessionRegistry {
+  private cast: ActiveCast | null = null;
+  private connection: CastConnection | null = null;
+  private notice: string | null = null;
+  private readonly listeners = new Set<() => void>();
+  private readonly openConnection: (device: CastDevice) => Promise<CastConnection>;
+  private readonly markPlayed: MarkPlayed;
+
+  constructor(deps: CastRegistryDeps = {}) {
+    this.openConnection = deps.openConnection ?? ((device) => CastConnection.open(device));
+    this.markPlayed = deps.markPlayed ?? defaultMarkPlayed;
+  }
+
+  active(): ActiveCast | null {
+    return this.cast;
+  }
+
+  /**
+   * The message left by a cast that ended badly, cleared by reading it.
+   *
+   * Once, because both front ends read this and only one should show it.
+   */
+  takeNotice(): string | null {
+    const notice = this.notice;
+    this.notice = null;
+    return notice;
+  }
+
+  onChange(cb: () => void): () => void {
+    this.listeners.add(cb);
+    return () => void this.listeners.delete(cb);
+  }
+
+  async start(input: StartCastInput): Promise<ActiveCast> {
+    // Close whatever was casting first, so two connections never hold two
+    // televisions at once.
+    await this.teardown();
+    const connection = await this.openConnection(input.device);
+    try {
+      await connection.load(input.media);
+    } catch (e) {
+      // Nothing is left claiming to be playing, and nothing is marked played.
+      connection.close();
+      throw e;
+    }
+    const cast: ActiveCast = {
+      device: input.device,
+      sid: input.sid,
+      index: input.index,
+      title: input.title,
+      status: INITIAL_STATUS,
+    };
+    this.cast = cast;
+    this.connection = connection;
+    connection.onStatus((status) => {
+      if (this.connection !== connection || !this.cast) return;
+      this.cast = { ...this.cast, status };
+      this.emit();
+    });
+    connection.onLost((message) => {
+      // A connection that has already been replaced closing is the expected
+      // consequence of replacing it, not a failure to report.
+      if (this.connection !== connection) return;
+      this.connection = null;
+      this.cast = null;
+      this.notice = message;
+      this.emit();
+    });
+    this.emit();
+    try {
+      await this.markPlayed(input.infoHash, input.filename);
+    } catch {
+      // A convenience list must never fail a play the user already started —
+      // the rule `recordStreamHistory` follows in the TUI.
+    }
+    return cast;
+  }
+
+  async play(): Promise<void> {
+    await this.command((c) => c.play());
+  }
+
+  async pause(): Promise<void> {
+    await this.command((c) => c.pause());
+  }
+
+  /**
+   * Stop casting.
+   *
+   * Tolerant of nothing casting: stopping nothing is what the caller wanted, and
+   * a stop button that errors is worse than one that does nothing.
+   */
+  async stop(): Promise<void> {
+    await this.teardown();
+    this.emit();
+  }
+
+  private async command(run: (c: CastConnection) => Promise<void>): Promise<void> {
+    if (!this.connection) throw new Error("Nothing is casting.");
+    await run(this.connection);
+  }
+
+  private async teardown(): Promise<void> {
+    const connection = this.connection;
+    if (!connection) return;
+    this.connection = null;
+    this.cast = null;
+    // The device's own player is quit before the socket goes, so the television
+    // returns to its own screen rather than sitting on a stalled frame.
+    await connection.stop().catch(() => {});
+    connection.close();
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/src/core/streamSession.test.ts
+++ b/src/core/streamSession.test.ts
@@ -435,3 +435,72 @@ describe("StreamSessionRegistry — stopAll", () => {
     expect(registry.list()).toEqual([]);
   });
 });
+
+describe("StreamSessionRegistry — adopt", () => {
+  it("registers a ready session without calling either resolver", () => {
+    const streamTorrentImpl = vi.fn();
+    const resolveDebridImpl = vi.fn();
+    const registry = new StreamSessionRegistry({
+      streamTorrentImpl: streamTorrentImpl as never,
+      resolveDebridImpl: resolveDebridImpl as never,
+    });
+    const session = registry.adopt({
+      infoHash: "abc",
+      name: "Kepler.S02.1080p.WEB-DL",
+      backend: "debrid",
+      provider: "realdebrid",
+      files: FILES,
+    });
+    expect(session.state).toBe("ready");
+    expect(session.files).toEqual(FILES);
+    expect(session.capability).toBeTruthy();
+    expect(session.provider).toBe("realdebrid");
+    expect(registry.get(session.id)).toBe(session);
+    // The whole point: the TUI already paid for this resolve.
+    expect(streamTorrentImpl).not.toHaveBeenCalled();
+    expect(resolveDebridImpl).not.toHaveBeenCalled();
+  });
+
+  it("mints a distinct id and capability per adopted session", () => {
+    const registry = new StreamSessionRegistry();
+    const a = registry.adopt({
+      infoHash: "abc",
+      name: "Kestrel.2010.1080p.BluRay.x264",
+      backend: "torrent",
+      files: FILES,
+    });
+    const b = registry.adopt({
+      infoHash: "abc",
+      name: "Kestrel.2010.1080p.BluRay.x264",
+      backend: "torrent",
+      files: FILES,
+    });
+    expect(a.id).not.toBe(b.id);
+    expect(a.capability).not.toBe(b.capability);
+  });
+
+  it("omits provider entirely for a torrent-backed session", () => {
+    const registry = new StreamSessionRegistry();
+    const session = registry.adopt({
+      infoHash: "abc",
+      name: "Ashfall.1999.1080p",
+      backend: "torrent",
+      files: FILES,
+    });
+    expect("provider" in session).toBe(false);
+  });
+
+  it("stops without touching a backend it does not own", async () => {
+    const registry = new StreamSessionRegistry();
+    const session = registry.adopt({
+      infoHash: "abc",
+      name: "Ashfall.1999.1080p",
+      backend: "torrent",
+      files: FILES,
+    });
+    // The TUI owns the WebTorrent session behind these files and stops it itself
+    // on picker cancel. Dropping the row must not reach for it.
+    await expect(registry.stop(session.id)).resolves.toBeUndefined();
+    expect(registry.get(session.id)).toBeNull();
+  });
+});

--- a/src/core/streamSession.ts
+++ b/src/core/streamSession.ts
@@ -70,6 +70,20 @@ export interface StartStreamInput {
 export const NO_DEBRID_TOKEN = "No debrid token configured for this stream.";
 
 /**
+ * Files a front end has already resolved, for {@link StreamSessionRegistry.adopt}.
+ *
+ * No `magnet`: nothing will ever re-resolve an adopted session, and
+ * `StreamSession` does not carry one.
+ */
+export interface AdoptStreamInput {
+  infoHash: string;
+  name: string;
+  backend: StreamBackend;
+  provider?: DebridProviderId;
+  files: StreamFile[];
+}
+
+/**
  * Owns live stream sessions for the whole process, so the TUI and the browser
  * see one list: a session started in the terminal is playable in a browser and
  * vice versa. One session type covers both backends — a debrid resolve and
@@ -202,6 +216,37 @@ export class StreamSessionRegistry {
     } finally {
       this.aborts.delete(session.id);
     }
+    return session;
+  }
+
+  /**
+   * Register files a front end has ALREADY resolved.
+   *
+   * The TUI resolves its own streams and hands the URLs straight to mpv, so its
+   * files were never in this registry. Casting needs them here, because a
+   * Chromecast can only fetch `/stream/:sid/:idx` — it cannot reach a debrid
+   * link it has no token for, nor the `localhost` WebTorrent server. Adopting is
+   * how that happens without spending a second resolve on the user's account.
+   *
+   * `backendHandle` is deliberately null: the caller still owns whatever serves
+   * these bytes and stops it on its own terms (the picker's cancel path). So
+   * `stop()` on an adopted session drops the row and reaches for nothing.
+   */
+  adopt(input: AdoptStreamInput): StreamSession {
+    const session: StreamSession = {
+      id: this.idFactory(),
+      capability: this.capabilityFactory(),
+      backendHandle: null,
+      backend: input.backend,
+      ...(input.provider ? { provider: input.provider } : {}),
+      infoHash: input.infoHash,
+      name: input.name,
+      state: "ready",
+      files: input.files,
+      progress: 1,
+      createdAt: this.now(),
+    };
+    this.sessions.set(session.id, session);
     return session;
   }
 

--- a/src/daemon/runtime.test.ts
+++ b/src/daemon/runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { promises as fs } from "node:fs";
 import { addInput, policySummary, startRuntime, type Runtime } from "./runtime";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { TorrentEngine } from "../download/engine";
 import { saveConfig } from "../config/config";
 import { saveQueue, saveSeeds } from "../download/persist";
@@ -21,7 +22,7 @@ function fakeRuntime(dir: string, has = false): { runtime: Runtime; add: ReturnT
   const runtime = {
     queue: { has: () => has, add } as unknown as Runtime["queue"],
     downloadDir: dir,
-    sessions: new StreamSessionRegistry(),
+    sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
   };
   return { runtime, add };
 }
@@ -101,7 +102,7 @@ describe("addInput", () => {
     const runtime = {
       queue: { has: () => false, add, addDebrid } as unknown as Runtime["queue"],
       downloadDir: dir,
-      sessions: new StreamSessionRegistry(),
+      sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
     };
     expect(await addInput(runtime, HASH, { name: "Kestrel", debridToken: "rd-tok" })).toBe("added");
     // Not awaited: addDebrid's promise resolves when the whole download does,

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -20,6 +20,7 @@ import {
 import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { getDebridProvider } from "../integrations/debrid";
 import type { DebridProviderId } from "../integrations/debrid/types";
 
@@ -29,6 +30,11 @@ export interface Runtime {
   // Live stream sessions, shared by every front-end in this process: a stream
   // started in the TUI is playable from the browser and vice versa.
   sessions: StreamSessionRegistry;
+  // The one active cast, shared by every front-end in this process for the same
+  // reason `sessions` is. Note the limit, which is stated rather than hidden: the
+  // TUI and `serve --web` are separate processes, so a cast started in one is
+  // invisible to the other unless the TUI is hosting the web UI itself.
+  casts: CastSessionRegistry;
   // True when the previous run died mid-restore and this boot came up in safe
   // mode: everything paused, no engines started (see download/bootguard.ts).
   recovered?: boolean;
@@ -89,7 +95,13 @@ export async function startRuntime(overrideDir?: string): Promise<Runtime> {
     console.error("[torlnk] recovered from a crashed start: restored downloads are paused");
   }
   const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
-  return { queue, downloadDir, sessions: new StreamSessionRegistry(), recovered: safe };
+  return {
+    queue,
+    downloadDir,
+    sessions: new StreamSessionRegistry(),
+    casts: new CastSessionRegistry(),
+    recovered: safe,
+  };
 }
 
 export type AddOutcome = "added" | "duplicate" | "invalid";

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "node:fs";
 import { handleApi, isAuthorized, extractMagnet, parseControl, applyControl, statusPayload } from "./serve";
 import type { Runtime } from "./runtime";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { DownloadQueue, type DebridDeps } from "../download/queue";
 import { rowsFromStatus } from "../web/static/dashboard";
 
@@ -58,7 +59,7 @@ describe("handleApi", () => {
         getSeeds: () => [],
       } as unknown as Runtime["queue"],
       downloadDir: dir,
-      sessions: new StreamSessionRegistry(),
+      sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
     };
   });
   afterEach(async () => {
@@ -200,7 +201,7 @@ describe("parseControl", () => {
 
 describe("applyControl", () => {
   const mkRuntime = (queue: Partial<Record<string, unknown>>): Runtime =>
-    ({ queue: queue as unknown as Runtime["queue"], downloadDir: "/tmp", sessions: new StreamSessionRegistry() });
+    ({ queue: queue as unknown as Runtime["queue"], downloadDir: "/tmp", sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry() });
 
   it("resumes a paused download", async () => {
     const resume = vi.fn();
@@ -287,7 +288,7 @@ describe("statusPayload over a real DownloadQueue", () => {
       const payload = statusPayload({
         queue,
         downloadDir: dir,
-        sessions: new StreamSessionRegistry(),
+        sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
       });
       const rows = rowsFromStatus(payload);
 

--- a/src/daemon/testHarness.ts
+++ b/src/daemon/testHarness.ts
@@ -16,6 +16,7 @@
 import net from "node:net";
 import { vi } from "vitest";
 import type { Runtime } from "./runtime";
+import { CastSessionRegistry } from "../core/cast/session";
 
 export interface Fake {
   runtime: Runtime;
@@ -36,6 +37,7 @@ export function fakeRuntime(downloadDir: string): Fake {
     } as unknown as Runtime["queue"],
     downloadDir,
     sessions: { stopAll } as unknown as Runtime["sessions"],
+    casts: new CastSessionRegistry(),
   };
   return { runtime, suspend, stopAll };
 }

--- a/src/daemon/watch.test.ts
+++ b/src/daemon/watch.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./watch";
 import type { Runtime } from "./runtime";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef01";
 const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
@@ -51,7 +52,7 @@ describe("processFile", () => {
     runtime = {
       queue: { has: () => false, add } as unknown as Runtime["queue"],
       downloadDir,
-      sessions: new StreamSessionRegistry(),
+      sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
     };
   });
   afterEach(async () => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -151,6 +151,7 @@ import { clearRutrackerCache } from "../sources/rutracker";
 import { clearCacheByPrefix } from "../sources/cache";
 import { vpnRouteIsSafe } from "../util/vpn";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { displayHosts, webUrl, withoutToken } from "../web/links";
 import { startWebServer, type WebServerHandle, type WebServerOptions } from "../web/server";
 import type { Runtime } from "../daemon/runtime";
@@ -263,6 +264,11 @@ export function App({
   // sessions the previous render's server handed out).
   const sessionsRef = useRef<StreamSessionRegistry | null>(null);
   if (!sessionsRef.current) sessionsRef.current = new StreamSessionRegistry();
+  // A ref for the same reason: a cast outlives any one render, and the web
+  // server mounted below is handed this exact instance so a cast started in the
+  // terminal is the one a browser on this process sees.
+  const castsRef = useRef<CastSessionRegistry | null>(null);
+  if (!castsRef.current) castsRef.current = new CastSessionRegistry();
   const [view, setView] = useState<View>("splash");
   const [query, setQuery] = useState("");
   const [section, setSection] = useState<Section>("all");
@@ -586,6 +592,7 @@ export function App({
         return downloadDirRef.current;
       },
       sessions,
+      casts: castsRef.current!,
     };
     // One reading of the token for the whole mount: the server is given it and
     // the displayed link embeds it, and those two must agree — a link carrying a

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -77,6 +77,7 @@ import { isCategory, parseSection } from "./store";
 import {
   StoreContext,
   type CaptureMode,
+  type CastRowStatus,
   type DownloadFocus,
   type Region,
   type Section,
@@ -269,6 +270,35 @@ export function App({
   // terminal is the one a browser on this process sees.
   const castsRef = useRef<CastSessionRegistry | null>(null);
   if (!castsRef.current) castsRef.current = new CastSessionRegistry();
+  // Mirrored into React state, because the registry is a plain object and a
+  // component cannot re-render from one. Kept in step by the subscription below.
+  const [castStatus, setCastStatus] = useState<CastRowStatus | null>(null);
+  // One subscription for the life of the app, so the cast row follows a device
+  // that was paused or stopped from the television's own remote — and so a lost
+  // connection reaches the screen rather than leaving a row that claims to be
+  // playing. The registry hands its notice over exactly once, which is why it is
+  // read here and not polled anywhere else in this process.
+  useEffect(() => {
+    const casts = castsRef.current!;
+    const sync = (): void => {
+      const active = casts.active();
+      setCastStatus(
+        active
+          ? {
+              deviceName: active.device.name,
+              title: active.title,
+              state: active.status.state,
+              positionSec: active.status.positionSec,
+              durationSec: active.status.durationSec,
+            }
+          : null,
+      );
+      const notice = casts.takeNotice();
+      if (notice) setNotice(notice);
+    };
+    sync();
+    return casts.onChange(sync);
+  }, []);
   const [view, setView] = useState<View>("splash");
   const [query, setQuery] = useState("");
   const [section, setSection] = useState<Section>("all");
@@ -2303,6 +2333,7 @@ export function App({
       omdbApiKey: resolveOmdbApiKey(config),
       adultEnabled: resolveAdultContent(config),
       streamActive: activeStream !== null,
+    castStatus,
       debridStatus,
       cachedHashes,
       refreshCachedHashes,
@@ -2366,6 +2397,7 @@ export function App({
     importChooser,
     importingTrakt,
     activeStream,
+    castStatus,
     captureMode,
     downloadFocus,
     seedFocus,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
 import os from "node:os";
+import { randomBytes } from "node:crypto";
 import {
   loadConfig,
   saveConfig,
@@ -73,6 +74,7 @@ import { openFolder } from "../util/openFolder";
 import { openUrl } from "../util/openUrl";
 import { prepareLine } from "../util/prepareLine";
 import { cleanText, formatBytes, truncate } from "../util/format";
+import { castClock } from "../util/castStatus";
 import { isCategory, parseSection } from "./store";
 import {
   StoreContext,
@@ -113,6 +115,7 @@ import { TokenPrompt } from "./components/TokenPrompt";
 import { ConfirmPrompt } from "./components/ConfirmPrompt";
 import { StreamPlayerPrompt } from "./components/StreamPlayerPrompt";
 import { StreamFilePrompt } from "./components/StreamFilePrompt";
+import { CastPrompt } from "./components/CastPrompt";
 import { SourcesPrompt } from "./components/SourcesPrompt";
 import { QualityPrompt } from "./components/QualityPrompt";
 import { DnsPrompt } from "./components/DnsPrompt";
@@ -153,6 +156,7 @@ import { clearCacheByPrefix } from "../sources/cache";
 import { vpnRouteIsSafe } from "../util/vpn";
 import { StreamSessionRegistry } from "../core/streamSession";
 import { CastSessionRegistry } from "../core/cast/session";
+import { parseManualDevice, type CastDevice } from "../core/cast/discover";
 import { displayHosts, webUrl, withoutToken } from "../web/links";
 import { startWebServer, type WebServerHandle, type WebServerOptions } from "../web/server";
 import type { Runtime } from "../daemon/runtime";
@@ -273,6 +277,26 @@ export function App({
   // Mirrored into React state, because the registry is a plain object and a
   // component cannot re-render from one. Kept in step by the subscription below.
   const [castStatus, setCastStatus] = useState<CastRowStatus | null>(null);
+  // The device list, while the prompt is open. `finding` covers the two seconds
+  // discovery spends listening on a multicast socket.
+  const [castPrompt, setCastPrompt] = useState<
+    { file: ResolvedFile; devices: CastDevice[]; finding: boolean } | null
+  >(null);
+  /**
+   * Set when a cast needed the web UI and started it.
+   *
+   * Casting requires an origin the TELEVISION can fetch from, and the TUI's own
+   * stream server binds `localhost` on an ephemeral port
+   * (src/integrations/torrentStream.ts). The web server is the only LAN-reachable,
+   * token-authenticated origin torlink has, so a cast brings it up — bound to a
+   * wildcard, with a generated token, because `startWebServer` rightly refuses a
+   * non-loopback bind without one. That is a real change to what this machine
+   * exposes, so it is announced rather than done quietly.
+   */
+  const [castWeb, setCastWeb] = useState(false);
+  // What the web server actually bound, for the cast routes to reach over
+  // loopback. A ref rather than state: nothing renders from it.
+  const webBoundRef = useRef<{ port: number; token: string | undefined } | null>(null);
   // One subscription for the life of the app, so the cast row follows a device
   // that was paused or stopped from the television's own remote — and so a lost
   // connection reaches the screen rather than leaving a row that claims to be
@@ -605,9 +629,16 @@ export function App({
   // down a listening socket and rebind it, which can fail EADDRINUSE against the
   // copy of itself that has not finished closing.
   useEffect(() => {
-    if (!web || !queue) return;
+    // `castWeb` is the second way in: a cast needs a LAN-reachable origin, and
+    // this is the only server torlink has that is one. It can only ever flip from
+    // false while no server is mounted (see `ensureCastWeb`), so it cannot tear
+    // down and rebind a socket that is already serving.
+    if ((!web && !castWeb) || !queue) return;
     const sessions = sessionsRef.current!;
-    const host = webHost?.trim() || "127.0.0.1";
+    // A cast needs an address a television can route to, so a wildcard rather
+    // than loopback — and therefore a token, which startWebServer requires for
+    // any non-loopback bind. An explicit --web-host still wins.
+    const host = webHost?.trim() || (castWeb ? "0.0.0.0" : "127.0.0.1");
     let handle: WebServerHandle | null = null;
     // Teardown can happen while listen() is still in flight, in which case the
     // cleanup below has no handle to close yet — so it sets this instead and the
@@ -629,7 +660,7 @@ export function App({
     // token the server does not enforce (or vice versa) is a dashboard that
     // won't open. Empty and whitespace-only both mean "no token", matching
     // web/server.ts's own check.
-    const token = webToken?.trim() || undefined;
+    const token = webToken?.trim() || (castWeb ? randomBytes(16).toString("base64url") : undefined);
     void (async () => {
       try {
         const started = await startWebServerImpl(runtime, {
@@ -660,7 +691,17 @@ export function App({
         // line is (web/links.ts): both land in terminal scrollback, which
         // `torlnk attach` keeps alive in a tmux session. `webStatus` holds the
         // real link, so shift+w still opens something that works.
-        setNotice(`${ICON.done} Web UI on ${withoutToken(url)}`);
+        // What the cast routes reach over loopback. The bound port, never the
+        // requested one, for the reason the line above reads it back.
+        webBoundRef.current = { port: started.port, token };
+        setNotice(
+          castWeb && !web
+            ? // Unmissable on purpose: pressing `c` has just put a
+              // token-protected dashboard on this machine's LAN address, which is
+              // more than "the web UI started".
+              `${ICON.done} Casting needs the TV to reach this machine, so the web UI is now on ${withoutToken(url)} (token required)`
+            : `${ICON.done} Web UI on ${withoutToken(url)}`,
+        );
         setWebStatus({ url });
       } catch (e) {
         // Every failure mode lands here, including startWebServer's refusal to
@@ -681,7 +722,7 @@ export function App({
       cancelled = true;
       void handle?.close();
     };
-  }, [web, queue, webPort, webHost, webToken, startWebServerImpl]);
+  }, [web, castWeb, queue, webPort, webHost, webToken, startWebServerImpl]);
 
   // `--port 8080` without `--web` parses fine and does nothing. Say so rather
   // than silently accepting a flag the user believes turned something on.
@@ -1478,6 +1519,178 @@ export function App({
       );
     },
     [playStream, streamSource, markPlayed, streamAllFiles],
+  );
+
+  // ---- casting -------------------------------------------------------------
+  //
+  // The terminal drives casting through its OWN web server's routes, over
+  // loopback. That looks indirect and is deliberate: those routes already hold
+  // the source ladder, the LAN origin rule, the refusal messages and the
+  // played-file write, and calling them is what keeps the terminal and the
+  // browser from growing two implementations of one decision — the
+  // copy-then-drift bug this codebase has recorded four times. The registry
+  // itself is shared in-process, so what the terminal casts, a browser on this
+  // process sees.
+
+  /**
+   * Make sure there is a web server a television can fetch from, and answer with
+   * how to reach it over loopback.
+   *
+   * Null when it could not be started, having already said why.
+   */
+  const ensureCastWeb = useCallback(async (): Promise<{ port: number; token?: string } | null> => {
+    const bound = webBoundRef.current;
+    if (bound) return { port: bound.port, ...(bound.token ? { token: bound.token } : {}) };
+    setCastWeb(true);
+    // Poll for the mount rather than threading a promise out of the effect: the
+    // effect owns the socket's lifetime, and a second owner is how a server
+    // outlives the component that started it. Ten seconds is far longer than a
+    // bind takes and short enough to give up in front of a user.
+    for (let i = 0; i < 100; i += 1) {
+      await new Promise((r) => setTimeout(r, 100));
+      const now = webBoundRef.current;
+      if (now) return { port: now.port, ...(now.token ? { token: now.token } : {}) };
+    }
+    setNotice("Could not start the web UI, so there is nothing for the TV to fetch from.");
+    return null;
+  }, []);
+
+  /** Call one of this process's own cast routes. */
+  const castApi = useCallback(
+    async (
+      where: { port: number; token?: string },
+      path: string,
+      body?: unknown,
+    ): Promise<{ ok: boolean; json: Record<string, unknown> }> => {
+      const res = await fetch(`http://127.0.0.1:${String(where.port)}${path}`, {
+        ...(body === undefined ? {} : { method: "POST", body: JSON.stringify(body) }),
+        headers: {
+          "Content-Type": "application/json",
+          ...(where.token ? { Authorization: `Bearer ${where.token}` } : {}),
+        },
+      });
+      const json = (await res.json()) as Record<string, unknown>;
+      return { ok: res.ok, json };
+    },
+    [],
+  );
+
+  /**
+   * `c` in the file picker: find the devices, then offer them.
+   *
+   * The session is adopted BEFORE the prompt opens, so choosing a device is one
+   * request rather than two — and adopted rather than re-resolved, because these
+   * files have already been paid for once (a debrid resolve is the user's
+   * account, a torrent is their bandwidth).
+   */
+  const castFromPicker = useCallback(
+    (file: ResolvedFile) => {
+      if (!streamSource) return;
+      setCastPrompt({ file, devices: [], finding: true });
+      void (async () => {
+        const where = await ensureCastWeb();
+        if (!where) {
+          setCastPrompt(null);
+          return;
+        }
+        try {
+          const { json } = await castApi(where, "/api/cast/devices");
+          const devices = (json.devices ?? []) as CastDevice[];
+          setCastPrompt((current) => (current ? { ...current, devices, finding: false } : null));
+        } catch {
+          setCastPrompt((current) => (current ? { ...current, finding: false } : null));
+        }
+      })();
+    },
+    [streamSource, ensureCastWeb, castApi],
+  );
+
+  /** Cast the picked file to `deviceId`, having adopted a session for it. */
+  const castTo = useCallback(
+    (deviceId: string) => {
+      const picked = castPrompt?.file;
+      const input = streamSource;
+      const all = streamAllFiles;
+      setCastPrompt(null);
+      if (!picked || !input || !all) return;
+      void (async () => {
+        const where = webBoundRef.current;
+        if (!where) return;
+        const index = all.findIndex((f) => f.url === picked.url);
+        if (index < 0) return;
+        const session = sessionsRef.current!.adopt({
+          infoHash: input.id,
+          name: input.name,
+          // Every file, not just the video candidates: the subtitle the cast
+          // carries is addressed by its index in this same list.
+          files: all,
+          backend: activeStream ? "torrent" : "debrid",
+          ...(activeStream || !config
+            ? {}
+            : { provider: resolveActiveDebrid(config)?.provider }),
+        });
+        const subtitle = preferredSubtitle(subtitlesFor(picked, all));
+        const subtitleIndex = subtitle ? all.findIndex((f) => f.url === subtitle.url) : -1;
+        try {
+          const { ok, json } = await castApi(
+            { port: where.port, ...(where.token ? { token: where.token } : {}) },
+            "/api/cast/start",
+            {
+              deviceId,
+              sid: session.id,
+              index,
+              ...(subtitleIndex >= 0 ? { subtitleIndex } : {}),
+            },
+          );
+          // The route's message is already written to be read by a person — that
+          // is what a CastError means — so it is shown as it stands.
+          if (!ok) setNotice(String(json.error ?? "Could not cast that."));
+        } catch (e) {
+          setNotice(`Could not cast: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      })();
+    },
+    [castPrompt, streamSource, streamAllFiles, activeStream, config, castApi],
+  );
+
+  /** Save a typed address, then cast to it. Read-modify-write, never a snapshot. */
+  const castToAddress = useCallback(
+    (address: string) => {
+      void (async () => {
+        try {
+          const current = await loadConfig();
+          await saveConfig({ ...current, castDevice: address });
+          setConfig({ ...current, castDevice: address });
+        } catch {
+          // A setting that could not be saved must not stop this cast: the
+          // address is still usable for it, it just will not be remembered.
+        }
+        const manual = parseManualDevice(address);
+        if (manual) castTo(manual.id);
+      })();
+    },
+    [castTo, setConfig],
+  );
+
+  /** `p` and `x` on the cast row. Same routes the browser's buttons call. */
+  const castCommand = useCallback(
+    (action: "play" | "pause" | "stop") => {
+      const where = webBoundRef.current;
+      if (!where) return;
+      void (async () => {
+        try {
+          const { ok, json } = await castApi(
+            { port: where.port, ...(where.token ? { token: where.token } : {}) },
+            "/api/cast/command",
+            { action },
+          );
+          if (!ok) setNotice(String(json.error ?? "That did not work."));
+        } catch {
+          // The socket to our own server. Nothing useful to say.
+        }
+      })();
+    },
+    [castApi],
   );
 
   const cancelPreparing = useCallback(() => {
@@ -2456,6 +2669,19 @@ export function App({
         if (key.escape) cancelPreparing();
         return; // swallow other keys while preparing
       }
+      // The cast row's two keys, ahead of the stream's own `x`. A cast and a
+      // local stream can both be live — casting does not stop the torrent
+      // feeding it — and while a television is playing, "stop" means the thing
+      // on the television. Stopping the cast leaves the stream running, which is
+      // what makes pressing `x` twice do the two obvious things in order.
+      if (castStatus && (input === "x" || input === "X")) {
+        castCommand("stop");
+        return;
+      }
+      if (castStatus && (input === "p" || input === "P")) {
+        castCommand(castStatus.state === "paused" ? "play" : "pause");
+        return;
+      }
       if (activeStream && (input === "x" || input === "X")) {
         stopStream();
         return;
@@ -2835,6 +3061,40 @@ export function App({
           </Box>
         ) : null}
 
+        {castPrompt ? (
+          <Box marginTop={1}>
+            <CastPrompt
+              width={Math.max(24, Math.min(cols - 4, 72))}
+              devices={castPrompt.devices}
+              finding={castPrompt.finding}
+              {...(config?.castDevice ? { configured: config.castDevice } : {})}
+              onSelect={(device) => castTo(device.id)}
+              onAddress={castToAddress}
+              onCancel={() => setCastPrompt(null)}
+            />
+          </Box>
+        ) : null}
+
+        {castStatus ? (
+          <Box marginTop={1} flexDirection="column">
+            <Box>
+              <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+              <Text>{`Casting to ${castStatus.deviceName}`}</Text>
+              <Text dimColor>{`  ${truncate(cleanText(castStatus.title), 40)}`}</Text>
+            </Box>
+            <Box>
+              <Text dimColor>{`  ${castClock(castStatus)}`}</Text>
+            </Box>
+            <Box marginTop={1}>
+              <Text color={COLOR.alt}>p</Text>
+              <Text dimColor>{castStatus.state === "paused" ? " resume" : " pause"}</Text>
+              <Text dimColor>{` ${ICON.dot} `}</Text>
+              <Text color={COLOR.alt}>x</Text>
+              <Text dimColor> stop casting</Text>
+            </Box>
+          </Box>
+        ) : null}
+
         {streamFiles ? (
           <Box marginTop={1}>
             <StreamFilePrompt
@@ -2863,6 +3123,7 @@ export function App({
                   : undefined
               }
               onSelect={playFromPicker}
+              {...(streamSource ? { onCast: castFromPicker } : {})}
               onCancel={() => {
                 setStreamFiles(null);
                 setStreamAllFiles(null);

--- a/src/ui/App.web.test.tsx
+++ b/src/ui/App.web.test.tsx
@@ -20,6 +20,7 @@ import type { Config } from "../config/config";
 import type { Runtime } from "../daemon/runtime";
 import type { WebServerHandle } from "../web/server";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 
 const DOWNLOAD_DIR = "/tmp/torlink-web-test";
 const TAB = "\t";
@@ -186,6 +187,9 @@ describe("App --web mount", () => {
       expect(options.port).toBe(19001);
       expect(runtime.queue).toBeInstanceOf(FakeQueue);
       expect(runtime.sessions).toBeInstanceOf(StreamSessionRegistry);
+      // The cast registry is handed over the same way and for the same reason: a
+      // cast started in the terminal is the one a browser on this process sees.
+      expect(runtime.casts).toBeInstanceOf(CastSessionRegistry);
       expect(runtime.downloadDir).toBe(DOWNLOAD_DIR);
 
       // The injected log is the whole point: it must reach the file logger.

--- a/src/ui/components/CastPrompt.test.tsx
+++ b/src/ui/components/CastPrompt.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { CastPrompt } from "./CastPrompt";
+import type { CastDevice } from "../../core/cast/discover";
+
+// Ink processes stdin on a tick, so every write needs one before the next write
+// or the assertion — the same helper the other prompt tests use.
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 20));
+
+const DEVICES: CastDevice[] = [
+  { id: "abc", name: "Living Room TV", model: "Chromecast", host: "10.0.0.5", port: 8009 },
+  { id: "k1", name: "Kitchen display", model: "Google TV Streamer", host: "10.0.0.6", port: 8009 },
+];
+
+function setup(over: Partial<Parameters<typeof CastPrompt>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onAddress = vi.fn();
+  const onCancel = vi.fn();
+  const r = render(
+    <CastPrompt
+      width={80}
+      devices={DEVICES}
+      finding={false}
+      onSelect={onSelect}
+      onAddress={onAddress}
+      onCancel={onCancel}
+      {...over}
+    />,
+  );
+  return { ...r, onSelect, onAddress, onCancel };
+}
+
+describe("CastPrompt", () => {
+  it("lists devices with their models", () => {
+    const { lastFrame } = setup();
+    expect(lastFrame()).toContain("Living Room TV");
+    expect(lastFrame()).toContain("Kitchen display");
+    expect(lastFrame()).toContain("Google TV Streamer");
+  });
+
+  it("selects the highlighted device on enter", async () => {
+    const { stdin, onSelect } = setup();
+    stdin.write("\r");
+    await flush();
+    expect(onSelect).toHaveBeenCalledWith(DEVICES[0]);
+  });
+
+  it("moves the cursor before selecting", async () => {
+    const { stdin, onSelect } = setup();
+    stdin.write("[B"); // down
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSelect).toHaveBeenCalledWith(DEVICES[1]);
+  });
+
+  it("wraps the cursor, so up from the first row reaches the last", async () => {
+    const { stdin, onSelect } = setup();
+    stdin.write("[A"); // up
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onSelect).toHaveBeenCalledWith(DEVICES[1]);
+  });
+
+  it("says it is looking while discovery runs, and offers no address field yet", () => {
+    const { lastFrame } = setup({ devices: [], finding: true });
+    expect(lastFrame()).toMatch(/Looking for/i);
+    // No field while there is still hope: offering one mid-search invites the
+    // user to type an address they do not need.
+    expect(lastFrame()).not.toMatch(/address/i);
+  });
+
+  it("explains mDNS when nothing was found, and offers the address field", () => {
+    // The Docker / VLAN case. Without this the feature looks broken rather than
+    // blocked, which is the whole reason the configured address exists.
+    const { lastFrame } = setup({ devices: [], finding: false });
+    expect(lastFrame()).toMatch(/No Chromecast found/i);
+    expect(lastFrame()).toMatch(/Docker|VLAN/i);
+  });
+
+  it("submits a typed address", async () => {
+    const { stdin, onAddress } = setup({ devices: [], finding: false });
+    stdin.write("192.168.0.40");
+    await flush();
+    stdin.write("\r");
+    await flush();
+    expect(onAddress).toHaveBeenCalledWith("192.168.0.40");
+  });
+
+  it("shows the configured address as the field's placeholder, so it is discoverable", () => {
+    const { lastFrame } = setup({ devices: [], finding: false, configured: "192.168.0.40" });
+    expect(lastFrame()).toContain("192.168.0.40");
+  });
+
+  it("does not offer the field while devices exist, so nothing competes for the arrow keys", () => {
+    const { lastFrame } = setup();
+    expect(lastFrame()).not.toMatch(/type an address/i);
+  });
+
+  it("cancels on escape, in both states", async () => {
+    const withDevices = setup();
+    withDevices.stdin.write("");
+    await flush();
+    expect(withDevices.onCancel).toHaveBeenCalledOnce();
+    const empty = setup({ devices: [], finding: false });
+    empty.stdin.write("");
+    await flush();
+    expect(empty.onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("selects nothing on enter when the list is empty, rather than crashing", async () => {
+    const { stdin, onSelect, onAddress } = setup({ devices: [], finding: true });
+    stdin.write("\r");
+    await flush();
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onAddress).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/CastPrompt.tsx
+++ b/src/ui/components/CastPrompt.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { TextField } from "./TextField";
+import { wrapStep } from "../move";
+import { COLOR, ICON } from "../theme";
+import type { CastDevice } from "../../core/cast/discover";
+
+interface CastPromptProps {
+  width: number;
+  devices: CastDevice[];
+  /** True while discovery is still listening. */
+  finding: boolean;
+  /** The configured address, shown as the field's placeholder. */
+  configured?: string;
+  onSelect: (device: CastDevice) => void;
+  /** Save this address and cast to it. */
+  onAddress: (address: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Pick a Chromecast to cast to.
+ *
+ * TWO STATES, and only ever one at a time. With devices it is a list. With none
+ * — and discovery finished — it explains that mDNS does not cross a Docker
+ * bridge or a VLAN, and offers a field to type an address into.
+ *
+ * The field is deliberately absent while there are devices, and not merely
+ * hidden: `TextField` runs its own `useInput`, so a field mounted beside the list
+ * would consume the arrow keys the list needs. Confining it to the empty state
+ * removes the focus problem instead of managing it.
+ */
+export function CastPrompt({
+  width,
+  devices,
+  finding,
+  configured,
+  onSelect,
+  onAddress,
+  onCancel,
+}: CastPromptProps) {
+  const [cursor, setCursor] = useState(0);
+  const clamped = Math.min(cursor, Math.max(0, devices.length - 1));
+  const empty = devices.length === 0;
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    // Everything below is the list's. With no devices the field owns the keys,
+    // and an enter on an empty list must select nothing rather than crash.
+    if (empty) return;
+    if (key.upArrow) setCursor(wrapStep(clamped, -1, devices.length));
+    else if (key.downArrow) setCursor(wrapStep(clamped, 1, devices.length));
+    else if (key.return) {
+      const device = devices[clamped];
+      if (device) onSelect(device);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel
+        title="cast to"
+        width={width}
+        focused
+        count={empty ? undefined : `${String(clamped + 1)}/${String(devices.length)}`}
+      >
+        {devices.map((device, i) => {
+          const selected = i === clamped;
+          return (
+            <Box key={device.id}>
+              <Text color={selected ? COLOR.accent : undefined}>
+                {selected ? `${ICON.pointer} ` : "  "}
+              </Text>
+              {/* A device name is whatever someone typed into the Google Home
+                  app, so it is rendered as text and never parsed. */}
+              <Text color={selected ? COLOR.text : undefined}>{device.name}</Text>
+              {device.model ? <Text dimColor>{`  ${device.model}`}</Text> : null}
+            </Box>
+          );
+        })}
+        {empty && finding ? <Text dimColor>Looking for Chromecasts…</Text> : null}
+        {empty && !finding ? (
+          <Box flexDirection="column">
+            <Text color={COLOR.warn}>{`${ICON.warn} No Chromecast found on this network.`}</Text>
+            <Text dimColor>
+              Discovery uses mDNS, which does not cross a Docker bridge or a VLAN.
+            </Text>
+            <Box>
+              <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+              <Box flexGrow={1} minWidth={0}>
+                <TextField
+                  placeholder={configured ? `current: ${configured}` : "address, or host:port"}
+                  onSubmit={(value) => {
+                    const trimmed = value.trim();
+                    if (trimmed) onAddress(trimmed);
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        ) : null}
+      </Panel>
+      <Box marginTop={1}>
+        <Text color={COLOR.alt}>↵</Text>
+        <Text dimColor>{empty ? " save and cast" : " cast"}</Text>
+        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text color={COLOR.alt}>esc</Text>
+        <Text dimColor> back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/StreamFilePrompt.test.tsx
+++ b/src/ui/components/StreamFilePrompt.test.tsx
@@ -153,3 +153,46 @@ describe("StreamFilePrompt", () => {
     expect(lastFrame()).not.toContain("CC");
   });
 });
+
+describe("StreamFilePrompt — casting", () => {
+  it("casts the highlighted file on c, without also playing it locally", async () => {
+    const onCast = vi.fn();
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <StreamFilePrompt
+        width={80}
+        files={files}
+        onSelect={onSelect}
+        onCast={onCast}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write("c");
+    await flush();
+    expect(onCast).toHaveBeenCalledOnce();
+    // Casting instead of playing, never as well as: two copies of the same film
+    // starting at once is the worst thing this key could do.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("advertises the key only when a cast handler was given", () => {
+    const withCast = render(
+      <StreamFilePrompt width={80} files={files} onSelect={() => {}} onCast={() => {}} onCancel={() => {}} />,
+    );
+    expect(withCast.lastFrame()).toMatch(/cast/i);
+    const without = render(
+      <StreamFilePrompt width={80} files={files} onSelect={() => {}} onCancel={() => {}} />,
+    );
+    expect(without.lastFrame()).not.toMatch(/cast/i);
+  });
+
+  it("ignores c when no cast handler was given, rather than swallowing the key", async () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <StreamFilePrompt width={80} files={files} onSelect={onSelect} onCancel={() => {}} />,
+    );
+    stdin.write("c");
+    await flush();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/StreamFilePrompt.tsx
+++ b/src/ui/components/StreamFilePrompt.tsx
@@ -48,6 +48,14 @@ interface StreamFilePromptProps {
    * nothing can produce one.
    */
   preselect?: number;
+  /**
+   * Cast the highlighted file to a Chromecast (the `c` key).
+   *
+   * Optional, and the key is inert without it: the caller only passes it where
+   * casting can actually work, and a key that silently does nothing is the
+   * failure this codebase keeps refusing (see `vlcLinks` on macOS).
+   */
+  onCast?: (file: StreamFile) => void;
   // Toggle the current torrent as a favourite (the `b` key).
   onFavourite?: () => void;
   // Whether the current torrent is already favourited (drives the star glyph).
@@ -61,6 +69,7 @@ export function StreamFilePrompt({
   files,
   allFiles,
   onSelect,
+  onCast,
   onCancel,
   maxRows = 8,
   watched = [],
@@ -92,6 +101,14 @@ export function StreamFilePrompt({
     }
     if (input === "b" || input === "B") {
       onFavourite?.();
+      return;
+    }
+    if (input === "c" || input === "C") {
+      // Instead of playing, never as well as: two copies of the same film
+      // starting half a minute apart is the worst thing this key could do. The
+      // picker stays open, as it does after a local play.
+      const file = sorted[clamped];
+      if (file) onCast?.(file);
       return;
     }
     if (input === "s" || input === "S") {
@@ -164,19 +181,33 @@ export function StreamFilePrompt({
           );
         })}
       </Panel>
+      {/* One row, and it has to FIT: at the old eleven-column separator this was
+          94 columns with five hints, so Ink wrapped it mid-word ("↑ mov" over
+          "strea") long before casting was added. Three columns keeps six hints
+          inside 80. */}
       <Box marginTop={1}>
         <Text color={COLOR.alt}>↑↓</Text>
         <Text dimColor> move</Text>
-        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text dimColor>{` ${ICON.dot} `}</Text>
         <Text color={COLOR.alt}>↵</Text>
         <Text dimColor> stream</Text>
-        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text dimColor>{` ${ICON.dot} `}</Text>
         <Text color={COLOR.alt}>s</Text>
         <Text dimColor>{` sort: ${sortMode}`}</Text>
-        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        <Text dimColor>{` ${ICON.dot} `}</Text>
         <Text color={COLOR.alt}>b</Text>
         <Text dimColor>{` ${favourited ? "★" : "☆"} favourite`}</Text>
-        <Text dimColor>{`     ${ICON.dot}     `}</Text>
+        {/* Advertised only where it is bound. A hint for a key that does nothing
+            is worse than no hint — the rule this codebase applied to VLC on
+            macOS and to `x` in the list panes. */}
+        {onCast ? (
+          <>
+            <Text dimColor>{` ${ICON.dot} `}</Text>
+            <Text color={COLOR.alt}>c</Text>
+            <Text dimColor> cast</Text>
+          </>
+        ) : null}
+        <Text dimColor>{` ${ICON.dot} `}</Text>
         <Text color={COLOR.alt}>esc</Text>
         <Text dimColor> cancel</Text>
       </Box>

--- a/src/ui/keymap.test.ts
+++ b/src/ui/keymap.test.ts
@@ -183,6 +183,23 @@ describe("grouping keys", () => {
     expect(search?.hints.some((h) => h.keys === "space")).toBe(true);
   });
 
+  it("advertises the cast key in the help sheet", () => {
+    const search = HELP_GROUPS.find((g) => g.title === "Search");
+    expect(search?.hints.some((h) => h.keys === "c" && /cast/i.test(h.label))).toBe(true);
+  });
+
+  it("does NOT advertise the cast key in the results footer, because it is not bound there", () => {
+    // `c` belongs to the stream file picker, which draws its own hint row (see
+    // StreamFilePrompt). Advertising it here would promise something the next
+    // keypress in the results list will not do — the same reason this file is
+    // careful about `x` meaning Remove or Stop stream depending on state.
+    for (const debrid of [undefined, "Real-Debrid"]) {
+      expect(footerHints("content", "all", null, null, debrid).some((h) => h.keys === "c")).toBe(
+        false,
+      );
+    }
+  });
+
   it("keeps the grouping hint inside the truncated footer width", () => {
     // The results row is 115 columns bare and 131 with a debrid provider, so
     // Footer.tsx truncates it at 80. A hint the user cannot see is not a hint —

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -65,6 +65,10 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "shift+d", label: "Download to a chosen folder" },
       { keys: "r", label: "Download via debrid (Real-Debrid / TorBox)" },
       { keys: "v", label: "Stream" },
+      // Bound in the stream file picker, which draws its own hint row — so it is
+      // advertised here and deliberately NOT in `footerHints`, where it would
+      // promise something the results list will not do.
+      { keys: "c", label: "Cast to a TV (Chromecast) — in the stream file picker" },
       { keys: "b", label: "Favourite a video (detail view / stream picker)" },
       { keys: "y", label: "Copy magnet" },
       { keys: "m", label: "Paste magnet" },

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -9,6 +9,21 @@ import type { Sort } from "./sort";
 import type { StreamHistoryItem } from "../core/streamHistory";
 import type { PickIntent } from "../util/releasePick";
 
+/**
+ * The cast row's data, flattened from `ActiveCast` (src/core/cast/session.ts).
+ *
+ * Flattened rather than the core type itself so the store carries no live object
+ * — `Store` is state the TUI re-renders from, and a registry instance in it would
+ * invite a component to reach past the props it was given.
+ */
+export interface CastRowStatus {
+  deviceName: string;
+  title: string;
+  state: "loading" | "playing" | "paused" | "idle";
+  positionSec: number;
+  durationSec: number | null;
+}
+
 export type View = "splash" | "browser";
 
 export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music" | "books" | "porn";
@@ -190,6 +205,11 @@ export interface Store {
   // globally for stopping the stream, so components with their own "x"
   // handler (clear history, sign out) must ignore it.
   streamActive: boolean;
+  // What is playing on a Chromecast right now, or null. Display only: nothing in
+  // torlink persists a playback position, so this drives the cast row and is
+  // never written down. Per-process, like the registry behind it — a cast started
+  // in a separate `serve --web` is not visible here.
+  castStatus: CastRowStatus | null;
   // The validated debrid account (whichever provider is active), or null when
   // unknown/not connected.
   debridStatus: DebridStatus | null;

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -185,6 +185,7 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
     debridConfigured: false,
     debridProvider: null,
     streamActive: false,
+    castStatus: null,
     debridStatus: null,
     cachedHashes: new Set(),
     refreshCachedHashes: noop,

--- a/src/util/castStatus.test.ts
+++ b/src/util/castStatus.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { castClock, formatCastTime } from "./castStatus";
+
+describe("formatCastTime", () => {
+  it("is h:mm:ss, zero-padded past the hours", () => {
+    expect(formatCastTime(0)).toBe("0:00:00");
+    expect(formatCastTime(61)).toBe("0:01:01");
+    expect(formatCastTime(3_661)).toBe("1:01:01");
+    expect(formatCastTime(36_000)).toBe("10:00:00");
+  });
+
+  it("floors a fractional position and clamps an unusable one", () => {
+    // The input is a float from a television, and a receiver has been seen to
+    // report a small negative one while it is still seeking.
+    expect(formatCastTime(12.9)).toBe("0:00:12");
+    expect(formatCastTime(-5)).toBe("0:00:00");
+    expect(formatCastTime(NaN)).toBe("0:00:00");
+    expect(formatCastTime(Infinity)).toBe("0:00:00");
+  });
+});
+
+describe("castClock", () => {
+  it("reads position over duration while playing", () => {
+    expect(castClock({ state: "playing", positionSec: 724, durationSec: 6_512 })).toBe(
+      "0:12:04 / 1:48:32",
+    );
+  });
+
+  it("shows position alone when the duration is unknown, rather than inventing 0:00:00", () => {
+    expect(castClock({ state: "playing", positionSec: 5, durationSec: null })).toBe("0:00:05");
+  });
+
+  it("names the state when it is not playing", () => {
+    expect(castClock({ state: "loading", positionSec: 0, durationSec: null })).toBe(
+      "Loading on the TV…",
+    );
+    expect(castClock({ state: "idle", positionSec: 0, durationSec: null })).toBe(
+      "Finished on the TV.",
+    );
+    expect(castClock({ state: "paused", positionSec: 61, durationSec: 600 })).toBe(
+      "Paused · 0:01:01 / 0:10:00",
+    );
+  });
+
+  it("ignores a position a loading receiver reports, because there is nothing to be at yet", () => {
+    expect(castClock({ state: "loading", positionSec: 99, durationSec: 600 })).toBe(
+      "Loading on the TV…",
+    );
+  });
+});

--- a/src/util/castStatus.test.ts
+++ b/src/util/castStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { castClock, formatCastTime } from "./castStatus";
+import { castBlockerClause, castClock, formatCastTime } from "./castStatus";
 
 describe("formatCastTime", () => {
   it("is h:mm:ss, zero-padded past the hours", () => {
@@ -46,5 +46,26 @@ describe("castClock", () => {
     expect(castClock({ state: "loading", positionSec: 99, durationSec: 600 })).toBe(
       "Loading on the TV…",
     );
+  });
+});
+
+describe("castBlockerClause", () => {
+  it("names the container first, because it is the one a user can recognise", () => {
+    expect(castBlockerClause(["container", "audio"])).toBe("it won't demux this container");
+    expect(castBlockerClause(["video"])).toBe("it can't decode this video");
+    expect(castBlockerClause(["audio"])).toBe("it can't decode this audio");
+  });
+
+  it("never names the subject, because both callers already have", () => {
+    // THE BUG THIS PINS, seen on the wire from a real device: the server had its
+    // own copy of this text that began "a Chromecast…", so the refusal read
+    // "A Chromecast can't play this one — a Chromecast won't demux this container".
+    for (const blockers of [["container"], ["video"], ["audio"], []]) {
+      expect(castBlockerClause(blockers)).not.toMatch(/chromecast/i);
+    }
+  });
+
+  it("never returns an empty string, so a refusal always says why", () => {
+    expect(castBlockerClause([])).not.toBe("");
   });
 });

--- a/src/util/castStatus.ts
+++ b/src/util/castStatus.ts
@@ -44,3 +44,24 @@ export function castClock(status: {
     status.durationSec === null ? elapsed : `${elapsed} / ${formatCastTime(status.durationSec)}`;
   return status.state === "paused" ? `Paused · ${clock}` : clock;
 }
+
+/**
+ * Why a Chromecast is refusing this file, as a clause.
+ *
+ * A CLAUSE, not a sentence: both callers put "A Chromecast can't play this one —"
+ * in front of it. The server briefly had its own copy that said "a Chromecast
+ * won't demux this container", which read back from a real device as "A Chromecast
+ * can't play this one — a Chromecast won't demux this container". One
+ * implementation, so the subject is named exactly once.
+ *
+ * The container is named first because it is the blocker a user can recognise and
+ * act on ("it's an mkv"); a codec name is not.
+ */
+export function castBlockerClause(blockers: readonly string[]): string {
+  if (blockers.includes("container")) return "it won't demux this container";
+  if (blockers.includes("video")) return "it can't decode this video";
+  if (blockers.includes("audio")) return "it can't decode this audio";
+  // Never empty: a refusal with no reason is the thing this feature keeps
+  // refusing to ship.
+  return "this file isn't something it can play";
+}

--- a/src/util/castStatus.ts
+++ b/src/util/castStatus.ts
@@ -1,0 +1,46 @@
+/**
+ * How a cast's progress reads, for both front ends.
+ *
+ * It started in `src/web/static/castModel.ts` and moved down here the moment the
+ * terminal's cast row needed the same line — the pattern this codebase records
+ * four copy-then-drift bugs for. `src/util/`, not `src/core/`, because it is
+ * presentation shared by two front ends, and it must stay browser-safe: the web
+ * bundle imports it.
+ */
+
+/** A cast's state as both front ends receive it. */
+export type CastPlaybackState = "loading" | "playing" | "paused" | "idle";
+
+/**
+ * `h:mm:ss`.
+ *
+ * Defensive about its input because the input is a float from a television: a
+ * receiver reports `currentTime` as a float, and has been seen to report a small
+ * negative one while it is still seeking.
+ */
+export function formatCastTime(seconds: number): string {
+  const total = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  return `${String(h)}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/**
+ * The one line under the device's name.
+ *
+ * A duration the receiver has not reported is null, not zero: showing
+ * "0:00:05 / 0:00:00" would read as a broken file rather than an unknown length.
+ */
+export function castClock(status: {
+  state: CastPlaybackState;
+  positionSec: number;
+  durationSec: number | null;
+}): string {
+  if (status.state === "loading") return "Loading on the TV…";
+  if (status.state === "idle") return "Finished on the TV.";
+  const elapsed = formatCastTime(status.positionSec);
+  const clock =
+    status.durationSec === null ? elapsed : `${elapsed} / ${formatCastTime(status.durationSec)}`;
+  return status.state === "paused" ? `Paused · ${clock}` : clock;
+}

--- a/src/util/playability.test.ts
+++ b/src/util/playability.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { blockersFor, classifyFromName, extensionOf, type MediaFacts } from "./playability";
+import {
+  BROWSER_PROFILE,
+  CHROMECAST_PROFILE,
+  blockersFor,
+  castContentType,
+  classifyFromName,
+  extensionOf,
+  type MediaFacts,
+} from "./playability";
 
 const facts = (over: Partial<MediaFacts> = {}): MediaFacts => ({
   container: "mp4",
@@ -104,5 +112,75 @@ describe("blockersFor", () => {
     // pessimistically here would send files to the card that play fine today;
     // the runtime error/stall detection is what covers being wrong.
     expect(blockersFor(facts({ videoCodec: "", audioCodec: "" }))).toEqual([]);
+  });
+
+  // THE REGRESSION GUARD for adding profiles to a module the web player depends
+  // on: the no-argument form must answer exactly what it answered before they
+  // existed. Every case above is already that guard; this one pins that naming
+  // the browser profile explicitly is the same thing.
+  it("defaults to the browser profile", () => {
+    expect(blockersFor(facts({ audioCodec: "ac3" }))).toEqual(
+      blockersFor(facts({ audioCodec: "ac3" }), BROWSER_PROFILE),
+    );
+    expect(blockersFor(facts({ audioCodec: "ac3" }))).toEqual(["audio"]);
+  });
+});
+
+describe("blockersFor with the Chromecast profile", () => {
+  it("blocks matroska for a Chromecast too — the device demuxes no more of it than a browser", () => {
+    expect(blockersFor(facts({ container: "mkv" }), CHROMECAST_PROFILE)).toEqual(["container"]);
+  });
+
+  it("allows ac3 and eac3, which the browser refuses", () => {
+    // The recorded trade-off: this is HDMI passthrough, so a television that
+    // cannot take it plays silently. Blocking would instead REFUSE a file that
+    // would almost certainly have played, and on the torrent backend there is
+    // no transcode rung underneath to fall back to. Silence is recoverable in
+    // one keypress; a refusal is not recoverable at all.
+    expect(blockersFor(facts({ audioCodec: "ac3" }), CHROMECAST_PROFILE)).toEqual([]);
+    expect(blockersFor(facts({ audioCodec: "eac3" }), CHROMECAST_PROFILE)).toEqual([]);
+  });
+
+  it("still blocks dts and truehd", () => {
+    expect(blockersFor(facts({ audioCodec: "dts" }), CHROMECAST_PROFILE)).toEqual(["audio"]);
+    expect(blockersFor(facts({ audioCodec: "truehd" }), CHROMECAST_PROFILE)).toEqual(["audio"]);
+  });
+
+  it("blocks hevc, because a model name is a guess and there is no video transcode", () => {
+    expect(blockersFor(facts({ videoCodec: "hevc" }), CHROMECAST_PROFILE)).toEqual(["video"]);
+    expect(blockersFor(facts({ videoCodec: "av1" }), CHROMECAST_PROFILE)).toEqual(["video"]);
+  });
+
+  it("is the pair that lets the browser's fallback card offer to cast", () => {
+    // An mp4 carrying AC3: the browser refuses the audio, a Chromecast takes it.
+    // This is the whole point of having two profiles rather than one list.
+    const f = classifyFromName("Kestrel.2010.1080p.BluRay.x264.AC3.mp4");
+    expect(blockersFor(f)).toEqual(["audio"]);
+    expect(blockersFor(f, CHROMECAST_PROFILE)).toEqual([]);
+  });
+
+  it("agrees with the browser about an mkv, which neither can demux", () => {
+    const f = classifyFromName("Kepler.S02E04.1080p.WEB-DL.mkv");
+    expect(blockersFor(f)).toEqual(["container"]);
+    expect(blockersFor(f, CHROMECAST_PROFILE)).toEqual(["container"]);
+  });
+});
+
+describe("castContentType", () => {
+  it("names the container for a direct play", () => {
+    expect(castContentType("mp4", false)).toBe("video/mp4");
+    expect(castContentType("m4v", false)).toBe("video/mp4");
+    expect(castContentType("webm", false)).toBe("video/webm");
+  });
+
+  it("names HLS whenever the source is a manifest, whatever the file's own container", () => {
+    expect(castContentType("mkv", true)).toBe("application/vnd.apple.mpegurl");
+    expect(castContentType("mp4", true)).toBe("application/vnd.apple.mpegurl");
+  });
+
+  it("falls back to video/mp4 for a container it does not know, rather than an empty type", () => {
+    // An empty contentType is a LOAD_FAILED with no reason. mp4 is the honest
+    // guess: it is what a direct-play rung will have been chosen for.
+    expect(castContentType("", false)).toBe("video/mp4");
   });
 });

--- a/src/util/playability.ts
+++ b/src/util/playability.ts
@@ -57,16 +57,54 @@ export function extensionOf(filename: string): string {
   return m ? m[1]!.toLowerCase() : "";
 }
 
-// Containers every browser that matters demuxes. Short on purpose: mkv is not
-// one of them in any shipping browser, and mkv is what most of the scene ships.
-const SAFE_CONTAINERS = new Set(["mp4", "m4v", "webm"]);
+/**
+ * What one decoder will take.
+ *
+ * Two exist: a browser and a Chromecast. They are the same question asked of
+ * different hardware, so they live in one module — a second list somewhere else
+ * is the copy-then-drift bug this codebase has recorded four times.
+ */
+export interface PlaybackProfile {
+  containers: ReadonlySet<string>;
+  video: ReadonlySet<string>;
+  audio: ReadonlySet<string>;
+}
 
-// Codecs a browser will decode from one of those containers. Conservative:
-// ac3/eac3 are Safari-only, and av1 is absent on older hardware, so neither is
-// listed. Being wrong in this direction costs a fallback card; being wrong in
-// the other costs a black rectangle.
-const SAFE_VIDEO = new Set(["h264", "vp8", "vp9"]);
-const SAFE_AUDIO = new Set(["aac", "mp3", "opus", "vorbis", "flac"]);
+/**
+ * A browser. Unchanged from what this module always answered.
+ *
+ * Containers short on purpose: mkv is not one of them in any shipping browser,
+ * and mkv is what most of the scene ships. Codecs conservative: ac3/eac3 are
+ * Safari-only, and av1 is absent on older hardware, so neither is listed. Being
+ * wrong in this direction costs a fallback card; being wrong in the other costs
+ * a black rectangle.
+ */
+export const BROWSER_PROFILE: PlaybackProfile = {
+  containers: new Set(["mp4", "m4v", "webm"]),
+  video: new Set(["h264", "vp8", "vp9"]),
+  audio: new Set(["aac", "mp3", "opus", "vorbis", "flac"]),
+};
+
+/**
+ * A Chromecast, which differs from a browser in exactly one direction.
+ *
+ * Containers and video are identical: the device demuxes no Matroska, and HEVC
+ * stays out even though an Ultra or a Google TV device decodes it — the `md` TXT
+ * key names a model, a model name is a guess about both the device's decoder and
+ * the television behind it, and there is no video transcode to fall back to.
+ *
+ * Audio gains ac3 and eac3, which is passthrough and therefore depends on the
+ * HDMI link. Where that link cannot take it the result is silent video, which is
+ * bad — and still better than the alternative, which REFUSES a file that would
+ * almost certainly have played, with no transcode rung underneath it on the
+ * torrent backend. Silence is one keypress from recoverable; a refusal is not
+ * recoverable at all.
+ */
+export const CHROMECAST_PROFILE: PlaybackProfile = {
+  containers: new Set(["mp4", "m4v", "webm"]),
+  video: new Set(["h264", "vp8", "vp9"]),
+  audio: new Set(["aac", "mp3", "opus", "vorbis", "flac", "ac3", "eac3"]),
+};
 
 /**
  * Map the release parser's vocabulary onto the names above.
@@ -141,18 +179,37 @@ export function classifyFromName(filename: string, releaseName?: string): MediaF
 }
 
 /**
- * Every reason a browser will refuse this file.
+ * Every reason `profile`'s decoder will refuse this file.
  *
  * An unknown *container* blocks — that is the existing behaviour and it is
  * right, because showing a card is honest and takes one tap to work around
  * where a black rectangle looks like the app is broken. An unknown *codec* does
  * not block: most release names say nothing about audio, and blocking there
  * would send files to the card that play fine.
+ *
+ * The profile is optional and defaults to the browser so that every existing
+ * call site keeps its exact previous answer; the tests pin that.
  */
-export function blockersFor(facts: MediaFacts): Blocker[] {
+export function blockersFor(
+  facts: MediaFacts,
+  profile: PlaybackProfile = BROWSER_PROFILE,
+): Blocker[] {
   const blockers: Blocker[] = [];
-  if (!SAFE_CONTAINERS.has(facts.container)) blockers.push("container");
-  if (facts.videoCodec && !SAFE_VIDEO.has(facts.videoCodec)) blockers.push("video");
-  if (facts.audioCodec && !SAFE_AUDIO.has(facts.audioCodec)) blockers.push("audio");
+  if (!profile.containers.has(facts.container)) blockers.push("container");
+  if (facts.videoCodec && !profile.video.has(facts.videoCodec)) blockers.push("video");
+  if (facts.audioCodec && !profile.audio.has(facts.audioCodec)) blockers.push("audio");
   return blockers;
+}
+
+/**
+ * The `contentType` a cast `LOAD` must name.
+ *
+ * Getting it wrong is a LOAD_FAILED rather than a guess the receiver recovers
+ * from, so this is a function with tests rather than a ternary at the call site.
+ * An HLS manifest is HLS whatever the file inside it was.
+ */
+export function castContentType(container: string, hls: boolean): string {
+  if (hls) return "application/vnd.apple.mpegurl";
+  if (container === "webm") return "video/webm";
+  return "video/mp4";
 }

--- a/src/web/castOrigin.test.ts
+++ b/src/web/castOrigin.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { castOrigin } from "./castOrigin";
+import type { NetInterfaces } from "./links";
+
+const IFACES: NetInterfaces = {
+  lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+  en0: [{ address: "192.168.0.98", family: "IPv4", internal: false }],
+};
+
+const LOOPBACK_ONLY: NetInterfaces = { lo0: IFACES.lo0 };
+
+describe("castOrigin", () => {
+  it("names a LAN address for a wildcard bind, never loopback", () => {
+    expect(castOrigin("0.0.0.0", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+    expect(castOrigin("", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+    expect(castOrigin("::", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+  });
+
+  it("uses an explicit non-loopback bind address as given", () => {
+    expect(castOrigin("192.168.0.98", 9161, IFACES)).toBe("http://192.168.0.98:9161");
+    expect(castOrigin("torlink.lan", 9161, IFACES)).toBe("http://torlink.lan:9161");
+  });
+
+  it("brackets an IPv6 literal, or the port reads as another hextet", () => {
+    expect(castOrigin("2001:db8::1", 9161, IFACES)).toBe("http://[2001:db8::1]:9161");
+  });
+
+  it("is null for a loopback bind, because nothing on the LAN can reach it", () => {
+    // The honest answer, and the one this module exists to give. Handing a
+    // television the machine's LAN address when the server is listening only on
+    // loopback would be a URL that never answers — a cast that fails with no
+    // explanation, instead of a button that says why it cannot work.
+    expect(castOrigin("127.0.0.1", 9161, IFACES)).toBeNull();
+    expect(castOrigin("localhost", 9161, IFACES)).toBeNull();
+    expect(castOrigin("::1", 9161, IFACES)).toBeNull();
+  });
+
+  it("is null when a wildcard bind found no non-loopback address at all", () => {
+    // A machine with no network. A caller turns this into "no address a
+    // Chromecast could reach this on"; it must not fall back to loopback.
+    expect(castOrigin("0.0.0.0", 9161, LOOPBACK_ONLY)).toBeNull();
+  });
+
+  it("ignores an internal or IPv6 interface when picking a LAN address", () => {
+    const mixed: NetInterfaces = {
+      lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      utun0: [{ address: "fe80::1", family: "IPv6", internal: false }],
+      en0: [{ address: "10.0.0.7", family: "IPv4", internal: false }],
+    };
+    expect(castOrigin("0.0.0.0", 9161, mixed)).toBe("http://10.0.0.7:9161");
+  });
+});

--- a/src/web/castOrigin.ts
+++ b/src/web/castOrigin.ts
@@ -1,0 +1,47 @@
+import { displayHosts, type NetInterfaces } from "./links";
+
+/**
+ * Addresses that mean "this machine only". A device on the LAN cannot reach any
+ * of them, whatever URL it is handed.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * The origin a Chromecast must fetch media from.
+ *
+ * Deliberately NOT `requestOrigin` (./stream.ts), which every other absolute URL
+ * in this app comes from. That reads the request's `Host`, which is right for a
+ * playlist the user's own machine opens and wrong for a television: a user
+ * browsing `http://localhost:9161` would hand the device a URL pointing at the
+ * device itself, and a user reaching the server over one interface would hand it
+ * one it may not route to.
+ *
+ * So this keys off the address the server was BOUND to, which is a fact about
+ * what is reachable rather than a claim by a client.
+ *
+ * Null in the two cases where casting genuinely cannot work, and null rather
+ * than a guess in both, because a URL that cannot answer is worse than a button
+ * that says why:
+ *
+ * - A loopback bind. Nothing on the LAN can reach the server at all, so naming
+ *   the machine's LAN address would produce a cast that fails silently on the
+ *   device with no explanation on screen.
+ * - A wildcard bind on a machine with no non-loopback IPv4 address.
+ */
+export function castOrigin(
+  host: string,
+  port: number,
+  interfaces: NetInterfaces,
+): string | null {
+  const trimmed = host.trim();
+  if (LOOPBACK_HOSTS.has(trimmed.toLowerCase())) return null;
+  const { local, lan } = displayHosts(trimmed, interfaces);
+  // `displayHosts` answers a wildcard bind with loopback as `local` and the LAN
+  // addresses beside it; anything else it answers with the bound address itself,
+  // bracketed if it is an IPv6 literal.
+  if (local === "127.0.0.1") {
+    const first = lan[0];
+    return first ? `http://${first}:${port}` : null;
+  }
+  return `http://${local}:${port}`;
+}

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -19,6 +19,10 @@ import { DownloadQueue } from "../download/queue";
 import { defaultConfig, type Config, type FavouriteItem } from "../config/config";
 import { StreamSessionRegistry, type StreamSession } from "../core/streamSession";
 import { CastSessionRegistry } from "../core/cast/session";
+import { CastError } from "../core/cast/connection";
+import type { CastDevice } from "../core/cast/discover";
+import type { MediaFacts } from "../util/playability";
+import type { StreamFile } from "../util/player";
 import { SOURCES } from "../sources/registry";
 import { HttpError } from "../util/net";
 import type { Health } from "../sources/sourceHealth";
@@ -27,6 +31,7 @@ import type { ReccEvent } from "../recc/client";
 import type { StreamHistoryItem } from "../core/streamHistory";
 import type { Source, SourceId, TorrentResult } from "../sources/types";
 import type {
+  CastDevicesResponse,
   LibraryResponse,
   PreferencesResponse,
   PublicSearchSnapshot,
@@ -3421,5 +3426,330 @@ describe("GET /api/sources reccConfigured", () => {
     const body = JSON.stringify(res.json);
     expect(body).not.toContain("zzq-secret-9317");
     expect(body).not.toContain("recc.internal");
+  });
+});
+
+// ---- casting ----------------------------------------------------------------
+//
+// `castSourceImpl` is injected in every test here rather than reaching through
+// the stream deps: the real one is `mediaSourceFor` (src/web/stream.ts), which
+// spawns ffprobe and calls a debrid API. The route's own job is picking the URL,
+// the content type and the refusal, and that is what these pin.
+describe("the cast routes", () => {
+  const DISCOVERED: CastDevice = {
+    id: "abc",
+    name: "Living Room TV",
+    model: "Chromecast",
+    host: "10.0.0.5",
+    port: 8009,
+  };
+  const LAN = "http://192.168.0.98:9161";
+
+  const facts = (over: Partial<MediaFacts> = {}): MediaFacts => ({
+    container: "mp4",
+    videoCodec: "h264",
+    audioCodec: "aac",
+    source: "name",
+    subtitles: [],
+    ...over,
+  });
+
+  /** A runtime holding one ready, adopted session over `files`. */
+  function castRuntime(
+    files: StreamFile[] = [
+      { url: "https://cdn.example/1", filename: "Kestrel.2010.1080p.BluRay.x264.mp4", bytes: 9 },
+    ],
+  ) {
+    const sessions = new StreamSessionRegistry({
+      idFactory: () => "sid-cast",
+      capabilityFactory: () => "cap-cast",
+    });
+    const casts = new CastSessionRegistry({ markPlayed: async () => {} });
+    const rt: Runtime = {
+      queue: new DownloadQueue(),
+      downloadDir: "/tmp/dl",
+      sessions,
+      casts,
+    };
+    sessions.adopt({
+      infoHash: "0".repeat(40),
+      name: "Kestrel.2010.1080p.BluRay.x264-GROUP",
+      backend: "debrid",
+      provider: "realdebrid",
+      files,
+    });
+    return { runtime: rt, casts, sid: "sid-cast", capability: "cap-cast" };
+  }
+
+  function castDeps(over: Partial<WebDeps> = {}): WebDeps {
+    return deps({
+      discoverCastImpl: async () => [DISCOVERED],
+      castOriginImpl: () => LAN,
+      castSourceImpl: async () => ({ facts: facts(), hls: null }),
+      ...over,
+    });
+  }
+
+  const get = (d: WebDeps): Promise<WebResponse> =>
+    handleWebApi(d, "GET", "/api/cast/devices", new URLSearchParams(), AUTH, "");
+  const post = (d: WebDeps, path: string, body: unknown): Promise<WebResponse> =>
+    handleWebApi(d, "POST", path, new URLSearchParams(), AUTH, JSON.stringify(body));
+
+  describe("GET /api/cast/devices", () => {
+    it("lists discovered devices without their addresses", async () => {
+      const res = await get(castDeps());
+      expect(res.status).toBe(200);
+      // No host and no port: the browser picks by id, and publishing the LAN
+      // topology of the user's house to any tab buys nothing.
+      expect(res.json).toEqual({
+        devices: [{ id: "abc", name: "Living Room TV", model: "Chromecast" }],
+        castable: true,
+        reason: null,
+      });
+    });
+
+    it("includes the configured address whether discovery saw anything or not", async () => {
+      const res = await get(
+        castDeps({
+          discoverCastImpl: async () => [],
+          loadConfigImpl: async () => ({ ...defaultConfig, castDevice: "192.168.0.40" }),
+        }),
+      );
+      expect((res.json as CastDevicesResponse).devices).toEqual([
+        { id: "manual:192.168.0.40:8009", name: "192.168.0.40", model: "" },
+      ]);
+      expect((res.json as CastDevicesResponse).castable).toBe(true);
+    });
+
+    it("does not list the configured address twice when discovery found it too", async () => {
+      const res = await get(
+        castDeps({
+          discoverCastImpl: async () => [{ ...DISCOVERED, host: "192.168.0.40" }],
+          loadConfigImpl: async () => ({ ...defaultConfig, castDevice: "192.168.0.40" }),
+        }),
+      );
+      // One row, not two: a user who typed an address that mDNS also finds
+      // should not have to guess which of two identical rows is the real device.
+      expect((res.json as CastDevicesResponse).devices).toEqual([
+        { id: "abc", name: "Living Room TV", model: "Chromecast" },
+      ]);
+    });
+
+    it("says why casting is unavailable when nothing answered", async () => {
+      const res = await get(castDeps({ discoverCastImpl: async () => [] }));
+      expect(res.json).toMatchObject({ devices: [], castable: false });
+      expect((res.json as CastDevicesResponse).reason).toMatch(/No Chromecast found/);
+    });
+
+    it("says why casting is unavailable when this machine has no reachable address", async () => {
+      const res = await get(castDeps({ castOriginImpl: () => null }));
+      expect(res.json).toMatchObject({ castable: false });
+      expect((res.json as CastDevicesResponse).reason).toMatch(/could reach/i);
+    });
+
+    it("needs the token", async () => {
+      const res = await handleWebApi(
+        castDeps({ token: "secret" }),
+        "GET",
+        "/api/cast/devices",
+        new URLSearchParams(),
+        undefined,
+        "",
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/cast/start", () => {
+    it("casts the stream handle built from the LAN origin, not from Host", async () => {
+      const { runtime: rt, casts, sid, capability } = castRuntime();
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      const res = await post(castDeps({ runtime: rt }), "/api/cast/start", {
+        deviceId: "abc",
+        sid,
+        index: 0,
+      });
+      expect(res.status).toBe(200);
+      const arg = start.mock.calls[0]![0];
+      expect(arg.media.url).toBe(`${LAN}/stream/${sid}/0?k=${capability}`);
+      expect(arg.media.contentType).toBe("video/mp4");
+      expect(arg.media.title).toBe("Kestrel 2010");
+      expect(arg.device).toEqual(DISCOVERED);
+      // The played-file write needs both, and neither is on the wire.
+      expect(arg.infoHash).toBe("0".repeat(40));
+      expect(arg.filename).toBe("Kestrel.2010.1080p.BluRay.x264.mp4");
+    });
+
+    it("casts an HLS manifest with the HLS content type when the file itself is blocked", async () => {
+      // The debrid provider's transcode: the only rung above direct play today.
+      const { runtime: rt, casts, sid } = castRuntime([
+        { url: "https://cdn.example/1", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 9 },
+      ]);
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      const res = await post(
+        castDeps({
+          runtime: rt,
+          castSourceImpl: async () => ({
+            facts: facts({ container: "mkv" }),
+            hls: "https://provider.example/m.m3u8",
+          }),
+        }),
+        "/api/cast/start",
+        { deviceId: "abc", sid, index: 0 },
+      );
+      expect(res.status).toBe(200);
+      const arg = start.mock.calls[0]![0];
+      expect(arg.media.contentType).toBe("application/vnd.apple.mpegurl");
+      expect(arg.media.url).toBe("https://provider.example/m.m3u8");
+    });
+
+    it("refuses a file no Chromecast can play, naming the reason", async () => {
+      const { runtime: rt, casts, sid } = castRuntime([
+        { url: "https://cdn.example/1", filename: "Kepler.S02E04.1080p.WEB-DL.mkv", bytes: 9 },
+      ]);
+      const start = vi.spyOn(casts, "start");
+      const res = await post(
+        castDeps({
+          runtime: rt,
+          castSourceImpl: async () => ({ facts: facts({ container: "mkv" }), hls: null }),
+        }),
+        "/api/cast/start",
+        { deviceId: "abc", sid, index: 0 },
+      );
+      // 409, not 200 with a message: nothing was started.
+      expect(res.status).toBe(409);
+      expect((res.json as { error: string }).error).toMatch(/can't play this one/);
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    it("casts an mp4 carrying AC3, which the browser refuses and the device does not", async () => {
+      const { runtime: rt, casts, sid } = castRuntime();
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      const res = await post(
+        castDeps({
+          runtime: rt,
+          castSourceImpl: async () => ({ facts: facts({ audioCodec: "ac3" }), hls: null }),
+        }),
+        "/api/cast/start",
+        { deviceId: "abc", sid, index: 0 },
+      );
+      expect(res.status).toBe(200);
+      expect(start).toHaveBeenCalledOnce();
+    });
+
+    it("passes the chosen subtitle as a vtt handle on the same origin", async () => {
+      const { runtime: rt, casts, sid, capability } = castRuntime([
+        { url: "https://cdn.example/1", filename: "Kepler.S02E04.1080p.WEB-DL.mp4", bytes: 9 },
+        { url: "https://cdn.example/2", filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", bytes: 4 },
+      ]);
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      await post(castDeps({ runtime: rt }), "/api/cast/start", {
+        deviceId: "abc",
+        sid,
+        index: 0,
+        subtitleIndex: 1,
+      });
+      const arg = start.mock.calls[0]![0];
+      expect(arg.media.subtitleUrl).toBe(`${LAN}/stream/${sid}/1.vtt?k=${capability}`);
+      expect(arg.media.subtitleLabel).toBe("English");
+    });
+
+    it("ignores a subtitle index that is not a subtitle, rather than casting a video as a track", async () => {
+      const { runtime: rt, casts, sid } = castRuntime();
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      await post(castDeps({ runtime: rt }), "/api/cast/start", {
+        deviceId: "abc",
+        sid,
+        index: 0,
+        subtitleIndex: 0,
+      });
+      expect(start.mock.calls[0]![0].media.subtitleUrl).toBeUndefined();
+    });
+
+    it("404s an unknown session, an out-of-range index, and an unknown device", async () => {
+      const { runtime: rt, sid } = castRuntime();
+      const d = castDeps({ runtime: rt });
+      expect((await post(d, "/api/cast/start", { deviceId: "abc", sid: "nope", index: 0 })).status).toBe(404);
+      expect((await post(d, "/api/cast/start", { deviceId: "abc", sid, index: 9 })).status).toBe(404);
+      expect((await post(d, "/api/cast/start", { deviceId: "nope", sid, index: 0 })).status).toBe(404);
+    });
+
+    it("409s when this machine has no address a device could fetch from", async () => {
+      const { runtime: rt, sid } = castRuntime();
+      const res = await post(castDeps({ runtime: rt, castOriginImpl: () => null }), "/api/cast/start", {
+        deviceId: "abc",
+        sid,
+        index: 0,
+      });
+      expect(res.status).toBe(409);
+      expect((res.json as { error: string }).error).toMatch(/could reach/i);
+    });
+
+    it("400s a body missing a field, rather than casting something undefined", async () => {
+      const { runtime: rt, sid } = castRuntime();
+      const d = castDeps({ runtime: rt });
+      expect((await post(d, "/api/cast/start", {})).status).toBe(400);
+      expect((await post(d, "/api/cast/start", { deviceId: "abc", sid })).status).toBe(400);
+      expect(
+        (await handleWebApi(d, "POST", "/api/cast/start", new URLSearchParams(), AUTH, "not json"))
+          .status,
+      ).toBe(400);
+    });
+
+    it("reports a device that refused with its own message, not a 500", async () => {
+      const { runtime: rt, casts, sid } = castRuntime();
+      vi.spyOn(casts, "start").mockRejectedValue(new CastError("Living Room TV didn't answer — it may be off."));
+      const res = await post(castDeps({ runtime: rt }), "/api/cast/start", {
+        deviceId: "abc",
+        sid,
+        index: 0,
+      });
+      expect(res.status).toBe(502);
+      expect((res.json as { error: string }).error).toBe("Living Room TV didn't answer — it may be off.");
+    });
+  });
+
+  describe("POST /api/cast/command", () => {
+    it("pauses, plays and stops the active cast", async () => {
+      const { runtime: rt, casts } = castRuntime();
+      const pause = vi.spyOn(casts, "pause").mockResolvedValue(undefined);
+      const play = vi.spyOn(casts, "play").mockResolvedValue(undefined);
+      const stop = vi.spyOn(casts, "stop").mockResolvedValue(undefined);
+      const d = castDeps({ runtime: rt });
+      expect((await post(d, "/api/cast/command", { action: "pause" })).status).toBe(200);
+      expect((await post(d, "/api/cast/command", { action: "play" })).status).toBe(200);
+      expect((await post(d, "/api/cast/command", { action: "stop" })).status).toBe(200);
+      expect(pause).toHaveBeenCalledOnce();
+      expect(play).toHaveBeenCalledOnce();
+      expect(stop).toHaveBeenCalledOnce();
+    });
+
+    it("is a clean 409 when nothing is casting, not a crash", async () => {
+      const { runtime: rt } = castRuntime();
+      const res = await post(castDeps({ runtime: rt }), "/api/cast/command", { action: "pause" });
+      expect(res.status).toBe(409);
+    });
+
+    it("400s an action it does not know", async () => {
+      const { runtime: rt } = castRuntime();
+      const res = await post(castDeps({ runtime: rt }), "/api/cast/command", { action: "seek" });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/cast/status", () => {
+    it("reports nothing casting, so a page that polls has one shape to read", async () => {
+      const { runtime: rt } = castRuntime();
+      const res = await handleWebApi(
+        castDeps({ runtime: rt }),
+        "GET",
+        "/api/cast/status",
+        new URLSearchParams(),
+        AUTH,
+        "",
+      );
+      expect(res.status).toBe(200);
+      expect(res.json).toEqual({ casting: null, notice: null });
+    });
   });
 });

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3618,7 +3618,12 @@ describe("the cast routes", () => {
       );
       // 409, not 200 with a message: nothing was started.
       expect(res.status).toBe(409);
-      expect((res.json as { error: string }).error).toMatch(/can't play this one/);
+      const message = (res.json as { error: string }).error;
+      expect(message).toBe("A Chromecast can't play this one — it won't demux this container.");
+      // Named once. The server briefly had its own copy of the clause that began
+      // "a Chromecast…", and the refusal read back from a real device as
+      // "A Chromecast can't play this one — a Chromecast won't demux this container".
+      expect(message.match(/chromecast/gi)).toHaveLength(1);
       expect(start).not.toHaveBeenCalled();
     });
 

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -18,6 +18,7 @@ import {
 import { DownloadQueue } from "../download/queue";
 import { defaultConfig, type Config, type FavouriteItem } from "../config/config";
 import { StreamSessionRegistry, type StreamSession } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { SOURCES } from "../sources/registry";
 import { HttpError } from "../util/net";
 import type { Health } from "../sources/sourceHealth";
@@ -35,11 +36,17 @@ import type {
 } from "./wire";
 import type { Runtime } from "../daemon/runtime";
 
-function runtime(sessions = new StreamSessionRegistry()): Runtime {
+function runtime(
+  sessions = new StreamSessionRegistry(),
+  // markPlayed stubbed by default: the real one writes the developer's own
+  // config.json and stream history, exactly the seam `saveConfigImpl` exists for.
+  casts = new CastSessionRegistry({ markPlayed: async () => {} }),
+): Runtime {
   return {
     queue: new DownloadQueue(),
     downloadDir: "/tmp/dl",
     sessions,
+    casts,
   };
 }
 
@@ -1890,7 +1897,7 @@ describe("POST /api/add — adding a search hit by hash and name", () => {
       runtime: {
         queue: { has: () => false, add, addDebrid } as unknown as Runtime["queue"],
         downloadDir: "/tmp/dl",
-        sessions: new StreamSessionRegistry(),
+        sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
       },
       add,
       addDebrid,

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -71,10 +71,10 @@ import {
   castContentType,
   classifyFromName,
   extensionOf,
-  type Blocker,
 } from "../util/playability";
 import { isBrowserRenderable, subtitleLanguage } from "../util/subtitleFiles";
 import { playlistTitle } from "../util/playlistTitle";
+import { castBlockerClause } from "../util/castStatus";
 import type {
   AddResponse,
   CachedResponse,
@@ -1813,7 +1813,7 @@ async function startCast(deps: WebDeps, bodyText: string): Promise<WebResponse> 
   // local-ffmpeg rung in this tree — `src/util/ffmpegBin.ts` is used only for
   // ffprobe — so a blocked file with no manifest cannot be cast, and says so.
   if (blockers.length > 0 && !source.hls) {
-    return { status: 409, json: { error: `A Chromecast can't play this one — ${castRefusal(blockers)}.` } };
+    return { status: 409, json: { error: `A Chromecast can't play this one — ${castBlockerClause(blockers)}.` } };
   }
   const useHls = blockers.length > 0 && source.hls !== null;
   const url = useHls
@@ -1856,13 +1856,6 @@ async function startCast(deps: WebDeps, bodyText: string): Promise<WebResponse> 
     return { status: 502, json: { error: message } };
   }
   return { status: 200, json: castStatusOf(deps.runtime.casts) };
-}
-
-/** The container is named first, because it is the blocker a user can recognise. */
-function castRefusal(blockers: Blocker[]): string {
-  if (blockers.includes("container")) return "a Chromecast won't demux this container";
-  if (blockers.includes("video")) return "it can't decode this video codec";
-  return "it can't decode this audio";
 }
 
 async function castCommand(deps: WebDeps, bodyText: string): Promise<WebResponse> {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -3,6 +3,9 @@ import { isAuthorized } from "../daemon/auth";
 import { getPoster, POSTER_HOSTS, type CachedPoster } from "../core/posterCache";
 import type { StreamSession } from "../core/streamSession";
 import { classifyStreamRoute, type StreamRoute } from "../core/streamRoute";
+import { discover, parseManualDevice, type CastDevice } from "../core/cast/discover";
+import { CastError } from "../core/cast/connection";
+import type { MediaSource } from "./stream";
 import {
   historyItemFor,
   loadStreamHistory,
@@ -62,9 +65,22 @@ import { hintForGroup, parseRelease } from "../util/release";
 import { shouldQuery, SUGGEST_LIMIT } from "../util/titleSuggest";
 import { streamCandidates } from "../util/videoFiles";
 import { toggleSavedSearches } from "../util/savedSearchList";
+import {
+  CHROMECAST_PROFILE,
+  blockersFor,
+  castContentType,
+  classifyFromName,
+  extensionOf,
+  type Blocker,
+} from "../util/playability";
+import { isBrowserRenderable, subtitleLanguage } from "../util/subtitleFiles";
+import { playlistTitle } from "../util/playlistTitle";
 import type {
   AddResponse,
   CachedResponse,
+  CastDevicesResponse,
+  CastStatusResponse,
+  PublicCastDevice,
   ContinueWatchingResponse,
   LibraryResponse,
   PreferencesResponse,
@@ -133,6 +149,33 @@ export interface WebDeps {
    * timed out.
    */
   debridStatusImpl?: (provider: DebridProviderId, token: string) => Promise<DebridStatus | null>;
+  /**
+   * How Chromecasts are found. Defaults to a real mDNS query, which is two
+   * seconds of listening on a multicast socket — injected so a test never opens
+   * one, and so a test can produce the "nothing answered" branch without
+   * depending on what is switched on in the room.
+   */
+  discoverCastImpl?: () => Promise<CastDevice[]>;
+  /**
+   * The origin a Chromecast must fetch media from, or null when this machine has
+   * none it could reach.
+   *
+   * A dependency rather than a call to `castOrigin` here because only the server
+   * knows what it actually bound (see `startWebServer`), and because it must NOT
+   * be derived from the request: `Host` is a claim by a client, and a user
+   * browsing `http://localhost:9161` would otherwise hand a television a URL
+   * pointing at the television.
+   */
+  castOriginImpl?: () => string | null;
+  /**
+   * What one file is and the best source for it — `mediaSourceFor`
+   * (./stream.ts), the same answer the player page's `.info` gets.
+   *
+   * Injected because the real one spawns ffprobe and may call a debrid API, and
+   * because the fields it needs (the probe cache, the HLS resolver) live in
+   * `StreamDeps` rather than here; `startWebServer` closes over both.
+   */
+  castSourceImpl?: (session: StreamSession, index: number) => Promise<MediaSource>;
   /**
    * How one source is queried during `/api/search`. Passed straight through to
    * `runSearch`, so the default (`cachedSearch`) and every behaviour around it —
@@ -1656,6 +1699,200 @@ async function checkCached(deps: WebDeps, bodyText: string): Promise<WebResponse
   return { status: 200, json: out };
 }
 
+// ---- casting ----------------------------------------------------------------
+//
+// Three routes and a status read. What is NOT here is the protocol, the discovery
+// or the session bookkeeping: those are `src/core/cast/`, front-end-agnostic, and
+// the TUI drives the same registry through the same methods. These routes only
+// turn an HTTP request into one of those calls, and pick the URL a device fetches.
+
+const NO_DEVICES = "No Chromecast found on this network.";
+const NO_ORIGIN = "This machine has no network address a Chromecast could reach it on.";
+
+/** What a device may be told about this file, as the browser sees a device. */
+function toPublicCastDevice(device: CastDevice): PublicCastDevice {
+  return { id: device.id, name: device.name, model: device.model };
+}
+
+/**
+ * Every device that could be cast to: what answered, plus the configured address.
+ *
+ * The configured one goes last and only when discovery did not already report the
+ * same host, so a user who typed an address that mDNS also finds sees one row.
+ */
+async function castDevices(deps: WebDeps): Promise<CastDevice[]> {
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const found = await (deps.discoverCastImpl ?? (() => discover()))();
+  // Typed rather than trusted: `loadConfig` spreads the parsed JSON, so a
+  // hand-edited `castDevice: 8009` would arrive here as a number.
+  const manual = parseManualDevice(
+    typeof config.castDevice === "string" ? config.castDevice : undefined,
+  );
+  if (!manual || found.some((d) => d.host === manual.host && d.port === manual.port)) return found;
+  return [...found, manual];
+}
+
+async function castDevicesRoute(deps: WebDeps): Promise<WebResponse> {
+  const devices = await castDevices(deps);
+  const origin = (deps.castOriginImpl ?? (() => null))();
+  // Two independent reasons casting cannot happen, and the file's own blockers
+  // are a third the client already knows from `.info`. Naming which one is the
+  // difference between "the network" and "this file" for the person looking at a
+  // disabled button.
+  const reason = devices.length === 0 ? NO_DEVICES : origin === null ? NO_ORIGIN : null;
+  const out: CastDevicesResponse = {
+    devices: devices.map(toPublicCastDevice),
+    castable: reason === null,
+    reason,
+  };
+  return { status: 200, json: out };
+}
+
+/** The status shape, shared by the route and the SSE event so a page has one parser. */
+export function castStatusOf(casts: Runtime["casts"]): CastStatusResponse {
+  const active = casts.active();
+  return {
+    casting: active
+      ? {
+          deviceName: active.device.name,
+          title: active.title,
+          state: active.status.state,
+          positionSec: active.status.positionSec,
+          durationSec: active.status.durationSec,
+        }
+      : null,
+    notice: casts.takeNotice(),
+  };
+}
+
+interface StartCastBody {
+  deviceId?: unknown;
+  sid?: unknown;
+  index?: unknown;
+  subtitleIndex?: unknown;
+}
+
+async function startCast(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+  let body: StartCastBody;
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { status: 400, json: { error: "invalid json body" } };
+    }
+    body = parsed as StartCastBody;
+  } catch {
+    return { status: 400, json: { error: "invalid json body" } };
+  }
+  const deviceId = typeof body.deviceId === "string" ? body.deviceId : "";
+  const sid = typeof body.sid === "string" ? body.sid : "";
+  const index = typeof body.index === "number" ? body.index : NaN;
+  if (!deviceId || !sid || !Number.isInteger(index)) {
+    return { status: 400, json: { error: "missing deviceId, sid or index" } };
+  }
+
+  const session = deps.runtime.sessions.get(sid);
+  if (!session) return { status: 404, json: { error: "unknown session" } };
+  const file = session.files[index];
+  if (!file) return { status: 404, json: { error: "unknown file" } };
+  const device = (await castDevices(deps)).find((d) => d.id === deviceId);
+  // 404 for a device that is not in the list, and it says nothing about whether
+  // some other id would have been found.
+  if (!device) return { status: 404, json: { error: "unknown device" } };
+
+  const origin = (deps.castOriginImpl ?? (() => null))();
+  if (origin === null) return { status: 409, json: { error: NO_ORIGIN } };
+
+  const source = await (deps.castSourceImpl ??
+    (() => Promise.resolve({ facts: classifyFromName(file.filename, session.name), hls: null })))(
+    session,
+    index,
+  );
+  const blockers = blockersFor(source.facts, CHROMECAST_PROFILE);
+  // The ladder, with the Chromecast profile in place of the browser's: direct
+  // play, then the provider's transcode, then an honest refusal. There is no
+  // local-ffmpeg rung in this tree — `src/util/ffmpegBin.ts` is used only for
+  // ffprobe — so a blocked file with no manifest cannot be cast, and says so.
+  if (blockers.length > 0 && !source.hls) {
+    return { status: 409, json: { error: `A Chromecast can't play this one — ${castRefusal(blockers)}.` } };
+  }
+  const useHls = blockers.length > 0 && source.hls !== null;
+  const url = useHls
+    ? source.hls!
+    : `${origin}/stream/${sid}/${index}?k=${encodeURIComponent(session.capability)}`;
+
+  // The subtitle handle, only when the index names something `<track>`-shaped —
+  // the same guard the `.vtt` representation applies. Casting a video as a text
+  // track would be a LOAD the device silently ignores.
+  const subtitleFile =
+    typeof body.subtitleIndex === "number" ? session.files[body.subtitleIndex] : undefined;
+  const subtitle =
+    subtitleFile && isBrowserRenderable(subtitleFile.filename)
+      ? {
+          subtitleUrl: `${origin}/stream/${sid}/${String(body.subtitleIndex)}.vtt?k=${encodeURIComponent(session.capability)}`,
+          subtitleLabel: subtitleLanguage(subtitleFile.filename).label,
+        }
+      : {};
+
+  try {
+    await deps.runtime.casts.start({
+      device,
+      sid,
+      index,
+      infoHash: session.infoHash,
+      filename: file.filename,
+      title: playlistTitle(file.filename),
+      media: {
+        url,
+        contentType: castContentType(extensionOf(file.filename), useHls),
+        title: playlistTitle(file.filename),
+        ...subtitle,
+      },
+    });
+  } catch (e) {
+    // A CastError's message is already fit for the screen — that is what the type
+    // means. 502, because the failure is upstream of us: the device refused, or
+    // never answered.
+    const message = e instanceof CastError ? e.message : "Could not cast to that device.";
+    return { status: 502, json: { error: message } };
+  }
+  return { status: 200, json: castStatusOf(deps.runtime.casts) };
+}
+
+/** The container is named first, because it is the blocker a user can recognise. */
+function castRefusal(blockers: Blocker[]): string {
+  if (blockers.includes("container")) return "a Chromecast won't demux this container";
+  if (blockers.includes("video")) return "it can't decode this video codec";
+  return "it can't decode this audio";
+}
+
+async function castCommand(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+  let action = "";
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const value = (parsed as { action?: unknown }).action;
+      if (typeof value === "string") action = value;
+    }
+  } catch {
+    return { status: 400, json: { error: "invalid json body" } };
+  }
+  if (action !== "play" && action !== "pause" && action !== "stop") {
+    return { status: 400, json: { error: "unknown action" } };
+  }
+  try {
+    if (action === "play") await deps.runtime.casts.play();
+    else if (action === "pause") await deps.runtime.casts.pause();
+    else await deps.runtime.casts.stop();
+  } catch (e) {
+    // Nothing casting is a 409 and not a 500: the client asked for something
+    // reasonable against state that has moved on, which is ordinary when a cast
+    // ended on the device itself.
+    const message = e instanceof Error ? e.message : "Nothing is casting.";
+    return { status: 409, json: { error: message } };
+  }
+  return { status: 200, json: castStatusOf(deps.runtime.casts) };
+}
+
 /** True when `handleWebApi` owns this path; false means it is a static asset. */
 export function isApiPath(urlPath: string): boolean {
   return urlPath.startsWith("/api/") || LEGACY_API_PATHS.has(urlPath);
@@ -1778,6 +2015,25 @@ export async function handleWebApi(
 
   if (method === "POST" && urlPath === STREAM_BASE) {
     return startStream(deps, bodyText);
+  }
+
+  // Casting. Past the same token gate, and it needs it for the same reason: none
+  // of these delegates to handleApi, and `start` spends the user's debrid account
+  // and puts their stream on a screen in their house.
+  if (method === "GET" && urlPath === "/api/cast/devices") {
+    return castDevicesRoute(deps);
+  }
+
+  if (method === "GET" && urlPath === "/api/cast/status") {
+    return { status: 200, json: castStatusOf(deps.runtime.casts) };
+  }
+
+  if (method === "POST" && urlPath === "/api/cast/start") {
+    return startCast(deps, bodyText);
+  }
+
+  if (method === "POST" && urlPath === "/api/cast/command") {
+    return castCommand(deps, bodyText);
   }
 
   const sid = streamSessionId(urlPath);

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { startWebServer, writeWebResponse, type WebServerHandle } from "./server";
 import { DownloadQueue } from "../download/queue";
 import { StreamSessionRegistry } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import { SOURCES } from "../sources/registry";
 import { defaultConfig, type Config } from "../config/config";
 import type { TorrentResult } from "../sources/types";
@@ -16,7 +17,7 @@ function runtime(): Runtime {
   return {
     queue: new DownloadQueue(),
     downloadDir: "/tmp/dl",
-    sessions: new StreamSessionRegistry(),
+    sessions: new StreamSessionRegistry(), casts: new CastSessionRegistry(),
   };
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -10,6 +10,7 @@
 // Default port 9162 sits next to the add API's 9161.
 
 import http from "node:http";
+import os from "node:os";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import {
@@ -25,9 +26,11 @@ import {
   handleStreamRequest,
   isPlayPath,
   isStreamPath,
+  mediaSourceFor,
   parsePlayPath,
   type StreamDeps,
 } from "./stream";
+import { castOrigin } from "./castOrigin";
 import { ProbeCache } from "../core/probeCache";
 import { HlsVerdictCache } from "../core/hlsVerdictCache";
 import { makeCheckHls, probeFetch } from "./hlsHealth";
@@ -246,10 +249,6 @@ export async function startWebServer(
     log("warning: no built web assets found (dist/web); run `npm run build`. API only.");
   }
 
-  // One deps object for every route, built once. `runtime` and `token` come
-  // last so an override cannot swap the queue or weaken the gate.
-  const routeDeps: WebDeps = { ...options.webDeps, runtime, token };
-
   // One probe cache for this process, so opening a player page twice does not
   // spawn ffprobe twice. Bounded, so it needs no teardown of its own.
   const probeCache = new ProbeCache();
@@ -267,6 +266,57 @@ export async function startWebServer(
   // (session, file), cached, so a reload costs nothing.
   const checkHls = makeCheckHls({ fetchImpl: probeFetch });
   const hlsVerdictCache = new HlsVerdictCache();
+
+  /**
+   * The stream route's deps, rebuilt per use rather than held.
+   *
+   * `proxyDebrid` is resolved fresh every time, not read once at boot: `serve
+   * --web` is a separate process from any TUI that might flip the flag, so a held
+   * snapshot would silently serve a stale value. An explicit
+   * `options.streamDeps.proxyDebrid` (a test, driving the branch without a real
+   * debrid provider) still wins over the config read.
+   *
+   * A function rather than an inline literal because the cast routes need the
+   * same deps to answer the same source question — see `castSourceImpl` below.
+   */
+  const buildStreamDeps = async (): Promise<StreamDeps> => ({
+    resolveHls,
+    checkHls,
+    // Spread after the defaults so a test can override them, and before the
+    // fields below so it cannot override those.
+    ...options.streamDeps,
+    sessions: runtime.sessions,
+    log,
+    trustProxy: options.trustProxy === true,
+    probeCache,
+    hlsVerdictCache,
+    proxyDebrid:
+      options.streamDeps?.proxyDebrid ??
+      (await (options.webDeps?.loadConfigImpl ?? loadConfig)()).proxyDebridStreams === true,
+  });
+
+  // Set once the socket is bound, because `port: 0` means the requested port is
+  // not the real one — the same reason the log line below reads it back from the
+  // server. A cast before the server is listening is impossible, so the null
+  // window is not reachable from a request.
+  let boundPort = port;
+
+  // One deps object for every route, built once. `runtime` and `token` come last
+  // so an override cannot swap the queue or weaken the gate; the two cast seams
+  // sit before the spread so a test can replace them.
+  const routeDeps: WebDeps = {
+    // The origin a television fetches from. NOT the request's `Host`, which is a
+    // claim by a client: a user browsing `http://localhost:9161` would otherwise
+    // hand the device a URL pointing at the device itself. `host` is what this
+    // server actually bound, which is a fact about what is reachable.
+    castOriginImpl: () => castOrigin(host, boundPort, os.networkInterfaces()),
+    // The same answer the player page's `.info` gets, from the same function, so
+    // a browser and a television cannot disagree about one file.
+    castSourceImpl: async (session, index) => mediaSourceFor(await buildStreamDeps(), session, index),
+    ...options.webDeps,
+    runtime,
+    token,
+  };
 
   // Live SSE responses, so close() can end them. Without this, http's close()
   // waits for every connection to end and an event stream never does.
@@ -439,26 +489,7 @@ export async function startWebServer(
       // send an Authorization header. Only the path is logged: the query string
       // carries that capability, and a Real-Debrid Location is a credential.
       if (isStreamPath(urlPath)) {
-        // Resolved fresh per request, not read once at boot: `serve --web` is a
-        // separate process from any TUI that might flip the flag, so a held
-        // snapshot here would silently serve a stale value. An explicit
-        // `options.streamDeps.proxyDebrid` (a test, driving the branch without a
-        // real debrid provider) still wins over the config read.
-        const streamDeps: StreamDeps = {
-          resolveHls,
-          checkHls,
-          // Spread after the default so a test can override it, and before the
-          // fields below so it cannot override those.
-          ...options.streamDeps,
-          sessions: runtime.sessions,
-          log,
-          trustProxy: options.trustProxy === true,
-          probeCache,
-          hlsVerdictCache,
-          proxyDebrid:
-            options.streamDeps?.proxyDebrid ??
-            (await (options.webDeps?.loadConfigImpl ?? loadConfig)()).proxyDebridStreams === true,
-        };
+        const streamDeps = await buildStreamDeps();
         const wrote = await handleStreamRequest(
           streamDeps,
           req,
@@ -588,6 +619,8 @@ export async function startWebServer(
   // `port: 0` asks the OS to pick, so the caller can only learn the real port
   // from here. A string address means a unix socket, which this never binds.
   const bound = address && typeof address === "object" ? address.port : port;
+  // What `castOriginImpl` names, now that it is known.
+  boundPort = bound;
   // The bind, not a URL. This server knows where it is listening; it does not
   // know what a browser should type — a wildcard bind has no single answer, and
   // printing `http://0.0.0.0:9161` here is what sent users to a dead address.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import {
+  castStatusOf,
   handleWebApi,
   isApiPath,
   parseSearchParams,
@@ -21,7 +22,7 @@ import {
   type WebDeps,
   type WebResponse,
 } from "./routes";
-import { subscribeToQueue } from "./sse";
+import { subscribeToCasts, subscribeToQueue } from "./sse";
 import {
   handleStreamRequest,
   isPlayPath,
@@ -395,7 +396,15 @@ export async function startWebServer(
       return;
     }
     serveStream(req, res, (write) =>
-      subscribeToQueue(runtime.queue, write, () => statusPayload(runtime)),
+      subscribeToQueue(
+        runtime.queue,
+        write,
+        () => statusPayload(runtime),
+        // On the same channel, so one EventSource carries both. It is what lets a
+        // cast started from a laptop appear on a phone pointed at this server —
+        // within this process, which is the limit `Runtime.casts` documents.
+        subscribeToCasts(runtime.casts, () => castStatusOf(runtime.casts)),
+      ),
     );
     log(`GET /api/events -> 200 (stream, ${streams.size} open)`);
   };

--- a/src/web/sse.test.ts
+++ b/src/web/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { HEARTBEAT_MS, sseFrame, subscribeToQueue } from "./sse";
+import { HEARTBEAT_MS, sseFrame, subscribeToCasts, subscribeToQueue } from "./sse";
 import { DownloadQueue } from "../download/queue";
 
 describe("sseFrame", () => {
@@ -398,6 +398,127 @@ describe("subscribeToQueue", () => {
       queue.emit("update");
 
       expect(timeouts()).toBe(before);
+    } finally {
+      stop();
+    }
+  });
+});
+
+describe("subscribeToCasts", () => {
+  /** The one method sse.ts needs, so it imports nothing from src/core/cast. */
+  function fakeCasts() {
+    const listeners = new Set<() => void>();
+    return {
+      onChange(cb: () => void): () => void {
+        listeners.add(cb);
+        return () => void listeners.delete(cb);
+      },
+      changed(): void {
+        for (const cb of [...listeners]) cb();
+      },
+      count(): number {
+        return listeners.size;
+      },
+    };
+  }
+
+  function frames(written: string[]): string[] {
+    return written.join("").split("\n\n").filter(Boolean);
+  }
+
+  it("sends the current cast state at once, so a page arriving mid-cast is not blank", () => {
+    const written: string[] = [];
+    const casts = fakeCasts();
+    const stop = subscribeToQueue(
+      new DownloadQueue(),
+      (c) => written.push(c),
+      () => ({ downloads: [], seeds: [] }),
+      subscribeToCasts(casts, () => ({ casting: null, notice: null })),
+    );
+    try {
+      const cast = frames(written).filter((f) => f.startsWith("event: cast"));
+      expect(cast).toHaveLength(1);
+      expect(cast[0]).toContain('"casting":null');
+    } finally {
+      stop();
+    }
+  });
+
+  it("sends a frame whenever the cast changes", () => {
+    const written: string[] = [];
+    const casts = fakeCasts();
+    let state: unknown = { casting: null, notice: null };
+    const stop = subscribeToQueue(
+      new DownloadQueue(),
+      (c) => written.push(c),
+      () => ({ downloads: [], seeds: [] }),
+      subscribeToCasts(casts, () => state),
+    );
+    try {
+      state = {
+        casting: {
+          deviceName: "Living Room TV",
+          title: "Kepler S02E04",
+          state: "playing",
+          positionSec: 12,
+          durationSec: 600,
+        },
+        notice: null,
+      };
+      casts.changed();
+      const cast = frames(written).filter((f) => f.startsWith("event: cast"));
+      expect(cast).toHaveLength(2);
+      expect(cast[1]).toContain("Living Room TV");
+    } finally {
+      stop();
+    }
+  });
+
+  it("shares the queue's channel, so a browser needs one EventSource", () => {
+    const written: string[] = [];
+    const casts = fakeCasts();
+    const stop = subscribeToQueue(
+      new DownloadQueue(),
+      (c) => written.push(c),
+      () => ({ downloads: [], seeds: [] }),
+      subscribeToCasts(casts, () => ({ casting: null, notice: null })),
+    );
+    try {
+      expect(frames(written).some((f) => f.startsWith("event: status"))).toBe(true);
+      expect(frames(written).some((f) => f.startsWith("event: cast"))).toBe(true);
+    } finally {
+      stop();
+    }
+  });
+
+  it("unsubscribes from the registry when the connection ends", () => {
+    const written: string[] = [];
+    const casts = fakeCasts();
+    const stop = subscribeToQueue(
+      new DownloadQueue(),
+      (c) => written.push(c),
+      () => ({ downloads: [], seeds: [] }),
+      subscribeToCasts(casts, () => ({ casting: null, notice: null })),
+    );
+    expect(casts.count()).toBe(1);
+    stop();
+    // A listener per dead client on a process that runs for weeks is the leak
+    // every producer in this module is careful about.
+    expect(casts.count()).toBe(0);
+    const before = written.length;
+    casts.changed();
+    expect(written.length).toBe(before);
+  });
+
+  it("is optional: the queue stream works with no cast producer attached", () => {
+    const written: string[] = [];
+    const stop = subscribeToQueue(new DownloadQueue(), (c) => written.push(c), () => ({
+      downloads: [],
+      seeds: [],
+    }));
+    try {
+      expect(frames(written).some((f) => f.startsWith("event: status"))).toBe(true);
+      expect(frames(written).some((f) => f.startsWith("event: cast"))).toBe(false);
     } finally {
       stop();
     }

--- a/src/web/sse.ts
+++ b/src/web/sse.ts
@@ -30,6 +30,12 @@ export function sseFrame(event: string, data: unknown): string {
 export type SseWrite = (chunk: string) => void;
 
 /**
+ * A second source of events on one channel. Given the open channel, it sends
+ * what it has and returns its own teardown, which the channel's `onClose` runs.
+ */
+export type SseProducer = (channel: SseChannel) => () => void;
+
+/**
  * One SSE connection's lifecycle, with no idea what it is streaming.
  *
  * Extracted from `subscribeToQueue` when `/api/search` needed the same three
@@ -119,13 +125,20 @@ export function subscribeToQueue(
   queue: DownloadQueue,
   write: SseWrite,
   snapshot: () => unknown,
+  attach?: SseProducer,
 ): () => void {
   let pending = false;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let detach: (() => void) | null = null;
 
   const channel = openSseChannel(write, () => {
     queue.off("update", onUpdate);
     if (flushTimer) clearTimeout(flushTimer);
+    // Whatever the second producer registered, removed on the same path and for
+    // the same reason: a listener per dead client on a process that runs for
+    // weeks is the leak this module is careful about throughout.
+    detach?.();
+    detach = null;
   });
 
   const flush = (): void => {
@@ -161,6 +174,44 @@ export function subscribeToQueue(
   // `alive`, but still a listener per dead client on a long-lived daemon.
   queue.on("update", onUpdate);
   channel.send("status", snapshot);
+  // After the queue's own first frame, so the two producers' opening frames
+  // arrive in a fixed order rather than one that depends on argument evaluation.
+  detach = attach?.(channel) ?? null;
 
   return channel.stop;
+}
+
+/**
+ * The one method the cast registry needs to expose here.
+ *
+ * Structural rather than an import of `CastSessionRegistry`, so this module
+ * keeps depending on nothing from `src/core/cast` — and so its tests can drive
+ * it without one.
+ */
+export interface CastChangeSource {
+  onChange(cb: () => void): () => void;
+}
+
+/**
+ * Push cast state onto an existing channel, as `cast` events.
+ *
+ * A producer rather than its own subscription, so a browser needs ONE
+ * `EventSource` for both the queue and the cast: two streams would mean two
+ * heartbeats, two teardowns and two chances to leak one.
+ *
+ * Unthrottled, unlike the queue's frames: a cast emits on a status from the
+ * device, which is roughly once a second, where a busy queue emits per progress
+ * tick per torrent.
+ */
+export function subscribeToCasts(casts: CastChangeSource, snapshot: () => unknown): SseProducer {
+  return (channel) => {
+    // Subscribed before the first send for the reason the queue is: a snapshot
+    // that throws must unwind with the listener registered and removable.
+    const off = casts.onChange(() => {
+      if (!channel.alive) return;
+      channel.send("cast", snapshot);
+    });
+    channel.send("cast", snapshot);
+    return off;
+  };
 }

--- a/src/web/static/castModel.test.ts
+++ b/src/web/static/castModel.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  castBlockerReason,
+  castButtonView,
+  castControls,
+  castStatusLine,
+  formatCastTime,
+} from "./castModel";
+import type { CastDevicesResponse, CastStatusResponse } from "../wire";
+
+const ONE_DEVICE: CastDevicesResponse = {
+  devices: [{ id: "abc", name: "Living Room TV", model: "Chromecast" }],
+  castable: true,
+  reason: null,
+};
+const TWO_DEVICES: CastDevicesResponse = {
+  devices: [
+    { id: "abc", name: "Living Room TV", model: "Chromecast" },
+    { id: "k1", name: "Kitchen display", model: "Google TV Streamer" },
+  ],
+  castable: true,
+  reason: null,
+};
+const NONE: CastDevicesResponse = {
+  devices: [],
+  castable: false,
+  reason: "No Chromecast found on this network.",
+};
+const LOOKING: CastDevicesResponse = { devices: [], castable: false, reason: null };
+const IDLE: CastStatusResponse = { casting: null, notice: null };
+
+const casting = (
+  over: Partial<NonNullable<CastStatusResponse["casting"]>> = {},
+): CastStatusResponse => ({
+  casting: {
+    deviceName: "Living Room TV",
+    title: "Kepler S02E04",
+    state: "playing",
+    positionSec: 0,
+    durationSec: 600,
+    ...over,
+  },
+  notice: null,
+});
+
+describe("castButtonView", () => {
+  it("is hidden until the device list has been fetched, so nothing flickers", () => {
+    expect(castButtonView({ devices: null, status: null, castBlockers: [], hasHls: false })).toEqual({
+      state: "hidden",
+      label: "",
+      disabledReason: null,
+    });
+  });
+
+  it("offers casting when a device answered and the file is playable", () => {
+    expect(castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: [], hasHls: false })).toEqual({
+      state: "ready",
+      label: "Cast to TV",
+      disabledReason: null,
+    });
+  });
+
+  it("says it is looking while discovery has not reported a reason yet", () => {
+    expect(castButtonView({ devices: LOOKING, status: IDLE, castBlockers: [], hasHls: false })).toEqual({
+      state: "finding",
+      label: "Finding devices…",
+      disabledReason: null,
+    });
+  });
+
+  it("is disabled with the network's reason when nothing answered", () => {
+    expect(castButtonView({ devices: NONE, status: IDLE, castBlockers: [], hasHls: false })).toEqual({
+      state: "disabled",
+      label: "Cast to TV",
+      disabledReason: "No Chromecast found on this network.",
+    });
+  });
+
+  it("is disabled with the FILE's reason when no Chromecast can play it, even with a device present", () => {
+    // Which of the two reasons is shown matters: "the network" and "this file"
+    // send the user to completely different places.
+    expect(
+      castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: ["container"], hasHls: false }),
+    ).toEqual({
+      state: "disabled",
+      label: "Cast to TV",
+      disabledReason: "A Chromecast can't play this one — it won't demux this container.",
+    });
+  });
+
+  it("offers casting for a blocked file that has an HLS manifest, which is the rung above it", () => {
+    // The debrid provider's transcode. Same file, different backend, different
+    // answer — which is why this takes `hasHls` rather than deciding from the
+    // blockers alone.
+    expect(
+      castButtonView({ devices: ONE_DEVICE, status: IDLE, castBlockers: ["container"], hasHls: true }),
+    ).toMatchObject({ state: "ready" });
+  });
+
+  it("prefers the file's reason over the network's when both are true", () => {
+    // Nothing found AND unplayable: fixing the network would still not cast this
+    // file, so the file is the more useful thing to say.
+    expect(
+      castButtonView({ devices: NONE, status: IDLE, castBlockers: ["video"], hasHls: false }),
+    ).toMatchObject({ disabledReason: "A Chromecast can't play this one — it can't decode this video." });
+  });
+
+  it("names the device once something is casting", () => {
+    expect(castButtonView({ devices: ONE_DEVICE, status: casting(), castBlockers: [], hasHls: false })).toEqual({
+      state: "casting",
+      label: "Playing on Living Room TV",
+      disabledReason: null,
+    });
+  });
+
+  it("still reports casting when the file itself is blocked, because it is already playing", () => {
+    // It got there via HLS. A "can't play this" label over a playing television
+    // would be absurd.
+    expect(
+      castButtonView({ devices: ONE_DEVICE, status: casting(), castBlockers: ["container"], hasHls: true }),
+    ).toMatchObject({ state: "casting" });
+  });
+
+  it("does not depend on how many devices there are", () => {
+    expect(castButtonView({ devices: TWO_DEVICES, status: IDLE, castBlockers: [], hasHls: false })).toMatchObject({
+      state: "ready",
+    });
+  });
+});
+
+describe("castStatusLine", () => {
+  it("reads position over duration", () => {
+    expect(castStatusLine(casting({ positionSec: 724, durationSec: 6_512 }))).toBe(
+      "0:12:04 / 1:48:32",
+    );
+  });
+
+  it("shows position alone when the duration is unknown, rather than inventing 0:00:00", () => {
+    expect(castStatusLine(casting({ positionSec: 5, durationSec: null }))).toBe("0:00:05");
+  });
+
+  it("says what it is doing when it is not playing", () => {
+    expect(castStatusLine(casting({ state: "loading", positionSec: 0, durationSec: null }))).toBe(
+      "Loading on the TV…",
+    );
+    expect(castStatusLine(casting({ state: "paused", positionSec: 61, durationSec: 600 }))).toBe(
+      "Paused · 0:01:01 / 0:10:00",
+    );
+    expect(castStatusLine(casting({ state: "idle", positionSec: 0, durationSec: null }))).toBe(
+      "Finished on the TV.",
+    );
+  });
+
+  it("is null when nothing is casting", () => {
+    expect(castStatusLine(IDLE)).toBeNull();
+  });
+});
+
+describe("formatCastTime", () => {
+  it("is h:mm:ss, zero-padded past the hours", () => {
+    expect(formatCastTime(0)).toBe("0:00:00");
+    expect(formatCastTime(61)).toBe("0:01:01");
+    expect(formatCastTime(3_661)).toBe("1:01:01");
+    expect(formatCastTime(36_000)).toBe("10:00:00");
+  });
+
+  it("floors a fractional position and clamps a negative or unusable one", () => {
+    // The receiver reports currentTime as a float, and has been seen to report a
+    // small negative one while it is still seeking.
+    expect(formatCastTime(12.9)).toBe("0:00:12");
+    expect(formatCastTime(-5)).toBe("0:00:00");
+    expect(formatCastTime(NaN)).toBe("0:00:00");
+  });
+});
+
+describe("castControls", () => {
+  it("offers pause and stop while playing, play and stop while paused", () => {
+    expect(castControls(casting({ state: "playing" }))).toEqual(["pause", "stop"]);
+    expect(castControls(casting({ state: "paused" }))).toEqual(["play", "stop"]);
+  });
+
+  it("offers only stop before playback has started, or after it has ended", () => {
+    // Pausing something that has not started is a button that appears to do
+    // nothing, which is the failure this whole feature keeps avoiding.
+    expect(castControls(casting({ state: "loading" }))).toEqual(["stop"]);
+    expect(castControls(casting({ state: "idle" }))).toEqual(["stop"]);
+  });
+
+  it("offers nothing when nothing is casting", () => {
+    expect(castControls(IDLE)).toEqual([]);
+  });
+});
+
+describe("castBlockerReason", () => {
+  it("names the container first, because it is the one a user can recognise", () => {
+    expect(castBlockerReason(["container", "audio"])).toBe("it won't demux this container");
+    expect(castBlockerReason(["video"])).toBe("it can't decode this video");
+    expect(castBlockerReason(["audio"])).toBe("it can't decode this audio");
+  });
+
+  it("never returns an empty string, so a disabled button always says why", () => {
+    expect(castBlockerReason([])).not.toBe("");
+  });
+});

--- a/src/web/static/castModel.test.ts
+++ b/src/web/static/castModel.test.ts
@@ -4,9 +4,10 @@ import {
   castButtonView,
   castControls,
   castStatusLine,
+  castSubtitleIndex,
   formatCastTime,
 } from "./castModel";
-import type { CastDevicesResponse, CastStatusResponse } from "../wire";
+import type { CastDevicesResponse, CastStatusResponse, StreamInfoResponse } from "../wire";
 
 const ONE_DEVICE: CastDevicesResponse = {
   devices: [{ id: "abc", name: "Living Room TV", model: "Chromecast" }],
@@ -200,5 +201,38 @@ describe("castBlockerReason", () => {
 
   it("never returns an empty string, so a disabled button always says why", () => {
     expect(castBlockerReason([])).not.toBe("");
+  });
+});
+
+describe("castSubtitleIndex", () => {
+  const info = (files: { index: number; language: string; renderable: boolean }[]) =>
+    ({
+      subtitles: {
+        embedded: [],
+        files: files.map((f) => ({ ...f, filename: `sub.${f.language}.srt`, label: f.language })),
+      },
+    }) as unknown as StreamInfoResponse;
+
+  it("picks the first English renderable sibling, matching what <track> defaults to", () => {
+    // The page cannot know which track the browser's own menu has selected, so
+    // the cast takes the one the page marked default. Same rule as
+    // `subtitleTracks`, so the television shows what the browser would have.
+    expect(castSubtitleIndex(info([
+      { index: 1, language: "fr", renderable: true },
+      { index: 2, language: "en", renderable: true },
+    ]))).toBe(2);
+  });
+
+  it("falls back to the first renderable when nothing is English", () => {
+    expect(castSubtitleIndex(info([{ index: 3, language: "fr", renderable: true }]))).toBe(3);
+  });
+
+  it("ignores a track a browser could not render, because the .vtt route refuses it too", () => {
+    expect(castSubtitleIndex(info([{ index: 4, language: "en", renderable: false }]))).toBeUndefined();
+  });
+
+  it("is undefined with no info and with no siblings", () => {
+    expect(castSubtitleIndex(null)).toBeUndefined();
+    expect(castSubtitleIndex(info([]))).toBeUndefined();
   });
 });

--- a/src/web/static/castModel.ts
+++ b/src/web/static/castModel.ts
@@ -1,5 +1,5 @@
 import type { Blocker } from "../../util/playability";
-import { castClock, formatCastTime } from "../../util/castStatus";
+import { castBlockerClause, castClock, formatCastTime } from "../../util/castStatus";
 import type { CastDevicesResponse, CastStatusResponse, StreamInfoResponse } from "../wire";
 
 /**
@@ -35,14 +35,15 @@ export interface CastButtonInput {
   hasHls: boolean;
 }
 
-/** The container is named first, because it is the blocker a user can recognise. */
+/**
+ * Why a Chromecast is refusing this file.
+ *
+ * Delegates to `src/util`, shared with the server's own refusal — the two said the
+ * same thing in different words until one of them read back from a real device as
+ * "A Chromecast can't play this one — a Chromecast won't demux this container".
+ */
 export function castBlockerReason(blockers: Blocker[]): string {
-  if (blockers.includes("container")) return "it won't demux this container";
-  if (blockers.includes("video")) return "it can't decode this video";
-  if (blockers.includes("audio")) return "it can't decode this audio";
-  // Never empty: a disabled button with no reason is the thing this whole
-  // feature is written to avoid.
-  return "this file isn't something it can play";
+  return castBlockerClause(blockers);
 }
 
 export function castButtonView(input: CastButtonInput): CastButtonView {

--- a/src/web/static/castModel.ts
+++ b/src/web/static/castModel.ts
@@ -1,5 +1,5 @@
 import type { Blocker } from "../../util/playability";
-import type { CastDevicesResponse, CastStatusResponse } from "../wire";
+import type { CastDevicesResponse, CastStatusResponse, StreamInfoResponse } from "../wire";
 
 /**
  * Every decision the cast button makes, as functions.
@@ -120,4 +120,22 @@ export function castControls(status: CastStatusResponse): CastControl[] {
   // Loading, or finished. Pausing something that has not started is a button
   // that appears to do nothing.
   return ["stop"];
+}
+
+/**
+ * Which subtitle to send with the cast, as an index into the session's files.
+ *
+ * The page cannot know which track the browser's own subtitle menu has selected
+ * — that state lives inside the `<video>` element and is not readable — so the
+ * cast takes the one the page marked `default`, which is the same rule
+ * `subtitleTracks` (./subtitleModel.ts) applies. The television then shows what
+ * the browser would have shown.
+ *
+ * Renderable only, for the same reason the `.vtt` route refuses anything else:
+ * an ass/ssa track converted to WebVTT is neither.
+ */
+export function castSubtitleIndex(info: StreamInfoResponse | null): number | undefined {
+  const files = (info?.subtitles.files ?? []).filter((f) => f.renderable);
+  const chosen = files.find((f) => f.language === "en") ?? files[0];
+  return chosen?.index;
 }

--- a/src/web/static/castModel.ts
+++ b/src/web/static/castModel.ts
@@ -1,4 +1,5 @@
 import type { Blocker } from "../../util/playability";
+import { castClock, formatCastTime } from "../../util/castStatus";
 import type { CastDevicesResponse, CastStatusResponse, StreamInfoResponse } from "../wire";
 
 /**
@@ -81,32 +82,13 @@ export function castButtonView(input: CastButtonInput): CastButtonView {
 }
 
 /**
- * `h:mm:ss`.
+ * The line under "Playing on <device>", or null when nothing is casting.
  *
- * Defensive about its input because the input is a float from a television: the
- * receiver reports `currentTime` as a float, and has been seen to report a small
- * negative one while it is still seeking.
+ * The formatting itself is `castClock` in `src/util/`, shared with the terminal's
+ * cast row — this is only the "is anything casting" half.
  */
-export function formatCastTime(seconds: number): string {
-  const total = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
-  const h = Math.floor(total / 3600);
-  const m = Math.floor((total % 3600) / 60);
-  const s = total % 60;
-  return `${String(h)}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
-
-/** The line under "Playing on <device>", or null when nothing is casting. */
 export function castStatusLine(status: CastStatusResponse): string | null {
-  const casting = status.casting;
-  if (!casting) return null;
-  if (casting.state === "loading") return "Loading on the TV…";
-  if (casting.state === "idle") return "Finished on the TV.";
-  // A duration the receiver has not reported is null, not zero: showing
-  // "0:00:05 / 0:00:00" would read as a broken file rather than an unknown length.
-  const elapsed = formatCastTime(casting.positionSec);
-  const clock =
-    casting.durationSec === null ? elapsed : `${elapsed} / ${formatCastTime(casting.durationSec)}`;
-  return casting.state === "paused" ? `Paused · ${clock}` : clock;
+  return status.casting ? castClock(status.casting) : null;
 }
 
 export type CastControl = "play" | "pause" | "stop";
@@ -139,3 +121,7 @@ export function castSubtitleIndex(info: StreamInfoResponse | null): number | und
   const chosen = files.find((f) => f.language === "en") ?? files[0];
   return chosen?.index;
 }
+
+// Re-exported so this module stays the browser's one cast vocabulary, even though
+// the implementation now lives in src/util for the terminal to share.
+export { formatCastTime };

--- a/src/web/static/castModel.ts
+++ b/src/web/static/castModel.ts
@@ -1,0 +1,123 @@
+import type { Blocker } from "../../util/playability";
+import type { CastDevicesResponse, CastStatusResponse } from "../wire";
+
+/**
+ * Every decision the cast button makes, as functions.
+ *
+ * It exists because `player.ts` is DOM wiring with no test reachable without
+ * jsdom — which this repo deliberately does not have — and this codebase has
+ * twice caught a decision that belonged in a module like this sitting in the
+ * wiring instead. If you are about to write a conditional in `player.ts` that
+ * chooses what to show or what to send, it belongs here.
+ *
+ * Nothing here imports `node:*`: this module is bundled for the browser, and
+ * `npm run build` is the only thing that proves it stayed that way.
+ */
+
+export type CastButtonState = "hidden" | "ready" | "finding" | "disabled" | "casting";
+
+export interface CastButtonView {
+  state: CastButtonState;
+  label: string;
+  /** Shown beside a disabled button. Null in every other state. */
+  disabledReason: string | null;
+}
+
+export interface CastButtonInput {
+  /** Null until `/api/cast/devices` has answered. */
+  devices: CastDevicesResponse | null;
+  /** Null until the first `cast` event or status read. */
+  status: CastStatusResponse | null;
+  /** From `.info` — what a Chromecast would refuse about this file. */
+  castBlockers: Blocker[];
+  /** Whether a provider HLS manifest exists: the one rung above direct play. */
+  hasHls: boolean;
+}
+
+/** The container is named first, because it is the blocker a user can recognise. */
+export function castBlockerReason(blockers: Blocker[]): string {
+  if (blockers.includes("container")) return "it won't demux this container";
+  if (blockers.includes("video")) return "it can't decode this video";
+  if (blockers.includes("audio")) return "it can't decode this audio";
+  // Never empty: a disabled button with no reason is the thing this whole
+  // feature is written to avoid.
+  return "this file isn't something it can play";
+}
+
+export function castButtonView(input: CastButtonInput): CastButtonView {
+  const { devices, status, castBlockers, hasHls } = input;
+  // Hidden rather than disabled while the list is unknown: a button that appears
+  // disabled and then becomes enabled a moment later reads as a glitch.
+  if (!devices) return { state: "hidden", label: "", disabledReason: null };
+
+  if (status?.casting) {
+    return {
+      state: "casting",
+      label: `Playing on ${status.casting.deviceName}`,
+      disabledReason: null,
+    };
+  }
+
+  // The file's own limit comes first, because fixing the network would not help.
+  // Not consulted while something is casting: it got there via HLS, and a
+  // "can't play this" label over a playing television would be absurd.
+  if (castBlockers.length > 0 && !hasHls) {
+    return {
+      state: "disabled",
+      label: "Cast to TV",
+      disabledReason: `A Chromecast can't play this one — ${castBlockerReason(castBlockers)}.`,
+    };
+  }
+
+  // No devices and no reason means discovery has not finished. With a reason, it
+  // has, and the reason is the useful thing to say.
+  if (!devices.castable) {
+    return devices.reason === null
+      ? { state: "finding", label: "Finding devices…", disabledReason: null }
+      : { state: "disabled", label: "Cast to TV", disabledReason: devices.reason };
+  }
+
+  return { state: "ready", label: "Cast to TV", disabledReason: null };
+}
+
+/**
+ * `h:mm:ss`.
+ *
+ * Defensive about its input because the input is a float from a television: the
+ * receiver reports `currentTime` as a float, and has been seen to report a small
+ * negative one while it is still seeking.
+ */
+export function formatCastTime(seconds: number): string {
+  const total = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  return `${String(h)}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/** The line under "Playing on <device>", or null when nothing is casting. */
+export function castStatusLine(status: CastStatusResponse): string | null {
+  const casting = status.casting;
+  if (!casting) return null;
+  if (casting.state === "loading") return "Loading on the TV…";
+  if (casting.state === "idle") return "Finished on the TV.";
+  // A duration the receiver has not reported is null, not zero: showing
+  // "0:00:05 / 0:00:00" would read as a broken file rather than an unknown length.
+  const elapsed = formatCastTime(casting.positionSec);
+  const clock =
+    casting.durationSec === null ? elapsed : `${elapsed} / ${formatCastTime(casting.durationSec)}`;
+  return casting.state === "paused" ? `Paused · ${clock}` : clock;
+}
+
+export type CastControl = "play" | "pause" | "stop";
+
+/** Which controls to offer. Stop is always available once something is casting. */
+export function castControls(status: CastStatusResponse): CastControl[] {
+  const casting = status.casting;
+  if (!casting) return [];
+  if (casting.state === "playing") return ["pause", "stop"];
+  if (casting.state === "paused") return ["play", "stop"];
+  // Loading, or finished. Pausing something that has not started is a button
+  // that appears to do nothing.
+  return ["stop"];
+}

--- a/src/web/static/player.html
+++ b/src/web/static/player.html
@@ -38,6 +38,12 @@
       <p id="file-name" class="file-name"></p>
       <div id="stage" class="stage"></div>
       <div id="actions" class="actions"></div>
+      <!-- Casting: a hand-off like the buttons above, so it sits beside them.
+           Its own container rather than a child of #actions because that row is
+           rebuilt per file with replaceChildren, which would drop a live cast's
+           controls the moment anything else re-rendered. Empty (and so invisible)
+           until the device list answers — see castButtonView's "hidden". -->
+      <div id="cast" class="actions cast"></div>
       <p id="notice" class="notice" hidden></p>
       <!-- The rest of the torrent: what is up next, and everything else in it.
            Empty for a single-file session, so a film looks exactly as it did. -->

--- a/src/web/static/player.ts
+++ b/src/web/static/player.ts
@@ -45,7 +45,20 @@ import {
   subtitleTracks,
   type TrackSpec,
 } from "./subtitleModel";
-import type { LibraryRequest, StreamFilesResponse, StreamInfoResponse } from "../wire";
+import {
+  castButtonView,
+  castControls,
+  castStatusLine,
+  castSubtitleIndex,
+  type CastControl,
+} from "./castModel";
+import type {
+  CastDevicesResponse,
+  CastStatusResponse,
+  LibraryRequest,
+  StreamFilesResponse,
+  StreamInfoResponse,
+} from "../wire";
 
 const el = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
 
@@ -198,10 +211,18 @@ function showFallback(
   }
 
   stage.replaceChildren(card);
+  // The <video> is gone, so there is nothing for a stopped cast to resume. The
+  // cast button itself stays: a file the browser refuses is often one the
+  // television takes (an mp4 carrying AC3), which is the point of two profiles.
+  castVideo = null;
+  renderCast();
 }
 
 function createVideo(): HTMLVideoElement {
   const video = document.createElement("video");
+  // Recorded so a cast can pause it and a stopped cast can resume it. One place,
+  // because every path onto the stage comes through here.
+  castVideo = video;
   video.className = "player";
   video.controls = true;
   video.autoplay = true;
@@ -367,6 +388,208 @@ function mountVideo(target: PlayerTarget, src: string, tracks: TrackSpec[]): voi
   tryPlay(video);
 }
 
+// ---- casting ----------------------------------------------------------------
+//
+// Wiring only. Every decision — the label, the disabled reason, the status line,
+// which controls to offer, which subtitle to send — is in `castModel.ts`, which
+// has tests. Nothing below chooses anything.
+
+const castBox = el<HTMLDivElement>("cast");
+
+/**
+ * What the cast UI is drawn from. All three start null, which `castButtonView`
+ * reports as "hidden" — so nothing appears until the server has answered.
+ */
+let castDevices: CastDevicesResponse | null = null;
+let castStatus: CastStatusResponse | null = null;
+let castInfo: StreamInfoResponse | null = null;
+let castTarget: PlayerTarget | null = null;
+/** The <video> element on screen, so a cast can pause it and a stop can resume. */
+let castVideo: HTMLVideoElement | null = null;
+/** True while the device list is expanded, so a re-render does not collapse it. */
+let castPickerOpen = false;
+
+function castHeaders(): Record<string, string> {
+  return { "Content-Type": "application/json", ...authHeadersFor(readStoredToken()) };
+}
+
+/**
+ * Ask the server what can be cast to.
+ *
+ * Null on any failure, including the 401 a cold-opened player link gets: this
+ * page authenticates media with the session capability in `?k=`, but `/api/cast/*`
+ * needs the bearer token, which only a tab that came from the dashboard has. Null
+ * means the button stays hidden, which is the honest answer — someone else's link
+ * cannot drive the devices in this house.
+ */
+async function fetchCastDevices(): Promise<CastDevicesResponse | null> {
+  try {
+    const res = await fetch("/api/cast/devices", { headers: castHeaders() });
+    if (!res.ok) return null;
+    return (await res.json()) as CastDevicesResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function castCommand(action: CastControl): Promise<void> {
+  try {
+    const res = await fetch("/api/cast/command", {
+      method: "POST",
+      headers: castHeaders(),
+      body: JSON.stringify({ action }),
+    });
+    const body = (await res.json()) as CastStatusResponse & { error?: string };
+    if (!res.ok) {
+      showNotice(body.error ?? "That did not work.");
+      return;
+    }
+    castStatus = body;
+    renderCast();
+  } catch {
+    showNotice("Could not reach torlnk.");
+  }
+}
+
+async function startCast(deviceId: string): Promise<void> {
+  if (!castTarget) return;
+  castPickerOpen = false;
+  const subtitleIndex = castSubtitleIndex(castInfo);
+  try {
+    const res = await fetch("/api/cast/start", {
+      method: "POST",
+      headers: castHeaders(),
+      body: JSON.stringify({
+        deviceId,
+        sid: castTarget.sid,
+        index: castTarget.index,
+        ...(subtitleIndex === undefined ? {} : { subtitleIndex }),
+      }),
+    });
+    const body = (await res.json()) as CastStatusResponse & { error?: string };
+    if (!res.ok) {
+      // The server's message is already fit for the screen — a CastError's is
+      // written to be read by a person. Persisted, because it explains a
+      // television that is going to stay blank.
+      showNotice(body.error ?? "Could not cast that.", { persist: true });
+      renderCast();
+      return;
+    }
+    castStatus = body;
+    renderCast();
+  } catch {
+    showNotice("Could not reach torlnk.");
+  }
+}
+
+function renderCast(): void {
+  const view = castButtonView({
+    devices: castDevices,
+    status: castStatus,
+    castBlockers: castInfo?.castBlockers ?? [],
+    hasHls: castInfo?.hls != null,
+  });
+  const children: HTMLElement[] = [];
+
+  if (view.state === "casting" && castStatus) {
+    // The local element stops: two copies of the same film, half a minute apart,
+    // is the worst thing this feature could do.
+    castVideo?.pause();
+    const label = document.createElement("p");
+    label.className = "cast-label";
+    label.textContent = view.label;
+    children.push(label);
+    const line = castStatusLine(castStatus);
+    if (line) {
+      const status = document.createElement("p");
+      status.className = "cast-status";
+      status.textContent = line;
+      children.push(status);
+    }
+    for (const control of castControls(castStatus)) {
+      children.push(
+        button(control === "stop" ? "Stop casting" : control === "play" ? "Resume" : "Pause", () => {
+          void castCommand(control);
+        }),
+      );
+    }
+  } else if (view.state === "ready") {
+    const devices = castDevices?.devices ?? [];
+    if (castPickerOpen && devices.length > 1) {
+      for (const device of devices) {
+        // textContent, never markup: a device name is whatever someone typed
+        // into the Google Home app.
+        children.push(
+          button(device.model ? `${device.name} · ${device.model}` : device.name, () => {
+            void startCast(device.id);
+          }),
+        );
+      }
+      children.push(
+        button("Cancel", () => {
+          castPickerOpen = false;
+          renderCast();
+        }),
+      );
+    } else {
+      children.push(
+        button(view.label, () => {
+          // One device casts straight away; several open the list. A picker for a
+          // single television is a click that asks a question with one answer.
+          if (devices.length === 1) void startCast(devices[0]!.id);
+          else {
+            castPickerOpen = true;
+            renderCast();
+          }
+        }),
+      );
+    }
+  } else if (view.state === "disabled" || view.state === "finding") {
+    const b = button(view.label, () => {});
+    b.disabled = true;
+    children.push(b);
+    if (view.disabledReason !== null) {
+      // A paragraph, not a `title` attribute: a phone can never show a tooltip,
+      // and this is the whole explanation.
+      const why = document.createElement("p");
+      why.className = "cast-why";
+      why.textContent = view.disabledReason;
+      children.push(why);
+    }
+  }
+
+  castBox.replaceChildren(...children);
+  // The local player comes back when a cast ends, wherever it ended — the Stop
+  // button here, the TV's own remote, or a dropped connection.
+  if (view.state !== "casting") castVideo?.play().catch(() => {});
+}
+
+/**
+ * Follow cast state for as long as this page is open.
+ *
+ * The same `/api/events` stream the dashboard uses, so a cast started on a laptop
+ * shows on a phone looking at this server. The token rides in `?k=` because
+ * `EventSource` cannot set a header; with no token there is nothing to follow,
+ * and the button is hidden anyway.
+ */
+function followCast(): void {
+  const token = readStoredToken();
+  if (!token) return;
+  const source = new EventSource(`/api/events?k=${encodeURIComponent(token)}`);
+  source.addEventListener("cast", (event) => {
+    try {
+      const body = JSON.parse((event as MessageEvent<string>).data) as CastStatusResponse;
+      castStatus = body;
+      // A cast that ended badly says so once, and persists: it explains a
+      // television that has stopped, which a four-second notice would not.
+      if (body.notice) showNotice(body.notice, { persist: true });
+      renderCast();
+    } catch {
+      // A frame this page cannot parse is not worth interrupting playback for.
+    }
+  });
+}
+
 async function render(): Promise<void> {
   const target = parsePlayerLocation(location.pathname, location.search);
   if (!target || !target.capability) {
@@ -374,6 +597,15 @@ async function render(): Promise<void> {
     showFallback("no-link", "");
     return;
   }
+
+  castTarget = target;
+  // Not awaited: discovery listens on a multicast socket for two seconds, and a
+  // player page must not wait on the network to show a film. The button appears
+  // when it answers (`castButtonView` reports "hidden" until then).
+  void fetchCastDevices().then((devices) => {
+    castDevices = devices;
+    renderCast();
+  });
 
   nameLabel.textContent = target.filename || "Unnamed file";
   nameLabel.title = target.filename;
@@ -447,6 +679,8 @@ async function render(): Promise<void> {
   // browser refuses is now known up front rather than discovered by a decode
   // error that, for mkv in Chrome, never even fires.
   const info = await fetchInfo(target);
+  castInfo = info;
+  renderCast();
   const tracks = subtitleTracks(info, target);
   const download = subtitleDownload(info, target);
   if (download) {
@@ -660,4 +894,5 @@ if (back.kind === "href") {
   });
 }
 
+followCast();
 void render();

--- a/src/web/static/playerModel.test.ts
+++ b/src/web/static/playerModel.test.ts
@@ -154,6 +154,7 @@ describe("chooseSource", () => {
   const info = (over: Partial<StreamInfoResponse> = {}): StreamInfoResponse => ({
     facts: { container: "mp4", videoCodec: "h264", audioCodec: "aac", source: "probe" as const, subtitles: [] },
     blockers: [],
+    castBlockers: [],
     hls: null,
     subtitles: { embedded: [], files: [] },
     ...over,

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1416,6 +1416,32 @@ select:focus-visible {
   color: var(--accent);
 }
 
+/* Casting. A hand-off like the buttons above it, so it borrows their layout
+   rather than introducing a second row language; `align-items` centres the
+   status text against the buttons beside it. */
+.cast {
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+/* "Playing on Living Room TV" — the one line that says the television, not the
+   browser, is showing this. Weighted, because it changes what every other
+   control on the page means. */
+.cast-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+/* The clock, and why a button is disabled. Both are secondary to the controls,
+   and both are prose rather than labels. `.cast-why` is a paragraph and not a
+   `title` attribute because a phone can never show a tooltip. */
+.cast-status,
+.cast-why {
+  margin: 0;
+  color: var(--dim);
+  font-size: 0.9rem;
+}
+
 /* The rest of the torrent. Borrows the picker's vocabulary deliberately — this
    is the same list of the same files, and it should not look like a new idea
    just because it is on a different page. */

--- a/src/web/static/subtitleModel.test.ts
+++ b/src/web/static/subtitleModel.test.ts
@@ -15,6 +15,7 @@ const target: PlayerTarget = { sid: "abc", index: 0, capability: "cap", filename
 const info = (over: Partial<StreamInfoResponse>): StreamInfoResponse => ({
   facts: { container: "mkv", videoCodec: "h264", audioCodec: "aac", source: "probe", subtitles: [] },
   blockers: [],
+  castBlockers: [],
   hls: null,
   subtitles: { embedded: [], files: [] },
   ...over,

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./stream";
 import { DownloadQueue } from "../download/queue";
 import { StreamSessionRegistry, type StreamSessionDeps } from "../core/streamSession";
+import { CastSessionRegistry } from "../core/cast/session";
 import type { TorrentStreamSession } from "../integrations/torrentStream";
 import type { StreamFile } from "../util/player";
 import type { Runtime } from "../daemon/runtime";
@@ -207,7 +208,12 @@ afterEach(async () => {
 });
 
 function runtimeWith(sessions: StreamSessionRegistry): Runtime {
-  return { queue: new DownloadQueue(), downloadDir: "/tmp/dl", sessions };
+  return {
+    queue: new DownloadQueue(),
+    downloadDir: "/tmp/dl",
+    sessions,
+    casts: new CastSessionRegistry(),
+  };
 }
 
 async function start(

--- a/src/web/stream.test.ts
+++ b/src/web/stream.test.ts
@@ -999,6 +999,29 @@ describe("GET /stream/:sid/:idx.info", () => {
     expect(body.hls).toBeNull();
   });
 
+  it("reports cast blockers beside the browser's, because the two decoders differ", async () => {
+    // An mp4 carrying AC3: the browser refuses the audio, a Chromecast passes it
+    // through to the television. This is the pair that lets the fallback card
+    // offer to cast, and the reason there are two profiles rather than one list.
+    const { base, capability, id } = await infoSession({
+      files: [{ url: CDN, filename: "Kestrel.2010.1080p.BluRay.x264.AC3.mp4", bytes: 123 }],
+      name: "Kestrel.2010.1080p.BluRay.x264.AC3-GROUP",
+      streamDeps: { probeImpl: async () => null },
+    });
+    const body = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).json();
+    expect(body.blockers).toEqual(["audio"]);
+    expect(body.castBlockers).toEqual([]);
+  });
+
+  it("agrees with the browser about an mkv, which neither can demux", async () => {
+    const { base, capability, id } = await infoSession({
+      streamDeps: { probeImpl: async () => null },
+    });
+    const body = await (await fetch(`${base}/stream/${id}/0.info?k=${capability}`)).json();
+    expect(body.blockers).toEqual(["container"]);
+    expect(body.castBlockers).toEqual(["container"]);
+  });
+
   it("prefers the probe when there is one", async () => {
     const { base, capability, id } = await infoSession({
       streamDeps: {
@@ -1785,6 +1808,32 @@ describe("the .vtt representation", () => {
     expect(res.headers["content-type"]).toBe("text/vtt; charset=utf-8");
     expect(res.body).toMatch(/^WEBVTT/);
     expect(res.body).toContain("00:00:01.000 --> 00:00:02.000");
+  });
+
+  it("serves it with CORS, because a Chromecast fetches tracks cross-origin", async () => {
+    // Without this the device drops the track SILENTLY, which reads to the user
+    // as "casting ignores subtitles". Safe here because `?k=` already authorised
+    // the request: the header widens who may READ the response, not who may ask.
+    const { deps, sid, cap } = await readySession(
+      [
+        { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+        { filename: "Kepler.S02E04.1080p.WEB-DL.eng.srt", url: "http://up.test/s", bytes: 40 },
+      ],
+      { body: "1\n00:00:01,000 --> 00:00:02,000\nHello\n" },
+    );
+    const res = await request(deps, `/stream/${sid}/1.vtt?k=${cap}`);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  });
+
+  it("does NOT put CORS on the media itself", async () => {
+    // The media is a range-proxied video or a redirect to a debrid link. Nothing
+    // cross-origin reads it, and widening it would let any page on the LAN read
+    // the user's stream once it had guessed a handle.
+    const { deps, sid, cap } = await readySession([
+      { filename: "Kepler.S02E04.1080p.WEB-DL.mkv", url: "http://up.test/v", bytes: 900 },
+    ]);
+    const res = await request(deps, `/stream/${sid}/0?k=${cap}`);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
   });
 
   it("refuses an index that is not a subtitle file", async () => {

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -22,7 +22,13 @@ import https from "node:https";
 import { isAuthorized } from "../daemon/auth";
 import { streamHandle, toPublicSession } from "./routes";
 import { probeUrl } from "../core/probe";
-import { blockersFor, classifyFromName, extensionOf, type MediaFacts } from "../util/playability";
+import {
+  CHROMECAST_PROFILE,
+  blockersFor,
+  classifyFromName,
+  extensionOf,
+  type MediaFacts,
+} from "../util/playability";
 import type { ProbeCache } from "../core/probeCache";
 import type { HlsVerdictCache } from "../core/hlsVerdictCache";
 import type { StreamSession, StreamSessionRegistry } from "../core/streamSession";
@@ -519,6 +525,7 @@ export async function handleStreamRequest(
     const body: StreamInfoResponse = {
       facts,
       blockers: blockersFor(facts),
+      castBlockers: blockersFor(facts, CHROMECAST_PROFILE),
       hls,
       subtitles: {
         embedded: facts.subtitles,
@@ -582,6 +589,13 @@ export async function handleStreamRequest(
       // Same reason as the playlist: the URL that produced this carries a
       // capability for a session that will be reaped.
       "Cache-Control": "no-store",
+      // A Chromecast's receiver runs on an HTTPS origin of Google's and fetches
+      // sidecar tracks cross-origin; without this it drops the track SILENTLY,
+      // which reads to the user as "casting ignores subtitles". ONLY this
+      // representation gets it — the media handle must not, and a test pins that.
+      // It is safe here because `?k=` has already authorised the request: the
+      // header widens who may READ the response, not who may make it.
+      "Access-Control-Allow-Origin": "*",
     });
     if (method !== "HEAD") res.end(payload);
     else res.end();

--- a/src/web/stream.ts
+++ b/src/web/stream.ts
@@ -362,6 +362,103 @@ function backendProtocols(session: StreamSession): readonly string[] {
 }
 
 /**
+ * What one file in a session actually is, and the best source available for it.
+ *
+ * Extracted from the `.info` branch when casting needed the same answer. It must
+ * stay one implementation: two would be the copy-then-drift bug this codebase
+ * has recorded four times, and this particular pair would drift into the browser
+ * and a television disagreeing about the same file.
+ *
+ * `facts` are the *decoder-agnostic* truth about the media. Which blockers they
+ * imply is the caller's question, because a browser and a Chromecast answer it
+ * differently (`blockersFor`, `src/util/playability.ts`).
+ */
+export interface MediaSource {
+  facts: MediaFacts;
+  /** A provider HLS manifest, verified usable, or null. */
+  hls: string | null;
+}
+
+export async function mediaSourceFor(
+  deps: StreamDeps,
+  session: StreamSession,
+  index: number,
+): Promise<MediaSource> {
+  const file = session.files[index]!;
+  const container = extensionOf(file.filename);
+  let facts = deps.probeCache?.get(session.id, index);
+  if (!facts) {
+    // Only probe a file we would otherwise refuse.
+    //
+    // A probe is a spawn plus a network round trip against a CDN or a
+    // half-downloaded torrent, and it is bounded at 15s. Paying that on every
+    // player page load — including for the mp4 that was going to play
+    // instantly — to catch the uncommon mp4-carrying-HEVC would make the common
+    // path markedly slower in order to serve the rare one. So the name decides
+    // first, and the probe runs only when the name says this needs more than
+    // direct play, where the accurate answer is what picks the rung.
+    //
+    // The cost of this order: an mp4 whose HEVC the name does not mention still
+    // gets optimism, a decode error and the fallback card — the same as before
+    // this route existed, and one tap from working. That is the trade.
+    //
+    // The BROWSER profile decides whether to probe, deliberately, even though a
+    // cast asks about a Chromecast: probing is a cost, the browser profile is the
+    // stricter of the two, and a file it would refuse is exactly the set worth
+    // spending a probe on. A file only the Chromecast profile refuses (HEVC in an
+    // mp4 that the name declares) is already named by `classifyFromName`.
+    //
+    // `session.name` is the release the file came from. A debrid provider often
+    // renames the file itself ("1.mkv"), so the release name is the richer codec
+    // signal and the server is the only place that has both.
+    const fromName = classifyFromName(file.filename, session.name);
+    if (blockersFor(fromName).length === 0) {
+      facts = fromName;
+    } else {
+      const probe = deps.probeImpl ?? ((url: string, c: string) => probeUrl(url, c));
+      // A probe failure is not an error: classifyFromName is always available.
+      facts = (await probe(file.url, container)) ?? fromName;
+    }
+    deps.probeCache?.set(session.id, index, facts);
+  }
+  // Rung 2 is the provider's own manifest, which the client fetches from the
+  // provider directly. That is the whole point of it — and the exact thing
+  // relaying exists to stop, so the two features have to agree: while relaying,
+  // no URL handed to a player may point at the provider. Offering it anyway
+  // would route the containers a browser cannot demux — the ones most likely to
+  // be a big remux — around the relay the user asked for, and show the provider
+  // the viewer's address. The ladder falls to a direct play through this handle
+  // instead.
+  const resolved =
+    deps.resolveHls && deps.proxyDebrid !== true ? await deps.resolveHls(session, index) : null;
+  // A manifest existing is not the same as a manifest working. Measured against
+  // Real-Debrid: for 1080p HEVC its transcoder runs at 0.65x realtime and serves
+  // the segments it has not finished as complete 200s with a Content-Length
+  // matching a truncated body — so the client cannot tell, and playback freezes a
+  // few seconds in with no error event to react to. See `hlsHealth.ts` for the
+  // measurements.
+  //
+  // So the rung is offered only when a segment past the transcoder's opening
+  // burst comes back whole. The check is skipped entirely when nothing injected
+  // one, which keeps a caller that has not wired it on the previous behaviour
+  // rather than silently dropping every manifest.
+  let hls = resolved;
+  if (resolved !== null && deps.checkHls) {
+    const remembered = deps.hlsVerdictCache?.get(session.id, index);
+    const usable = remembered ?? (await deps.checkHls(resolved));
+    deps.hlsVerdictCache?.set(session.id, index, usable);
+    if (!usable) {
+      // The verdict, never the URL: a transcode manifest is an unguessable URL
+      // minted for one file, i.e. a capability, and belongs in a log line no more
+      // than an unrestricted link does.
+      deps.log("stream: provider transcode is not keeping up; not offering HLS");
+      hls = null;
+    }
+  }
+  return { facts, hls };
+}
+
+/**
  * Serve one stream request. Writes the response itself — this route owns its
  * socket, unlike everything in `routes.ts`.
  *
@@ -456,72 +553,7 @@ export async function handleStreamRequest(
   // backend split — because the answer is about the media, not about which
   // backend happens to be serving it.
   if (rep === "info") {
-    const container = extensionOf(file.filename);
-    let facts = deps.probeCache?.get(parsed.sid, parsed.index);
-    if (!facts) {
-      // Only probe a file we would otherwise refuse.
-      //
-      // A probe is a spawn plus a network round trip against a CDN or a
-      // half-downloaded torrent, and it is bounded at 15s. Paying that on every
-      // player page load — including for the mp4 that was going to play
-      // instantly — to catch the uncommon mp4-carrying-HEVC would make the
-      // common path markedly slower in order to serve the rare one. So the name
-      // decides first, and the probe runs only when the name says this needs
-      // more than direct play, where the accurate answer is what picks the rung.
-      //
-      // The cost of this order: an mp4 whose HEVC the name does not mention
-      // still gets optimism, a decode error and the fallback card — the same as
-      // before this route existed, and one tap from working. That is the trade.
-      //
-      // `session.name` is the release the file came from. A debrid provider
-      // often renames the file itself ("1.mkv"), so the release name is the
-      // richer codec signal and the server is the only place that has both.
-      const fromName = classifyFromName(file.filename, session.name);
-      if (blockersFor(fromName).length === 0) {
-        facts = fromName;
-      } else {
-        const probe = deps.probeImpl ?? ((url: string, c: string) => probeUrl(url, c));
-        // A probe failure is not an error: classifyFromName is always available.
-        facts = (await probe(file.url, container)) ?? fromName;
-      }
-      deps.probeCache?.set(parsed.sid, parsed.index, facts);
-    }
-    // Rung 2 is the provider's own manifest, which the browser fetches from the
-    // provider directly. That is the whole point of it — and the exact thing
-    // relaying exists to stop, so the two features have to agree: while
-    // relaying, no URL handed to the player may point at the provider. Offering
-    // it anyway would route the containers a browser cannot demux — the ones
-    // most likely to be a big remux — around the relay the user asked for, and
-    // show the provider the viewer's address. The ladder falls to a direct play
-    // through this handle instead.
-    const resolved =
-      deps.resolveHls && deps.proxyDebrid !== true
-        ? await deps.resolveHls(session, parsed.index)
-        : null;
-    // A manifest existing is not the same as a manifest working. Measured
-    // against Real-Debrid: for 1080p HEVC its transcoder runs at 0.65x realtime
-    // and serves the segments it has not finished as complete 200s with a
-    // Content-Length matching a truncated body — so the browser cannot tell, and
-    // playback freezes a few seconds in with no error event to react to. See
-    // `hlsHealth.ts` for the measurements.
-    //
-    // So the rung is offered only when a segment past the transcoder's opening
-    // burst comes back whole. The check is skipped entirely when nothing injected
-    // one, which keeps a caller that has not wired it on the previous behaviour
-    // rather than silently dropping every manifest.
-    let hls = resolved;
-    if (resolved !== null && deps.checkHls) {
-      const remembered = deps.hlsVerdictCache?.get(parsed.sid, parsed.index);
-      const usable = remembered ?? (await deps.checkHls(resolved));
-      deps.hlsVerdictCache?.set(parsed.sid, parsed.index, usable);
-      if (!usable) {
-        // The verdict, never the URL: a transcode manifest is an unguessable URL
-        // minted for one file, i.e. a capability, and belongs in a log line no
-        // more than an unrestricted link does.
-        deps.log("stream: provider transcode is not keeping up; not offering HLS");
-        hls = null;
-      }
-    }
+    const { facts, hls } = await mediaSourceFor(deps, session, parsed.index);
     const body: StreamInfoResponse = {
       facts,
       blockers: blockersFor(facts),

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -155,6 +155,16 @@ export interface StreamInfoResponse {
   facts: MediaFacts;
   /** Empty means the browser should be able to play this file as it is. */
   blockers: Blocker[];
+  /**
+   * Empty means a Chromecast should be able to play this file as it is.
+   *
+   * Separate from `blockers` because the two decoders genuinely differ: a
+   * Chromecast passes AC3 and E-AC3 through to the television, which no browser
+   * will decode. See `CHROMECAST_PROFILE` (src/util/playability.ts) for the
+   * trade-off that allows — silence on a TV whose HDMI link cannot take
+   * passthrough — and for why HEVC stays blocked on both.
+   */
+  castBlockers: Blocker[];
   /** A provider HLS manifest the browser can play directly, or null. */
   hls: string | null;
   /**

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -890,3 +890,52 @@ export interface CachedRequest {
 export interface CachedResponse {
   cached: string[];
 }
+
+/**
+ * One Chromecast, as the browser sees it.
+ *
+ * NOTE WHAT IS OMITTED: `host` and `port`. The page picks a device by `id` and
+ * the server holds the address, because a page has no use for it and publishing
+ * the LAN topology of the user's house to any tab buys nothing.
+ */
+export interface PublicCastDevice {
+  id: string;
+  name: string;
+  /** e.g. "Chromecast". Empty when the device did not say. */
+  model: string;
+}
+
+/**
+ * `GET /api/cast/devices` — what can be cast to, and why not when nothing can.
+ *
+ * `castable` is not just "the list is non-empty": casting also needs an address
+ * on this machine that a device could fetch from, which a loopback-bound server
+ * does not have. `reason` is null while discovery has not finished, which is what
+ * lets the button say "Finding devices…" rather than "none found".
+ */
+export interface CastDevicesResponse {
+  devices: PublicCastDevice[];
+  castable: boolean;
+  reason: string | null;
+}
+
+/**
+ * `GET /api/cast/status`, and the `cast` SSE event — the same shape, so a page
+ * has one parser for both.
+ *
+ * `positionSec` is state, not a store: nothing in torlink persists a playback
+ * position (`StreamHistoryItem` tracks a season and an episode), so this drives
+ * the line on screen and is never written to disk.
+ */
+export interface CastStatusResponse {
+  casting: null | {
+    deviceName: string;
+    title: string;
+    state: "loading" | "playing" | "paused" | "idle";
+    positionSec: number;
+    /** Null when the device has not said — a manifest it is still reading. */
+    durationSec: number | null;
+  };
+  /** A cast that ended badly, handed over exactly once. */
+  notice: string | null;
+}


### PR DESCRIPTION
Casting a stream to a Chromecast, from both front ends. In the browser it is a
**Cast to TV** button beside the other hand-off buttons; in the terminal it is
`c` in the stream file picker. Once it is playing: pause, resume, stop and a
live position, in both.

Design: `docs/superpowers/specs/2026-08-01-chromecast-design.md`.
Plan: `docs/superpowers/plans/2026-08-01-chromecast.md`.

## Why torlnk drives the device itself

Google's Cast Web Sender SDK is secure-context-only, and the normal way to reach
this dashboard is `http://192.168.x.x`. A cast button built on the SDK works from
`localhost` and nowhere else — the same dead-button problem `vlcLinks` already
refuses for desktop VLC. So `src/core/cast/` speaks CASTV2 directly: mDNS
discovery, a hand-written six-field protobuf codec, a TLS socket, `LAUNCH` of the
default receiver, `LOAD`, and the commands. That also puts it below both front
ends rather than inside one.

## Both front ends

| | Terminal | Browser |
| --- | --- | --- |
| Entry point | `c` in the file picker | **Cast to TV** in the hand-off row |
| Device list | `CastPrompt.tsx` | a button per device |
| While casting | a cast row, `p` / `x` | status line + controls |
| Reaching it | the same `/api/cast/*` routes, over loopback | the same routes |

The terminal deliberately drives casting **through its own web server's routes**
rather than the registry directly. Those routes already hold the source ladder,
the LAN-origin rule, the refusal messages and the played-file write; calling them
is what stops the two surfaces growing two implementations of one decision.

Nothing here is exempt from the both-front-ends rule — it lands in both.

## What it will and will not play, stated in the README

- MP4/WebM carrying H.264 casts directly.
- **AC3 and E-AC3 are passed through** to the television, which the browser
  refuses — so the fallback card can now offer to cast a file the dashboard
  cannot play. **The cost: on a TV or receiver that cannot decode it, you get
  picture and no sound.** Chosen because the alternative refuses files that would
  almost certainly have played, with no transcode rung underneath on the torrent
  backend. Recorded in the spec and pinned by a test.
- **An MKV casts only on the debrid backend**, via the provider's transcode.
  Straight from the swarm there is nothing to transcode it with, and the button
  says so. (The ladder's local-`ffmpeg` rung was never built — `ffmpegBin.ts`'s
  only consumer is `findFfprobe` — so casting covers exactly what the browser
  covers, and improves for free the day that rung lands.)
- **HEVC casts on neither backend**: a full re-encode needs per-platform hardware
  acceleration. A deliberate gap, same as the browser's.
- The subtitle the browser would have shown goes along as a sidecar track.

## Two things worth a reviewer's attention

1. **Casting from the terminal binds the web UI to the LAN.** The TV has to fetch
   the file from this machine, and the TUI's own stream server binds `localhost`
   on an ephemeral port (`src/integrations/torrentStream.ts:73`). So a cast brings
   the web UI up on a wildcard bind with a **generated token** — and says so in an
   unmissable notice, because it is a real change to what the machine serves.
2. **`Access-Control-Allow-Origin: *` on the `.vtt` representation only.** A
   receiver fetches sidecar tracks cross-origin and drops them *silently* without
   it. The media handle deliberately does **not** get it, and a test asserts both
   halves. Safe because `?k=` has already authorised the request: the header
   widens who may read the response, not who may make it.

Also: a cast is **per-process**. One started in the terminal is not visible to a
separate `torlnk serve --web`, and vice versa; where the TUI hosts the browser UI
itself (`shift+w`) it is one process and both surfaces see the one cast. Sharing
it would need a TUI↔daemon RPC that does not exist. The screen says "not casting"
rather than implying it knows about a cast it cannot see.

## Verified against a real device

Sintel (a Blender open movie — free to share) cast to a SHIELD Android TV: it
loaded, played with sound, and paused, resumed and stopped correctly. Discovery
found four real devices on the LAN. A loopback-bound server correctly reports
`castable: false` with the no-reachable-address reason; a `0.0.0.0` bind reports
true. An unknown session is a 404, a command with nothing casting is a 409, no
token is a 401, and a `.rar` is refused with a reason.

**That live test found two bugs, both fixed here and re-verified:**

- **The position never moved.** A receiver pushes `MEDIA_STATUS` on state
  *changes*, not while it plays, so the clock sat at the 0.3s the `LOAD` reported
  for a film that had been running thirty seconds. Pausing jumped it to 47.1s,
  which is what showed the number was always right and simply was not being asked
  for. Now a `GET_STATUS` every two seconds — confirmed advancing 2.2 → 22.2 over
  25 seconds, and the duration arrives too.
- **A refusal read "A Chromecast can't play this one — a Chromecast won't demux
  this container."** The server and the browser each had their own copy of that
  clause and had already drifted. Moved down to `src/util/castStatus.ts`; a test
  greps for the duplicated subject.

## Shared code moved down rather than copied

`castStatus.ts` (the clock and the refusal clause) and `mediaSourceFor` (extracted
from the `.info` branch, behaviour-neutral, its own commit) both exist because a
second consumer appeared. `blockersFor` gained an optional profile so every
existing call site keeps its exact previous answer — pinned by a test.

## Dependencies

One runtime dependency, `multicast-dns` (ten → eleven), plus `@types/` for it.
The protocol itself is hand-written rather than taking `protobufjs`: roughly a
megabyte into the bundled CLI to encode a message whose shape never varies.

## Gate

`npm test` (2878 passing), `npm run typecheck`, `npm run lint` (only the known
pre-existing `react-hooks/exhaustive-deps` warning in `App.tsx`), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
