### PR TITLE
test: de-flake real-socket serve tests (raise vitest testTimeout)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     setupFiles: ["./src/test-setup.ts"],
+    // The real-socket tests (serve.launch / shutdown) wait up to waitUntil's own
+    // 5s budget for a server to bind and print its boot line. With vitest's 5s
+    // default there is no headroom left, so a loaded CI runner tips them into a
+    // bare "Test timed out in 5000ms" flake (seen on node 24 / ubuntu). Raise the
+    // ceiling: the fast majority still finish in milliseconds — only genuinely
+    // slow or hung tests ever reach it.
+    testTimeout: 15000,
     // `.claude/**` holds git worktrees — whole second checkouts of this repo.
     // Without this the suite runs every test twice, once against a stale copy,
     // and a failure there reads as a failure here.


### PR DESCRIPTION
## Summary

CI intermittently fails with a bare `Test timed out in 5000ms` in `src/daemon/serve.launch.test.ts` (seen on **node 24 / ubuntu-latest**, while the *same commit* passed every other matrix cell — a classic flake, not a real break).

**Cause:** those tests use real sockets and call `waitUntil(() => isListening(port))`, whose own default budget is **5000 ms** — identical to vitest's default `testTimeout`. So the socket-bind wait plus the boot-line wait plus shutdown have **zero headroom** under the 5 s cap; on a loaded runner they tip over.

**Fix:** set a global `testTimeout: 15000` in `vitest.config.ts`. Fast tests (the vast majority) are unaffected — they still finish in milliseconds; only genuinely slow or hung tests ever use the higher ceiling.

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)