### PR TITLE
feat(cast): let a host advertise an address a TV can actually reach (WSL, bridged Docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ anything other than loopback requires a token.
   muxed *inside* the file are named on the fallback card so you know they're there — pulling one out
   has the same ffmpeg problem.
 - **No settings page, but there is a settings control.** Tokens, sources, limits, folders and the
-  [cast device address](#casting-to-a-tv) are still TUI-only — the browser has no page for them, and
+  [cast device and advertised-host addresses](#casting-to-a-tv) are still TUI-only — the browser has no page for them, and
   that includes reccd's own URL and bearer token; the
   browser only learns *whether* reccd is configured (which is what turns on title autocomplete and the
   **For You** tab), never its address or token. It also includes claiming your
@@ -363,6 +363,46 @@ direction and less fussy in another:
 Discovery uses mDNS, which does not cross a Docker bridge or a VLAN — so if you run torlnk in a container
 and the list comes back empty, that's why. The device list lets you type an address (`192.168.0.40`, or
 `host:port`) and remembers it, so a device mDNS can't reach still casts.
+
+##### Casting from WSL, or from a bridged container
+
+If torlnk runs somewhere the television can't reach it *back*, casting needs one more thing. WSL2 in its
+default mode is the case that bites: inside the VM, torlnk's own address is a `172.x` one that nothing on
+your LAN can route to, so it hands the TV a URL that goes nowhere and the TV reports it as a file it
+couldn't play — which blames the file for a network problem.
+
+The clean fix, if your Windows is new enough (Windows 11 22H2+, `wsl --version` reporting WSL 2.0 or
+later), is to put this in `%UserProfile%\.wslconfig` and run `wsl --shutdown`:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+```
+
+That makes WSL share the Windows host's network instead of hiding behind it, which fixes discovery *and*
+reachability — mDNS starts working too, which nothing below can do for you.
+
+Where mirrored mode isn't available, forward the port on the Windows side and then tell torlnk what
+address to advertise, because it has no way to work that out from inside the VM:
+
+```powershell
+netsh interface portproxy add v4tov4 listenport=9162 listenaddress=0.0.0.0 `
+  connectport=9162 connectaddress=<the WSL eth0 address>
+New-NetFirewallRule -DisplayName "torlnk" -Direction Inbound -LocalPort 9162 -Protocol TCP -Action Allow
+```
+
+Then tell torlnk what to advertise. Both cast settings take an environment variable, because the setups
+that need them are deployed into rather than configured on — a `.bashrc` or a compose file's
+`environment:` is where they naturally live, and neither has a TUI to open:
+
+```bash
+TORLINK_CAST_HOST=192.168.0.10        # your Windows machine's LAN address, or host:port
+TORLINK_CAST_DEVICE=192.168.0.40      # the TV, since mDNS won't cross the NAT either
+```
+
+Both are also plain config fields (`castAdvertiseHost` and `castDevice`), and the device one is what the
+terminal's device list writes when you type an address into it. The same applies to Docker without
+`--network host`.
 
 Two limits worth knowing. Casting needs the television to fetch the file *from this machine*, so a cast
 started in the terminal brings the browser UI up on your LAN address with a token if it isn't already

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -11,6 +11,8 @@ import {
   resolveActiveDebrid,
   resolveDebridTokenFor,
   resolveTorBoxToken,
+  resolveCastAdvertiseHost,
+  resolveCastDevice,
   qualityPrefsFrom,
   sanitiseQualityPrefs,
 } from "./config";
@@ -212,6 +214,22 @@ describe("config castDevice", () => {
   });
 });
 
