### PR TITLE
feat: season play reveals episodes and lands on next-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,12 @@ group at all.
 
 **A show nests the way a show does.** One row per season, newest first, holding the season packs and then
 each episode in order — so a search for a show is a handful of rows rather than forty siblings in seeder
-order. The season you are most likely to want opens itself; the rest stay shut until you ask. Acting on a
-collapsed season acts on its best **season pack**, so `play` on `Harrowgate S03` gets the season and not
-episode one. Inside a season the show's name is stated once, by the season row, and its children read
+order. The season you are most likely to want opens itself; the rest stay shut until you ask. A collapsed
+season that has a **season pack** plays the pack, so `play` on `Harrowgate S03` gets the season and not
+episode one — and the pack's file picker opens on the episode you are up to. A season that is only loose
+episodes has no such single torrent, so `play` there **reveals the episodes and selects the one you are up
+to** (the next one if you are part-way through, else the first) rather than silently playing episode one —
+you choose which to watch. Inside a season the show's name is stated once, by the season row, and its children read
 `Season pack`, `S03E01`, `S03E02`. The **group** control still turns all of it off and gives you every
 release as its own row.
 

--- a/docs/superpowers/plans/2026-08-10-season-play-episode-picker.md
+++ b/docs/superpowers/plans/2026-08-10-season-play-episode-picker.md
@@ -1,0 +1,585 @@
+# Season play → episode picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pressing play on a collapsed season made of loose episode releases reveals the episodes and lands on the next-up one instead of silently playing episode 1; and a live search auto-expands to the next-up episode instead of latching collapsed on the first sparse SSE frame.
+
+**Architecture:** Two new pure functions in the shared `src/util/resultGroup.ts` — `seasonPlayPlan` (what play does on a season row) and `expansionSeed` (what to auto-open/land on, and when to stop retrying). Both front ends (`src/web/static/app.ts`, `src/ui/components/Results.tsx`) become thin wiring over them, per CLAUDE.md ("decisions in pure modules; move shared logic down, never copy"). Season packs are left on their existing resolve→file-picker path (already preselects the next episode).
+
+**Tech Stack:** TypeScript, Vitest, Ink/React (TUI), vanilla DOM (web). Verify with `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`.
+
+---
+
+## File structure
+
+- `src/util/resultGroup.ts` — add `SeasonPlayPlan`, `seasonPlayPlan`, `ExpansionSeed`, `expansionSeed`. (Modify.)
+- `src/util/resultGroup.test.ts` — add tests for both. (Modify.)
+- `src/web/static/searchModel.ts` — re-export the two functions + types for the browser bundle. (Modify.)
+- `src/web/static/app.ts` — season-row play override; replace the inline seeding block with `expansionSeed`. (Modify.)
+- `src/ui/components/Results.tsx` — `v`-key reveal for season rows; seeding/landing effects use `expansionSeed` and stop disarming on a transient sparse frame. (Modify.)
+
+Fixtures use only the invented cast from CLAUDE.md (`Kepler.S02E0x` episodes, `Kepler.S02` pack, `Harrowgate.S03` pack). No real titles.
+
+---
+
+## Task 1: `seasonPlayPlan` in the shared module
+
+**Files:**
+- Modify: `src/util/resultGroup.ts`
+- Test: `src/util/resultGroup.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/util/resultGroup.test.ts` (import `seasonPlayPlan` in the existing top `import { … } from "./resultGroup"` block):
+
+```ts
+describe("seasonPlayPlan", () => {
+  // A show whose season 2 is present as loose episodes only.
+  const looseSeason = () =>
+    groupResults([
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+      r("Kepler.S02E03.1080p.WEB-DL"),
+    ]);
+  const seasonKey = "kepler|series|s2";
+  const upTo = (episode: number): PositionLookup => (showKey) =>
+    showKey === "kepler" ? { season: 2, episode } : null;
+
+  it("reveals loose episodes and lands on the next-up episode", () => {
+    const plan = seasonPlayPlan(looseSeason(), seasonKey, upTo(1));
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.expandKey).toBe(seasonKey);
+    expect(plan.selectKey).toBe("kepler|series|s2|e2");
+    expect(plan.select?.name).toBe("Kepler.S02E02.1080p.WEB-DL");
+  });
+
+  it("lands on the first episode when there is no watch position", () => {
+    const plan = seasonPlayPlan(looseSeason(), seasonKey);
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.selectKey).toBe("kepler|series|s2|e1");
+  });
+
+  it("lands on the first episode when the next-up episode is not in the results", () => {
+    // Up to E03 → next is E04, which the results do not have.
+    const plan = seasonPlayPlan(looseSeason(), seasonKey, upTo(3));
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.selectKey).toBe("kepler|series|s2|e1");
+  });
+
+  it("resolves (does not reveal) when the season contains a pack", () => {
+    const groups = groupResults([
+      r("Kepler.S02.1080p.WEB-DL"),
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+    ]);
+    const plan = seasonPlayPlan(groups, seasonKey, upTo(1));
+    expect(plan.kind).toBe("resolve");
+    if (plan.kind !== "resolve") throw new Error("expected resolve");
+    // members[0] is the best pack (packs sort ahead of episodes).
+    expect(plan.result.name).toBe("Kepler.S02.1080p.WEB-DL");
+  });
+
+  it("resolves for a key that is not a season node", () => {
+    const groups = groupResults([r("Kestrel.2010.1080p.BluRay.x264")]);
+    const plan = seasonPlayPlan(groups, "kestrel|2010|movie");
+    expect(plan.kind).toBe("resolve");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t seasonPlayPlan`
+Expected: FAIL — `seasonPlayPlan is not a function` / not exported.
+
+- [ ] **Step 3: Implement `seasonPlayPlan`**
+
+Add to `src/util/resultGroup.ts`, after `resultAtRow` (near line 514). It reuses the file's existing `seasonTree`, `isSeasonNode`, `SeasonNode`, `showKeyOf`, `PositionLookup`, `GroupableResult`, `ResultGroup`:
+
+```ts
+/**
+ * What pressing play on a SEASON row should do.
+ *
+ * A season made of loose episodes has no single "the season" torrent, so
+ * `members[0]` is merely the best release of episode one — playing it silently is
+ * the bug this fixes. Instead: reveal the episodes and land on the one you are up
+ * to. A season that DOES contain a pack keeps today's behaviour — grab the pack
+ * (`members[0]`; packs sort first) and let the resolve→file-picker path preselect
+ * the next episode, which also surfaces any extras inside the pack.
+ *
+ * Pure and shared so both front ends decide identically; the front ends only
+ * wire the two outcomes. `resultAtRow` is deliberately NOT changed — add,
+ * favourite and preview still resolve a release from it.
+ */
+export type SeasonPlayPlan<T> =
+  | { kind: "resolve"; result: T | null }
+  | { kind: "reveal"; expandKey: string; selectKey: string | null; select: T | null };
+
+export function seasonPlayPlan<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+  seasonKey: string,
+  positionFor?: PositionLookup,
+): SeasonPlayPlan<T> {
+  const node = seasonTree(groups).find(
+    (n): n is SeasonNode<T> => isSeasonNode(n) && n.key === seasonKey,
+  );
+  // Not a season row (a film, a single-episode group) or gone: behave as play
+  // does today — resolve the first member.
+  if (!node) {
+    return { kind: "resolve", result: groups.find((g) => g.key === seasonKey)?.members[0] ?? null };
+  }
+  // A child with no episode number is a pack: the whole season in one torrent.
+  if (node.children.some((c) => c.episode === undefined)) {
+    return { kind: "resolve", result: node.members[0] ?? null };
+  }
+  // Loose episodes only. Land on the next-up episode when the results have it,
+  // else the first episode. `children` are episodes ascending (seasonTree sorts).
+  const at = positionFor?.(showKeyOf(node.key)) ?? null;
+  const target =
+    (at &&
+      node.children.find((c) => c.season === at.season && c.episode === at.episode + 1)) ||
+    node.children[0]!;
+  return {
+    kind: "reveal",
+    expandKey: node.key,
+    selectKey: target.key,
+    select: target.members[0] ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t seasonPlayPlan`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/resultGroup.ts src/util/resultGroup.test.ts
+git commit -m "feat(core): seasonPlayPlan — reveal loose episodes, resolve packs"
+```
+
+---
+
+## Task 2: `expansionSeed` in the shared module
+
+**Files:**
+- Modify: `src/util/resultGroup.ts`
+- Test: `src/util/resultGroup.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/util/resultGroup.test.ts` (import `expansionSeed`):
+
+```ts
+describe("expansionSeed", () => {
+  const looseSeason = () =>
+    groupResults([
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+      r("Kepler.S02E03.1080p.WEB-DL"),
+    ]);
+  const upTo1: PositionLookup = (showKey) => (showKey === "kepler" ? { season: 2, episode: 1 } : null);
+
+  it("opens the season and points selection at the next-up episode", () => {
+    const seed = expansionSeed(looseSeason(), upTo1, false);
+    expect(seed.expandKeys).toContain("kepler|series|s2");
+    expect(seed.selectKey).toBe("kepler|series|s2|e2");
+    expect(seed.latch).toBe(true); // something was opened
+  });
+
+  it("does NOT latch on a sparse frame that forms no season, while the search runs", () => {
+    // One episode → seasonTree drops a single-child season, so nothing to open.
+    const oneEpisode = groupResults([r("Kepler.S02E01.1080p.WEB-DL")]);
+    const seed = expansionSeed(oneEpisode, upTo1, false);
+    expect(seed.expandKeys).toEqual([]);
+    expect(seed.latch).toBe(false); // keep retrying as more results stream in
+  });
+
+  it("latches once the search has settled even with nothing to open", () => {
+    const oneEpisode = groupResults([r("Kepler.S02E01.1080p.WEB-DL")]);
+    const seed = expansionSeed(oneEpisode, upTo1, true);
+    expect(seed.latch).toBe(true); // settled: stop retrying
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t expansionSeed`
+Expected: FAIL — `expansionSeed is not a function`.
+
+- [ ] **Step 3: Implement `expansionSeed`**
+
+Add to `src/util/resultGroup.ts`, after `seasonPlayPlan`. It reuses the existing `defaultExpandedKeys` and `nextUpRowKey`:
+
+```ts
+/**
+ * What a fresh result set should open and land on — and whether to stop trying.
+ *
+ * WHY `latch`: results stream in over SSE, so the FIRST frame is usually too
+ * sparse to have formed the multi-episode season. Seeding on that frame and
+ * latching (the previous behaviour in both front ends) opened nothing and never
+ * retried, so a search for a show you are part-way through rendered collapsed
+ * with no episode selected. Retry until either an expansion is applied or the
+ * search settles — never latch on a frame that produced neither.
+ */
+export interface ExpansionSeed {
+  /** Season keys to open. */
+  expandKeys: string[];
+  /** The group key to land selection on, or null. */
+  selectKey: string | null;
+  /** True once seeding is settled; the caller stops retrying. */
+  latch: boolean;
+}
+
+export function expansionSeed<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+  positionFor: PositionLookup | undefined,
+  searchSettled: boolean,
+): ExpansionSeed {
+  const expandKeys = defaultExpandedKeys(groups, positionFor);
+  return {
+    expandKeys,
+    selectKey: nextUpRowKey(groups, positionFor),
+    latch: expandKeys.length > 0 || searchSettled,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/util/resultGroup.test.ts -t expansionSeed`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/resultGroup.ts src/util/resultGroup.test.ts
+git commit -m "feat(core): expansionSeed — retry auto-expand until formed or settled"
+```
+
+---
+
+## Task 3: Re-export both functions for the browser bundle
+
+**Files:**
+- Modify: `src/web/static/searchModel.ts`
+
+- [ ] **Step 1: Add to the existing `resultGroup` re-export block** (around `searchModel.ts:59-70`)
+
+Change the block to include the new names and types (alphabetical, matching the file's style):
+
+```ts
+export {
+  defaultExpandedKeys,
+  expansionSeed,
+  groupCountLabel,
+  groupHeading,
+  nextUpRowKey,
+  positionNote,
+  resultAtRow,
+  seasonPlayPlan,
+  showKeyOf,
+  type ExpansionSeed,
+  type GroupRow,
+  type PositionLookup,
+  type ResultGroup,
+  type SeasonPlayPlan,
+} from "../../util/resultGroup";
+```
+
+- [ ] **Step 2: Verify the re-export type-checks**
+
+Run: `npm run typecheck`
+Expected: PASS (no new errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web/static/searchModel.ts
+git commit -m "chore(web): re-export seasonPlayPlan and expansionSeed"
+```
+
+---
+
+## Task 4: Web — season-row play reveals episodes
+
+**Files:**
+- Modify: `src/web/static/app.ts` (imports; `resultActions` ~2064; `renderGroupRow` ~2471)
+
+- [ ] **Step 1: Import the two helpers**
+
+In the `from "./searchModel"` import block (around `app.ts:51-82`), add `expansionSeed`, `seasonPlayPlan` (and, if needed later, `visibleGroups` is already imported). Alphabetical within the block.
+
+- [ ] **Step 2: Give `resultActions` an optional play override**
+
+Change the signature and the play-button wiring (`app.ts:2064` and `2077`):
+
+```ts
+function resultActions(
+  result: PublicSearchResult,
+  rowKey: string,
+  onPlay?: () => void,
+): HTMLDivElement {
+```
+
+and
+
+```ts
+  playButton.addEventListener("click", () => {
+    if (onPlay) onPlay();
+    else void play(rowForPlay(result));
+  });
+```
+
+- [ ] **Step 3: Compute the season play plan in `renderGroupRow` and pass the override**
+
+In `renderGroupRow` (`app.ts:2471`), replace the single `resultActions(best, row.key)` call inside the `body.append(...)` (line 2514) with a computed override for season rows:
+
+```ts
+  // A season made of loose episodes plays nothing on click: it reveals the
+  // episodes and lands on the one you are up to. The decision is seasonPlayPlan
+  // (pure); this is only the wiring. A pack season / any other row keeps play.
+  let onPlay: (() => void) | undefined;
+  if (row.kind === "season") {
+    const positionFor = positionLookup(savedState.continueWatching);
+    const plan = seasonPlayPlan(
+      visibleGroups(searchView, reportsHealthLookup(sources)),
+      row.key,
+      positionFor,
+    );
+    if (plan.kind === "reveal") {
+      const target = plan.select;
+      onPlay = () => {
+        expandedGroups.add(plan.expandKey);
+        if (target) selectResult(target);
+        else renderResults();
+      };
+    }
+  }
+  body.append(head, meta, resultActions(best, row.key, onPlay));
+```
+
+Note: `selectResult` already sets `selectedHash`, re-renders, and updates the preview; adding `plan.expandKey` to `expandedGroups` first means the re-render shows the episodes with the next-up row highlighted.
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Manual verification in the browser**
+
+Run: `npm run dev -- serve --web` (note the port/token it prints), then in a browser search a show with loose episodes and a known watch position. Press play on the collapsed season row.
+Expected: the season expands and the next-up episode row is highlighted; nothing starts playing. Pressing play on an episode row still plays it. A season that contains a pack still resolves→file-picker as before.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/app.ts
+git commit -m "feat(web): season play reveals loose episodes and lands on next-up"
+```
+
+---
+
+## Task 5: Web — fix the auto-expand seeding latch
+
+**Files:**
+- Modify: `src/web/static/app.ts` (`renderResults`, the `if (!seededExpansion)` block ~2559-2572)
+
+- [ ] **Step 1: Replace the seeding block with `expansionSeed`**
+
+Replace the whole `if (!seededExpansion) { … }` block (`app.ts:2559-2572`) with:
+
+```ts
+  if (!seededExpansion) {
+    const groups = visibleGroups(searchView, reportsHealthLookup(sources));
+    if (groups.length > 0) {
+      const positionFor = positionLookup(savedState.continueWatching);
+      // `running` is true between submit and the `done` frame; !running == settled.
+      const seed = expansionSeed(groups, positionFor, !searchView.running);
+      for (const key of seed.expandKeys) expandedGroups.add(key);
+      // Select the episode you are up to, resolved from the GROUPS (rows do not
+      // exist yet). Null when the results do not have it — nothing phantom.
+      const landing = seed.selectKey ? groups.find((g) => g.key === seed.selectKey) : undefined;
+      if (landing?.members[0]) selectedHash = landing.members[0].infoHash;
+      // Latch only once something was opened or the search settled, so a sparse
+      // first SSE frame no longer freezes the list collapsed.
+      seededExpansion = seed.latch;
+    }
+  }
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Manual verification**
+
+With `npm run dev -- serve --web` running, do a fresh search for a show you are part-way through (no manual expanding).
+Expected: once results finish streaming, the season is already expanded with the next-up episode highlighted — no click needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/web/static/app.ts
+git commit -m "fix(web): don't latch auto-expand on the first sparse SSE frame"
+```
+
+---
+
+## Task 6: Terminal — `v` on a loose-episode season reveals it
+
+**Files:**
+- Modify: `src/ui/components/Results.tsx` (imports ~21-30; `v` handler ~729-731)
+
+- [ ] **Step 1: Import the helpers**
+
+In the `from "../../util/resultGroup"` import block (`Results.tsx:21-30`), add `expansionSeed` and `seasonPlayPlan`.
+
+- [ ] **Step 2: Change the `v` (stream) handler to reveal a loose-episode season**
+
+Replace the `v` branch (`Results.tsx:729-731`):
+
+```ts
+      } else if (input === "v") {
+        const row = rows[clamped];
+        if (row?.kind === "season") {
+          const plan = seasonPlayPlan(
+            groupResults(results, hintForSection(section)),
+            row.key,
+            positionFor,
+          );
+          if (plan.kind === "reveal") {
+            // Reveal the episodes and land the cursor on the next-up one. selRef
+            // moves the cursor to the row once the rebuilt rows include it.
+            if (plan.select) selRef.current = { key: plan.selectKey!, hash: plan.select.infoHash };
+            setExpanded((current) => new Set(current).add(plan.expandKey));
+          } else if (plan.result) {
+            openStream(plan.result);
+          }
+        } else {
+          const r = resultAt(clamped);
+          if (r) openStream(r);
+        }
+      }
+```
+
+Note: `selRef`'s effect (`Results.tsx:485-499`) already moves the cursor to the row whose `key` matches `selRef.current.key` once the rows rebuild after expansion, with an infoHash fallback — the same mechanism the seeding "land" uses.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Run the existing Results tests**
+
+Run: `npx vitest run src/ui/components/Results.test.tsx`
+Expected: PASS (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/components/Results.tsx
+git commit -m "feat(ui): v on a loose-episode season reveals it and lands on next-up"
+```
+
+---
+
+## Task 7: Terminal — fix the auto-expand seeding + landing latches
+
+**Files:**
+- Modify: `src/ui/components/Results.tsx` (seeding effect ~393-404; landing effect ~644-662)
+
+- [ ] **Step 1: Rewrite the seeding effect to use `expansionSeed`**
+
+Replace the seeding effect (`Results.tsx:393-404`):
+
+```ts
+  useEffect(() => {
+    if (results.length === 0) {
+      seeded.current = false;
+      landed.current = false;
+      return;
+    }
+    if (seeded.current) return;
+    const seed = expansionSeed(
+      groupResults(results, hintForSection(section)),
+      positionFor,
+      !search.loading,
+    );
+    if (seed.expandKeys.length > 0) setExpanded(new Set(seed.expandKeys));
+    if (seed.latch) {
+      seeded.current = true;
+      // Arm the cursor "land" only when there is somewhere to land.
+      landed.current = seed.selectKey !== null;
+    }
+  }, [results, section, positionFor, search.loading]);
+```
+
+- [ ] **Step 2: Stop the landing effect disarming on a transient sparse frame**
+
+In the landing effect (`Results.tsx:644-662`), change the "no key" branch so it only gives up once the search has settled:
+
+```ts
+    if (!key) {
+      if (!search.loading) landed.current = false; // settled with nothing to land on
+      return;
+    }
+```
+
+And add `search.loading` to that effect's dependency array (keep the existing eslint-disable comment for `moveTo`):
+
+```ts
+  }, [rows, results, section, positionFor, search.loading]);
+```
+
+- [ ] **Step 3: Type-check and test**
+
+Run: `npm run typecheck && npx vitest run src/ui/components/Results.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/components/Results.tsx
+git commit -m "fix(ui): don't latch auto-expand/land on a sparse first frame"
+```
+
+---
+
+## Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole gate**
+
+Run: `npm test && npm run typecheck && npm run lint && npm run build`
+Expected: all PASS. The one known pre-existing lint warning (`react-hooks/exhaustive-deps` in `src/ui/App.tsx`) is allowed; no NEW warnings.
+
+- [ ] **Step 2: Manual smoke of both surfaces**
+
+- Web: `npm run dev -- serve --web` — search a part-watched show; confirm (a) it lands auto-expanded on next-up, and (b) play on a collapsed loose season reveals + highlights next-up without playing, while a pack season still resolves→file-picker.
+- Terminal: `npm run dev` — same show; confirm `v` on a collapsed loose season expands it and moves the cursor to next-up, and a fresh search lands on next-up.
+
+- [ ] **Step 3: Update docs if the web UI's limitations list mentions episode selection**
+
+Check `README.md` (and the web UI's own limitations copy) for any claim that season play picks a single release / has no episode chooser; update if now inaccurate. Commit any change:
+
+```bash
+git add README.md
+git commit -m "docs: season play now reveals episodes"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** loose-episode reveal (Tasks 1,4,6); pack unchanged/resolve (Task 1 test + web/TUI wiring leave the resolve path alone); next-up fallback to first episode (Task 1 tests); auto-expand latch fix both surfaces (Tasks 2,5,7); shared decision in `src/util` (Tasks 1,2); no change to `resultAtRow`/add/favourite/preview (only the play/`v` paths branch).
+- **Type consistency:** `seasonPlayPlan`/`SeasonPlayPlan`, `expansionSeed`/`ExpansionSeed`, `expandKey`/`selectKey`/`select` used identically across core, web, and TUI tasks.
+- **Known caveat (documented in spec):** if `/api/saved` / `streamHistory` has not loaded when the season first forms, expansion still fires but selection falls back to the first episode; in practice it loads before a search settles.

--- a/docs/superpowers/specs/2026-08-10-season-play-episode-picker-design.md
+++ b/docs/superpowers/specs/2026-08-10-season-play-episode-picker-design.md
@@ -1,0 +1,158 @@
+# Season play → episode picker
+
+**Date:** 2026-08-10
+**Surfaces:** both front ends (web + terminal), shared logic in `src/util`
+
+## Problem
+
+Searching a TV season in grouped mode (e.g. `silo s03`) collapses all the
+releases into one season row. Pressing **play** on that collapsed row silently
+resolves to the group's single "best" member and starts playing it — with no
+chance to choose an episode.
+
+For a season made of **loose episode releases** (no season pack), the children
+sort packs-first then episodes ascending, so `members[0]` is the best release of
+the **lowest** episode. Confirmed live: play on collapsed `Silo S03` streamed
+`Silo_S03E01_Kdo jste_.mkv` (E01) and jumped straight to the player.
+
+Two defects combine into the bad experience:
+
+1. **Season play ignores the episode structure.** `resultAtRow` returns
+   `members[0]` (`src/util/resultGroup.ts:512`); a loose-episode season plays E01
+   with no picker.
+2. **Continue-watching seeding never fires on a live search.** The browser
+   already has `defaultExpandedKeys` (open the season holding the next episode)
+   and `nextUpRowKey` (find the next-episode row), wired at `app.ts:2559-2572`.
+   But `seededExpansion` latches `true` on the **first** SSE frame, which arrives
+   too sparse to have formed the multi-episode season, so it seeds nothing and
+   never retries. Verified live: a fully-loaded `silo s03` search (position known,
+   header shows "up to E02", `next: {season:3, episode:3}` present in
+   `/api/saved`) still renders the season **collapsed** with nothing preselected.
+
+## What already works (do not rebuild)
+
+**Season packs are essentially already correct.** Play on a collapsed season that
+contains a pack grabs the pack (`members[0]`, packs sort first), resolves it, and
+— when it has multiple files — shows the file picker with the next episode
+**preselected**: `streamOutcome` → `nextEpisodeIndex(files, { next })`
+(`streamFlow.ts:188-200`), and `wantedEpisodeFor` (`streamFlow.ts:291`) finds the
+stored position even for a pack discovered in search. This satisfies the user's
+"prioritise seeing what's inside the pack (bloopers/outtakes/extras)" goal for
+free, including mixed pack+episode seasons.
+
+The gap is **only** the loose-episode-only season.
+
+## Desired behaviour
+
+Pressing play on a show/season never silently plays. It always leads to a
+"which one do you want?" choice, then plays from there. The **flow** is identical
+across cases; the **surface** fits the data (a hard constraint — pack contents
+can only be listed after a network resolve, loose episodes can be listed
+instantly):
+
+| Season shape | Play does | Surface |
+| --- | --- | --- |
+| Loose episodes only (Silo S03) | expand the season inline, move selection to the next-up episode; **does not auto-play** | instant inline episode rows |
+| Contains a pack (incl. mixed) | resolve the pack, show its file picker with next-up preselected (**unchanged**) | resolve-then-file-picker |
+
+"Next-up" = the episode after the stored high-water mark, when it is present in
+the results (`nextUpRowKey`). When there is no position, or the next episode is
+not in the results, selection falls back to the **first** episode of the season.
+Nothing phantom is ever selected or played.
+
+## Design
+
+### 1. Shared decision function (`src/util/resultGroup.ts`)
+
+A new pure function decides what play does on a season, so both front ends stay
+thin wiring (CLAUDE.md: decisions live in pure modules; move shared logic down,
+never copy). It rebuilds the tree from the already-available flat `groups`
+(cheap, click-time only) and returns a discriminated union:
+
+```ts
+export type SeasonPlayPlan<T> =
+  // Season has a pack (best pack = members[0]); run the existing play path.
+  | { kind: "resolve"; result: T }
+  // Loose episodes only; expand this season and select the next-up release.
+  | { kind: "reveal"; expandKey: string; select: T | null };
+
+export function seasonPlayPlan<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],   // the flat list the front end already has
+  seasonKey: string,
+  positionFor?: PositionLookup,
+): SeasonPlayPlan<T>;
+```
+
+Logic:
+- Find the `SeasonNode` for `seasonKey` via `seasonTree(groups)`.
+- **Has a pack** (`node.children.some(c => c.episode === undefined)`) →
+  `{ kind: "resolve", result: node.members[0] }`.
+- **Loose only** → pick the target episode group: `nextUpRowKey`-style match
+  against `positionFor`, else the first (lowest) episode child. Return
+  `{ kind: "reveal", expandKey: node.key, select: target.members[0] ?? null }`.
+- Not a season / not found → `{ kind: "resolve", result: members[0] }` (today's
+  behaviour; films and single-episode groups are untouched).
+
+`resultAtRow` is **not** changed — `add`, `favourite` and the preview lookup keep
+resolving a release from it exactly as now. Only the **play** action consults
+`seasonPlayPlan`.
+
+### 2. Web wiring (`src/web/static/app.ts`)
+
+Where the season row's play button is wired (`resultActions` / `renderGroupRow`,
+around `app.ts:2077`, `2514`), for a `kind: "season"` row call `seasonPlayPlan`:
+- `resolve` → existing `play(rowForPlay(result))`.
+- `reveal` → `expandedGroups.add(expandKey)`, set `selectedHash =
+  select.infoHash`, re-render, and scroll/focus the selected row into view. No
+  decision logic in `app.ts`.
+
+### 3. Terminal wiring (`src/ui/components/Results.tsx`)
+
+The stream key (`v`, `Results.tsx:729`) on a collapsed season calls the same
+`seasonPlayPlan`:
+- `resolve` → existing `openStream(...)` (→ `StreamFilePrompt` with preselection).
+- `reveal` → add `expandKey` to the expanded set, recompute rows, move the cursor
+  to the row for the selected release. Does not stream.
+
+This keeps the two front ends behaviourally aligned through the one shared
+function, as `resultAtRow`/`groupRowPlan` already are.
+
+### 4. Auto-expand seeding fix (both front ends)
+
+Replace the "latch on first non-empty frame" rule with "seed once we can, retry
+until then":
+
+- While not yet seeded, attempt seeding on each render.
+- Set the seeded latch `true` **only when** `defaultExpandedKeys` actually
+  returns a key to open (i.e. the multi-child season has formed) **or** the
+  search has completed (`done`) with nothing to open.
+- Once a seed is applied, latch — so re-seeding never re-opens a season the user
+  has since collapsed mid-stream.
+
+Apply the same correction to the terminal UI's equivalent seeding path if it
+shares the latch. Known minor ordering caveat (documented, not fixed here): if
+`/api/saved` has not loaded when the season first forms, the expansion still
+happens but selection falls back to the first episode rather than next-up; in
+practice saved loads before a search completes.
+
+## Testing
+
+- **Unit (`src/util/resultGroup.test.ts`)** for `seasonPlayPlan`:
+  - pack present → `resolve` with the best pack;
+  - mixed pack + episodes → `resolve` (pack prioritised);
+  - loose only, position known & next episode present → `reveal` selecting next-up;
+  - loose only, no position → `reveal` selecting the first episode;
+  - loose only, position's next episode absent from results → `reveal` selecting
+    the first episode (no phantom);
+  - non-season group / film → `resolve` (unchanged).
+- **Seeding fix**: a unit test over the seeding decision (extract the "should we
+  latch yet?" predicate into a pure helper if it is not already testable) proving
+  a sparse first frame does not latch and a later multi-child frame seeds.
+- Fixtures use the invented cast from CLAUDE.md (`Harrowgate.S03…` season pack,
+  `Kepler.S02E04…` episodes). No real titles.
+
+## Out of scope
+
+- No change to `resultAtRow`, `add`, `favourite`, or preview behaviour.
+- No new backend routes or wire types — grouping stays client-side from names.
+- No change to the pack file-picker itself (it already preselects next-up).

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -18,7 +18,7 @@ import { releaseBadges } from "../../util/releaseBadges";
 // The grouping engine, shared with the browser's results list. `groupCountLabel`
 // is deliberately NOT used here — see the "×5" comment on the count cell below.
 import {
-  defaultExpandedKeys,
+  expansionSeed,
   groupHeading,
   groupResults,
   groupRowPlan,
@@ -398,11 +398,18 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
       return;
     }
     if (seeded.current) return;
-    seeded.current = true;
-    landed.current = true;
-    const keys = defaultExpandedKeys(groupResults(results, hintForSection(section)), positionFor);
-    if (keys.length > 0) setExpanded(new Set(keys));
-  }, [results, section, positionFor]);
+    const seed = expansionSeed(
+      groupResults(results, hintForSection(section)),
+      positionFor,
+      !search.loading,
+    );
+    if (seed.expandKeys.length > 0) setExpanded(new Set(seed.expandKeys));
+    if (seed.latch) {
+      seeded.current = true;
+      // Arm the cursor "land" only when there is somewhere to land.
+      landed.current = seed.selectKey !== null;
+    }
+  }, [results, section, positionFor, search.loading]);
 
 
   useEffect(() => {
@@ -646,7 +653,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     if (!landed.current || rows.length === 0) return;
     const key = nextUpRowKey(groupResults(results, hintForSection(section)), positionFor);
     if (!key) {
-      landed.current = false; // nothing to land on; stop looking
+      if (!search.loading) landed.current = false; // settled with nothing to land on
       return;
     }
     const at = rows.findIndex((row) => row.key === key);
@@ -660,7 +667,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     // moveTo is recreated every render and intentionally left out: this fires
     // once per result set, and depending on it would re-run on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows, results, section, positionFor]);
+  }, [rows, results, section, positionFor, search.loading]);
 
   useInput(
     (input, key) => {

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -25,6 +25,7 @@ import {
   nextUpRowKey,
   positionNote,
   resultAtRow,
+  seasonPlayPlan,
   showKeyOf,
   type PositionLookup,
 } from "../../util/resultGroup";
@@ -727,8 +728,25 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
         const r = resultAt(clamped);
         if (r) openDebrid(r);
       } else if (input === "v") {
-        const r = resultAt(clamped);
-        if (r) openStream(r);
+        const row = rows[clamped];
+        if (row?.kind === "season") {
+          const plan = seasonPlayPlan(
+            groupResults(results, hintForSection(section)),
+            row.key,
+            positionFor,
+          );
+          if (plan.kind === "reveal") {
+            // Reveal the episodes and land the cursor on the next-up one. selRef
+            // moves the cursor to the row once the rebuilt rows include it.
+            if (plan.select) selRef.current = { key: plan.selectKey!, hash: plan.select.infoHash };
+            setExpanded((current) => new Set(current).add(plan.expandKey));
+          } else if (plan.result) {
+            openStream(plan.result);
+          }
+        } else {
+          const r = resultAt(clamped);
+          if (r) openStream(r);
+        }
       } else if (input === "y") {
         const r = resultAt(clamped);
         if (r) copyResultMagnet(r);

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -6,6 +6,7 @@ import {
   groupResults,
   groupRowPlan,
   defaultExpandedKeys,
+  expansionSeed,
   isSeasonNode,
   nextUpRowKey,
   positionNote,
@@ -625,5 +626,35 @@ describe("seasonPlayPlan", () => {
     expect(plan.kind).toBe("resolve");
     if (plan.kind !== "resolve") throw new Error("expected resolve");
     expect(plan.result).toBeNull();
+  });
+});
+
+describe("expansionSeed", () => {
+  const looseSeason = () =>
+    groupResults([
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+      r("Kepler.S02E03.1080p.WEB-DL"),
+    ]);
+  const upTo1: PositionLookup = (showKey) => (showKey === "kepler" ? { season: 2, episode: 1 } : null);
+
+  it("opens the season and points selection at the next-up episode", () => {
+    const seed = expansionSeed(looseSeason(), upTo1, false);
+    expect(seed.expandKeys).toContain("kepler|series|s2");
+    expect(seed.selectKey).toBe("kepler|series|s2|e2");
+    expect(seed.latch).toBe(true);
+  });
+
+  it("does NOT latch on a sparse frame that forms no season, while the search runs", () => {
+    const oneEpisode = groupResults([r("Kepler.S02E01.1080p.WEB-DL")]);
+    const seed = expansionSeed(oneEpisode, upTo1, false);
+    expect(seed.expandKeys).toEqual([]);
+    expect(seed.latch).toBe(false);
+  });
+
+  it("latches once the search has settled even with nothing to open", () => {
+    const oneEpisode = groupResults([r("Kepler.S02E01.1080p.WEB-DL")]);
+    const seed = expansionSeed(oneEpisode, upTo1, true);
+    expect(seed.latch).toBe(true);
   });
 });

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -11,7 +11,9 @@ import {
   positionNote,
   showKeyOf,
   resultAtRow,
+  seasonPlayPlan,
   seasonTree,
+  type PositionLookup,
 } from "./resultGroup";
 
 const r = (name: string) => ({ name });
@@ -561,5 +563,58 @@ describe("positionNote", () => {
 
   it("says nothing without a position", () => {
     expect(positionNote(3, null)).toBe("");
+  });
+});
+
+describe("seasonPlayPlan", () => {
+  const looseSeason = () =>
+    groupResults([
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+      r("Kepler.S02E03.1080p.WEB-DL"),
+    ]);
+  const seasonKey = "kepler|series|s2";
+  const upTo = (episode: number): PositionLookup => (showKey) =>
+    showKey === "kepler" ? { season: 2, episode } : null;
+
+  it("reveals loose episodes and lands on the next-up episode", () => {
+    const plan = seasonPlayPlan(looseSeason(), seasonKey, upTo(1));
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.expandKey).toBe(seasonKey);
+    expect(plan.selectKey).toBe("kepler|series|s2|e2");
+    expect(plan.select?.name).toBe("Kepler.S02E02.1080p.WEB-DL");
+  });
+
+  it("lands on the first episode when there is no watch position", () => {
+    const plan = seasonPlayPlan(looseSeason(), seasonKey);
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.selectKey).toBe("kepler|series|s2|e1");
+  });
+
+  it("lands on the first episode when the next-up episode is not in the results", () => {
+    const plan = seasonPlayPlan(looseSeason(), seasonKey, upTo(3));
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    expect(plan.selectKey).toBe("kepler|series|s2|e1");
+  });
+
+  it("resolves (does not reveal) when the season contains a pack", () => {
+    const groups = groupResults([
+      r("Kepler.S02.1080p.WEB-DL"),
+      r("Kepler.S02E01.1080p.WEB-DL"),
+      r("Kepler.S02E02.1080p.WEB-DL"),
+    ]);
+    const plan = seasonPlayPlan(groups, seasonKey, upTo(1));
+    expect(plan.kind).toBe("resolve");
+    if (plan.kind !== "resolve") throw new Error("expected resolve");
+    expect(plan.result?.name).toBe("Kepler.S02.1080p.WEB-DL");
+  });
+
+  it("resolves for a key that is not a season node", () => {
+    const groups = groupResults([r("Kestrel.2010.1080p.BluRay.x264")]);
+    const plan = seasonPlayPlan(groups, "kestrel|2010|movie");
+    expect(plan.kind).toBe("resolve");
   });
 });

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -616,5 +616,14 @@ describe("seasonPlayPlan", () => {
     const groups = groupResults([r("Kestrel.2010.1080p.BluRay.x264")]);
     const plan = seasonPlayPlan(groups, "kestrel|2010|movie");
     expect(plan.kind).toBe("resolve");
+    if (plan.kind !== "resolve") throw new Error("expected resolve");
+    expect(plan.result?.name).toBe("Kestrel.2010.1080p.BluRay.x264");
+  });
+
+  it("resolves to null for a key that matches no group at all", () => {
+    const plan = seasonPlayPlan(groupResults([r("Kepler.S02E01.1080p.WEB-DL")]), "nope|series|s9");
+    expect(plan.kind).toBe("resolve");
+    if (plan.kind !== "resolve") throw new Error("expected resolve");
+    expect(plan.result).toBeNull();
   });
 });

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -514,6 +514,56 @@ export function resultAtRow<T>(row: GroupRow<T>): T | null {
 }
 
 /**
+ * What pressing play on a SEASON row should do.
+ *
+ * A season made of loose episodes has no single "the season" torrent, so
+ * `members[0]` is merely the best release of episode one — playing it silently is
+ * the bug this fixes. Instead: reveal the episodes and land on the one you are up
+ * to. A season that DOES contain a pack keeps today's behaviour — grab the pack
+ * (`members[0]`; packs sort first) and let the resolve→file-picker path preselect
+ * the next episode, which also surfaces any extras inside the pack.
+ *
+ * Pure and shared so both front ends decide identically; the front ends only
+ * wire the two outcomes. `resultAtRow` is deliberately NOT changed — add,
+ * favourite and preview still resolve a release from it.
+ */
+export type SeasonPlayPlan<T> =
+  | { kind: "resolve"; result: T | null }
+  | { kind: "reveal"; expandKey: string; selectKey: string | null; select: T | null };
+
+export function seasonPlayPlan<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+  seasonKey: string,
+  positionFor?: PositionLookup,
+): SeasonPlayPlan<T> {
+  const node = seasonTree(groups).find(
+    (n): n is SeasonNode<T> => isSeasonNode(n) && n.key === seasonKey,
+  );
+  // Not a season row (a film, a single-episode group) or gone: behave as play
+  // does today — resolve the first member.
+  if (!node) {
+    return { kind: "resolve", result: groups.find((g) => g.key === seasonKey)?.members[0] ?? null };
+  }
+  // A child with no episode number is a pack: the whole season in one torrent.
+  if (node.children.some((c) => c.episode === undefined)) {
+    return { kind: "resolve", result: node.members[0] ?? null };
+  }
+  // Loose episodes only. Land on the next-up episode when the results have it,
+  // else the first episode. `children` are episodes ascending (seasonTree sorts).
+  const at = positionFor?.(showKeyOf(node.key)) ?? null;
+  const target =
+    (at &&
+      node.children.find((c) => c.season === at.season && c.episode === at.episode + 1)) ||
+    node.children[0]!;
+  return {
+    kind: "reveal",
+    expandKey: node.key,
+    selectKey: target.key,
+    select: target.members[0] ?? null,
+  };
+}
+
+/**
  * The note a season heading carries when you are part-way through it.
  *
  * "up to E07", NOT "watched" — the store holds a HIGH-WATER MARK, one entry per

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -564,6 +564,38 @@ export function seasonPlayPlan<T extends GroupableResult>(
 }
 
 /**
+ * What a fresh result set should open and land on — and whether to stop trying.
+ *
+ * WHY `latch`: results stream in over SSE, so the FIRST frame is usually too
+ * sparse to have formed the multi-episode season. Seeding on that frame and
+ * latching (the previous behaviour in both front ends) opened nothing and never
+ * retried, so a search for a show you are part-way through rendered collapsed
+ * with no episode selected. Retry until either an expansion is applied or the
+ * search settles — never latch on a frame that produced neither.
+ */
+export interface ExpansionSeed {
+  /** Season keys to open. */
+  expandKeys: string[];
+  /** The group key to land selection on, or null. */
+  selectKey: string | null;
+  /** True once seeding is settled; the caller stops retrying. */
+  latch: boolean;
+}
+
+export function expansionSeed<T extends GroupableResult>(
+  groups: readonly ResultGroup<T>[],
+  positionFor: PositionLookup | undefined,
+  searchSettled: boolean,
+): ExpansionSeed {
+  const expandKeys = defaultExpandedKeys(groups, positionFor);
+  return {
+    expandKeys,
+    selectKey: positionFor ? nextUpRowKey(groups, positionFor) : null,
+    latch: expandKeys.length > 0 || searchSettled,
+  };
+}
+
+/**
  * The note a season heading carries when you are part-way through it.
  *
  * "up to E07", NOT "watched" — the store holds a HIGH-WATER MARK, one entry per

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -551,9 +551,9 @@ export function seasonPlayPlan<T extends GroupableResult>(
   // Loose episodes only. Land on the next-up episode when the results have it,
   // else the first episode. `children` are episodes ascending (seasonTree sorts).
   const at = positionFor?.(showKeyOf(node.key)) ?? null;
+  const want = at ? nextOf(at) : null;
   const target =
-    (at &&
-      node.children.find((c) => c.season === at.season && c.episode === at.episode + 1)) ||
+    (want && node.children.find((c) => c.season === want.season && c.episode === want.episode)) ||
     node.children[0]!;
   return {
     kind: "reveal",

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -62,6 +62,7 @@ import {
   previewApplies,
   reportsHealthLookup,
   resultAtRow,
+  seasonPlayPlan,
   resultMeta,
   resultRowPlan,
   rowForPlay,
@@ -2061,7 +2062,11 @@ function mountResultPoster(
 // The four buttons a result offers, built once and used by both layouts: a
 // grid card that offered fewer of them than the list row would be a downgrade
 // dressed as a view option.
-function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivElement {
+function resultActions(
+  result: PublicSearchResult,
+  rowKey: string,
+  onPlay?: () => void,
+): HTMLDivElement {
   const actions = document.createElement("div");
   actions.className = "row-actions";
 
@@ -2074,7 +2079,10 @@ function resultActions(result: PublicSearchResult, rowKey: string): HTMLDivEleme
   // several releases of one title), while play() is handed rowForPlay(result),
   // whose id is the hash. See tagPlayKey for why the two identities are separate.
   tagPlayKey(playButton, result.infoHash, "play");
-  playButton.addEventListener("click", () => void play(rowForPlay(result)));
+  playButton.addEventListener("click", () => {
+    if (onPlay) onPlay();
+    else void play(rowForPlay(result));
+  });
   actions.append(playButton);
 
   const addButton = document.createElement("button");
@@ -2511,7 +2519,27 @@ function renderGroupRow(
 
   const body = document.createElement("div");
   body.className = "group-body";
-  body.append(head, meta, resultActions(best, row.key));
+  // A season made of loose episodes plays nothing on click: it reveals the
+  // episodes and lands on the one you are up to. The decision is seasonPlayPlan
+  // (pure); this is only the wiring. A pack season / any other row keeps play.
+  let onPlay: (() => void) | undefined;
+  if (row.kind === "season") {
+    const positionFor = positionLookup(savedState.continueWatching);
+    const plan = seasonPlayPlan(
+      visibleGroups(searchView, reportsHealthLookup(sources)),
+      row.key,
+      positionFor,
+    );
+    if (plan.kind === "reveal") {
+      const target = plan.select;
+      onPlay = () => {
+        expandedGroups.add(plan.expandKey);
+        if (target) selectResult(target);
+        else renderResults();
+      };
+    }
+  }
+  body.append(head, meta, resultActions(best, row.key, onPlay));
 
   if (!postersApply(searchView.group, sources?.omdbConfigured === true)) {
     li.append(toggle, body);

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -48,10 +48,9 @@ import {
   emptyView,
   exportBody,
   exportedNotice,
-  defaultExpandedKeys,
+  expansionSeed,
   groupCountLabel,
   groupHeading,
-  nextUpRowKey,
   positionLookup,
   positionNote,
   showKeyOf,
@@ -2587,16 +2586,17 @@ function renderResults(): void {
   if (!seededExpansion) {
     const groups = visibleGroups(searchView, reportsHealthLookup(sources));
     if (groups.length > 0) {
-      seededExpansion = true;
       const positionFor = positionLookup(savedState.continueWatching);
-      for (const key of defaultExpandedKeys(groups, positionFor)) expandedGroups.add(key);
-      // Select the episode you are up to, so it is the one already in the
-      // preview. Resolved from the GROUPS rather than the rows: the rows do not
-      // exist yet, and a group hands back its best member directly. Null when
-      // the results do not have that episode — nothing phantom gets selected.
-      const nextKey = nextUpRowKey(groups, positionFor);
-      const landing = nextKey ? groups.find((g) => g.key === nextKey) : undefined;
+      // `running` is true between submit and the `done` frame; !running == settled.
+      const seed = expansionSeed(groups, positionFor, !searchView.running);
+      for (const key of seed.expandKeys) expandedGroups.add(key);
+      // Select the episode you are up to, resolved from the GROUPS (rows do not
+      // exist yet). Null when the results do not have it — nothing phantom.
+      const landing = seed.selectKey ? groups.find((g) => g.key === seed.selectKey) : undefined;
       if (landing?.members[0]) selectedHash = landing.members[0].infoHash;
+      // Latch only once something was opened or the search settled, so a sparse
+      // first SSE frame no longer freezes the list collapsed.
+      seededExpansion = seed.latch;
     }
   }
   currentRows = resultRowPlan(searchView, reportsHealthLookup(sources), expandedGroups);

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -57,11 +57,9 @@ export {
   type SortField,
 } from "../../util/resultSort";
 export {
-  defaultExpandedKeys,
   expansionSeed,
   groupCountLabel,
   groupHeading,
-  nextUpRowKey,
   positionNote,
   resultAtRow,
   seasonPlayPlan,

--- a/src/web/static/searchModel.ts
+++ b/src/web/static/searchModel.ts
@@ -58,15 +58,19 @@ export {
 } from "../../util/resultSort";
 export {
   defaultExpandedKeys,
+  expansionSeed,
   groupCountLabel,
   groupHeading,
   nextUpRowKey,
   positionNote,
   resultAtRow,
+  seasonPlayPlan,
   showKeyOf,
+  type ExpansionSeed,
   type GroupRow,
   type PositionLookup,
   type ResultGroup,
+  type SeasonPlayPlan,
 } from "../../util/resultGroup";
 
 /**


### PR DESCRIPTION
## Why

Searching a TV season in grouped mode (e.g. `silo s03`) collapses the releases into one season row. Pressing **play** on that row used to silently resolve to the group's single best member and start it. For a season made of loose episode releases (no season pack), that meant it played the *lowest* episode — you asked for "the season" and got episode one, mid-way through a rewatch, with no chance to choose. Two defects combined:

1. Season play ignored the episode structure (`resultAtRow` → `members[0]`).
2. The continue-watching auto-expand never fired on a live search — `seededExpansion` latched on the first (sparse) SSE frame, before the multi-episode season had formed, and never retried. So the season rendered collapsed with nothing selected even when the position ("up to E02") was known.

## What

- **Loose-episode season** → play now **reveals the episodes and selects the one you are up to** (next-up from watch history, else the first episode) instead of playing episode one. You pick which to watch.
- **Season pack** (incl. mixed pack+episodes) → **unchanged**: resolve → file picker, which already preselects the next episode (and surfaces any extras inside the pack).
- **Auto-expand fix**: the seeding no longer latches on a sparse first SSE frame — it retries until a season forms or the search settles, so a search for a part-watched show lands already expanded on next-up.

## Both front ends

Ships in **both** surfaces over one shared, tested pure module (`src/util/resultGroup.ts`): `seasonPlayPlan` (play decision) and `expansionSeed` (auto-expand/land + latch). The browser (`src/web/static/app.ts`, play button) and terminal (`src/ui/components/Results.tsx`, `v` key) are thin wiring over it — no decision logic duplicated, no `src/web`↔`src/ui` imports.

## Test plan

- [x] `npm test` (2917 pass), `npm run typecheck`, `npm run lint` (only the known pre-existing App.tsx warning), `npm run build`
- [x] New unit tests for `seasonPlayPlan` (reveal/resolve/next-up/first-fallback/pack/non-season) and `expansionSeed` (sparse frame doesn't latch; settled or formed does)
- [x] Live browser smoke: `silo s03` auto-expands to the episode list; play on a collapsed loose season reveals + highlights the landing episode without navigating to the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)