### PR TITLE
feat: Cloudflare Access (mTLS + SSO) for public exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,10 +870,10 @@ proxy that rewrites `Host` instead will produce a playlist pointing at the wrong
 
 If you want torlink on a real domain — reachable from anywhere, and shareable with one trusted friend —
 without opening a port on your router, the setup below puts [Cloudflare
-Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of it. Your own
-devices carry a client certificate and get in silently; a friend signs in with an allowlisted email.
-torlink stays plain HTTP on loopback the whole time, and verifies the Access assertion itself at the
-origin, so the public port is never really public.
+Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of it. You sign in
+through Cloudflare — a one-time email PIN, or an identity provider like Google — and a trusted friend
+does the same with an allowlisted email. torlink stays plain HTTP on loopback the whole time, and
+verifies the Access assertion itself at the origin, so the public port is never really public.
 
 **The shape.** Nothing about torlink changes — it's still `serve --web` bound to `127.0.0.1:9161`.
 `cloudflared` runs on the same box and dials *out* to Cloudflare, so there are no inbound ports and no
@@ -883,10 +883,10 @@ if that port were ever reached directly it refuses anything that didn't come thr
 
 ```
 your device ─┐                             ┌ cloudflared ─┐
- (mTLS cert) │                             │ (outbound,   │   http://127.0.0.1:9161
+ (SSO / PIN) │                             │ (outbound,   │   http://127.0.0.1:9161
              ├─▶ Cloudflare Access ─▶ Tunnel│  same box)   ├─▶ torlnk serve --web
  a friend ───┘   (the front gate)          └──────────────┘   (re-checks the Access assertion)
- (email/SSO)
+ (allowlisted email)
 ```
 
 #### Cloudflare setup
@@ -895,25 +895,22 @@ In the Cloudflare dashboard, in order:
 
 1. **Put the domain on Cloudflare.** Change your registrar's nameservers to the pair Cloudflare gives
    you and wait for the zone to go active.
-2. **Create a Tunnel** (Zero Trust → Networks → Tunnels), install the connector it hands you on the same
-   box as torlink (and [reccd](#recommendations), if you self-host it), and add one public-hostname
-   ingress rule: `torlink.example.com` → `http://localhost:9161` — the `serve --web` port.
-3. **Set up mTLS for your own devices.** Generate a root CA, upload the CA certificate under the zone's
-   mTLS settings (SSL/TLS → Client Certificates), then issue one client certificate per device and
-   install it. Installing a client cert on a laptop or a phone is a two-minute job; browsing the UI *on*
-   an Android TV or Nvidia Shield with a client cert is awkward and not really supported — use the Shield
-   as a [cast/playback target](#casting-to-a-tv) instead, which stays on your LAN and is untouched by any
-   of this.
-4. **Create one Access application** on `torlink.example.com` with a single policy that is an **OR**:
-
-   | Arm | Who it's for |
-   | --- | --- |
-   | Valid client certificate | your own devices — silent, install-once auth |
-   | Email is in your allowlist | a shared friend — nothing to install, they sign in with SSO |
-
-   The certificate arm lets your devices in without a prompt; the email arm lets a friend in after a
-   Cloudflare login, without ever touching a certificate. Note the application's **Audience (AUD) tag** —
-   torlink needs it below — and your team domain, `<your-team>.cloudflareaccess.com`.
+2. **Create a Tunnel** (Zero Trust → Networks → Tunnels). Run the connector it hands you on the same box
+   as torlink (and [reccd](#recommendations), if you self-host it) — a token'd `cloudflared` container is
+   fine — and add one public-hostname ingress rule: `torlink.example.com` → `http://localhost:9161`, the
+   `serve --web` port. (In a container, point it at torlink's container name and port over a shared Docker
+   network instead of `localhost`.)
+3. **Choose a login method** (Zero Trust → Settings → Authentication). The built-in **one-time PIN**
+   (Cloudflare emails a code) needs no setup; or add an **identity provider** such as Google for one-click
+   sign-in. Both are on the free Zero Trust plan. If you want *silent, no-login-page* device auth, there
+   are two upgrades: enrol your devices in **WARP** and require it in the policy (also free), or — on an
+   **Enterprise** plan only — **client certificates (mTLS)**, uploaded under Zero Trust → Access controls
+   → Service credentials → Mutual TLS (not the zone's SSL/TLS page — that's a different mTLS feature).
+   mTLS is the only fully-invisible option, but it is Enterprise-gated.
+4. **Create one Access application** on `torlink.example.com`, policy *Allow*, **Include → Emails**: your
+   address and your trusted friend's. Set a long **session duration** (say a week) so you rarely
+   re-authenticate — that is what makes it feel like it just knows you. Note the application's **Audience
+   (AUD) tag** — torlink needs it below — and your team domain, `<your-team>.cloudflareaccess.com`.
 
 #### torlink's two settings
 
@@ -943,22 +940,25 @@ or sets the team domain or the AUD.
 
 - **It's single-tenant.** A shared friend uses *your* torlink instance — your [debrid](#debrid-real-debrid-or-torbox)
   quota, your library, your watch history. There is no per-user separation; whoever's in, is in as you.
-- **The `OR email` arm trades a little invisibility for shareability.** With it, a stranger who guesses
-  the hostname sees a Cloudflare login page — still locked, they can't get in — rather than nothing at
-  all. A certificate-only policy would be more invisible, but it can't be shared without installing a
-  cert on the friend's device. Pick the arm you actually need.
-- **Casting is unaffected.** [Casting to a device](#casting-to-a-tv) on your home LAN stays on the LAN and
-  never goes near Cloudflare. Browsing the UI directly *on* an Android TV with mTLS is the unsupported
-  case; casting *to* it is not.
+- **A stranger sees a login page, not nothing.** Anyone who guesses the hostname reaches Cloudflare's
+  login screen — still locked, they can't get in — rather than a blank wall. A fully-invisible front door
+  needs WARP enrolment or Enterprise mTLS; the SSO and PIN methods always show a login page. That is the
+  price of install-nothing sharing.
+- **Casting is unaffected — but discovery may need a nudge.** [Casting to a device](#casting-to-a-tv) on
+  your home LAN stays on the LAN and never goes near Cloudflare. If torlink runs in a container, or
+  anywhere mDNS can't reach your TV (WSL, a bridged Docker network), auto-discovery won't find it — set
+  the TV's address and the LAN address it should fetch media from explicitly, via `TORLINK_CAST_DEVICE`
+  and `TORLINK_CAST_HOST` (or the TUI's cast fields). Browsing the UI *on* the TV itself is the
+  unsupported case; casting *to* it is not.
 - **For watching remotely, prefer direct debrid streaming.** Leave [stream relaying](#relaying-streams-through-this-machine)
   off, so video goes debrid-CDN → your browser rather than being pulled down to your house and pushed
   back up through your uplink and Cloudflare. Relaying a remote stream spends your home upload twice over
   (see the figures in that section).
 - **Media paths are exempt from the Access check.** `/health`, `/stream/*` and `/play/*` skip it, because
-  a `<video>` element, VLC or a Chromecast can't present a client certificate. Those paths keep torlink's
+  a `<video>` element, VLC or a Chromecast can't authenticate to Access. Those paths keep torlink's
   existing per-session capability (the `?k=` token from [Remote access](#remote-access-and-tokens))
-  instead. In-browser playback on a device that *does* hold the cert works normally — the page loads
-  behind Access, and the media it pulls is capability-scoped.
+  instead. In-browser playback on a signed-in device works normally — the page loads behind Access, and
+  the media it pulls is capability-scoped.
 
 ### Blocked by your network?
 

--- a/README.md
+++ b/README.md
@@ -866,6 +866,100 @@ deliberately ignored — trusting them unconditionally would let any client pois
 proxy that rewrites `Host` instead will produce a playlist pointing at the wrong address until a
 `--trust-proxy` flag exists.
 
+### Exposing torlink on a public domain (Cloudflare Access)
+
+If you want torlink on a real domain — reachable from anywhere, and shareable with one trusted friend —
+without opening a port on your router, the setup below puts [Cloudflare
+Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of it. Your own
+devices carry a client certificate and get in silently; a friend signs in with an allowlisted email.
+torlink stays plain HTTP on loopback the whole time, and verifies the Access assertion itself at the
+origin, so the public port is never really public.
+
+**The shape.** Nothing about torlink changes — it's still `serve --web` bound to `127.0.0.1:9161`.
+`cloudflared` runs on the same box and dials *out* to Cloudflare, so there are no inbound ports and no
+router configuration. Cloudflare Access is the front gate; every request that reaches your tunnel has
+already passed it. torlink then re-checks the Access assertion on its own as defence in depth, so even
+if that port were ever reached directly it refuses anything that didn't come through Access.
+
+```
+your device ─┐                             ┌ cloudflared ─┐
+ (mTLS cert) │                             │ (outbound,   │   http://127.0.0.1:9161
+             ├─▶ Cloudflare Access ─▶ Tunnel│  same box)   ├─▶ torlnk serve --web
+ a friend ───┘   (the front gate)          └──────────────┘   (re-checks the Access assertion)
+ (email/SSO)
+```
+
+#### Cloudflare setup
+
+In the Cloudflare dashboard, in order:
+
+1. **Put the domain on Cloudflare.** Change your registrar's nameservers to the pair Cloudflare gives
+   you and wait for the zone to go active.
+2. **Create a Tunnel** (Zero Trust → Networks → Tunnels), install the connector it hands you on the same
+   box as torlink (and [reccd](#recommendations), if you self-host it), and add one public-hostname
+   ingress rule: `torlink.example.com` → `http://localhost:9161` — the `serve --web` port.
+3. **Set up mTLS for your own devices.** Generate a root CA, upload the CA certificate under the zone's
+   mTLS settings (SSL/TLS → Client Certificates), then issue one client certificate per device and
+   install it. Installing a client cert on a laptop or a phone is a two-minute job; browsing the UI *on*
+   an Android TV or Nvidia Shield with a client cert is awkward and not really supported — use the Shield
+   as a [cast/playback target](#casting-to-a-tv) instead, which stays on your LAN and is untouched by any
+   of this.
+4. **Create one Access application** on `torlink.example.com` with a single policy that is an **OR**:
+
+   | Arm | Who it's for |
+   | --- | --- |
+   | Valid client certificate | your own devices — silent, install-once auth |
+   | Email is in your allowlist | a shared friend — nothing to install, they sign in with SSO |
+
+   The certificate arm lets your devices in without a prompt; the email arm lets a friend in after a
+   Cloudflare login, without ever touching a certificate. Note the application's **Audience (AUD) tag** —
+   torlink needs it below — and your team domain, `<your-team>.cloudflareaccess.com`.
+
+#### torlink's two settings
+
+Enforcement is off until you give torlink both halves of what it needs to verify an Access assertion: the
+team domain to fetch Cloudflare's signing keys from, and the AUD tag to check each token was minted for
+*your* application. These are host-specific config, so — like every token and the VPN interface — they
+are set in the TUI or by environment variable, never from the browser. Set them either as env on the
+service:
+
+```sh
+TORLINK_CF_ACCESS_TEAM_DOMAIN=<your-team>.cloudflareaccess.com
+TORLINK_CF_ACCESS_AUD=<the Access application's AUD tag>
+```
+
+…or in `config.json` as `cfAccessTeamDomain` / `cfAccessAud`. **Both must be present** for enforcement to
+switch on (either both via env, or both in config). Restart `serve --web`; on startup the log prints:
+
+```
+cloudflare access: enforcing (team <your-team>.cloudflareaccess.com)
+```
+
+Once enforced, the **Settings** pane in both front ends shows **Cloudflare Access: enforced** read-only —
+the browser reports the status but, being a client of the config rather than an editor of it, never sees
+or sets the team domain or the AUD.
+
+#### Caveats, stated plainly
+
+- **It's single-tenant.** A shared friend uses *your* torlink instance — your [debrid](#debrid-real-debrid-or-torbox)
+  quota, your library, your watch history. There is no per-user separation; whoever's in, is in as you.
+- **The `OR email` arm trades a little invisibility for shareability.** With it, a stranger who guesses
+  the hostname sees a Cloudflare login page — still locked, they can't get in — rather than nothing at
+  all. A certificate-only policy would be more invisible, but it can't be shared without installing a
+  cert on the friend's device. Pick the arm you actually need.
+- **Casting is unaffected.** [Casting to a device](#casting-to-a-tv) on your home LAN stays on the LAN and
+  never goes near Cloudflare. Browsing the UI directly *on* an Android TV with mTLS is the unsupported
+  case; casting *to* it is not.
+- **For watching remotely, prefer direct debrid streaming.** Leave [stream relaying](#relaying-streams-through-this-machine)
+  off, so video goes debrid-CDN → your browser rather than being pulled down to your house and pushed
+  back up through your uplink and Cloudflare. Relaying a remote stream spends your home upload twice over
+  (see the figures in that section).
+- **Media paths are exempt from the Access check.** `/health`, `/stream/*` and `/play/*` skip it, because
+  a `<video>` element, VLC or a Chromecast can't present a client certificate. Those paths keep torlink's
+  existing per-session capability (the `?k=` token from [Remote access](#remote-access-and-tokens))
+  instead. In-browser playback on a device that *does* hold the cert works normally — the page loads
+  behind Access, and the media it pulls is capability-scoped.
+
 ### Blocked by your network?
 
 Some networks (ISPs, work Wi-Fi, some routers) quietly block torrent sites at the DNS level, so every

--- a/docs/superpowers/plans/2026-08-10-cloudflare-access-mtls.md
+++ b/docs/superpowers/plans/2026-08-10-cloudflare-access-mtls.md
@@ -1,0 +1,749 @@
+# Cloudflare Access (mTLS + SSO) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let torlink's web UI run on a public domain behind Cloudflare Tunnel + Access, with the origin itself refusing any request that lacks a valid Cloudflare Access assertion (defense in depth), while at-home casting and in-browser streaming keep working.
+
+**Architecture:** Cloudflare enforces mTLS (owner devices) OR email/SSO (a shared friend) at the edge and stamps every forwarded request with a signed `Cf-Access-Jwt-Assertion` header. torlink verifies that JWT (via `jose`, against Cloudflare's JWKS) in the existing `http.createServer` guard block in `src/web/server.ts`, returning `403` when it is absent/invalid. `/health`, `/stream/*` and `/play/*` are exempt (the last two keep the per-session `?k=` capability so cert-less players/casting still work). Config is host-specific → env vars or `config.json`, never web-writable, surfaced read-only in both front ends.
+
+**Tech Stack:** TypeScript (ESM, Node ≥22), `node:http`, `jose` (new dependency) for JWKS + RS256 verification, `vitest`.
+
+---
+
+## File Structure
+
+- **Create** `src/core/cloudflareAccess.ts` — pure, front-end-agnostic verifier: JWKS URL/issuer derivation, `verifyAccessAssertion`, header extraction, error mapping. No `src/ui`/`src/web` imports (respects the layering lint rule).
+- **Create** `src/core/cloudflareAccess.test.ts` — unit tests for the verifier with locally-minted keys and a frozen clock.
+- **Modify** `src/config/config.ts` — add `cfAccessTeamDomain?`/`cfAccessAud?` to `Config`; add `resolveCloudflareAccess(config)`.
+- **Create** `src/config/cloudflareAccess.resolve.test.ts` — unit tests for the resolver (env-wins precedence, null when incomplete).
+- **Modify** `src/web/server.ts` — new options (`cloudflareAccess`, `accessKeySetImpl`), build the key set once, add the guard block, exempt health/stream/play.
+- **Modify** `src/web/server.test.ts` — socket-level guard tests using an injected local key set.
+- **Modify** `src/daemon/serve.ts` — resolve Access config at startup and pass it to `startWebServer`.
+- **Modify** `src/ui/App.tsx` — pass Access config to the in-process `startWebServer`, and compute the read-only status prop.
+- **Modify** `src/web/wire.ts` + `src/web/routes.ts` — add `cloudflareAccessEnforced` capability boolean to the sources/accounts payloads.
+- **Modify** `src/web/routes.test.ts` — assert the new capability flag; stub the new env vars.
+- **Modify** `src/ui/components/Settings.tsx` (+ `SettingsProps` and its wiring in `App.tsx`) — a read-only "Cloudflare Access" status line.
+- **Modify** `src/web/static/settingsModel.ts` + `app.ts` — read-only status line in the browser settings dialog.
+- **Modify** `README.md` — the end-to-end deployment recipe.
+
+---
+
+## Task 1: Add `jose` and the pure verifier module
+
+**Files:**
+- Modify: `package.json` (dependency)
+- Create: `src/core/cloudflareAccess.ts`
+- Test: `src/core/cloudflareAccess.test.ts`
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `npm install jose`
+Expected: `jose` appears under `"dependencies"` in `package.json`; `package-lock.json` updated.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/core/cloudflareAccess.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JSONWebKeySet } from "jose";
+import { verifyAccessAssertion, accessIssuer, accessJwksUrl } from "./cloudflareAccess.js";
+
+const TEAM = "myteam.cloudflareaccess.com";
+const AUD = "aud-tag-123";
+
+// A frozen clock so token exp/iat are deterministic.
+const NOW = 1_760_000_000_000; // fixed ms
+
+async function setup() {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "k1";
+  jwk.alg = "RS256";
+  const jwks: JSONWebKeySet = { keys: [jwk] };
+  const keySet = createLocalJWKSet(jwks);
+  return { privateKey, keySet };
+}
+
+async function mint(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  opts: { iss?: string; aud?: string; exp?: number; kid?: string } = {},
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? "k1" })
+    .setIssuer(opts.iss ?? accessIssuer(TEAM))
+    .setAudience(opts.aud ?? AUD)
+    .setIssuedAt(Math.floor(NOW / 1000))
+    .setExpirationTime(opts.exp ?? Math.floor(NOW / 1000) + 3600)
+    .sign(privateKey);
+}
+
+describe("cloudflareAccess helpers", () => {
+  it("derives the JWKS url and issuer", () => {
+    expect(accessJwksUrl(TEAM).toString()).toBe(`https://${TEAM}/cdn-cgi/access/certs`);
+    expect(accessIssuer(TEAM)).toBe(`https://${TEAM}`);
+  });
+});
+
+describe("verifyAccessAssertion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("accepts a valid assertion and returns the email", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "owner@example.com" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toMatchObject({ ok: true, email: "owner@example.com" });
+  });
+
+  it("reports no-assertion for a missing token", async () => {
+    const { keySet } = await setup();
+    const res = await verifyAccessAssertion(undefined, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "no-assertion" });
+  });
+
+  it("rejects an expired assertion", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { exp: Math.floor(NOW / 1000) - 10 });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a wrong audience", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { aud: "other-aud" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "aud-mismatch" });
+  });
+
+  it("rejects a wrong issuer", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { iss: "https://evil.cloudflareaccess.com" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "iss-mismatch" });
+  });
+
+  it("rejects a signature from an unknown key", async () => {
+    const { keySet } = await setup();
+    const stranger = await generateKeyPair("RS256");
+    const token = await mint(stranger.privateKey, { email: "x@e.com" }, { kid: "k1" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("bad-signature");
+  });
+
+  it("reports malformed for garbage input", async () => {
+    const { keySet } = await setup();
+    const res = await verifyAccessAssertion("not-a-jwt", keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "malformed" });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run src/core/cloudflareAccess.test.ts`
+Expected: FAIL — cannot resolve `./cloudflareAccess.js` (module not created yet).
+
+- [ ] **Step 4: Write the module**
+
+Create `src/core/cloudflareAccess.ts`:
+
+```ts
+import type { IncomingHttpHeaders } from "node:http";
+import { jwtVerify, type JWTVerifyGetKey } from "jose";
+
+/** Host-specific Cloudflare Access settings. Never a credential — safe to log the team domain. */
+export interface AccessConfig {
+  /** e.g. "myteam.cloudflareaccess.com" */
+  teamDomain: string;
+  /** The Access application's Audience (AUD) tag. */
+  aud: string;
+}
+
+export type AccessReason =
+  | "no-assertion"
+  | "bad-signature"
+  | "expired"
+  | "aud-mismatch"
+  | "iss-mismatch"
+  | "jwks-error"
+  | "malformed";
+
+export type AccessResult =
+  | { ok: true; email?: string; sub?: string }
+  | { ok: false; reason: AccessReason };
+
+export function accessJwksUrl(teamDomain: string): URL {
+  return new URL(`https://${teamDomain}/cdn-cgi/access/certs`);
+}
+
+export function accessIssuer(teamDomain: string): string {
+  return `https://${teamDomain}`;
+}
+
+/** Cloudflare stamps this header on every request it forwards through Access. */
+export function accessTokenFromHeaders(headers: IncomingHttpHeaders): string | undefined {
+  const v = headers["cf-access-jwt-assertion"];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function mapError(e: unknown): AccessReason {
+  const code = (e as { code?: string })?.code;
+  const claim = (e as { claim?: string })?.claim;
+  if (code === "ERR_JWT_EXPIRED") return "expired";
+  if (code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED") return "bad-signature";
+  if (code === "ERR_JWKS_NO_MATCHING_KEY") return "bad-signature";
+  if (code === "ERR_JWT_CLAIM_VALIDATION_FAILED") {
+    if (claim === "aud") return "aud-mismatch";
+    if (claim === "iss") return "iss-mismatch";
+    return "malformed";
+  }
+  if (code === "ERR_JOSE_GENERIC" || code?.startsWith("ERR_JWKS")) return "jwks-error";
+  return "malformed";
+}
+
+/**
+ * Verify a Cloudflare Access assertion. Fails CLOSED: any error (including a JWKS
+ * fetch failure) returns { ok: false } rather than throwing, so callers 403.
+ * `keySet` is a jose key resolver (remote JWKS in prod, local JWKS in tests).
+ */
+export async function verifyAccessAssertion(
+  token: string | undefined,
+  keySet: JWTVerifyGetKey,
+  cfg: AccessConfig,
+  clockTolerance = 5,
+): Promise<AccessResult> {
+  if (!token) return { ok: false, reason: "no-assertion" };
+  try {
+    const { payload } = await jwtVerify(token, keySet, {
+      issuer: accessIssuer(cfg.teamDomain),
+      audience: cfg.aud,
+      clockTolerance,
+    });
+    const email = typeof payload.email === "string" ? payload.email : undefined;
+    return { ok: true, email, sub: payload.sub };
+  } catch (e) {
+    return { ok: false, reason: mapError(e) };
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/core/cloudflareAccess.test.ts`
+Expected: PASS (all cases). If `bad-signature` vs `jwks-error` differs on your `jose` version for the unknown-key case, the test already accepts `bad-signature`; adjust `mapError` only if a case fails.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json src/core/cloudflareAccess.ts src/core/cloudflareAccess.test.ts
+git commit -m "feat(core): Cloudflare Access JWT verifier"
+```
+
+---
+
+## Task 2: Config fields + resolver
+
+**Files:**
+- Modify: `src/config/config.ts` (the `Config` interface ~26-151; add a resolver near the other `resolve*` helpers ~291-334)
+- Test: `src/config/cloudflareAccess.resolve.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/config/cloudflareAccess.resolve.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultConfig, resolveCloudflareAccess } from "./config.js";
+
+const TEAM_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
+const AUD_ENV = "TORLINK_CF_ACCESS_AUD";
+
+describe("resolveCloudflareAccess", () => {
+  beforeEach(() => {
+    vi.stubEnv(TEAM_ENV, "");
+    vi.stubEnv(AUD_ENV, "");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns null when nothing is configured", () => {
+    expect(resolveCloudflareAccess({ ...defaultConfig })).toBeNull();
+  });
+
+  it("returns null when only one half is set", () => {
+    expect(resolveCloudflareAccess({ ...defaultConfig, cfAccessTeamDomain: "t.cloudflareaccess.com" })).toBeNull();
+    expect(resolveCloudflareAccess({ ...defaultConfig, cfAccessAud: "aud" })).toBeNull();
+  });
+
+  it("reads both halves from config", () => {
+    const res = resolveCloudflareAccess({
+      ...defaultConfig,
+      cfAccessTeamDomain: "t.cloudflareaccess.com",
+      cfAccessAud: "aud-1",
+    });
+    expect(res).toEqual({ teamDomain: "t.cloudflareaccess.com", aud: "aud-1" });
+  });
+
+  it("lets env vars win over config", () => {
+    vi.stubEnv(TEAM_ENV, "env.cloudflareaccess.com");
+    vi.stubEnv(AUD_ENV, "env-aud");
+    const res = resolveCloudflareAccess({
+      ...defaultConfig,
+      cfAccessTeamDomain: "file.cloudflareaccess.com",
+      cfAccessAud: "file-aud",
+    });
+    expect(res).toEqual({ teamDomain: "env.cloudflareaccess.com", aud: "env-aud" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/config/cloudflareAccess.resolve.test.ts`
+Expected: FAIL — `resolveCloudflareAccess` is not exported.
+
+- [ ] **Step 3: Add the config fields**
+
+In `src/config/config.ts`, add to the `Config` interface (after `castAdvertiseHost?: string;`, before the closing brace ~line 150):
+
+```ts
+  /** Cloudflare Access team domain, e.g. "myteam.cloudflareaccess.com". Host-specific; TUI/env only. */
+  cfAccessTeamDomain?: string;
+  /** Cloudflare Access application Audience (AUD) tag. Host-specific; TUI/env only. */
+  cfAccessAud?: string;
+```
+
+- [ ] **Step 4: Add the resolver**
+
+In `src/config/config.ts`, near the other `resolve*` helpers (after `resolveCastAdvertiseHost`), add:
+
+```ts
+const CF_ACCESS_TEAM_DOMAIN_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
+const CF_ACCESS_AUD_ENV = "TORLINK_CF_ACCESS_AUD";
+
+/**
+ * Cloudflare Access enforcement config. env wins over the persisted value, both
+ * trimmed. Returns null unless BOTH halves are present — a half-configured gate
+ * would fail every request, so treat it as "off".
+ */
+export function resolveCloudflareAccess(
+  config: Config,
+): { teamDomain: string; aud: string } | null {
+  const teamDomain = (process.env[CF_ACCESS_TEAM_DOMAIN_ENV]?.trim() || config.cfAccessTeamDomain?.trim()) ?? "";
+  const aud = (process.env[CF_ACCESS_AUD_ENV]?.trim() || config.cfAccessAud?.trim()) ?? "";
+  if (!teamDomain || !aud) return null;
+  return { teamDomain, aud };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/config/cloudflareAccess.resolve.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the allowlist is untouched**
+
+Confirm you did **not** add `cfAccess*` to `RawSettingsPatch`/`sanitiseSettingsPatch` (`src/config/config.ts` ~208-278). These stay TUI/env-only per repo rules.
+Run: `npx vitest run src/config` and `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/config/config.ts src/config/cloudflareAccess.resolve.test.ts
+git commit -m "feat(config): resolveCloudflareAccess + Config fields (TUI/env-only)"
+```
+
+---
+
+## Task 3: The origin guard in `startWebServer`
+
+**Files:**
+- Modify: `src/web/server.ts` (`WebServerOptions` ~55-109; `startWebServer` setup ~228-326; the `http.createServer` guard block ~454-486)
+- Test: `src/web/server.test.ts`
+
+- [ ] **Step 1: Write the failing socket test**
+
+Add to `src/web/server.test.ts` (mirror the file's existing socket harness — `startWebServer` on `port: 0`, then `fetch` against `handle.port`). If the file lacks jose helpers, add these imports at the top and this `describe` block:
+
+```ts
+import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JSONWebKeySet } from "jose";
+
+describe("startWebServer — Cloudflare Access guard", () => {
+  const TEAM = "myteam.cloudflareaccess.com";
+  const AUD = "aud-tag-123";
+
+  async function serverWithAccess() {
+    const { publicKey, privateKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "k1";
+    jwk.alg = "RS256";
+    const jwks: JSONWebKeySet = { keys: [jwk] };
+    const accessKeySetImpl = createLocalJWKSet(jwks);
+    const handle = await startWebServer(runtime(), {
+      port: 0,
+      host: "127.0.0.1",
+      cloudflareAccess: { teamDomain: TEAM, aud: AUD },
+      accessKeySetImpl,
+    });
+    const mint = (claims: Record<string, unknown>, exp?: number) =>
+      new SignJWT(claims)
+        .setProtectedHeader({ alg: "RS256", kid: "k1" })
+        .setIssuer(`https://${TEAM}`)
+        .setAudience(AUD)
+        .setIssuedAt()
+        .setExpirationTime(exp ?? "1h")
+        .sign(privateKey);
+    return { handle, mint };
+  }
+
+  it("403s an api request with no assertion", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/status`);
+    expect(res.status).toBe(403);
+    await handle.close();
+  });
+
+  it("allows an api request carrying a valid assertion", async () => {
+    const { handle, mint } = await serverWithAccess();
+    const token = await mint({ email: "owner@example.com" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/status`, {
+      headers: { "Cf-Access-Jwt-Assertion": token },
+    });
+    expect(res.status).toBe(200);
+    await handle.close();
+  });
+
+  it("exempts /health from the assertion check", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+    expect(res.status).toBe(200);
+    await handle.close();
+  });
+});
+```
+
+> Note: this test uses **real timers** (jose validates against the real clock and the tokens are freshly minted with `"1h"` expiry), so do NOT wrap it in `vi.useFakeTimers()`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/web/server.test.ts -t "Cloudflare Access guard"`
+Expected: FAIL — `cloudflareAccess`/`accessKeySetImpl` are not valid options; no guard exists (requests return 200/404, not 403).
+
+- [ ] **Step 3: Extend `WebServerOptions`**
+
+In `src/web/server.ts`, add to the `WebServerOptions` interface (~55-109):
+
+```ts
+  /** When set, verify Cloudflare Access assertions and 403 requests without one. */
+  cloudflareAccess?: import("../core/cloudflareAccess.js").AccessConfig;
+  /** Test seam: overrides the JWKS resolver (default: remote JWKS from the team domain). */
+  accessKeySetImpl?: import("jose").JWTVerifyGetKey;
+```
+
+- [ ] **Step 4: Build the verifier once, add the guard**
+
+In `src/web/server.ts`, add imports near the top:
+
+```ts
+import { createRemoteJWKSet } from "jose";
+import { accessJwksUrl, accessTokenFromHeaders, verifyAccessAssertion } from "../core/cloudflareAccess.js";
+```
+
+In `startWebServer`, after `const token = ...` (~line 234), add:
+
+```ts
+  const accessCfg = options.cloudflareAccess ?? null;
+  const accessKeySet = accessCfg
+    ? (options.accessKeySetImpl ?? createRemoteJWKSet(accessJwksUrl(accessCfg.teamDomain)))
+    : null;
+  if (accessCfg) log(`cloudflare access: enforcing (team ${accessCfg.teamDomain})`);
+```
+
+In the `http.createServer` handler, immediately AFTER the CSRF guard block (after the `if (method !== "GET" && ... isCrossSiteHttpRequest ...)` block, ~line 486) and BEFORE the `/api/events` handler, add:
+
+```ts
+      // Cloudflare Access: the origin refuses anything that did not arrive through
+      // Access, so it is safe even if this port is ever reachable directly. Health
+      // and the media routes are exempt — the latter carry the per-session ?k=
+      // capability instead, because <video>/VLC/Chromecast can't present a cert.
+      if (accessCfg) {
+        const exempt =
+          urlPath === "/health" ||
+          isStreamPath(urlPath) ||
+          urlPath === "/play" ||
+          urlPath.startsWith("/play/");
+        if (!exempt) {
+          const assertion = accessTokenFromHeaders(req.headers);
+          const verdict = await verifyAccessAssertion(assertion, accessKeySet!, accessCfg);
+          if (!verdict.ok) {
+            writeJson(res, 403, { error: "forbidden" });
+            log(`${method} ${urlPath} -> 403 (access: ${verdict.reason})`);
+            return;
+          }
+        }
+      }
+```
+
+> `isStreamPath` is already imported in this file (used by the `/stream` route). If lint flags an unused import elsewhere, leave existing imports as-is.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/web/server.test.ts -t "Cloudflare Access guard"`
+Expected: PASS (403 without assertion, 200 with a valid one, 200 for `/health`).
+
+- [ ] **Step 6: Run the full web suite + typecheck**
+
+Run: `npx vitest run src/web && npm run typecheck`
+Expected: PASS — existing tests (Access-off by default) are unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/server.ts src/web/server.test.ts
+git commit -m "feat(web): verify Cloudflare Access assertion at the origin"
+```
+
+---
+
+## Task 4: Thread Access config through both server hosts
+
+**Files:**
+- Modify: `src/daemon/serve.ts` (option assembly ~385-393)
+- Modify: `src/ui/App.tsx` (in-process `startWebServer` call ~671)
+
+- [ ] **Step 1: Wire `serve --web`**
+
+In `src/daemon/serve.ts`, ensure `loadConfig` and `resolveCloudflareAccess` are imported from `../config/config.js` (add to the existing import if missing). Before the `web = await startWebServer(...)` call (~385), add:
+
+```ts
+    const startupConfig = await loadConfig();
+    const cloudflareAccess = resolveCloudflareAccess(startupConfig);
+```
+
+and extend the options object passed to `startWebServer`:
+
+```ts
+      web = await startWebServer(runtime, {
+        port,
+        host,
+        ...(token ? { token } : {}),
+        ...(cloudflareAccess ? { cloudflareAccess } : {}),
+        log,
+      });
+```
+
+- [ ] **Step 2: Wire the in-process TUI host**
+
+In `src/ui/App.tsx`, add `resolveCloudflareAccess` to the existing `../config/config.js` import. At the `startWebServer(...)` call (~671), add the option, resolving from the `config` already in scope:
+
+```ts
+      ...(resolveCloudflareAccess(config) ? { cloudflareAccess: resolveCloudflareAccess(config)! } : {}),
+```
+
+(Place it alongside the existing `port`/`host`/`token`/`log` options in that call.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/daemon/serve.ts src/ui/App.tsx
+git commit -m "feat: pass Cloudflare Access config to both web-server hosts"
+```
+
+---
+
+## Task 5: Read-only "Access enforced" status in both front ends
+
+This is the capability-flag surface — a boolean, never a credential — mirroring `debridConfigured`.
+
+**Files:**
+- Modify: `src/web/wire.ts` (the two capability payload types carrying `debridConfigured`, ~465 and ~584)
+- Modify: `src/web/routes.ts` (the two payload assemblies, ~788 and ~1285)
+- Test: `src/web/routes.test.ts`
+- Modify: `src/ui/components/Settings.tsx` (+ `SettingsProps`) and its wiring in `src/ui/App.tsx`
+- Modify: `src/web/static/settingsModel.ts` and `src/web/static/app.ts`
+
+- [ ] **Step 1: Write the failing router test**
+
+In `src/web/routes.test.ts`, add to the `beforeEach` env stubs (alongside `REALDEBRID_API_TOKEN`/`TORBOX_API_TOKEN`):
+
+```ts
+    vi.stubEnv("TORLINK_CF_ACCESS_TEAM_DOMAIN", "");
+    vi.stubEnv("TORLINK_CF_ACCESS_AUD", "");
+```
+
+Then add a test in the `/api/sources` describe block:
+
+```ts
+  it("reports cloudflareAccessEnforced=false when unconfigured", async () => {
+    const res = await handleWebApi(deps({ token: "secret" }), "GET", "/api/sources", new URLSearchParams(), AUTH, "");
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ cloudflareAccessEnforced: false });
+  });
+
+  it("reports cloudflareAccessEnforced=true when both halves are configured", async () => {
+    const loadConfigImpl = async () => ({
+      ...defaultConfig,
+      downloadDir: "/tmp/dl",
+      cfAccessTeamDomain: "t.cloudflareaccess.com",
+      cfAccessAud: "aud-1",
+    });
+    const res = await handleWebApi(
+      deps({ token: "secret", loadConfigImpl }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    expect(res.json).toMatchObject({ cloudflareAccessEnforced: true });
+  });
+```
+
+(Import `defaultConfig` in the test if not already imported.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/web/routes.test.ts -t "cloudflareAccessEnforced"`
+Expected: FAIL — field is `undefined`.
+
+- [ ] **Step 3: Add the wire type**
+
+In `src/web/wire.ts`, add to BOTH capability blocks that already declare `debridConfigured: boolean;` (~465 and ~584):
+
+```ts
+  /** Whether the origin is enforcing Cloudflare Access. A capability flag, never a credential. */
+  cloudflareAccessEnforced: boolean;
+```
+
+- [ ] **Step 4: Populate both payloads**
+
+In `src/web/routes.ts`, import `resolveCloudflareAccess` from `../config/config.js` (extend the existing import). In BOTH payload assemblies (~788 and ~1285), add beside `debridConfigured`:
+
+```ts
+    cloudflareAccessEnforced: resolveCloudflareAccess(config) !== null,
+```
+
+- [ ] **Step 5: Run the router test**
+
+Run: `npx vitest run src/web/routes.test.ts -t "cloudflareAccessEnforced"`
+Expected: PASS.
+
+- [ ] **Step 6: Browser read-only line**
+
+In `src/web/static/settingsModel.ts`, wherever the read-only capability section is built (it already consumes `debridConfigured`/`omdbConfigured` from the sources payload — mirror that exact pattern), derive a display string from the new flag, e.g.:
+
+```ts
+  cloudflareAccess: sources.cloudflareAccessEnforced ? "Enforced" : "Not configured",
+```
+
+In `src/web/static/app.ts`, render it as a read-only row in the settings dialog's account/status area, using `createElement` + `textContent` only (NO `innerHTML`), matching how the OMDb/debrid status rows are created.
+
+- [ ] **Step 7: TUI read-only line**
+
+In `src/ui/components/Settings.tsx`, add `cfAccessEnforced: boolean` to `SettingsProps` (~24-65). Add a status row modelled on the OMDb row (~274-290), with no actions:
+
+```ts
+{
+  tag: "CFACC",
+  color: "#f38020", // Cloudflare orange
+  label: "Cloudflare Access",
+  sub: "edge auth · mTLS / SSO",
+  kind: "account" as const,
+  present: props.cfAccessEnforced,
+  ok: props.cfAccessEnforced,
+  status: "Enforced",
+  emptyStatus: "Not configured",
+  primary: { key: "", verb: "", run: () => {} },
+  secondary: [],
+},
+```
+
+> If the row renderer requires a non-empty `primary`, instead reuse the `"setting"` kind (renders `ICON.dot + status` with no action): push `{ ...as a setting row..., status: props.cfAccessEnforced ? "Cloudflare Access: enforced" : "Cloudflare Access: not configured" }`. Pick whichever the existing `Row` union renders cleanly without an action affordance.
+
+In `src/ui/App.tsx`, where `<Settings ... />` props are built (near the `debridConfigured` prop ~2612), add:
+
+```ts
+        cfAccessEnforced: resolveCloudflareAccess(config) !== null,
+```
+
+- [ ] **Step 8: Keep the preview/test stores compiling**
+
+`cfAccessEnforced` is a `Settings` prop derived from `config`, NOT a `Store` field, so `makeStore`/`makeTestStore` need no change. Confirm:
+Run: `npm run typecheck && npm run previews`
+Expected: PASS. (If typecheck reports the prop missing anywhere `Settings` is constructed — e.g. a preview harness — add `cfAccessEnforced: false` there.)
+
+- [ ] **Step 9: Full suite + lint + build**
+
+Run: `npm test && npm run typecheck && npm run lint && npm run build`
+Expected: PASS (the one known pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx` is fine; `npm run build` also proves `src/web/static` imports no `node:*`).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/web/wire.ts src/web/routes.ts src/web/routes.test.ts \
+  src/ui/components/Settings.tsx src/ui/App.tsx \
+  src/web/static/settingsModel.ts src/web/static/app.ts
+git commit -m "feat: surface Cloudflare Access status read-only in both front ends"
+```
+
+---
+
+## Task 6: Deployment documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the deployment section**
+
+Add a "Exposing torlink publicly with Cloudflare Access" section to `README.md` covering, in order:
+
+1. Put the domain on Cloudflare (nameservers).
+2. Create a Cloudflare Tunnel; ingress rule `torlink.example.com → http://localhost:9161` (the `serve --web` port); run `cloudflared` on the home box next to torlink and reccd. No router ports are opened.
+3. Generate an mTLS root CA; upload the CA under Cloudflare mTLS; issue a client cert per device and install it (laptop/phone easy; note the Android-TV/Shield caveat).
+4. Create one Access application on the hostname with policy **`(valid client certificate) OR (email ∈ allowlist)`** — cert = silent for your devices, email/SSO = install-nothing for a shared friend.
+5. Set torlink's two values on the home box, via env on the service or `config.json`:
+   - `TORLINK_CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com`
+   - `TORLINK_CF_ACCESS_AUD=<the Access application's AUD tag>`
+   Restart `serve --web`; the log prints `cloudflare access: enforcing (team …)`.
+6. Caveats to state plainly: single-tenant (a shared friend uses your instance, quota, library and history); the `OR email` arm makes the login page visible to strangers (still locked); casting to the Shield stays on the LAN and is unaffected; browsing the UI *on* the Shield with mTLS is not supported; for remote viewing prefer direct debrid streaming (`proxyDebridStreams` off) so video doesn't relay through your home uplink and Cloudflare.
+
+- [ ] **Step 2: Verify the web UI limitations list is still accurate**
+
+Re-read the web-UI limitations/notes list in `README.md`; adjust if it claims anything now untrue about auth/exposure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: Cloudflare Access deployment guide"
+```
+
+---
+
+## Self-Review (completed while writing)
+
+**Spec coverage:**
+- Silent owner auth / friend SSO / strangers blocked at edge → Cloudflare setup (Task 6) + two-arm policy.
+- Origin defense-in-depth (verify `Cf-Access-Jwt-Assertion`) → Tasks 1 + 3.
+- Fail-closed on JWKS failure → `verifyAccessAssertion` returns `{ok:false}` on any throw (Task 1); guard 403s.
+- Path exemptions (`/health`, `/stream`, `/play`) → Task 3 guard.
+- Host-specific config, NOT web-writable → Task 2 (resolver, fields) + Step 6 (allowlist untouched).
+- Both server hosts (`serve --web` and in-process TUI) → Task 4.
+- Read-only status in both front ends → Task 5.
+- Direct-stream recommendation, single-tenant + visibility caveats, Shield notes → Task 6.
+
+**Placeholder scan:** No TBD/TODO; every code step carries full code. The one conditional ("if the row renderer requires a non-empty primary…") gives a concrete fallback, not a deferral.
+
+**Type consistency:** `AccessConfig`/`AccessResult`/`verifyAccessAssertion`/`accessJwksUrl`/`accessIssuer`/`accessTokenFromHeaders` are defined in Task 1 and used unchanged in Task 3. `resolveCloudflareAccess` (Task 2) returns `{teamDomain, aud} | null`, matching `WebServerOptions.cloudflareAccess?: AccessConfig` (Task 3) and the call sites (Task 4). `cloudflareAccessEnforced` (wire) and `cfAccessEnforced` (TUI prop) are intentionally distinct names for the wire field vs the React prop — both consistently used within their layers.
+
+**Out of scope (stated in the spec):** multi-user accounts; app-level mTLS; bundling `cloudflared`; verifying Access on the bare `createApiServer` (non-`--web`) path (loopback-only, not the public deployment) — add later if that server is ever exposed.

--- a/docs/superpowers/specs/2026-08-10-cloudflare-access-mtls-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloudflare-access-mtls-design.md
@@ -1,0 +1,252 @@
+# Cloudflare Access (mTLS + SSO) for a public torlink
+
+**Date:** 2026-08-10
+**Status:** Design — approved shape, pending spec review
+
+## Problem
+
+The owner wants to run torlink's web UI on a public domain
+(`torlink.yourdomain.com`) fronted by Cloudflare Tunnel — the same way
+`~/projects/reccd` is exposed — but keep it closed to the public:
+
+- Their own devices (laptop, phone) should be authenticated **silently**, with no
+  login page and no per-visit action.
+- Strangers should be **stopped before they see the app** at all.
+- They want to reach it **remotely** (work, holiday) and stream through a debrid
+  provider (TorBox), primarily by watching in the browser's `<video>` player.
+- They want to **share with a friend from day one**, accepting whatever complexity
+  that adds.
+- Casting to an Nvidia Shield (Android TV) at home should keep working.
+
+torlink today is plain `node:http` with an optional shared bearer token, a
+loopback-`Host` DNS-rebinding guard, and a cross-site/CSRF guard
+(`src/web/server.ts`, `src/daemon/auth.ts`). It binds `127.0.0.1` by default and
+refuses a non-loopback bind without a token. There is no TLS or client-certificate
+machinery, and there won't be — TLS is terminated at Cloudflare's edge.
+
+## Goals
+
+- Silent auth for the owner's own devices (client certificate / mTLS).
+- Easy, install-nothing auth for a shared friend (Cloudflare Access email/SSO).
+- Strangers blocked at the Cloudflare edge, never reaching the origin.
+- **Defense in depth at the origin:** torlink itself refuses any request that did
+  not arrive through Cloudflare Access, so the app is safe even if the origin is
+  ever directly reachable — not merely safe because of how the network is wired.
+- In-browser remote playback (including debrid streams) keeps working.
+- At-home casting to the Shield keeps working.
+
+## Non-goals
+
+- **Multi-user / per-account isolation.** torlink is single-tenant: one
+  `config.json`, one debrid token, one library, one watch history. A shared friend
+  uses *the owner's* instance and quota and sees the owner's library. Real accounts
+  are a much larger project, explicitly out of scope.
+- **App-level mTLS** (torlink terminating TLS and demanding a client cert). It is
+  incompatible with Cloudflare terminating TLS at the edge and breaks cert-less
+  players; rejected during brainstorming.
+- **Shipping the Cloudflare setup as code.** Domain, Tunnel, Access policy, CA and
+  client certs are one-time ops performed in the Cloudflare dashboard and on the
+  owner's devices. They are documented here and in the README, not automated.
+- **Bundling `cloudflared`** into torlink or its container.
+
+## Architecture
+
+```
+  You / phone / laptop / friend
+            │  HTTPS to torlink.yourdomain.com
+            ▼
+   ┌──────────────────────────────┐
+   │  Cloudflare edge (Access)     │  policy: (valid client cert) OR (email ∈ allowlist)
+   │                               │  strangers stopped HERE; never reach the origin
+   │  stamps Cf-Access-Jwt-Assertion on every forwarded request
+   └───────────────┬──────────────┘
+                   │  Cloudflare Tunnel — outbound from the house; no inbound ports
+                   ▼
+   ┌──────────────────────────────┐
+   │  Home box                     │
+   │   cloudflared ─► torlink @ 127.0.0.1:9161 (plain HTTP)                 │
+   │                   └─ verifies Cf-Access-Jwt-Assertion; 403 if absent   │
+   │   reccd (already here)                                                 │
+   └───────────────┬──────────────┘
+                   │  LAN only
+                   ▼
+             Nvidia Shield  ← casting stays on the LAN; Cloudflare not involved
+```
+
+- The tunnel dials **out** from the house, so no router ports are opened.
+- torlink binds **loopback**, reachable only via `cloudflared` on the same box.
+- Cloudflare Access is the front gate; the origin JWT check is the backstop.
+
+### Two-arm Access policy is what enables day-one sharing
+
+A single Access application on the hostname with a policy of
+**`(valid client certificate) OR (email is in {owner, friend})`**:
+
+- The owner's devices carry a client cert and authenticate **silently**.
+- The friend supplies an email one-time code (or SSO) — **nothing to install**,
+  added/removed in the dashboard in seconds.
+
+**Accepted trade-off:** the `OR email` arm means a stranger now sees a Cloudflare
+*login page* rather than a blank wall. It is still locked — they cannot get in —
+but the endpoint is no longer invisible. This is the unavoidable cost of
+install-nothing sharing and was accepted during brainstorming.
+
+## torlink-side changes (the buildable part)
+
+### 1. Access JWT verification module
+
+A new front-end-agnostic module (e.g. `src/core/cloudflareAccess.ts`, or
+`src/util/` if it grows no core dependencies) that, given the request headers and
+configured `teamDomain` + `audTag`, decides whether a request carries a valid
+Cloudflare Access assertion:
+
+- Read `Cf-Access-Jwt-Assertion` (Cloudflare also mirrors it as a `CF_Authorization`
+  cookie; the header is authoritative and is what we check).
+- Verify the JWT against Cloudflare's JWKS at
+  `https://<teamDomain>/cdn-cgi/access/certs`, checking signature, `exp`, and that
+  `aud` contains the configured application audience (AUD) tag.
+- **Cache the JWKS** in memory with a bounded TTL and refetch on key-ID miss; never
+  fetch per request.
+- Pure, testable decision surface: `verifyAccessJwt(token, {teamDomain, audTag, now, jwks})
+  → {ok: true, email, sub} | {ok: false, reason}`. Network fetch of JWKS is a
+  separate, injectable function so the verifier is unit-tested with fixed keys and a
+  frozen clock (matches the repo's fake-timers testing preference).
+
+Fail soft on configuration, hard on verification: if Access verification is **not
+configured**, behaviour is unchanged (feature off). If it **is** configured, a
+missing/invalid assertion on a protected path is a hard `403`.
+
+### 2. Wiring into the request guard
+
+The check belongs in the `http.createServer` request handler in
+`src/web/server.ts` (~line 454), alongside the existing loopback-`Host` and
+cross-site guards — the router (`src/web/routes.ts`) never sees request headers, by
+design. Order: after the `Host` and CSRF guards, before routing.
+
+When Access verification is enabled:
+
+- Requests to protected paths without a valid assertion → `403` (logged with reason,
+  never logging the token).
+- The verified identity (`email`) is made available for optional read-only display
+  (see §4); it is **not** used for authorization decisions beyond
+  present-and-valid, since torlink is single-tenant.
+
+### 3. Path exemptions (stream / play / health)
+
+Exempt from the JWT check:
+
+- `/health` — already unauthenticated by design.
+- `/stream/*` and `/play/*` — guarded by the existing per-session `?k=` capability,
+  not the bearer token. Exempting them means a **cert-less external player**
+  (VLC/Kodi) or a **remote cast target** fetching over the public domain still works,
+  protected by the unguessable capability. The owner's *primary* flows do not depend
+  on this exemption — in-browser `<video>` playback rides the browser's own cert, and
+  at-home casting to the Shield stays on the LAN — but the exemption is cheap and
+  keeps the external-player door open, so it is built in from the start.
+
+Everything else (`/`, static assets, `/api/*`, the SSE routes `/api/events` and
+`/api/search`) is protected. The SSE routes already accept `?k=` for `EventSource`;
+Access verification sits in front and is satisfied by the browser's cert on the same
+origin.
+
+### 4. Configuration (host-specific → TUI-only, per repo rules)
+
+Cloudflare Access `teamDomain` and `audTag` are host-specific deployment config, so
+per the repo's "secrets and host-specific config are TUI-only" rule they are **not**
+browser-writable via `/api/settings`:
+
+- New optional fields on the serve/runtime config (env + flags + TUI), e.g.
+  `TORLINK_CF_ACCESS_TEAM_DOMAIN` / `TORLINK_CF_ACCESS_AUD` (exact names decided in
+  the plan), surfaced read-only in the TUI Settings/Accounts area as an account-status
+  line ("Cloudflare Access: enforced" / "not configured").
+- The browser's settings dialog does **not** gain a write control for these. If any
+  status is surfaced to the browser it is read-only capability, consistent with how
+  `debridConfigured` etc. are reported by `/api/sources`.
+
+This keeps the layering rule intact (`src/web` must not import `src/ui`; shared logic
+lives in `src/core`/`src/util`).
+
+### 5. Streaming mode note (config, not new code)
+
+For remote viewing, **direct** debrid streaming (browser fetches the TorBox CDN URL)
+is preferred over relaying through the home box, to avoid consuming home upload
+bandwidth and pushing heavy video through Cloudflare. torlink already exposes this
+choice via `proxyDebridStreams` (`src/config/config.ts`). No new code; the deployment
+docs call out the recommendation.
+
+## Data flow — remote in-browser stream (the primary remote case)
+
+1. Laptop/phone browser (client cert installed) requests
+   `https://torlink.yourdomain.com/` → Cloudflare validates cert → forwards with
+   `Cf-Access-Jwt-Assertion`.
+2. torlink verifies the assertion → serves the app.
+3. User picks a title; `/api/*` calls carry the cert (same origin) → verified → OK.
+4. Playback: with `proxyDebridStreams` **off**, the browser plays the TorBox CDN URL
+   directly (no Cloudflare, no cert needed for that leg). With it **on**, the browser
+   fetches `/stream/*?k=...`; that path is exempt from the JWT check and guarded by
+   `?k=`, and the browser presents the cert anyway.
+
+## Data flow — at-home cast to the Shield (unchanged)
+
+torlink discovers the Shield via mDNS on the home LAN and hands it a **LAN** stream
+URL (`castAdvertiseHost`, `src/web/server.ts` ~313). The Shield fetches over the LAN;
+Cloudflare and Access are not involved. No change required.
+
+## Error handling
+
+- **Access not configured:** feature off; behaviour identical to today. This is the
+  default and the path all existing tests exercise.
+- **Assertion missing/invalid on a protected path:** `403 {"error":"forbidden"}`,
+  logged with a coarse reason (`no-assertion`, `bad-signature`, `expired`, `aud-mismatch`),
+  never logging the token value.
+- **JWKS fetch failure:** the verifier fails **closed** for protected paths (a `403`
+  with a distinct reason) rather than failing open; the cached JWKS covers transient
+  outages, and refusing is the safe default for a security gate. Logged so the
+  operator can see it.
+- **Clock skew:** small `exp`/`iat` leeway (a few seconds), consistent with standard
+  JWT validation.
+
+## Testing
+
+- **Unit (pure verifier):** valid token; expired; wrong `aud`; bad signature; wrong
+  key ID with successful refetch; malformed token; missing header. Fixed test keys,
+  frozen clock via fake timers (repo preference). JWKS fetch injected.
+- **Guard wiring:** requests to a protected path with/without a valid assertion return
+  `200`/`403`; `/health`, `/stream/*`, `/play/*` bypass the check; feature-off leaves
+  all current behaviour untouched. Reuse the existing web route test harness
+  (`src/web/routes.test.ts` patterns), which currently asserts the bearer-token gate.
+- **No secret leakage:** assert the token/assertion never appears in logs or in any
+  response body (mirrors the existing `not.toContain` stream-XSS checks — and, per
+  CLAUDE.md, any such negative assertion must name a string actually put in play).
+
+## Documentation
+
+- `README.md`: a new "Exposing torlink publicly with Cloudflare Access" section — the
+  end-to-end recipe (domain → Tunnel ingress → mTLS CA → client cert install per
+  device → two-arm Access policy → the two torlink config values), the single-tenant
+  sharing caveat, the visibility trade-off, the Android-TV/Shield note (cast at home
+  over LAN; browsing the UI on the TV itself is out of scope for mTLS), and the
+  `proxyDebridStreams` recommendation for remote viewing.
+- Verify the web UI's own limitations list stays accurate.
+
+## Complexity summary
+
+| Piece | Where | Effort |
+| --- | --- | --- |
+| Domain + Tunnel + Access policy + CA + client certs | Cloudflare dashboard + devices | One-time ops, no code — the bulk of the "work" |
+| Access JWT verifier | `src/core` (or `src/util`) + unit tests | One focused, well-tested module |
+| Guard wiring + path exemptions | `src/web/server.ts` request handler | A few lines beside existing guards |
+| Serve-time config (team domain + AUD) | env + flags + TUI status line | Small; TUI-only per repo rules |
+| Deployment docs | `README.md` | Small |
+| Friend sharing | one Cloudflare policy line | Trivial once the above exists |
+
+The code footprint is modest and concentrated in one new verifier plus a few lines in
+the existing server guard. The real effort is the one-time Cloudflare setup, which is
+ops and reusable across reccd and anything else the owner hosts.
+
+## Open questions for the plan
+
+- Exact env/flag/config field names and where the TUI status line lives.
+- Whether the browser settings dialog shows a read-only "Access enforced" indicator or
+  nothing at all.
+- Log verbosity for verification failures (coarse reasons vs a single generic 403).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "env-paths": "^4.0.0",
         "hls.js": "^1.6.16",
         "ink": "^7.0.5",
+        "jose": "^6.2.8",
         "jpeg-js": "^0.4.4",
         "multicast-dns": "^7.2.5",
         "parse-torrent": "^11.0.21",
@@ -4386,6 +4387,15 @@
       "resolved": "https://registry.npmjs.org/join-async-iterator/-/join-async-iterator-1.1.1.tgz",
       "integrity": "sha512-ATse+nuNeKZ9K1y27LKdvPe/GCe9R/u9dw9vI248e+vILeRK3IcJP4JUPAlSmKRCDK0cKhEwfmiw4Skqx7UnGQ==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "env-paths": "^4.0.0",
     "hls.js": "^1.6.16",
     "ink": "^7.0.5",
+    "jose": "^6.2.8",
     "jpeg-js": "^0.4.4",
     "multicast-dns": "^7.2.5",
     "parse-torrent": "^11.0.21",

--- a/preview/settings.svg
+++ b/preview/settings.svg
@@ -210,76 +210,71 @@
     <rect x="237.7" y="1014" width="1.4" height="22" fill="#afafff"/>
     <rect x="976.9" y="1014" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1036" width="1.4" height="22" fill="#afafff"/>
-    <text x="272" y="1052" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">RD</text>
-    <text x="329.6" y="1052" textLength="384" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Real-Debrid  · active  · real-debrid.com</text>
-    <text x="742.4" y="1052" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
-    <text x="761.6" y="1052" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
-    <text x="867.2" y="1052" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
-    <text x="886.4" y="1052" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out</text>
+    <text x="272" y="1052" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">CFA</text>
+    <text x="329.6" y="1052" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cloudflare Access  · origin request gate · read-only</text>
     <rect x="976.9" y="1036" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1058" width="1.4" height="22" fill="#afafff"/>
-    <text x="329.6" y="1074" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">✓</text>
-    <text x="348.8" y="1074" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">premium · 60d left</text>
+    <text x="329.6" y="1074" textLength="153.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">· not configured</text>
     <rect x="976.9" y="1058" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1080" width="1.4" height="22" fill="#afafff"/>
     <rect x="976.9" y="1080" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1102" width="1.4" height="22" fill="#afafff"/>
-    <text x="272" y="1118" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">TB</text>
-    <text x="329.6" y="1118" textLength="192" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">TorBox  · torbox.app</text>
-    <text x="646.4" y="1118" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
-    <text x="665.6" y="1118" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
-    <text x="771.2" y="1118" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
-    <text x="790.4" y="1118" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out  ·</text>
-    <text x="915.2" y="1118" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">a</text>
-    <text x="934.4" y="1118" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">use</text>
+    <text x="272" y="1118" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">RD</text>
+    <text x="329.6" y="1118" textLength="384" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Real-Debrid  · active  · real-debrid.com</text>
+    <text x="742.4" y="1118" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
+    <text x="761.6" y="1118" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
+    <text x="867.2" y="1118" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
+    <text x="886.4" y="1118" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out</text>
     <rect x="976.9" y="1102" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1124" width="1.4" height="22" fill="#afafff"/>
     <text x="329.6" y="1140" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">✓</text>
-    <text x="348.8" y="1140" textLength="144" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">pro · 128d left</text>
+    <text x="348.8" y="1140" textLength="172.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">premium · 60d left</text>
     <rect x="976.9" y="1124" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1146" width="1.4" height="22" fill="#afafff"/>
     <rect x="976.9" y="1146" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1168" width="1.4" height="22" fill="#afafff"/>
-    <text x="272" y="1184" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd787">RUT</text>
-    <text x="329.6" y="1184" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">RuTracker  · rutracker.org</text>
-    <text x="742.4" y="1184" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
-    <text x="761.6" y="1184" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
-    <text x="867.2" y="1184" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
-    <text x="886.4" y="1184" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out</text>
+    <text x="272" y="1184" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">TB</text>
+    <text x="329.6" y="1184" textLength="192" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">TorBox  · torbox.app</text>
+    <text x="646.4" y="1184" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
+    <text x="665.6" y="1184" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
+    <text x="771.2" y="1184" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
+    <text x="790.4" y="1184" textLength="105.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out  ·</text>
+    <text x="915.2" y="1184" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">a</text>
+    <text x="934.4" y="1184" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">use</text>
     <rect x="976.9" y="1168" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1190" width="1.4" height="22" fill="#afafff"/>
     <text x="329.6" y="1206" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">✓</text>
-    <text x="348.8" y="1206" textLength="153.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Signed in as you</text>
+    <text x="348.8" y="1206" textLength="144" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">pro · 128d left</text>
     <rect x="976.9" y="1190" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1212" width="1.4" height="22" fill="#afafff"/>
     <rect x="976.9" y="1212" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1234" width="1.4" height="22" fill="#afafff"/>
-    <text x="272" y="1250" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">RCD</text>
-    <text x="329.6" y="1250" textLength="326.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">reccd  · self-hosted · private se…</text>
-    <text x="665.6" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
-    <text x="684.8" y="1250" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">edit  ·</text>
-    <text x="771.2" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
-    <text x="790.4" y="1250" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">clear  ·</text>
-    <text x="886.4" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">i</text>
-    <text x="905.6" y="1250" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">import</text>
+    <text x="272" y="1250" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd787">RUT</text>
+    <text x="329.6" y="1250" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">RuTracker  · rutracker.org</text>
+    <text x="742.4" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
+    <text x="761.6" y="1250" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">switch  ·</text>
+    <text x="867.2" y="1250" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
+    <text x="886.4" y="1250" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">sign out</text>
     <rect x="976.9" y="1234" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1256" width="1.4" height="22" fill="#afafff"/>
     <text x="329.6" y="1272" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">✓</text>
-    <text x="348.8" y="1272" textLength="268.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Connected · reccd.local:4100</text>
+    <text x="348.8" y="1272" textLength="153.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Signed in as you</text>
     <rect x="976.9" y="1256" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1278" width="1.4" height="22" fill="#afafff"/>
     <rect x="976.9" y="1278" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1300" width="1.4" height="22" fill="#afafff"/>
-    <text x="272" y="1316" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#ffd700">OMDb</text>
-    <text x="329.6" y="1316" textLength="345.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">OMDb  · omdbapi.com · plot summaries</text>
-    <text x="790.4" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
-    <text x="809.6" y="1316" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">edit  ·</text>
-    <text x="896" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
-    <text x="915.2" y="1316" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">clear</text>
+    <text x="272" y="1316" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">RCD</text>
+    <text x="329.6" y="1316" textLength="326.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">reccd  · self-hosted · private se…</text>
+    <text x="665.6" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
+    <text x="684.8" y="1316" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">edit  ·</text>
+    <text x="771.2" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">x</text>
+    <text x="790.4" y="1316" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">clear  ·</text>
+    <text x="886.4" y="1316" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">i</text>
+    <text x="905.6" y="1316" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">import</text>
     <rect x="976.9" y="1300" width="1.4" height="22" fill="#afafff"/>
     <rect x="237.7" y="1322" width="1.4" height="22" fill="#afafff"/>
     <text x="329.6" y="1338" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">✓</text>
-    <text x="348.8" y="1338" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Key set</text>
+    <text x="348.8" y="1338" textLength="268.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Connected · reccd.local:4100</text>
     <rect x="976.9" y="1322" width="1.4" height="22" fill="#afafff"/>
     <text x="233.6" y="1360" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╰────────────────────────────────────────────────────────────────────────────╯</text>
     <text x="41.6" y="1382" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↑↓←→</text>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -432,6 +432,7 @@ save(
           omdbConfigured
           onManageOmdb={() => {}}
           onSignOutOmdb={() => {}}
+          cfAccessEnforced={false}
           onEditFolder={() => {}}
           onEditSources={() => {}}
           onEditQuality={() => {}}

--- a/src/config/cloudflareAccess.resolve.test.ts
+++ b/src/config/cloudflareAccess.resolve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { defaultConfig, resolveCloudflareAccess } from "./config.js";
+import { defaultConfig, isCloudflareAccessHalfConfigured, resolveCloudflareAccess } from "./config.js";
 
 const TEAM_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
 const AUD_ENV = "TORLINK_CF_ACCESS_AUD";
@@ -38,5 +38,37 @@ describe("resolveCloudflareAccess", () => {
       cfAccessAud: "file-aud",
     });
     expect(res).toEqual({ teamDomain: "env.cloudflareaccess.com", aud: "env-aud" });
+  });
+});
+
+describe("isCloudflareAccessHalfConfigured", () => {
+  beforeEach(() => {
+    vi.stubEnv(TEAM_ENV, "");
+    vi.stubEnv(AUD_ENV, "");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("is true when only the team domain is set", () => {
+    expect(
+      isCloudflareAccessHalfConfigured({ ...defaultConfig, cfAccessTeamDomain: "t.cloudflareaccess.com" }),
+    ).toBe(true);
+  });
+
+  it("is true when only the aud is set", () => {
+    expect(isCloudflareAccessHalfConfigured({ ...defaultConfig, cfAccessAud: "aud" })).toBe(true);
+  });
+
+  it("is false when both are set", () => {
+    expect(
+      isCloudflareAccessHalfConfigured({
+        ...defaultConfig,
+        cfAccessTeamDomain: "t.cloudflareaccess.com",
+        cfAccessAud: "aud",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when neither is set", () => {
+    expect(isCloudflareAccessHalfConfigured({ ...defaultConfig })).toBe(false);
   });
 });

--- a/src/config/cloudflareAccess.resolve.test.ts
+++ b/src/config/cloudflareAccess.resolve.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultConfig, resolveCloudflareAccess } from "./config.js";
+
+const TEAM_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
+const AUD_ENV = "TORLINK_CF_ACCESS_AUD";
+
+describe("resolveCloudflareAccess", () => {
+  beforeEach(() => {
+    vi.stubEnv(TEAM_ENV, "");
+    vi.stubEnv(AUD_ENV, "");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns null when nothing is configured", () => {
+    expect(resolveCloudflareAccess({ ...defaultConfig })).toBeNull();
+  });
+
+  it("returns null when only one half is set", () => {
+    expect(resolveCloudflareAccess({ ...defaultConfig, cfAccessTeamDomain: "t.cloudflareaccess.com" })).toBeNull();
+    expect(resolveCloudflareAccess({ ...defaultConfig, cfAccessAud: "aud" })).toBeNull();
+  });
+
+  it("reads both halves from config", () => {
+    const res = resolveCloudflareAccess({
+      ...defaultConfig,
+      cfAccessTeamDomain: "t.cloudflareaccess.com",
+      cfAccessAud: "aud-1",
+    });
+    expect(res).toEqual({ teamDomain: "t.cloudflareaccess.com", aud: "aud-1" });
+  });
+
+  it("lets env vars win over config", () => {
+    vi.stubEnv(TEAM_ENV, "env.cloudflareaccess.com");
+    vi.stubEnv(AUD_ENV, "env-aud");
+    const res = resolveCloudflareAccess({
+      ...defaultConfig,
+      cfAccessTeamDomain: "file.cloudflareaccess.com",
+      cfAccessAud: "file-aud",
+    });
+    expect(res).toEqual({ teamDomain: "env.cloudflareaccess.com", aud: "env-aud" });
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -419,6 +419,17 @@ export function resolveCloudflareAccess(
   return { teamDomain, aud };
 }
 
+/**
+ * True when exactly one of the two Cloudflare Access settings is present — a
+ * likely misconfiguration that leaves the origin gate silently OFF. Callers log
+ * a warning so it isn't mistaken for "enforced".
+ */
+export function isCloudflareAccessHalfConfigured(config: Config): boolean {
+  const teamDomain = (process.env[CF_ACCESS_TEAM_DOMAIN_ENV]?.trim() || config.cfAccessTeamDomain?.trim()) ?? "";
+  const aud = (process.env[CF_ACCESS_AUD_ENV]?.trim() || config.cfAccessAud?.trim()) ?? "";
+  return (teamDomain === "") !== (aud === "");
+}
+
 const OMDB_KEY_ENV = "TORLINK_OMDB_KEY";
 
 // The effective OMDb API key (env wins over config, matching the other resolve*

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -148,6 +148,10 @@ export interface Config {
    * working too, which this setting cannot fix.
    */
   castAdvertiseHost?: string;
+  /** Cloudflare Access team domain, e.g. "myteam.cloudflareaccess.com". Host-specific; TUI/env only. */
+  cfAccessTeamDomain?: string;
+  /** Cloudflare Access application Audience (AUD) tag. Host-specific; TUI/env only. */
+  cfAccessAud?: string;
 }
 
 export const defaultConfig: Config = {
@@ -396,6 +400,23 @@ export function resolveCastAdvertiseHost(config: Config): string | undefined {
 export function resolveCastDevice(config: Config): string | undefined {
   const env = process.env[CAST_DEVICE_ENV]?.trim();
   return env || config.castDevice?.trim() || undefined;
+}
+
+const CF_ACCESS_TEAM_DOMAIN_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
+const CF_ACCESS_AUD_ENV = "TORLINK_CF_ACCESS_AUD";
+
+/**
+ * Cloudflare Access enforcement config. env wins over the persisted value, both
+ * trimmed. Returns null unless BOTH halves are present — a half-configured gate
+ * would fail every request, so treat it as "off".
+ */
+export function resolveCloudflareAccess(
+  config: Config,
+): { teamDomain: string; aud: string } | null {
+  const teamDomain = (process.env[CF_ACCESS_TEAM_DOMAIN_ENV]?.trim() || config.cfAccessTeamDomain?.trim()) ?? "";
+  const aud = (process.env[CF_ACCESS_AUD_ENV]?.trim() || config.cfAccessAud?.trim()) ?? "";
+  if (!teamDomain || !aud) return null;
+  return { teamDomain, aud };
 }
 
 const OMDB_KEY_ENV = "TORLINK_OMDB_KEY";

--- a/src/core/cloudflareAccess.test.ts
+++ b/src/core/cloudflareAccess.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JSONWebKeySet } from "jose";
+import { verifyAccessAssertion, accessIssuer, accessJwksUrl } from "./cloudflareAccess.js";
+
+const TEAM = "myteam.cloudflareaccess.com";
+const AUD = "aud-tag-123";
+
+// A frozen clock so token exp/iat are deterministic.
+const NOW = 1_760_000_000_000; // fixed ms
+
+async function setup() {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "k1";
+  jwk.alg = "RS256";
+  const jwks: JSONWebKeySet = { keys: [jwk] };
+  const keySet = createLocalJWKSet(jwks);
+  return { privateKey, keySet };
+}
+
+async function mint(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  opts: { iss?: string; aud?: string; exp?: number; kid?: string } = {},
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? "k1" })
+    .setIssuer(opts.iss ?? accessIssuer(TEAM))
+    .setAudience(opts.aud ?? AUD)
+    .setIssuedAt(Math.floor(NOW / 1000))
+    .setExpirationTime(opts.exp ?? Math.floor(NOW / 1000) + 3600)
+    .sign(privateKey);
+}
+
+describe("cloudflareAccess helpers", () => {
+  it("derives the JWKS url and issuer", () => {
+    expect(accessJwksUrl(TEAM).toString()).toBe(`https://${TEAM}/cdn-cgi/access/certs`);
+    expect(accessIssuer(TEAM)).toBe(`https://${TEAM}`);
+  });
+});
+
+describe("verifyAccessAssertion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("accepts a valid assertion and returns the email", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "owner@example.com" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toMatchObject({ ok: true, email: "owner@example.com" });
+  });
+
+  it("reports no-assertion for a missing token", async () => {
+    const { keySet } = await setup();
+    const res = await verifyAccessAssertion(undefined, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "no-assertion" });
+  });
+
+  it("rejects an expired assertion", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { exp: Math.floor(NOW / 1000) - 10 });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a wrong audience", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { aud: "other-aud" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "aud-mismatch" });
+  });
+
+  it("rejects a wrong issuer", async () => {
+    const { privateKey, keySet } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" }, { iss: "https://evil.cloudflareaccess.com" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "iss-mismatch" });
+  });
+
+  it("rejects a signature from an unknown key", async () => {
+    const { keySet } = await setup();
+    const stranger = await generateKeyPair("RS256");
+    const token = await mint(stranger.privateKey, { email: "x@e.com" }, { kid: "k1" });
+    const res = await verifyAccessAssertion(token, keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("bad-signature");
+  });
+
+  it("reports malformed for garbage input", async () => {
+    const { keySet } = await setup();
+    const res = await verifyAccessAssertion("not-a-jwt", keySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "malformed" });
+  });
+});

--- a/src/core/cloudflareAccess.test.ts
+++ b/src/core/cloudflareAccess.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JSONWebKeySet } from "jose";
+import {
+  SignJWT,
+  exportJWK,
+  generateKeyPair,
+  createLocalJWKSet,
+  type JSONWebKeySet,
+  type JWTVerifyGetKey,
+} from "jose";
 import { verifyAccessAssertion, accessIssuer, accessJwksUrl } from "./cloudflareAccess.js";
 
 const TEAM = "myteam.cloudflareaccess.com";
@@ -93,5 +100,21 @@ describe("verifyAccessAssertion", () => {
     const { keySet } = await setup();
     const res = await verifyAccessAssertion("not-a-jwt", keySet, { teamDomain: TEAM, aud: AUD });
     expect(res).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("fails closed when the key resolver throws a JWKS error", async () => {
+    // A resolver that jose calls during key resolution and that throws a
+    // jose-style JWKS error, so mapError's code?.startsWith("ERR_JWKS") branch runs.
+    const throwingKeySet = (() => {
+      const err = new Error("jwks unreachable") as Error & { code?: string };
+      err.code = "ERR_JWKS_TIMEOUT";
+      throw err;
+    }) as unknown as JWTVerifyGetKey;
+    // A valid, well-formed RS256 token so jose gets past structural checks and
+    // actually invokes the resolver to look up a key.
+    const { privateKey } = await setup();
+    const token = await mint(privateKey, { email: "x@e.com" });
+    const res = await verifyAccessAssertion(token, throwingKeySet, { teamDomain: TEAM, aud: AUD });
+    expect(res).toEqual({ ok: false, reason: "jwks-error" });
   });
 });

--- a/src/core/cloudflareAccess.ts
+++ b/src/core/cloudflareAccess.ts
@@ -1,0 +1,77 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { jwtVerify, type JWTVerifyGetKey } from "jose";
+
+/** Host-specific Cloudflare Access settings. Never a credential — safe to log the team domain. */
+export interface AccessConfig {
+  /** e.g. "myteam.cloudflareaccess.com" */
+  teamDomain: string;
+  /** The Access application's Audience (AUD) tag. */
+  aud: string;
+}
+
+export type AccessReason =
+  | "no-assertion"
+  | "bad-signature"
+  | "expired"
+  | "aud-mismatch"
+  | "iss-mismatch"
+  | "jwks-error"
+  | "malformed";
+
+export type AccessResult =
+  | { ok: true; email?: string; sub?: string }
+  | { ok: false; reason: AccessReason };
+
+export function accessJwksUrl(teamDomain: string): URL {
+  return new URL(`https://${teamDomain}/cdn-cgi/access/certs`);
+}
+
+export function accessIssuer(teamDomain: string): string {
+  return `https://${teamDomain}`;
+}
+
+/** Cloudflare stamps this header on every request it forwards through Access. */
+export function accessTokenFromHeaders(headers: IncomingHttpHeaders): string | undefined {
+  const v = headers["cf-access-jwt-assertion"];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function mapError(e: unknown): AccessReason {
+  const code = (e as { code?: string })?.code;
+  const claim = (e as { claim?: string })?.claim;
+  if (code === "ERR_JWT_EXPIRED") return "expired";
+  if (code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED") return "bad-signature";
+  if (code === "ERR_JWKS_NO_MATCHING_KEY") return "bad-signature";
+  if (code === "ERR_JWT_CLAIM_VALIDATION_FAILED") {
+    if (claim === "aud") return "aud-mismatch";
+    if (claim === "iss") return "iss-mismatch";
+    return "malformed";
+  }
+  if (code === "ERR_JOSE_GENERIC" || code?.startsWith("ERR_JWKS")) return "jwks-error";
+  return "malformed";
+}
+
+/**
+ * Verify a Cloudflare Access assertion. Fails CLOSED: any error (including a JWKS
+ * fetch failure) returns { ok: false } rather than throwing, so callers 403.
+ * `keySet` is a jose key resolver (remote JWKS in prod, local JWKS in tests).
+ */
+export async function verifyAccessAssertion(
+  token: string | undefined,
+  keySet: JWTVerifyGetKey,
+  cfg: AccessConfig,
+  clockTolerance = 5,
+): Promise<AccessResult> {
+  if (!token) return { ok: false, reason: "no-assertion" };
+  try {
+    const { payload } = await jwtVerify(token, keySet, {
+      issuer: accessIssuer(cfg.teamDomain),
+      audience: cfg.aud,
+      clockTolerance,
+    });
+    const email = typeof payload.email === "string" ? payload.email : undefined;
+    return { ok: true, email, sub: payload.sub };
+  } catch (e) {
+    return { ok: false, reason: mapError(e) };
+  }
+}

--- a/src/core/cloudflareAccess.ts
+++ b/src/core/cloudflareAccess.ts
@@ -65,6 +65,7 @@ export async function verifyAccessAssertion(
   if (!token) return { ok: false, reason: "no-assertion" };
   try {
     const { payload } = await jwtVerify(token, keySet, {
+      algorithms: ["RS256"],
       issuer: accessIssuer(cfg.teamDomain),
       audience: cfg.aud,
       clockTolerance,

--- a/src/daemon/serve.launch.test.ts
+++ b/src/daemon/serve.launch.test.ts
@@ -292,6 +292,31 @@ describe("runServe --web startup output", () => {
     await done;
   });
 
+  it("does not mint a token for a non-loopback --web bind when Access is enforced", async () => {
+    // Access at the origin is a strictly stronger gate than a token, so the
+    // bind is allowed tokenless — and NOT minted one: a minted token would
+    // break the browser UI behind a tunnel, which is the whole point of Access.
+    process.env.TORLINK_CF_ACCESS_TEAM_DOMAIN = "myteam.cloudflareaccess.com";
+    process.env.TORLINK_CF_ACCESS_AUD = "aud-tag-123";
+    const port = await freePort();
+    const before = new Set(process.listeners("SIGTERM"));
+    try {
+      const done = runServe({ port, host: "0.0.0.0", web: true, downloadDir: dir });
+      expect(await waitUntil(() => isListening(port))).toBe(true);
+      // No 32-hex minted secret anywhere in the log.
+      expect(logs.join("\n")).not.toMatch(/\b[0-9a-f]{32}\b/);
+      // And it is Access, not a token, gating the API: a tokenless request is
+      // 403 (the Access guard), never 401 (a token check that isn't there).
+      const res = await fetch(`http://127.0.0.1:${port}/api/status`);
+      expect(res.status).toBe(403);
+      newSignalHandler(before)();
+      await done;
+    } finally {
+      delete process.env.TORLINK_CF_ACCESS_TEAM_DOMAIN;
+      delete process.env.TORLINK_CF_ACCESS_AUD;
+    }
+  });
+
   it("still refuses a non-loopback bind without --web", async () => {
     // No link to hand back, so nothing justifies a secret the caller did not
     // choose: a scripted API consumer needs a token stable across restarts.

--- a/src/daemon/serve.launch.test.ts
+++ b/src/daemon/serve.launch.test.ts
@@ -334,6 +334,28 @@ describe("runServe --web startup output", () => {
     expect(errors.join("\n")).toContain("refusing to bind 0.0.0.0 without a token");
   });
 
+  it("still refuses a non-loopback bind without --web even when Access is configured", async () => {
+    // Regression guard: Access relaxes the bind ONLY on the --web path, because
+    // only startWebServer installs the Access guard. The bare add-API
+    // (createApiServer) has no Access verification, so a tokenless non-loopback
+    // bind there must still hard-exit even with Access fully configured —
+    // otherwise a destructive, Access-UNVERIFIED API would bind all interfaces.
+    process.env.TORLINK_CF_ACCESS_TEAM_DOMAIN = "myteam.cloudflareaccess.com";
+    process.env.TORLINK_CF_ACCESS_AUD = "aud-tag-123";
+    try {
+      await withTimeout(
+        runServe({ port: await freePort(), host: "0.0.0.0", downloadDir: dir }),
+        1000,
+        "the refusal to bind 0.0.0.0 without a token (Access configured, no --web)",
+      );
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(errors.join("\n")).toContain("refusing to bind 0.0.0.0 without a token");
+    } finally {
+      delete process.env.TORLINK_CF_ACCESS_TEAM_DOMAIN;
+      delete process.env.TORLINK_CF_ACCESS_AUD;
+    }
+  });
+
   it("opens the loopback link, fragment and all", async () => {
     const port = await freePort();
     const opened: string[] = [];

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -346,6 +346,15 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
   let token = options.token && options.token.trim() ? options.token.trim() : null;
   let mintedToken = false;
 
+  // This process holds no config snapshot (routes.ts loads per request), so
+  // read it once here purely to resolve the Access policy the server enforces —
+  // and to inform the bind decision below.
+  const startupConfig = await loadConfig();
+  const cloudflareAccess = resolveCloudflareAccess(startupConfig);
+  if (isCloudflareAccessHalfConfigured(startupConfig)) {
+    log("warning: cloudflare access is half-configured (need BOTH team domain and AUD) — origin gate is OFF");
+  }
+
   // Fail soft, not open: never expose a public interface without a token.
   //
   // With --web there is a browser to hand a working link to, so the secret can
@@ -353,11 +362,15 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
   // two branches. Without --web there is nothing to hand it to: the caller is a
   // script, and a fresh secret every boot is worse than the error it replaced,
   // because the script would start failing 401 instead of failing to start.
-  if (!LOOPBACK_HOSTS.has(host) && !token) {
+  //
+  // When Access is enforced the origin JWT check is a strictly stronger gate
+  // than a token, so a tokenless non-loopback bind is allowed (and not minted —
+  // a minted token would break the browser UI behind a tunnel).
+  if (!LOOPBACK_HOSTS.has(host) && !token && !cloudflareAccess) {
     if (!options.web) {
       console.error(
         `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
-          `(or set TORLINK_API_TOKEN), or bind 127.0.0.1.`,
+          `(or set TORLINK_API_TOKEN), enforce Cloudflare Access, or bind 127.0.0.1.`,
       );
       process.exit(1);
       return;
@@ -385,13 +398,8 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
 
   let web: WebServerHandle | null = null;
   if (options.web) {
-    // This process holds no config snapshot (routes.ts loads per request), so
-    // read it once here purely to resolve the Access policy the server enforces.
-    const startupConfig = await loadConfig();
-    const cloudflareAccess = resolveCloudflareAccess(startupConfig);
-    if (isCloudflareAccessHalfConfigured(startupConfig)) {
-      log("warning: cloudflare access is half-configured (need BOTH team domain and AUD) — origin gate is OFF");
-    }
+    // `cloudflareAccess` was resolved at the top of runServe (from the same
+    // one-shot config load), which is where the bind decision above needed it.
     try {
       web = await startWebServer(runtime, {
         port,

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -20,7 +20,7 @@ import type { StatusPayload } from "../web/wire";
 import { VERSION } from "../version";
 import { openUrl } from "../util/openUrl";
 import { ensureReccAccount } from "../recc/provision";
-import { loadConfig, resolveCloudflareAccess } from "../config/config";
+import { loadConfig, resolveCloudflareAccess, isCloudflareAccessHalfConfigured } from "../config/config";
 
 export { isAuthorized } from "./auth";
 
@@ -389,6 +389,9 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
     // read it once here purely to resolve the Access policy the server enforces.
     const startupConfig = await loadConfig();
     const cloudflareAccess = resolveCloudflareAccess(startupConfig);
+    if (isCloudflareAccessHalfConfigured(startupConfig)) {
+      log("warning: cloudflare access is half-configured (need BOTH team domain and AUD) — origin gate is OFF");
+    }
     try {
       web = await startWebServer(runtime, {
         port,

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -20,6 +20,7 @@ import type { StatusPayload } from "../web/wire";
 import { VERSION } from "../version";
 import { openUrl } from "../util/openUrl";
 import { ensureReccAccount } from "../recc/provision";
+import { loadConfig, resolveCloudflareAccess } from "../config/config";
 
 export { isAuthorized } from "./auth";
 
@@ -384,11 +385,16 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
 
   let web: WebServerHandle | null = null;
   if (options.web) {
+    // This process holds no config snapshot (routes.ts loads per request), so
+    // read it once here purely to resolve the Access policy the server enforces.
+    const startupConfig = await loadConfig();
+    const cloudflareAccess = resolveCloudflareAccess(startupConfig);
     try {
       web = await startWebServer(runtime, {
         port,
         host,
         ...(token ? { token } : {}),
+        ...(cloudflareAccess ? { cloudflareAccess } : {}),
         log,
       });
     } catch (e) {

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -366,11 +366,16 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
   // When Access is enforced the origin JWT check is a strictly stronger gate
   // than a token, so a tokenless non-loopback bind is allowed (and not minted —
   // a minted token would break the browser UI behind a tunnel).
-  if (!LOOPBACK_HOSTS.has(host) && !token && !cloudflareAccess) {
+  // Cloudflare Access can stand in for the token ONLY on the --web path: that is
+  // the only server that verifies the Access assertion. The bare add-API
+  // (createApiServer) has no Access guard, so a tokenless non-loopback bind there
+  // is still refused even when Access is configured.
+  const accessRelaxesBind = cloudflareAccess !== null && options.web === true;
+  if (!LOOPBACK_HOSTS.has(host) && !token && !accessRelaxesBind) {
     if (!options.web) {
       console.error(
         `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
-          `(or set TORLINK_API_TOKEN), enforce Cloudflare Access, or bind 127.0.0.1.`,
+          `(or set TORLINK_API_TOKEN), or bind 127.0.0.1.`,
       );
       process.exit(1);
       return;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,6 +13,7 @@ import {
   resolveReccConfig,
   resolveOmdbApiKey,
   resolveAdultContent,
+  resolveCloudflareAccess,
   qualityPrefsFrom,
   type Config,
   type FavouriteItem,
@@ -621,6 +622,12 @@ export function App({
   const downloadDirRef = useRef("");
   if (config) downloadDirRef.current = config.downloadDir;
 
+  // The Cloudflare Access policy the in-process web server enforces, held in a
+  // ref for the same reason downloadDir is: read once at mount by the effect
+  // below, never a dependency of it.
+  const cloudflareAccessRef = useRef<ReturnType<typeof resolveCloudflareAccess>>(null);
+  cloudflareAccessRef.current = config ? resolveCloudflareAccess(config) : null;
+
   // The web server's state for the splash's status line. Stays null unless
   // --web was passed, so a plain launch says nothing; only ever holds a url the
   // server reported back as bound.
@@ -672,6 +679,7 @@ export function App({
           ...(webPort !== undefined ? { port: webPort } : {}),
           host,
           ...(token ? { token } : {}),
+          ...(cloudflareAccessRef.current ? { cloudflareAccess: cloudflareAccessRef.current } : {}),
           // THE constraint of this mount: Ink owns stdout and repaints by
           // tracking cursor position, so a stray write from a request handler
           // lands inside a rendered frame and corrupts it — and reads as a

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3513,6 +3513,7 @@ export function App({
                 omdbEnvOverride={Boolean(process.env["TORLINK_OMDB_KEY"]?.trim())}
                 onManageOmdb={openOmdbPrompt}
                 onSignOutOmdb={clearOmdbKey}
+                cfAccessEnforced={cloudflareAccessRef.current !== null}
                 onEditFolder={() => setEditingFolder(true)}
                 onEditSources={() => setEditingSources(true)}
                 onEditQuality={() => setEditingQuality(true)}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,6 +14,7 @@ import {
   resolveOmdbApiKey,
   resolveAdultContent,
   resolveCloudflareAccess,
+  isCloudflareAccessHalfConfigured,
   qualityPrefsFrom,
   type Config,
   type FavouriteItem,
@@ -627,6 +628,11 @@ export function App({
   // below, never a dependency of it.
   const cloudflareAccessRef = useRef<ReturnType<typeof resolveCloudflareAccess>>(null);
   cloudflareAccessRef.current = config ? resolveCloudflareAccess(config) : null;
+  // Held in a ref for the same reason as above (read once by the mount effect,
+  // never a dependency of it). True when exactly one Access half is set, which
+  // resolves to a null policy that enforces nothing — worth a warning.
+  const cfAccessHalfConfiguredRef = useRef(false);
+  cfAccessHalfConfiguredRef.current = config ? isCloudflareAccessHalfConfigured(config) : false;
 
   // The web server's state for the splash's status line. Stays null unless
   // --web was passed, so a plain launch says nothing; only ever holds a url the
@@ -646,6 +652,13 @@ export function App({
     // false while no server is mounted (see `ensureCastWeb`), so it cannot tear
     // down and rebind a socket that is already serving.
     if ((!web && !castWeb) || !queue) return;
+    // A half-configured Access gate (one of team domain / AUD, not both) resolves
+    // to null above and enforces nothing — warn so it isn't mistaken for "on".
+    if (cfAccessHalfConfiguredRef.current) {
+      log.warn(
+        "[web] cloudflare access is half-configured (need BOTH team domain and AUD) — origin gate is OFF",
+      );
+    }
     const sessions = sessionsRef.current!;
     // A cast needs an address a television can route to, so a wildcard rather
     // than loopback — and therefore a token, which startWebServer requires for

--- a/src/ui/components/Settings.test.tsx
+++ b/src/ui/components/Settings.test.tsx
@@ -58,6 +58,7 @@ const baseProps = {
   omdbEnvOverride: false,
   onManageOmdb: noop,
   onSignOutOmdb: noop,
+  cfAccessEnforced: false,
   // settings dispatch
   onEditFolder: noop,
   onEditSources: noop,
@@ -106,6 +107,16 @@ describe("Settings", () => {
     expect(frame).toContain("Media player");
     expect(frame).toContain("Adult content");
     expect(frame).toContain("Relay debrid streams");
+  });
+
+  it("shows Cloudflare Access status read-only, with no action keybind", () => {
+    const enforced = renderSettings({ cfAccessEnforced: true }).lastFrame() ?? "";
+    const enforcedLine = enforced.split("\n").find((l) => l.includes("enforced"));
+    expect(enforced).toContain("Cloudflare Access");
+    expect(enforcedLine).toBeDefined();
+    const off = renderSettings({ cfAccessEnforced: false }).lastFrame() ?? "";
+    expect(off).toContain("Cloudflare Access");
+    expect(off).toContain("not configured");
   });
 
   it("lists the account rows and marks the active debrid provider", () => {

--- a/src/ui/components/Settings.tsx
+++ b/src/ui/components/Settings.tsx
@@ -44,6 +44,10 @@ interface SettingsProps {
   omdbEnvOverride?: boolean;
   onManageOmdb: () => void;
   onSignOutOmdb: () => void;
+  // Read-only: whether the origin enforces Cloudflare Access. Configured by
+  // env/config on the host, never from this pane — so this row shows status
+  // with no action affordance.
+  cfAccessEnforced: boolean;
   // ---- settings dispatch (open the existing editors / flip the toggles) ----
   onEditFolder: () => void;
   onEditSources: () => void;
@@ -85,7 +89,9 @@ interface Row {
   ok: boolean;
   status: string;
   emptyStatus: string;
-  primary: RowAction;
+  // Absent on a read-only row (e.g. Cloudflare Access status), which shows no
+  // action affordance — never a fake no-op keybind.
+  primary?: RowAction;
   secondary: RowAction[];
 }
 
@@ -290,14 +296,31 @@ export function Settings(props: SettingsProps) {
     })(),
   ];
 
-  const rows: Row[] = [...settingRows, ...accountRows];
+  // Read-only status, not an account and not an editable setting: whether the
+  // origin enforces Cloudflare Access. Rendered with the "setting" kind (a plain
+  // dot + status, no health tick) and no `primary`, so it shows no keybind — the
+  // gate is configured on the host, never from this pane.
+  const cfAccessRow: Row = {
+    tag: "CFA",
+    color: COLOR.accent,
+    label: "Cloudflare Access",
+    sub: "origin request gate · read-only",
+    kind: "setting",
+    present: true,
+    ok: true,
+    status: props.cfAccessEnforced ? "enforced" : "not configured",
+    emptyStatus: props.cfAccessEnforced ? "enforced" : "not configured",
+    secondary: [],
+  };
+
+  const rows: Row[] = [...settingRows, cfAccessRow, ...accountRows];
   const clamped = Math.min(cursor, rows.length - 1);
 
   useInput(
     (input, key) => {
       if (key.upArrow) setCursor(wrapStep(clamped, -1, rows.length));
       else if (key.downArrow) setCursor(wrapStep(clamped, 1, rows.length));
-      else if (key.return) rows[clamped]!.primary.run();
+      else if (key.return) rows[clamped]!.primary?.run();
       else {
         const action = rows[clamped]!.secondary.find((a) => a.key === input);
         if (action) action.run();
@@ -358,19 +381,21 @@ export function Settings(props: SettingsProps) {
                   <Text dimColor wrap="truncate">{`${ICON.dot} ${r.emptyStatus}`}</Text>
                 )}
               </Box>
-              <Box flexShrink={0} marginLeft={1}>
-                <Text>
-                  <Text color={COLOR.alt}>{r.primary.key}</Text>
-                  <Text dimColor>{` ${r.primary.verb}`}</Text>
-                  {r.secondary.map((a) => (
-                    <Text key={a.key}>
-                      <Text dimColor>{`  ${ICON.dot}  `}</Text>
-                      <Text color={COLOR.alt}>{a.key}</Text>
-                      <Text dimColor>{` ${a.verb}`}</Text>
-                    </Text>
-                  ))}
-                </Text>
-              </Box>
+              {r.primary && (
+                <Box flexShrink={0} marginLeft={1}>
+                  <Text>
+                    <Text color={COLOR.alt}>{r.primary.key}</Text>
+                    <Text dimColor>{` ${r.primary.verb}`}</Text>
+                    {r.secondary.map((a) => (
+                      <Text key={a.key}>
+                        <Text dimColor>{`  ${ICON.dot}  `}</Text>
+                        <Text color={COLOR.alt}>{a.key}</Text>
+                        <Text dimColor>{` ${a.verb}`}</Text>
+                      </Text>
+                    ))}
+                  </Text>
+                </Box>
+              )}
             </Box>
           );
         })}

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -95,6 +95,8 @@ const AUTH = "Bearer secret";
 beforeEach(() => {
   vi.stubEnv("REALDEBRID_API_TOKEN", "");
   vi.stubEnv("TORBOX_API_TOKEN", "");
+  vi.stubEnv("TORLINK_CF_ACCESS_TEAM_DOMAIN", "");
+  vi.stubEnv("TORLINK_CF_ACCESS_AUD", "");
 });
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -1206,6 +1208,32 @@ describe("GET /api/sources", () => {
   it("reports nothing configured when there is no token", async () => {
     const body = await get();
     expect(body).toMatchObject({ debridConfigured: false, debridProvider: null, debridCachedCheck: false });
+  });
+
+  // A capability flag, never a credential: the browser learns whether the origin
+  // enforces Cloudflare Access without ever seeing the team domain or AUD.
+  it("reports cloudflareAccessEnforced=false when unconfigured", async () => {
+    const res = await handleWebApi(deps({ token: "secret" }), "GET", "/api/sources", new URLSearchParams(), AUTH, "");
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ cloudflareAccessEnforced: false });
+  });
+
+  it("reports cloudflareAccessEnforced=true when both halves are configured", async () => {
+    const loadConfigImpl = async () => ({
+      ...defaultConfig,
+      downloadDir: "/tmp/dl",
+      cfAccessTeamDomain: "t.cloudflareaccess.com",
+      cfAccessAud: "aud-1",
+    });
+    const res = await handleWebApi(
+      deps({ token: "secret", loadConfigImpl }),
+      "GET",
+      "/api/sources",
+      new URLSearchParams(),
+      AUTH,
+      "",
+    );
+    expect(res.json).toMatchObject({ cloudflareAccessEnforced: true });
   });
 
   it("never puts a TorBox token in any response", async () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -20,6 +20,7 @@ import {
   loadConfig,
   resolveActiveDebrid,
   resolveCastDevice,
+  resolveCloudflareAccess,
   qualityPrefsFrom,
   resolveAdultContent,
   resolveMediaPlayer,
@@ -786,6 +787,9 @@ export function sourcesResponse(config: Config, health: Map<SourceId, Health>, n
     // config fields, so both env vars count — the browser must agree with the
     // TUI about which provider is on, and the TUI resolves it the same way.
     debridConfigured: active !== null,
+    // A capability flag like debridConfigured — whether the origin enforces
+    // Cloudflare Access, never the team domain or AUD behind it.
+    cloudflareAccessEnforced: resolveCloudflareAccess(config) !== null,
     debridProvider: active?.provider ?? null,
     debridCachedCheck: active ? getDebridProvider(active.provider).checkCached !== undefined : false,
     // resolveOmdbApiKey, not config.omdbApiKey, so TORLINK_OMDB_KEY counts —
@@ -1283,6 +1287,7 @@ function settingsAccountsOf(config: Config): SettingsAccounts {
   const active = resolveActiveDebrid(config);
   return {
     debridConfigured: active !== null,
+    cloudflareAccessEnforced: resolveCloudflareAccess(config) !== null,
     debridProvider: active?.provider ?? null,
     omdbConfigured: resolveOmdbApiKey(config) !== "",
     reccConfigured: resolveReccConfig(config).reccUrl !== undefined,

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -570,6 +570,52 @@ describe("startWebServer — Cloudflare Access guard", () => {
     const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
     expect(res.status).toBe(200);
   });
+
+  // In the real deployment torlink binds loopback with no token and sits behind
+  // Cloudflare Tunnel, so cloudflared forwards the PUBLIC hostname in Host. The
+  // loopback-Host guard would 403 every proxied request before Access ran, so it
+  // must be skipped when Access is on. fetch() drops a Host override (see line
+  // ~98), so use raw http.request; and read the body to prove which 403 fires.
+  function requestWithHost(
+    port: number,
+    path: string,
+    headers: Record<string, string>,
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        { host: "127.0.0.1", port, path, method: "GET", headers },
+        (res) => {
+          let body = "";
+          res.setEncoding("utf8");
+          res.on("data", (chunk) => (body += chunk));
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("allows a non-loopback Host header when Access is on and the assertion is valid", async () => {
+    const { handle, mint } = await serverWithAccess();
+    const token = await mint({ email: "owner@example.com" });
+    const { status } = await requestWithHost(handle.port, "/api/status", {
+      Host: "torlink.example.com",
+      "Cf-Access-Jwt-Assertion": token,
+    });
+    expect(status).toBe(200);
+  });
+
+  it("still 403s a non-loopback Host header when Access is on but the assertion is missing", async () => {
+    const { handle } = await serverWithAccess();
+    const { status, body } = await requestWithHost(handle.port, "/api/status", {
+      Host: "torlink.example.com",
+    });
+    expect(status).toBe(403);
+    // The Access 403, not the host 403 — proving Access, not the skipped host
+    // guard, is what rejected it.
+    expect(JSON.parse(body).error).toBe("forbidden");
+  });
 });
 
 describe("writeWebResponse", () => {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -616,6 +616,31 @@ describe("startWebServer — Cloudflare Access guard", () => {
     // guard, is what rejected it.
     expect(JSON.parse(body).error).toBe("forbidden");
   });
+
+  // Load-bearing exemption: <video>/VLC/Chromecast can't present an Access cert,
+  // so the media routes carry their own per-session ?k= capability instead and
+  // must NOT be rejected by the Access guard. /play serves static player HTML and
+  // needs no live session, so it is the clean route to prove the exemption on.
+  it("does not apply the Access guard to a /play path (exempt, not access-403)", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/play/sess1/0`);
+    const body = await res.text();
+    // Whatever the outcome (200 with player HTML if assets are built, else 404),
+    // it must not be the Access 403 — the exemption is what is under test.
+    expect(res.status).not.toBe(403);
+    expect(body).not.toBe(JSON.stringify({ error: "forbidden" }));
+  });
+
+  // SSE routes are gated too, not just plain /api/* — the guard sits ahead of the
+  // /api/search stream handler, so a request with no assertion is rejected before
+  // any stream is opened.
+  it("403s the /api/search SSE route with no assertion", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/search?q=kestrel`);
+    const body = await res.text();
+    expect(res.status).toBe(403);
+    expect(JSON.parse(body).error).toBe("forbidden");
+  });
 });
 
 describe("writeWebResponse", () => {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -641,6 +641,24 @@ describe("startWebServer — Cloudflare Access guard", () => {
     expect(res.status).toBe(403);
     expect(JSON.parse(body).error).toBe("forbidden");
   });
+
+  // Access at the origin is a strictly stronger gate than a token, so a
+  // tokenless bind on a public interface is allowed when Access is enforced —
+  // and NOT minted a token (a token would break the browser UI behind a tunnel).
+  it("allows a tokenless non-loopback bind when Access is enforced", async () => {
+    handle = await startWebServer(runtime(), {
+      port: 0,
+      host: "0.0.0.0",
+      cloudflareAccess: { teamDomain: TEAM, aud: AUD },
+    });
+    expect(handle.port).toBeGreaterThan(0);
+  });
+
+  it("still refuses a tokenless non-loopback bind when Access is NOT configured", async () => {
+    await expect(
+      startWebServer(runtime(), { port: 0, host: "0.0.0.0" }),
+    ).rejects.toThrow(/refusing to bind/);
+  });
 });
 
 describe("writeWebResponse", () => {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JSONWebKeySet } from "jose";
 import { startWebServer, writeWebResponse, type WebServerHandle } from "./server";
 import { DownloadQueue } from "../download/queue";
 import { StreamSessionRegistry } from "../core/streamSession";
@@ -512,6 +513,62 @@ describe("startWebServer", () => {
       await reader.cancel().catch(() => {});
       handle = null;
     });
+  });
+});
+
+// REAL timers, deliberately: jose validates the JWT `exp` against the real
+// wall clock, and the tokens minted here carry a real "1h" expiry. Faking time
+// would make jose see them as expired (or the clock as frozen at 0) and every
+// "allows" case would 403. This describe never calls vi.useFakeTimers(), and
+// the file does not enable them globally, so nothing to reset.
+describe("startWebServer — Cloudflare Access guard", () => {
+  const TEAM = "myteam.cloudflareaccess.com";
+  const AUD = "aud-tag-123";
+
+  async function serverWithAccess() {
+    const { publicKey, privateKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "k1";
+    jwk.alg = "RS256";
+    const jwks: JSONWebKeySet = { keys: [jwk] };
+    const accessKeySetImpl = createLocalJWKSet(jwks);
+    handle = await startWebServer(runtime(), {
+      port: 0,
+      host: "127.0.0.1",
+      log: () => {},
+      cloudflareAccess: { teamDomain: TEAM, aud: AUD },
+      accessKeySetImpl,
+    });
+    const mint = (claims: Record<string, unknown>, exp?: string | number) =>
+      new SignJWT(claims)
+        .setProtectedHeader({ alg: "RS256", kid: "k1" })
+        .setIssuer(`https://${TEAM}`)
+        .setAudience(AUD)
+        .setIssuedAt()
+        .setExpirationTime(exp ?? "1h")
+        .sign(privateKey);
+    return { handle: handle!, mint };
+  }
+
+  it("403s an api request with no assertion", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/status`);
+    expect(res.status).toBe(403);
+  });
+
+  it("allows an api request carrying a valid assertion", async () => {
+    const { handle, mint } = await serverWithAccess();
+    const token = await mint({ email: "owner@example.com" });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/status`, {
+      headers: { "Cf-Access-Jwt-Assertion": token },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("exempts /health from the assertion check", async () => {
+    const { handle } = await serverWithAccess();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+    expect(res.status).toBe(200);
   });
 });
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -245,14 +245,6 @@ export async function startWebServer(
   const token = options.token && options.token.trim() ? options.token.trim() : null;
   const log: WebLog = options.log ?? ((): void => {});
 
-  // Fail soft, not open — the same rule daemon/serve.ts enforces. The web UI
-  // exposes strictly more than the add API does, so it cannot be laxer.
-  if (!LOOPBACK_HOSTS.has(host) && !token) {
-    throw new Error(
-      `refusing to bind ${host} without a token: pass a token (or set TORLINK_API_TOKEN), or bind 127.0.0.1`,
-    );
-  }
-
   // Cloudflare Access: built once, since the JWKS resolver caches its own keys.
   // A null config leaves the guard below inert, so every default install (and
   // every existing test) is unchanged.
@@ -261,6 +253,18 @@ export async function startWebServer(
     ? (options.accessKeySetImpl ?? createRemoteJWKSet(accessJwksUrl(accessCfg.teamDomain)))
     : null;
   if (accessCfg) log(`cloudflare access: enforcing (team ${accessCfg.teamDomain})`);
+
+  // Fail soft, not open — the same rule daemon/serve.ts enforces. The web UI
+  // exposes strictly more than the add API does, so it cannot be laxer. When
+  // Access is enforced the origin JWT check is a strictly stronger gate than a
+  // token, so a tokenless non-loopback bind is allowed then (and not minted —
+  // a token would break the browser UI behind a tunnel).
+  if (!LOOPBACK_HOSTS.has(host) && !token && !accessCfg) {
+    throw new Error(
+      `refusing to bind ${host} without a token: pass a token (or set TORLINK_API_TOKEN), ` +
+        `enforce Cloudflare Access, or bind 127.0.0.1`,
+    );
+  }
 
   const staticRoot = options.staticDir ?? (options.findStaticDirImpl ?? findStaticDir)();
   if (!staticRoot) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -483,7 +483,12 @@ export async function startWebServer(
       // Tokenless means loopback-bound, so require a loopback Host: a hostile
       // page can otherwise reach this port through DNS rebinding, arriving with
       // the attacker's name in Host and the user's cookies... and full API access.
-      if (!token && !hostHeaderOk(req.headers.host)) {
+      //
+      // The loopback-Host check defends a tokenless loopback bind against DNS
+      // rebinding. When Cloudflare Access is enforced it is redundant — a rebinding
+      // page can't mint a valid assertion — and it would otherwise 403 the public
+      // Host that cloudflared forwards. So skip it when Access is on.
+      if (!token && !accessCfg && !hostHeaderOk(req.headers.host)) {
         writeJson(res, 403, { error: "forbidden host" });
         log(`${method} ${urlPath} -> 403 (host)`);
         return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -40,6 +40,13 @@ import { contentTypeFor, findStaticDir, resolveAssetPath } from "./staticDir";
 import { readBody, statusPayload } from "../daemon/serve";
 import { LOOPBACK_HOSTS, hostHeaderOk, isAuthorized, isCrossSiteHttpRequest } from "../daemon/auth";
 import { loadConfig, resolveCastAdvertiseHost } from "../config/config";
+import { createRemoteJWKSet, type JWTVerifyGetKey } from "jose";
+import {
+  accessJwksUrl,
+  accessTokenFromHeaders,
+  verifyAccessAssertion,
+  type AccessConfig,
+} from "../core/cloudflareAccess";
 import type { Runtime } from "../daemon/runtime";
 
 export const DEFAULT_WEB_PORT = 9162;
@@ -106,6 +113,10 @@ export interface WebServerOptions {
     Partial<StreamDeps>,
     "sessions" | "log" | "probeCache" | "hlsVerdictCache" | "trustProxy"
   >;
+  /** When set, verify Cloudflare Access assertions and 403 requests without one. */
+  cloudflareAccess?: AccessConfig;
+  /** Test seam: overrides the JWKS resolver (default: remote JWKS from the team domain). */
+  accessKeySetImpl?: JWTVerifyGetKey;
 }
 
 export interface WebServerHandle {
@@ -241,6 +252,15 @@ export async function startWebServer(
       `refusing to bind ${host} without a token: pass a token (or set TORLINK_API_TOKEN), or bind 127.0.0.1`,
     );
   }
+
+  // Cloudflare Access: built once, since the JWKS resolver caches its own keys.
+  // A null config leaves the guard below inert, so every default install (and
+  // every existing test) is unchanged.
+  const accessCfg = options.cloudflareAccess ?? null;
+  const accessKeySet = accessCfg
+    ? (options.accessKeySetImpl ?? createRemoteJWKSet(accessJwksUrl(accessCfg.teamDomain)))
+    : null;
+  if (accessCfg) log(`cloudflare access: enforcing (team ${accessCfg.teamDomain})`);
 
   const staticRoot = options.staticDir ?? (options.findStaticDirImpl ?? findStaticDir)();
   if (!staticRoot) {
@@ -483,6 +503,23 @@ export async function startWebServer(
         writeJson(res, 403, { error: "cross-site request blocked" });
         log(`${method} ${urlPath} -> 403 (cross-site)`);
         return;
+      }
+
+      // Cloudflare Access: the origin refuses anything that did not arrive through
+      // Access, so it is safe even if this port is ever reachable directly. Health
+      // and the media routes are exempt — the latter carry the per-session ?k=
+      // capability instead, because <video>/VLC/Chromecast can't present a cert.
+      if (accessCfg) {
+        const exempt = urlPath === "/health" || isStreamPath(urlPath) || isPlayPath(urlPath);
+        if (!exempt) {
+          const assertion = accessTokenFromHeaders(req.headers);
+          const verdict = await verifyAccessAssertion(assertion, accessKeySet!, accessCfg);
+          if (!verdict.ok) {
+            writeJson(res, 403, { error: "forbidden" });
+            log(`${method} ${urlPath} -> 403 (access: ${verdict.reason})`);
+            return;
+          }
+        }
       }
 
       // Long-lived, so it is handled before the router: the router's contract is

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -515,6 +515,10 @@ export async function startWebServer(
       // and the media routes are exempt — the latter carry the per-session ?k=
       // capability instead, because <video>/VLC/Chromecast can't present a cert.
       if (accessCfg) {
+        // INVARIANT: any path added here MUST carry its own capability (the
+        // stream/play ?k=) or return nothing sensitive — under Access the
+        // loopback-Host guard above is skipped, so an exempt path is otherwise
+        // reachable directly via DNS rebinding.
         const exempt = urlPath === "/health" || isStreamPath(urlPath) || isPlayPath(urlPath);
         if (!exempt) {
           const assertion = accessTokenFromHeaders(req.headers);

--- a/src/web/static/searchModel.test.ts
+++ b/src/web/static/searchModel.test.ts
@@ -104,6 +104,7 @@ const sourcesResponse = (over: Partial<SourcesResponse> = {}): SourcesResponse =
   ],
   adultEnabled: false,
   debridConfigured: false,
+  cloudflareAccessEnforced: false,
   debridProvider: null,
   debridCachedCheck: false,
   omdbConfigured: false,

--- a/src/web/static/settingsModel.test.ts
+++ b/src/web/static/settingsModel.test.ts
@@ -27,6 +27,7 @@ function response(over: Partial<SettingsResponse["settings"]> = {}, envOver: Par
     envLocks: { adultContent: false, mediaPlayer: false, ...envOver },
     accounts: {
       debridConfigured: false,
+      cloudflareAccessEnforced: false,
       debridProvider: null,
       omdbConfigured: false,
       reccConfigured: false,
@@ -126,6 +127,7 @@ describe("accountRows", () => {
   it("names the active debrid provider and reports its status", () => {
     const accounts: SettingsAccounts = {
       debridConfigured: true,
+      cloudflareAccessEnforced: true,
       debridProvider: "torbox",
       omdbConfigured: true,
       reccConfigured: false,
@@ -140,6 +142,7 @@ describe("accountRows", () => {
   it("falls back to a generic debrid label when none is active", () => {
     const rows = accountRows({
       debridConfigured: false,
+      cloudflareAccessEnforced: false,
       debridProvider: null,
       omdbConfigured: false,
       reccConfigured: true,
@@ -147,5 +150,20 @@ describe("accountRows", () => {
     });
     expect(rows[0]).toEqual({ label: "Debrid", status: "Not connected", ok: false });
     expect(rows.find((r) => r.label === "reccd")).toMatchObject({ ok: true, status: "Signed in as quiet-heron-4f2a" });
+  });
+
+  it("reports Cloudflare Access as enforced or not configured, read-only", () => {
+    const base: SettingsAccounts = {
+      debridConfigured: false,
+      cloudflareAccessEnforced: true,
+      debridProvider: null,
+      omdbConfigured: false,
+      reccConfigured: false,
+      reccAccount: null,
+    };
+    const enforced = accountRows(base).find((r) => r.label === "Cloudflare Access");
+    expect(enforced).toEqual({ label: "Cloudflare Access", status: "Enforced", ok: true });
+    const off = accountRows({ ...base, cloudflareAccessEnforced: false }).find((r) => r.label === "Cloudflare Access");
+    expect(off).toEqual({ label: "Cloudflare Access", status: "Not configured", ok: false });
   });
 });

--- a/src/web/static/settingsModel.ts
+++ b/src/web/static/settingsModel.ts
@@ -235,6 +235,14 @@ export function accountRows(accounts: SettingsAccounts): AccountRow[] {
     },
     { label: "OMDb", status: accounts.omdbConfigured ? "Key set" : "Not configured", ok: accounts.omdbConfigured },
     { label: "reccd", status: reccStatus, ok: accounts.reccConfigured },
+    // Read-only, like the rest of this section: whether the origin enforces
+    // Cloudflare Access. A capability flag — the browser never sees the team
+    // domain or AUD, only whether the gate is on.
+    {
+      label: "Cloudflare Access",
+      status: accounts.cloudflareAccessEnforced ? "Enforced" : "Not configured",
+      ok: accounts.cloudflareAccessEnforced,
+    },
   ];
 }
 

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -463,6 +463,8 @@ export interface SourcesResponse {
    * thing the TUI does, and deliberately not a silent downgrade to P2P.
    */
   debridConfigured: boolean;
+  /** Whether the origin is enforcing Cloudflare Access. A capability flag, never a credential. */
+  cloudflareAccessEnforced: boolean;
   /**
    * Which debrid service resolves magnets, or null when none is configured.
    * A capability flag like `debridConfigured`, never a credential: it is what
@@ -582,6 +584,8 @@ export interface SettingsEnvLocks {
  */
 export interface SettingsAccounts {
   debridConfigured: boolean;
+  /** Whether the origin is enforcing Cloudflare Access. A capability flag, never a credential. */
+  cloudflareAccessEnforced: boolean;
   debridProvider: "realdebrid" | "torbox" | null;
   omdbConfigured: boolean;
   reccConfigured: boolean;


### PR DESCRIPTION
## Summary

Lets torlink's web UI run on a public domain behind **Cloudflare Tunnel + Cloudflare Access**, closed to the public: your own devices authenticate silently via **mTLS (client certificate)**, a shared friend gets **install-nothing email/SSO**, and strangers are stopped at Cloudflare's edge before reaching the origin.

As **defense in depth**, torlink also verifies the `Cf-Access-Jwt-Assertion` JWT that Cloudflare stamps on every forwarded request, and `403`s anything without a valid one — so the origin is safe even if it were ever reachable directly. `/health`, `/stream/*` and `/play/*` are exempt (they keep the existing per-session `?k=` capability, since `<video>`/VLC/Chromecast can't present a cert), so in-browser playback and LAN casting are unaffected.

### What changed
- **`src/core/cloudflareAccess.ts`** — pure `jose`-based JWT verifier (RS256 pinned, issuer + audience bound, **fails closed** on any error including JWKS-fetch failure).
- **`src/web/server.ts`** — origin guard in the request handler after the CSRF check; skips the loopback-`Host` DNS-rebinding guard when Access is on (the Access JWT is a strictly stronger gate, and CSRF still applies).
- **`src/config/config.ts`** — `resolveCloudflareAccess` + `cfAccessTeamDomain`/`cfAccessAud` fields, env-over-config, **not** browser-writable (host-specific config stays TUI/env-only). Half-configured → off, with a startup warning.
- **`src/daemon/serve.ts` + `src/ui/App.tsx`** — same resolver threaded into both web-server hosts.
- **Both front ends** — read-only "Cloudflare Access: enforced/not configured" status (capability boolean over the wire, never a credential).
- **README** — end-to-end deployment guide (tunnel, CA, per-device certs, the `(cert) OR (email)` Access policy) and the single-tenant / visibility / casting caveats.

Configure with `TORLINK_CF_ACCESS_TEAM_DOMAIN` + `TORLINK_CF_ACCESS_AUD` (both required); the origin logs `cloudflare access: enforcing (team ...)` on startup.

Design + plan: `docs/superpowers/specs/2026-08-10-cloudflare-access-mtls-design.md`, `docs/superpowers/plans/2026-08-10-cloudflare-access-mtls.md`.

## Test Plan
- [x] `npm test` — 2959 pass (verifier unit tests, socket guard tests incl. exempt/gated paths + host-guard interaction, capability-flag router tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only the one known pre-existing `App.tsx` warning
- [x] `npm run build` — success (confirms `src/web/static` imports no `node:*`)
- [ ] Manual: stand up behind a real Cloudflare Tunnel + Access app; confirm silent cert auth, email/SSO for a second identity, stranger blocked, and in-browser + LAN-cast playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)