### PR TITLE
fix: route poster and HLS-probe fetches through the custom-DNS dispatcher

### DIFF
--- a/src/core/posterCache.test.ts
+++ b/src/core/posterCache.test.ts
@@ -10,6 +10,7 @@ import {
   posterFileName,
   prunePosters,
 } from "./posterCache";
+import * as net from "../util/net";
 
 const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
 
@@ -62,6 +63,23 @@ describe("getPoster", () => {
     expect(second?.path).toBe(first?.path);
     expect(second?.bytes).toBe(JPEG.length);
     await expect(fs.readFile(first!.path)).resolves.toEqual(JPEG);
+  });
+
+  // The regression this guards: getPoster used the global `fetch` rather than
+  // torlink's `torlinkFetch`, so poster fetches silently skipped the custom-DNS
+  // dispatcher every other request honours. On a box with custom DNS set (common
+  // where a network sinkholes DNS), every poster 404'd while search, OMDb and
+  // debrid — all routed through torlinkFetch — worked. The default MUST be the
+  // shared fetch so posters resolve the same way as everything else.
+  it("uses torlink's DNS-aware fetch when no fetchImpl is injected", async () => {
+    const spy = vi.spyOn(net, "torlinkFetch").mockResolvedValue(okResponse(JPEG));
+    try {
+      const hit = await getPoster("https://m.media-amazon.com/a.jpg", { dir });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(hit).not.toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("returns null for a non-http url without fetching", async () => {

--- a/src/core/posterCache.ts
+++ b/src/core/posterCache.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { postersDir } from "../config/paths";
 import { renderPosterFile } from "../util/poster";
-import type { FetchImpl } from "../util/net";
+import { torlinkFetch, type FetchImpl } from "../util/net";
 import { log } from "../util/logger";
 
 // Hosts we are willing to fetch poster images from. The daemon fetching an
@@ -192,7 +192,10 @@ export async function getPoster(
 ): Promise<CachedPoster | null> {
   if (!posterUrlAllowed(url)) return null;
   const dir = opts.dir ?? postersDir;
-  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  // torlinkFetch, not the global `fetch`: poster CDNs must resolve through the
+  // custom-DNS dispatcher every other request uses, or a box whose network
+  // sinkholes DNS serves working search results with no poster behind any of them.
+  const fetchImpl = opts.fetchImpl ?? torlinkFetch;
   const file = path.join(dir, posterFileName(url));
 
   try {

--- a/src/util/net.ts
+++ b/src/util/net.ts
@@ -11,7 +11,12 @@ export type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>;
 // torlink's real fetch: undici's fetch, so a custom-DNS dispatcher (when set)
 // and response decompression come from the same undici instance. With no custom
 // DNS it behaves exactly like the platform fetch. Tests inject their own impl.
-const dohFetch: FetchImpl = (url, init) => {
+//
+// Anything the daemon fetches from the network MUST go through this rather than
+// the global `fetch`, or it silently skips the custom-DNS dispatcher — which is
+// how the poster cache once ended up unreachable on a box whose network
+// sinkholed DNS while every other request (routed here) resolved fine.
+export const torlinkFetch: FetchImpl = (url, init) => {
   const dispatcher = getDnsDispatcher();
   const opts = dispatcher ? { ...init, dispatcher } : init;
   return undiciFetch(url, opts as Parameters<typeof undiciFetch>[1]) as unknown as Promise<Response>;
@@ -136,7 +141,7 @@ export async function fetchResilient(
     retries = DEFAULT_RETRIES,
     baseMs = DEFAULT_BASE_MS,
     capMs = DEFAULT_CAP_MS,
-    fetchImpl = dohFetch,
+    fetchImpl = torlinkFetch,
     sleepImpl = realSleep,
     retryCdn503 = false,
     onAttempt,

--- a/src/web/hlsHealth.test.ts
+++ b/src/web/hlsHealth.test.ts
@@ -4,9 +4,11 @@ import {
   SEGMENT_QUANTUM,
   looksTruncated,
   makeCheckHls,
+  probeFetch,
   probeTarget,
   segmentUris,
 } from "./hlsHealth";
+import * as net from "../util/net";
 
 // A media playlist in the shape Real-Debrid actually serves: no version tag, no
 // stream-inf, relative segment names, ENDLIST at the bottom.
@@ -163,5 +165,25 @@ describe("makeCheckHls", () => {
     const fetchImpl = fetcher(manifest(704), okSegment);
     await makeCheckHls({ fetchImpl })(MANIFEST_URL);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("probeFetch", () => {
+  // The regression: probeFetch used the global `fetch`, so HLS health probes to
+  // the provider CDN skipped the custom-DNS dispatcher every other request uses —
+  // the same bug that made the poster cache unreachable on a custom-DNS box. The
+  // production probe MUST go through torlinkFetch, and still read status + bytes
+  // off the streamed body.
+  it("fetches through torlink's DNS-aware fetch and reports status and byte count", async () => {
+    const spy = vi
+      .spyOn(net, "torlinkFetch")
+      .mockResolvedValue(new Response(new Uint8Array([1, 2, 3, 4, 5]), { status: 200 }));
+    try {
+      const res = await probeFetch("https://28.stream.example.test/seg.ts", 1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(res).toEqual({ status: 200, bytes: 5, body: expect.any(String) });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/web/hlsHealth.ts
+++ b/src/web/hlsHealth.ts
@@ -27,6 +27,8 @@
 // Nothing here throws. Every "no" is the same `false`, because the caller's next
 // move is identical for all of them: fall to the next rung.
 
+import { torlinkFetch } from "../util/net";
+
 /**
  * The boundary the provider rounds a partial segment to.
  *
@@ -219,7 +221,11 @@ const MAX_TEXT_BYTES = 1024 * 1024;
  */
 export async function probeFetch(url: string, timeoutMs: number): Promise<ProbeResponse | null> {
   try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs), redirect: "follow" });
+    // torlinkFetch, not the global `fetch`: the manifest and its segments live on
+    // the debrid provider's CDN, so on a box with custom DNS the probe must resolve
+    // through the same dispatcher as everything else or it fails for the same
+    // reason the poster cache once did — see the note in src/util/net.ts.
+    const res = await torlinkFetch(url, { signal: AbortSignal.timeout(timeoutMs), redirect: "follow" });
     let bytes = 0;
     // Budgeted in BYTES read, not in string length: the two differ for anything
     // non-ASCII, and the point of the cap is to avoid decoding megabytes of a


### PR DESCRIPTION
## What

`getPoster` (`src/core/posterCache.ts`) and `probeFetch` (`src/web/hlsHealth.ts`) fetched with the **global `fetch`**, while every other outbound request in torlink goes through `dohFetch` in `src/util/net.ts` — which installs a DNS-over-HTTPS dispatcher when custom DNS is configured. Global `fetch` uses the system resolver, so those two paths silently **skipped custom DNS**.

## Why it mattered (the reported bug)

On `tl.reccd.stream` (tokenless, behind a Cloudflare tunnel) **every poster 404'd** — `GET /api/poster?url=…` returned `{ "error": "poster unavailable" }`, confirmed in the logs as a bare 404. Yet search, OMDb and debrid all worked.

The undici dispatcher only changes **DNS resolution**; the connect to the resolved IP is identical. So the only way OMDb (via `dohFetch`) can produce poster URLs while every poster fetch (via global `fetch`) fails is a DNS divergence: the box has **custom DoH DNS** configured (common where a network sinkholes DNS), the system resolver can't resolve `m.media-amazon.com`, and `getPoster` was the one server-side fetch not going through the shared dispatcher. `probeFetch` (HLS playback health checks against the debrid provider's CDN) had the identical latent bug.

## Change

- Export the shared fetch from `src/util/net.ts` as **`torlinkFetch`** (was the private `dohFetch`; behaviour unchanged).
- `getPoster` and `probeFetch` default to `torlinkFetch` instead of global `fetch`.
- Regression tests in both suites assert the default routes through `torlinkFetch` (each fails on the old wiring).

The fetch swap is behaviour-preserving except that both paths now resolve the same way as everything else.

## Both front ends

The poster fix lives in `src/core` and is shared by both surfaces, so it fixes the browser (`/api/poster`) and the TUI (`cachedPosterRows`) in one change. No surface-specific work needed.

## Verification

- `npm test` — 169 files / 2974 tests pass
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (only the pre-existing `App.tsx` `exhaustive-deps` warning)
- `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)