+describe("config castAdvertiseHost", () => {
+  it("round-trips the host a TV should fetch from", async () => {
+    await saveConfig({
+      downloadDir: "/tmp/dl",
+      trackers: [],
+      castAdvertiseHost: "192.168.0.10:8080",
+    });
+    expect((await loadConfig()).castAdvertiseHost).toBe("192.168.0.10:8080");
+  });
+
+  it("stays absent when nothing was set, so castOrigin keeps guessing", async () => {
+    await saveConfig({ downloadDir: "/tmp/dl", trackers: [] });
+    expect((await loadConfig()).castAdvertiseHost).toBeUndefined();
+  });
+});
+
 describe("config favourites", () => {
   it("round-trips favourites with watched episodes", async () => {
     await saveConfig({
@@ -407,5 +425,43 @@ describe("qualityPrefsFrom", () => {
   it("carries the configured preference through", () => {
     expect(qualityPrefsFrom({ maxResolution: "720p", requireFeatures: ["dd"] } as Config))
       .toEqual({ maxResolution: "720p", require: ["dd"], exclude: [] });
+  });
+});
+
+describe("cast resolvers", () => {
+  // Env wins over config, matching every other resolve* helper. It matters more
+  // for these two than most: the setups that need them (WSL, a bridged container)
+  // are deployed into rather than configured on, and have no TUI to open.
+  afterEach(() => {
+    delete process.env.TORLINK_CAST_HOST;
+    delete process.env.TORLINK_CAST_DEVICE;
+  });
+
+  it("prefers the env var over the config file", () => {
+    process.env.TORLINK_CAST_HOST = "192.168.0.10:8080";
+    process.env.TORLINK_CAST_DEVICE = "192.168.0.40";
+    const cfg = { downloadDir: "/tmp", trackers: [], castAdvertiseHost: "wrong", castDevice: "wrong" };
+    expect(resolveCastAdvertiseHost(cfg)).toBe("192.168.0.10:8080");
+    expect(resolveCastDevice(cfg)).toBe("192.168.0.40");
+  });
+
+  it("falls back to the config file, trimmed", () => {
+    const cfg = {
+      downloadDir: "/tmp",
+      trackers: [],
+      castAdvertiseHost: "  192.168.0.10  ",
+      castDevice: "  192.168.0.40  ",
+    };
+    expect(resolveCastAdvertiseHost(cfg)).toBe("192.168.0.10");
+    expect(resolveCastDevice(cfg)).toBe("192.168.0.40");
+  });
+
+  it("is undefined when neither is set, and when both are blank", () => {
+    expect(resolveCastAdvertiseHost({ downloadDir: "/tmp", trackers: [] })).toBeUndefined();
+    expect(resolveCastDevice({ downloadDir: "/tmp", trackers: [] })).toBeUndefined();
+    process.env.TORLINK_CAST_HOST = "   ";
+    expect(
+      resolveCastAdvertiseHost({ downloadDir: "/tmp", trackers: [], castAdvertiseHost: "  " }),
+    ).toBeUndefined();
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -132,6 +132,22 @@ export interface Config {
    * UI is a client of this config and reads the resulting device list.
    */
   castDevice?: string;
+  /**
+   * The host a Chromecast should fetch media from, when it is not this machine's
+   * own address — a host, or `host:port`.
+   *
+   * For a torlnk that a television cannot reach at the address torlnk sees on
+   * itself. WSL2 in its default NAT mode is the case: inside the VM `eth0` is a
+   * `172.x` address that is unroutable from the LAN, so a cast fails on the TV as
+   * "couldn't play this file", blaming the file for a network problem. Set this to
+   * the Windows host's LAN address (with the forwarded port, if it differs) and
+   * casting works. Bridged Docker is the same shape.
+   *
+   * Better still, where it is available: WSL2's `networkingMode=mirrored`, which
+   * removes the problem rather than working around it — mDNS discovery starts
+   * working too, which this setting cannot fix.
+   */
+  castAdvertiseHost?: string;
 }
 
 export const defaultConfig: Config = {
@@ -282,6 +298,28 @@ export function resolveReccConfig(config: Config): ReccClientConfig {
   const url = process.env[RECC_URL_ENV]?.trim() || config.reccUrl?.trim() || undefined;
   const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
   return { reccUrl: url, reccToken: token };
+}
+
+const CAST_ADVERTISE_ENV = "TORLINK_CAST_HOST";
+const CAST_DEVICE_ENV = "TORLINK_CAST_DEVICE";
+
+/**
+ * The host a Chromecast should fetch media from, or undefined to work it out.
+ *
+ * Env wins over config, matching every other resolve* helper — and it matters
+ * more here than most: the setups that need this are the ones torlnk is *deployed*
+ * into rather than configured on. A WSL user's `.bashrc` and a compose file's
+ * `environment:` are where this naturally lives, and neither has a TUI to open.
+ */
+export function resolveCastAdvertiseHost(config: Config): string | undefined {
+  const env = process.env[CAST_ADVERTISE_ENV]?.trim();
+  return env || config.castAdvertiseHost?.trim() || undefined;
+}
+
+/** The configured Chromecast address, if any. Env wins, for the reason above. */
+export function resolveCastDevice(config: Config): string | undefined {
+  const env = process.env[CAST_DEVICE_ENV]?.trim();
+  return env || config.castDevice?.trim() || undefined;
 }
 
 const OMDB_KEY_ENV = "TORLINK_OMDB_KEY";

--- a/src/web/castOrigin.test.ts
+++ b/src/web/castOrigin.test.ts
@@ -41,6 +41,60 @@ describe("castOrigin", () => {
     expect(castOrigin("0.0.0.0", 9161, LOOPBACK_ONLY)).toBeNull();
   });
 
+  describe("the advertised-host override", () => {
+    // WSL2 in its default NAT mode is the case this exists for. Inside the VM,
+    // os.networkInterfaces() reports eth0 at 172.x — non-internal, IPv4, and
+    // perfectly plausible — so without an override this hands the television a
+    // URL it cannot route to, and the failure surfaces as "couldn't play this
+    // file", blaming the file for a network problem. Bridged Docker is the same
+    // shape.
+    const WSL: NetInterfaces = {
+      lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      eth0: [{ address: "172.23.61.4", family: "IPv4", internal: false }],
+    };
+
+    it("wins over the interface that was guessed", () => {
+      expect(castOrigin("0.0.0.0", 9161, WSL, "192.168.0.10")).toBe("http://192.168.0.10:9161");
+    });
+
+    it("wins even over an explicit non-loopback bind", () => {
+      expect(castOrigin("172.23.61.4", 9161, WSL, "192.168.0.10")).toBe("http://192.168.0.10:9161");
+    });
+
+    it("wins over a loopback bind, because the port is forwarded from elsewhere", () => {
+      // The portproxy case: the server listens on loopback inside the VM and
+      // Windows forwards to it. Nothing about this machine's own interfaces can
+      // tell us that, which is exactly why this is a setting and not a guess.
+      expect(castOrigin("127.0.0.1", 9161, WSL, "192.168.0.10")).toBe("http://192.168.0.10:9161");
+    });
+
+    it("accepts host:port and lets the port it names win", () => {
+      // Forwarded ports are usually not the same number on both sides.
+      expect(castOrigin("0.0.0.0", 9161, WSL, "192.168.0.10:8080")).toBe(
+        "http://192.168.0.10:8080",
+      );
+    });
+
+    it("brackets an IPv6 literal", () => {
+      expect(castOrigin("0.0.0.0", 9161, WSL, "2001:db8::5")).toBe("http://[2001:db8::5]:9161");
+    });
+
+    it("falls back to the guess when it is blank or unusable", () => {
+      expect(castOrigin("0.0.0.0", 9161, IFACES, "   ")).toBe("http://192.168.0.98:9161");
+      expect(castOrigin("0.0.0.0", 9161, IFACES, undefined)).toBe("http://192.168.0.98:9161");
+      // A port that is not a number would produce a URL nothing can fetch, so the
+      // guess is better than honouring it.
+      expect(castOrigin("0.0.0.0", 9161, IFACES, "tv.local:nope")).toBe("http://192.168.0.98:9161");
+    });
+
+    it("is not defeated by a loopback address being configured", () => {
+      // Naming loopback as the advertised host cannot be what anyone meant: it is
+      // the one answer guaranteed to be wrong for a television.
+      expect(castOrigin("0.0.0.0", 9161, WSL, "localhost")).toBeNull();
+      expect(castOrigin("0.0.0.0", 9161, WSL, "127.0.0.1")).toBeNull();
+    });
+  });
+
   it("ignores an internal or IPv6 interface when picking a LAN address", () => {
     const mixed: NetInterfaces = {
       lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],

--- a/src/web/castOrigin.ts
+++ b/src/web/castOrigin.ts
@@ -27,12 +27,28 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
  *   the machine's LAN address would produce a cast that fails silently on the
  *   device with no explanation on screen.
  * - A wildcard bind on a machine with no non-loopback IPv4 address.
+ *
+ * `advertise` overrides the whole guess, and is the escape hatch for a host whose
+ * own interfaces are the wrong answer. WSL2 in its default NAT mode is the case
+ * it was added for: inside the VM `eth0` is a `172.x` address that looks entirely
+ * plausible here and is unroutable from the LAN, so a cast would fail on the
+ * television as "couldn't play this file" — blaming the file for a network
+ * problem. Bridged Docker is the same shape. It is a setting rather than a
+ * heuristic because nothing observable from inside the VM distinguishes "my
+ * address" from "the address a TV should use"; only the person who configured the
+ * port forwarding knows.
  */
 export function castOrigin(
   host: string,
   port: number,
   interfaces: NetInterfaces,
+  advertise?: string,
 ): string | null {
+  // The override first, because it exists precisely for the case where this
+  // machine's own interfaces are the WRONG answer and nothing here can tell.
+  const named = parseAdvertised(advertise, port);
+  if (named.kind === "origin") return named.value;
+  if (named.kind === "refuse") return null;
   const trimmed = host.trim();
   if (LOOPBACK_HOSTS.has(trimmed.toLowerCase())) return null;
   const { local, lan } = displayHosts(trimmed, interfaces);
@@ -44,4 +60,54 @@ export function castOrigin(
     return first ? `http://${first}:${port}` : null;
   }
   return `http://${local}:${port}`;
+}
+
+/**
+ * What a configured advertised host means.
+ *
+ * Three answers, not two: "nothing was configured" and "what was configured
+ * cannot work" must behave differently. The first falls back to the guess; the
+ * second refuses outright, because quietly ignoring a setting the user
+ * deliberately wrote is how a cast fails with no explanation on either screen.
+ */
+type Advertised =
+  | { kind: "origin"; value: string }
+  | { kind: "refuse" }
+  | { kind: "none" };
+
+/**
+ * Split `host`, `host:port`, `[v6]` or `[v6]:port`.
+ *
+ * A bare IPv6 literal is ALL colons, so a trailing `:5` in `2001:db8::5` is a
+ * hextet and not a port — which is why an IPv6 host must be bracketed to carry
+ * one. Getting this wrong produced `http://[2001:db8:]:5`.
+ */
+function splitAdvertised(raw: string): { host: string; port: number | null } | null {
+  const bracketed = /^\[(.+)\](?::(\d+))?$/.exec(raw);
+  if (bracketed) {
+    return { host: bracketed[1]!, port: bracketed[2] ? Number(bracketed[2]) : null };
+  }
+  // Two or more colons can only be IPv6, and unbracketed IPv6 carries no port.
+  if ((raw.match(/:/g) ?? []).length >= 2) return { host: raw, port: null };
+  const withPort = /^([^:]+):(\d+)$/.exec(raw);
+  if (withPort) return { host: withPort[1]!, port: Number(withPort[2]) };
+  // A trailing colon with a non-numeric port ("tv.local:nope") is a typo.
+  if (raw.includes(":")) return null;
+  return { host: raw, port: null };
+}
+
+function parseAdvertised(raw: string | undefined, defaultPort: number): Advertised {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return { kind: "none" };
+  const split = splitAdvertised(trimmed);
+  // A typo falls back to the guess rather than refusing: the guess is right on
+  // most hosts, and this setting is only ever needed on a minority of them.
+  if (!split || !split.host) return { kind: "none" };
+  const port = split.port ?? defaultPort;
+  if (port < 1 || port > 65_535) return { kind: "none" };
+  // Loopback cannot be what anyone meant: it is the one answer guaranteed to be
+  // wrong for a television. Refused rather than ignored, so the UI says why.
+  if (LOOPBACK_HOSTS.has(split.host.toLowerCase())) return { kind: "refuse" };
+  const host = split.host.includes(":") ? `[${split.host}]` : split.host;
+  return { kind: "origin", value: `http://${host}:${port}` };
 }

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3484,7 +3484,7 @@ describe("the cast routes", () => {
   function castDeps(over: Partial<WebDeps> = {}): WebDeps {
     return deps({
       discoverCastImpl: async () => [DISCOVERED],
-      castOriginImpl: () => LAN,
+      castOriginImpl: async () => LAN,
       castSourceImpl: async () => ({ facts: facts(), hls: null }),
       ...over,
     });
@@ -3542,7 +3542,7 @@ describe("the cast routes", () => {
     });
 
     it("says why casting is unavailable when this machine has no reachable address", async () => {
-      const res = await get(castDeps({ castOriginImpl: () => null }));
+      const res = await get(castDeps({ castOriginImpl: async () => null }));
       expect(res.json).toMatchObject({ castable: false });
       expect((res.json as CastDevicesResponse).reason).toMatch(/could reach/i);
     });
@@ -3578,6 +3578,22 @@ describe("the cast routes", () => {
       // The played-file write needs both, and neither is on the wire.
       expect(arg.infoHash).toBe("0".repeat(40));
       expect(arg.filename).toBe("Kestrel.2010.1080p.BluRay.x264.mp4");
+    });
+
+    it("casts the origin the server advertises, wherever that came from", async () => {
+      // The WSL / bridged-Docker case, end to end: `castOriginImpl` resolves the
+      // configured advertised host, and the URL the television is handed is built
+      // from that rather than from any interface this process can see.
+      const { runtime: rt, casts, sid, capability } = castRuntime();
+      const start = vi.spyOn(casts, "start").mockResolvedValue({} as never);
+      await post(
+        castDeps({ runtime: rt, castOriginImpl: async () => "http://192.168.0.10:8080" }),
+        "/api/cast/start",
+        { deviceId: "abc", sid, index: 0 },
+      );
+      expect(start.mock.calls[0]![0].media.url).toBe(
+        `http://192.168.0.10:8080/stream/${sid}/0?k=${capability}`,
+      );
     });
 
     it("casts an HLS manifest with the HLS content type when the file itself is blocked", async () => {
@@ -3681,7 +3697,7 @@ describe("the cast routes", () => {
 
     it("409s when this machine has no address a device could fetch from", async () => {
       const { runtime: rt, sid } = castRuntime();
-      const res = await post(castDeps({ runtime: rt, castOriginImpl: () => null }), "/api/cast/start", {
+      const res = await post(castDeps({ runtime: rt, castOriginImpl: async () => null }), "/api/cast/start", {
         deviceId: "abc",
         sid,
         index: 0,

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -19,6 +19,7 @@ import {
 import {
   loadConfig,
   resolveActiveDebrid,
+  resolveCastDevice,
   qualityPrefsFrom,
   resolveAdultContent,
   resolveOmdbApiKey,
@@ -166,7 +167,7 @@ export interface WebDeps {
    * browsing `http://localhost:9161` would otherwise hand a television a URL
    * pointing at the television.
    */
-  castOriginImpl?: () => string | null;
+  castOriginImpl?: () => Promise<string | null>;
   /**
    * What one file is and the best source for it — `mediaSourceFor`
    * (./stream.ts), the same answer the player page's `.info` gets.
@@ -1723,18 +1724,17 @@ function toPublicCastDevice(device: CastDevice): PublicCastDevice {
 async function castDevices(deps: WebDeps): Promise<CastDevice[]> {
   const config = await (deps.loadConfigImpl ?? loadConfig)();
   const found = await (deps.discoverCastImpl ?? (() => discover()))();
-  // Typed rather than trusted: `loadConfig` spreads the parsed JSON, so a
-  // hand-edited `castDevice: 8009` would arrive here as a number.
-  const manual = parseManualDevice(
-    typeof config.castDevice === "string" ? config.castDevice : undefined,
-  );
+  // Via the resolver, so `TORLINK_CAST_DEVICE` works for a deployment with no TUI
+  // to open — and because it trims, which matters when `loadConfig` spreads the
+  // parsed JSON and a hand-edited value arrives as anything at all.
+  const manual = parseManualDevice(resolveCastDevice(config));
   if (!manual || found.some((d) => d.host === manual.host && d.port === manual.port)) return found;
   return [...found, manual];
 }
 
 async function castDevicesRoute(deps: WebDeps): Promise<WebResponse> {
   const devices = await castDevices(deps);
-  const origin = (deps.castOriginImpl ?? (() => null))();
+  const origin = await (deps.castOriginImpl ?? (() => Promise.resolve(null)))();
   // Two independent reasons casting cannot happen, and the file's own blockers
   // are a third the client already knows from `.info`. Naming which one is the
   // difference between "the network" and "this file" for the person looking at a
@@ -1799,7 +1799,7 @@ async function startCast(deps: WebDeps, bodyText: string): Promise<WebResponse> 
   // some other id would have been found.
   if (!device) return { status: 404, json: { error: "unknown device" } };
 
-  const origin = (deps.castOriginImpl ?? (() => null))();
+  const origin = await (deps.castOriginImpl ?? (() => Promise.resolve(null)))();
   if (origin === null) return { status: 409, json: { error: NO_ORIGIN } };
 
   const source = await (deps.castSourceImpl ??

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,7 +39,7 @@ import { makeResolveHls } from "./hlsSource";
 import { contentTypeFor, findStaticDir, resolveAssetPath } from "./staticDir";
 import { readBody, statusPayload } from "../daemon/serve";
 import { LOOPBACK_HOSTS, hostHeaderOk, isAuthorized, isCrossSiteHttpRequest } from "../daemon/auth";
-import { loadConfig } from "../config/config";
+import { loadConfig, resolveCastAdvertiseHost } from "../config/config";
 import type { Runtime } from "../daemon/runtime";
 
 export const DEFAULT_WEB_PORT = 9162;
@@ -310,7 +310,13 @@ export async function startWebServer(
     // claim by a client: a user browsing `http://localhost:9161` would otherwise
     // hand the device a URL pointing at the device itself. `host` is what this
     // server actually bound, which is a fact about what is reachable.
-    castOriginImpl: () => castOrigin(host, boundPort, os.networkInterfaces()),
+    castOriginImpl: async () => {
+      // Config per call, never a snapshot: `serve --web` is a separate process
+      // from any TUI where the user may have just fixed this very setting, and a
+      // held copy would keep handing a television an address that does not work.
+      const cfg = await (options.webDeps?.loadConfigImpl ?? loadConfig)();
+      return castOrigin(host, boundPort, os.networkInterfaces(), resolveCastAdvertiseHost(cfg));
+    },
     // The same answer the player page's `.info` gets, from the same function, so
     // a browser and a television cannot disagree about one file.
     castSourceImpl: async (session, index) => mediaSourceFor(await buildStreamDeps(), session, index),


### PR DESCRIPTION
Follow-up to #79, from a question it could not answer: *"I'm on Windows running
torlnk in WSL — would that see the Chromecast on the wider network?"*

No, and for two separate reasons. Only one of them #79 could already work around.

| | What happens in NAT'd WSL2 | Covered by #79? |
| --- | --- | --- |
| **Discovery** | mDNS is multicast and does not cross the WSL NAT boundary, so the device list is empty | **Yes** — type the TV's address into the device list |
| **The TV fetching the file** | `castOrigin` read `os.networkInterfaces()` *inside* the VM, found `eth0` at `172.x`, and handed the television a URL nothing on the LAN can route to | **No** |

The second one is the bad one, because of how it fails: the TV cannot fetch, so it
answers `LOAD_FAILED`, and torlnk reports **"couldn't play this file"** — blaming
the file for a network problem. The user is then debugging the wrong thing.

`castOrigin`'s assumption was that this machine's own interfaces are ones a
television can reach. That holds on bare metal, on Docker with `--network host`,
and on WSL2 in mirrored mode. It does not hold on NAT'd WSL2 or bridged Docker.

## The change

An override for the advertised origin: **`TORLINK_CAST_HOST`**, or
`castAdvertiseHost` in `config.json`. `TORLINK_CAST_DEVICE` joins it for the
existing device setting.

- **A setting, not a heuristic.** Nothing observable from inside the VM
  distinguishes "my address" from "the address a television should use" — only
  whoever configured the port forwarding knows. Guessing would trade one silent
  wrong answer for another.
- **Env vars, because of who needs this.** These setups are *deployed into* rather
  than configured on: a `.bashrc` or a compose file's `environment:` is where this
  lives, and neither has a TUI to open. Env wins over config, matching every other
  `resolve*` helper in `config.ts`.
- **Read per request, never snapshotted** — `serve --web` is a separate process
  from any TUI where the user may have just fixed this very setting. That made
  `castOriginImpl` async.
- **Naming loopback there is refused, not ignored.** It is the one answer
  guaranteed to be wrong for a television, and silently falling back to the guess
  would discard a setting the user deliberately wrote. A typo'd port *does* fall
  back, because the guess is right on most hosts.

The README leads with WSL2's `networkingMode=mirrored` rather than with this
setting, because mirrored mode fixes **discovery too** — which no amount of
advertised-host configuration can do. The override is documented as the fallback
for Windows 10 and anywhere mirrored mode is unavailable, alongside the
`netsh portproxy` and firewall commands it needs to be useful.

## Notes for review

- `parseAdvertised` had two bugs I wrote and the tests caught: a greedy `:(\d+)$`
  turned `2001:db8::5` into host `2001:db8:` port `5`, and a configured loopback
  fell through to the guess instead of refusing. Both are pinned now.
- The WSL fixture in `castOrigin.test.ts` is a real-shaped one (`eth0` at
  `172.23.61.4`, non-internal, IPv4) precisely because it is *plausible* — that
  plausibility is the whole bug.
- Untested against real WSL: I have no Windows machine here. The unit tests cover
  the address logic, but if you can try it, `TORLINK_CAST_HOST` plus a portproxy
  is the path to exercise.

`npm test` (2891), `npm run typecheck`, `npm run lint` (only the known pre-existing
`App.tsx` warning), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
