### PR TITLE
docs: Cloudflare Access + Tunnel deployment compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,31 @@ Once enforced, the **Settings** pane in both front ends shows **Cloudflare Acces
 the browser reports the status but, being a client of the config rather than an editor of it, never sees
 or sets the team domain or the AUD.
 
+#### As containers
+
+`docker-compose.access.yml` brings up torlink **and** its Tunnel connector together. Build from this
+checkout:
+
+```sh
+docker compose -f docker-compose.access.yml up -d --build
+```
+
+The parts that catch people out:
+
+- **The `cloudflared` sidecar is required** — it *is* the Tunnel connector, and nothing reaches torlink
+  without it. It lives in the same compose so it shares the project's default network and resolves torlink
+  by service name, so point the Tunnel's public hostname at `http://torlnk:9162` (the service name), not
+  `localhost`. Use it *instead of* the standalone `docker run cloudflare/cloudflared …` the dashboard
+  suggests — not as well.
+- **No `TORLINK_API_TOKEN`** — with the two Access settings present, torlink binds `0.0.0.0` tokenless
+  because Access is the gate; a token would only add a `#k=` login step in front of the one Cloudflare
+  already does.
+- **The healthcheck hits `/health`, not `/`** — with Access on, `/` needs an assertion the check can't
+  present, whereas `/health` is exempt.
+
+`CF_TUNNEL_TOKEN` and the two `TORLINK_CF_ACCESS_*` values are read from the environment, so they pair
+with a `.env` file or a secrets manager rather than being written into the compose file.
+
 #### Caveats, stated plainly
 
 - **It's single-tenant.** A shared friend uses *your* torlink instance — your [debrid](#debrid-real-debrid-or-torbox)

--- a/docker-compose.access.yml
+++ b/docker-compose.access.yml
@@ -1,0 +1,83 @@
+# torlnk behind Cloudflare Tunnel + Cloudflare Access, for a public domain.
+#
+# Where docker-compose.yml binds loopback and hands you a token'd link, this
+# variant runs torlnk with NO token and lets Cloudflare Access be the gate:
+# torlnk verifies the Cf-Access-Jwt-Assertion header itself, so binding 0.0.0.0
+# behind the tunnel is safe. The dashboard side (Tunnel, Access application,
+# login method) is in the README under
+# "Exposing torlink on a public domain (Cloudflare Access)".
+#
+#   docker compose -f docker-compose.access.yml up -d --build
+#
+# Secrets come from the environment — a .env file next to this one, or a secrets
+# manager. Required:
+#   CF_TUNNEL_TOKEN                - the token from your dashboard-managed Tunnel
+#   TORLINK_CF_ACCESS_TEAM_DOMAIN  - <your-team>.cloudflareaccess.com
+#   TORLINK_CF_ACCESS_AUD          - the Access application's Audience (AUD) tag
+#
+# Both services sit on the compose project's DEFAULT network, so cloudflared
+# reaches torlnk by its service name — point your Tunnel's public hostname at
+# http://torlnk:9162 in the dashboard. (No named network needed; a named/external
+# one is only for reaching a cloudflared that lives in a *different* compose.)
+
+services:
+  torlnk:
+    build: .
+    image: torlnk:local
+    container_name: torlnk
+    restart: unless-stopped
+
+    environment:
+      # Enforcement switches on only when BOTH are set. With them set, torlnk
+      # binds 0.0.0.0 tokenless (the Dockerfile's CMD) because Access is the gate.
+      TORLINK_CF_ACCESS_TEAM_DOMAIN: ${TORLINK_CF_ACCESS_TEAM_DOMAIN:?set your <team>.cloudflareaccess.com}
+      TORLINK_CF_ACCESS_AUD:         ${TORLINK_CF_ACCESS_AUD:?set the Access application AUD tag}
+      # Optional — cast to a TV that mDNS can't reach (a container can't see the
+      # LAN's mDNS). Give the TV's address and a LAN address it can fetch media
+      # from. Example IPs are RFC 5737 documentation addresses; use your own.
+      #   TORLINK_CAST_DEVICE: "192.0.2.10"        # the TV: host, or host:port
+      #   TORLINK_CAST_HOST:   "192.0.2.20:9162"   # a LAN address that reaches this container's 9162
+      REALDEBRID_API_TOKEN: ${REALDEBRID_API_TOKEN:-}
+      TORBOX_API_TOKEN: ${TORBOX_API_TOKEN:-}
+      TORLINK_OMDB_KEY: ${TORLINK_OMDB_KEY:-}
+
+    volumes:
+      # One directory holds config (tokens), queue, watch history, seeds, posters.
+      - ./state:/state
+      - ./state/Downloads/torlink:/state/Downloads/torlink
+
+    # Only needed if you cast to a LAN device: the TV fetches /stream directly
+    # over the LAN (an Access-exempt, ?k=-guarded path), so the web port has to be
+    # reachable on the LAN. Browser access does NOT need this — it comes in
+    # through the tunnel. Match the port to TORLINK_CAST_HOST above.
+    # ports:
+    #   - "9162:9162"
+
+    healthcheck:
+      # /health, not /, because with Access enforced every non-exempt path
+      # (including /) requires an assertion this check can't present. /health is
+      # exempt (as are /stream and /play).
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:9162/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
+  cloudflared:
+    # The Tunnel connector. Replaces the standalone
+    # `docker run cloudflare/cloudflared ... --token ...` the dashboard suggests —
+    # run one or the other, not both. It reads the token from the environment so
+    # it never lands on the command line or in `docker inspect`.
+    image: cloudflare/cloudflared:latest
+    container_name: torlnk-cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:?set CF_TUNNEL_TOKEN from your Tunnel}
+    depends_on: [torlnk]


### PR DESCRIPTION
## Summary

Follow-up to #84. Adds a ready-to-adapt deployment example for running torlink publicly behind Cloudflare Tunnel + Access, since the stock `docker-compose.yml` is deliberately the loopback/token default and doesn't show the tunnel wiring.

- **`docker-compose.access.yml`** — torlink (tokenless, Access-gated, healthcheck on `/health`) **plus the `cloudflared` Tunnel connector** as a sidecar in the same file. Both sit on the compose project's default network, so the connector resolves torlink by service name (`http://torlnk:9162`) with no named/external network needed. Placeholders only — no real hostnames, IPs, or tokens; `CF_TUNNEL_TOKEN` and the two `TORLINK_CF_ACCESS_*` values are read from the environment (a `.env` file or a secrets manager).
- **README** — a new "As containers" subsection under the Access guide that calls out the three easy-to-miss points: the sidecar is *required* (it's the connector), there's no `TORLINK_API_TOKEN` (Access is the gate), and the healthcheck must hit `/health` (since `/` needs an assertion under Access).

No code changes — example + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)