### PR TITLE
fix(web): force debrid and never direct P2P when a provider is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,14 @@ the list. The header, the category tabs and the sort controls are pinned too, so
 re-sort without scrolling back to the top of a long browse. Press **`/`** to jump to the search box from
 anywhere, and drive the list with the arrow keys.
 
-From a result you can **add** it to the queue, **add via RD** or **add via TorBox** where that debrid
-provider is configured, **play** it straight away, **copy magnet**, or **export .torrent** — the same
+From a result you can **add** it to the queue, **play** it straight away, **copy magnet**, or
+**export .torrent** — the same
 metadata-only export as the terminal's `e`, writing the file into the download folder on the machine
 torlink is running on, and telling you which folder that was. Under TorBox, a result already on their servers
 also carries a **cached** marker — Real-Debrid results never show one, for the same reason the terminal
-doesn't (see [Debrid](#debrid-real-debrid-or-torbox)).
+doesn't (see [Debrid](#debrid-real-debrid-or-torbox)). Where a debrid provider is configured the plain
+**add** is replaced by **add via RD** / **add via TorBox**: the browser routes every add through the
+provider and never downloads direct peer-to-peer (the terminal keeps its plain `d`, which warns first).
 
 `torlnk serve --web` lands on serve's own port, **`http://127.0.0.1:9161`**, and **opens your browser
 there for you**. `torlnk --web` lands on **`http://127.0.0.1:9162`** and prints the address on the
@@ -465,8 +467,11 @@ itself.
 
 **With a debrid account connected**, `v` and **play** stream from that provider's servers instead:
 faster, no waiting on seeders, and your IP never touches the swarm. torlink takes that route
-automatically whenever an account is active, and only falls back to a torrent stream if you confirm it —
-so connecting a debrid provider never quietly drops you onto peer-to-peer. By default the browser's player
+automatically whenever an account is active. In the terminal it falls back to a torrent stream only if you
+confirm it, so a debrid provider never quietly drops you onto peer-to-peer. The browser (`serve --web`) is
+stricter still: it is typically a headless or remote box whose IP must never touch the swarm, so when a
+provider is configured it *always* uses it and never streams — or downloads — direct peer-to-peer, even if
+the account looks lapsed (it attempts the provider and reports what the provider says). By default the browser's player
 redirects straight to their CDN, so the video never passes through the machine running torlnk — you get
 their bandwidth and native seeking. If you'd rather the link to your account never left the server, you
 can [relay it through this machine](#relaying-streams-through-this-machine) instead.

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -510,10 +510,14 @@ describe("POST /api/stream", () => {
   });
 });
 
-describe("POST /api/stream — torrent-confirm", () => {
-  // A configured Real-Debrid account that isn't premium. The TUI always warns
-  // here; the browser must be given the chance to do the same.
-  function confirmDeps(over: Partial<WebDeps> = {}) {
+describe("POST /api/stream — a configured provider is never swapped for P2P", () => {
+  // A configured Real-Debrid account whose live probe says it isn't premium.
+  // The old behaviour offered a P2P confirm here; the policy now is "force
+  // debrid, never direct" whenever a provider is configured, so the stream is
+  // attempted through debrid regardless of the (possibly stale) inactive status.
+  // If the account really is dead, debrid reports that through the session —
+  // which never puts the box's IP into a public swarm.
+  function inactiveDeps(over: Partial<WebDeps> = {}) {
     return deps({
       loadConfigImpl: async () => ({ ...defaultConfig, realDebridToken: "rd-token" }),
       debridStatusImpl: async () => ({
@@ -527,48 +531,34 @@ describe("POST /api/stream — torrent-confirm", () => {
     });
   }
 
-  it("refuses with a distinct state instead of quietly streaming over P2P", async () => {
-    // THE MUTATION THIS KILLS: treating torrent-confirm as torrent-auto. That
-    // reads as a harmless simplification and puts the user's own IP into a
-    // public swarm, after they deliberately set Real-Debrid up so it wouldn't
-    // be. Nothing may start until a human says yes.
-    const streamTorrentImpl = vi.fn(async () => torrentBackend());
-    const sessions = registry({ streamTorrentImpl });
-    const res = await post(confirmDeps({ runtime: runtime(sessions) }), { magnet: MAGNET });
-
-    expect(res.status).toBe(409);
-    expect(res.json).toEqual({
-      route: "torrent-confirm",
-      reason: "your Real-Debrid plan isn't active",
-    });
-    expect(streamTorrentImpl).not.toHaveBeenCalled();
-    expect(sessions.list()).toEqual([]);
-  });
-
-  it("is not satisfied by a truthy-but-not-true confirm", async () => {
-    const sessions = registry();
-    const res = await post(confirmDeps({ runtime: runtime(sessions) }), {
-      magnet: MAGNET,
-      confirm: "yes",
-    });
-    expect(res.status).toBe(409);
-    expect(sessions.list()).toEqual([]);
-  });
-
-  it("streams over P2P once the client confirms", async () => {
+  it("routes through debrid rather than offering a P2P fallback", async () => {
+    // THE MUTATION THIS KILLS: falling back to (or offering) a direct P2P swarm
+    // when a provider is configured but its account looks inactive. That leaks
+    // the box's IP — exactly what a debrid provider is set up to avoid.
     const streamTorrentImpl = vi.fn(async () => torrentBackend());
     const resolveDebridImpl = vi.fn(async () => [{ url: RD_URL, filename: "big.mkv", bytes: 900 }]);
     const sessions = registry({ streamTorrentImpl, resolveDebridImpl });
-    const res = await post(confirmDeps({ runtime: runtime(sessions) }), {
+    const res = await post(inactiveDeps({ runtime: runtime(sessions) }), { magnet: MAGNET });
+
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ session: { backend: "debrid" } });
+    expect(resolveDebridImpl).toHaveBeenCalledWith("realdebrid", "rd-token", MAGNET, expect.anything());
+    expect(streamTorrentImpl).not.toHaveBeenCalled();
+  });
+
+  it("ignores a P2P confirm flag — the client cannot opt the box into a swarm", async () => {
+    const streamTorrentImpl = vi.fn(async () => torrentBackend());
+    const resolveDebridImpl = vi.fn(async () => [{ url: RD_URL, filename: "big.mkv", bytes: 900 }]);
+    const sessions = registry({ streamTorrentImpl, resolveDebridImpl });
+    const res = await post(inactiveDeps({ runtime: runtime(sessions) }), {
       magnet: MAGNET,
       confirm: true,
     });
 
     expect(res.status).toBe(200);
-    expect(res.json).toMatchObject({ session: { backend: "torrent" } });
-    expect(streamTorrentImpl).toHaveBeenCalled();
-    // Confirmed means P2P, not "try Real-Debrid anyway with a dead account".
-    expect(resolveDebridImpl).not.toHaveBeenCalled();
+    expect(res.json).toMatchObject({ session: { backend: "debrid" } });
+    expect(resolveDebridImpl).toHaveBeenCalled();
+    expect(streamTorrentImpl).not.toHaveBeenCalled();
   });
 });
 
@@ -2142,6 +2132,47 @@ describe("POST /api/add — adding a search hit by hash and name", () => {
     const { runtime: rt, add } = addRuntime();
     await post(deps({ runtime: rt }), { infoHash: HASH, name: "Kestrel", via: "p2p", sizeBytes: 4096 });
     expect(add).toHaveBeenCalledWith(expect.objectContaining({ sizeBytes: 4096 }), "/tmp/dl");
+  });
+
+  // Policy: with a debrid provider configured the web server never issues a
+  // direct P2P download — it would put the box's IP in a public swarm and write
+  // to its disk. These three cover every way a P2P download could otherwise slip
+  // through.
+  const debridConfig = async () => ({ ...defaultConfig, downloadDir: "/tmp/dl", realDebridToken: "rd-tok" });
+
+  it("forces debrid for a pasted magnet, closing the silent legacy-P2P gap", async () => {
+    // The add-box sends only { magnet } — no name, no via. That used to fall
+    // through to the legacy /add handler and download direct P2P with no prompt,
+    // even with a provider configured. It must go through debrid instead.
+    const { runtime: rt, add, addDebrid } = addRuntime();
+    const res = await post(
+      deps({ runtime: rt, loadConfigImpl: debridConfig }),
+      { magnet: `magnet:?xt=urn:btih:${HASH}&dn=Example` },
+    );
+    expect(res.status).toBe(200);
+    expect(addDebrid).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Example" }),
+      "/tmp/dl",
+      "realdebrid",
+      "rd-tok",
+    );
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("forces debrid even when the client explicitly asks for p2p", async () => {
+    const { runtime: rt, add, addDebrid } = addRuntime();
+    const res = await post(
+      deps({ runtime: rt, loadConfigImpl: debridConfig }),
+      { infoHash: HASH, name: "Kestrel", via: "p2p" },
+    );
+    expect(res.status).toBe(200);
+    expect(addDebrid).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Kestrel" }),
+      "/tmp/dl",
+      "realdebrid",
+      "rd-tok",
+    );
+    expect(add).not.toHaveBeenCalled();
   });
 
   it("rejects an unknown `via` instead of guessing a network", async () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -109,7 +109,6 @@ import type {
   PublicWritableSettings,
   SourcesResponse,
   StartStreamResponse,
-  StreamConfirmResponse,
   SavedSearchesResponse,
 } from "./wire";
 
@@ -389,8 +388,10 @@ interface StartStreamBody {
   magnet?: unknown;
   infoHash?: unknown;
   name?: unknown;
-  // Set by a client that has shown the user the `torrent-confirm` reason and
-  // had them accept it. Never inferred, never defaulted true.
+  // Legacy field: older clients set this after a `torrent-confirm` prompt to opt
+  // into a P2P stream. The web server no longer offers that fallback when a
+  // debrid provider is configured (see startStream's docblock), so it is now
+  // accepted-but-ignored rather than a break in the wire contract.
   confirm?: unknown;
 }
 
@@ -408,15 +409,16 @@ function parseStartBody(bodyText: string): StartStreamBody | null {
  * POST /api/stream — start a session and answer with its id, its capability
  * and its (public) state.
  *
- * Routing is `classifyStreamRoute`, the same decision the TUI makes, for the
- * same reason: a configured debrid account (Real-Debrid or TorBox) should be
- * used, and one that is configured but not working must not be quietly
- * swapped for a P2P swarm. The `torrent-confirm` case is reported to the
- * client as its own status and its own body and NOT downgraded to
- * `torrent-auto` here — the user set a debrid provider up precisely so their
- * IP would stay out of swarms, and a server that decides "close enough" on
- * their behalf exposes it without them ever seeing a prompt. The client asks,
- * and comes back with `confirm: true` if they accept.
+ * Routing starts from `classifyStreamRoute`, the same decision the TUI makes,
+ * but the web server applies a stricter policy on top: when a debrid provider
+ * is configured it is ALWAYS used and the server never streams direct P2P.
+ * `serve --web` is typically a headless/remote box behind a tunnel, where a P2P
+ * swarm would expose the server's own IP — so the TUI's "confirm, then stream
+ * P2P" fallback for an inactive account is not offered here. A configured
+ * provider that looks inactive is still attempted through debrid (the status
+ * probe can be stale); a genuinely dead account surfaces as a session error,
+ * never as a silent swarm. With no provider configured, P2P is the only option
+ * and is used directly. `confirm` in the body is therefore ignored.
  */
 async function startStream(deps: WebDeps, bodyText: string): Promise<WebResponse> {
   const body = parseStartBody(bodyText);
@@ -447,14 +449,15 @@ async function startStream(deps: WebDeps, bodyText: string): Promise<WebResponse
 
   let route: StreamRoute = classified;
   if (classified.kind === "torrent-confirm") {
-    if (body.confirm !== true) {
-      const refusal: StreamConfirmResponse = { route: "torrent-confirm", reason: classified.reason };
-      // 409, not 200: nothing was started. A success status with a "please ask
-      // the user" body is the shape a client accidentally treats as done.
-      return { status: 409, json: refusal };
-    }
-    // Confirmed by a human, so it proceeds as an ordinary P2P stream.
-    route = { kind: "torrent-auto" };
+    // Policy for the web server: with a debrid provider configured, never fall
+    // back to (or offer) a direct P2P swarm — that exposes the box's IP, which
+    // is the whole reason a provider was set up. classifyStreamRoute only asks
+    // for a confirm when a provider IS configured but its account looks
+    // inactive, so force the debrid route here regardless. The status probe can
+    // be stale, so attempting debrid may just work; and if the account really
+    // is dead, the debrid resolve reports it through the session rather than
+    // silently streaming over P2P. `active` is necessarily set in this branch.
+    route = active ? { kind: "debrid", provider: active.provider } : { kind: "torrent-auto" };
   }
 
   // begin(), not start(): a Real-Debrid cache can take minutes and the answer
@@ -864,7 +867,19 @@ async function addToQueue(
 
   const name = typeof body.name === "string" ? body.name.trim() : "";
   const rawVia = typeof body.via === "string" ? body.via.trim() : "";
-  if (!name && !rawVia) {
+
+  // Policy: when a debrid provider is configured the web server forces every
+  // add through debrid and never issues a direct P2P download — a headless/
+  // remote box would otherwise put its own IP into a public swarm and write the
+  // torrent to its disk. `active` decides it, so it is resolved up front.
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const active = resolveActiveDebrid(config);
+
+  // The legacy fallthrough (a bare `{ magnet }` add-box body: no name, no via)
+  // downloads direct P2P. It is only safe when NO provider is configured — with
+  // one set, that same body must be routed to debrid below instead of quietly
+  // hitting the swarm, so it does not fall through here.
+  if (!name && !rawVia && !active) {
     return fromApi(await handleApi(deps.runtime, deps.token, "POST", "/add", authHeader, bodyText));
   }
   if (rawVia && rawVia !== "p2p" && rawVia !== "debrid") {
@@ -884,17 +899,19 @@ async function addToQueue(
     options.sizeBytes = body.sizeBytes;
   }
 
-  if (rawVia === "debrid") {
-    const config = await (deps.loadConfigImpl ?? loadConfig)();
-    const active = resolveActiveDebrid(config);
-    if (!active) {
-      return {
-        status: 400,
-        json: { error: "Set a Real-Debrid or TorBox token first — open the Settings tab." },
-      };
-    }
+  if (active) {
+    // Force debrid regardless of what the client asked for (or omitted): an
+    // explicit `via: "p2p"` and the pasted-magnet fallthrough both land here.
     options.debridToken = active.token;
     options.debridProvider = active.provider;
+  } else if (rawVia === "debrid") {
+    // Asked for debrid with nothing configured. A silent P2P fallback would put
+    // the user's IP in a public swarm right after they asked for the thing that
+    // keeps it out of one, so refuse rather than guess.
+    return {
+      status: 400,
+      json: { error: "Set a Real-Debrid or TorBox token first — open the Settings tab." },
+    };
   }
 
   const outcome = await addInput(deps.runtime, input, options);

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -2286,12 +2286,20 @@ function resultActions(
   });
   actions.append(playButton);
 
-  const addButton = document.createElement("button");
-  addButton.type = "button";
-  addButton.textContent = "add";
-  tagControl(addButton, rowKey, "add");
-  addButton.addEventListener("click", () => void addResult(result, "p2p"));
-  actions.append(addButton);
+  // A labelled debrid add button replaces the plain (P2P) "add" whenever a
+  // provider is configured — the server forces debrid in that case (it never
+  // downloads direct P2P on a headless box), so a P2P "add" button here would
+  // promise a network the server won't use. `debridProvider` guards the same
+  // `debridConfigured: true` with a null provider case the button below does.
+  const debridAddAvailable = Boolean(sources?.debridConfigured && sources.debridProvider);
+  if (!debridAddAvailable) {
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.textContent = "add";
+    tagControl(addButton, rowKey, "add");
+    addButton.addEventListener("click", () => void addResult(result, "p2p"));
+    actions.append(addButton);
+  }
 
   // Labelled by what the click will do, and rebuilt from savedState on every
   // render — the results list is re-rendered on every snapshot frame, so a
@@ -2313,8 +2321,9 @@ function resultActions(
   // Offered only where the TUI offers `r`: when a debrid token is actually
   // configured. A button that always answered "set a token first" is noise.
   // `debridProvider` guards against `debridConfigured: true` with a null
-  // provider producing a button labelled "add via null".
-  if (sources?.debridConfigured && sources.debridProvider) {
+  // provider producing a button labelled "add via null". This is the only add
+  // button shown when a provider is configured — see the plain "add" above.
+  if (debridAddAvailable && sources?.debridProvider) {
     const debridButton = document.createElement("button");
     debridButton.type = "button";
     debridButton.textContent = debridAddLabel(sources.debridProvider);


### PR DESCRIPTION
## What

`serve --web` is typically a **headless or remote box** (often behind a Cloudflare tunnel). A direct peer-to-peer transfer there exposes the *server's* own IP to the swarm and writes torrents to its disk — almost never what the operator wants once they've connected a debrid provider. This makes the web server **always use the provider when one is configured, and never stream or download direct P2P.**

## Why

Investigation of the web routing found three ways a direct-P2P transfer could still happen with a provider configured. One was fully silent:

| Path | Before | After |
| --- | --- | --- |
| **Stream** (`POST /api/stream`) | inactive account → `409 torrent-confirm` → confirmed client streams **P2P** | routes through **debrid** regardless (probe can be stale; a dead account surfaces as a session error, never a swarm). `confirm` accepted-but-ignored |
| **Search "add" (P2P) button** | prompts, then **P2P download** | plain P2P "add" hidden when a provider is configured; only **add via RD/TorBox** shown |
| **Pasted-magnet add-box** (`{ magnet }`, no `name`/`via`) | fell through to legacy `/add` → **P2P download, no prompt at all** | forced through **debrid** |

The pasted-magnet box was the only *fully silent* contradiction — the reported concern.

## How

- **Server is authoritative** (`src/web/routes.ts`): `startStream` forces the debrid route where it used to offer a P2P confirm; `addToQueue` forces `via=debrid` whenever `resolveActiveDebrid` is non-null (covering an explicit `via:"p2p"` and the bare-magnet fallthrough), and no longer delegates that case to the legacy handler.
- **Browser coherence** (`src/web/static/app.ts`): the plain P2P "add" button is hidden when a provider is configured, so the UI never offers a network the server won't use.
- Removed the now-unused `StreamConfirmResponse` import; the `confirm` field is documented as legacy accepted-but-ignored.

## Scope: web only, on purpose

Per the repo's "a feature ships in both front ends" rule — this one deliberately does not. The policy targets the **headless web server**, whose IP/disk shouldn't touch the swarm. The **TUI runs on the user's own machine**, where choosing a direct-P2P stream/download is theirs to make, so its confirm prompts and plain `d`/`v` behaviour are unchanged. `README.md` documents the web-vs-terminal divergence.

## Tests

- Rewrote the `POST /api/stream` "torrent-confirm" suite to assert debrid is forced (no P2P) even for an inactive-looking account and even with `confirm: true`.
- Added `POST /api/add` cases: a pasted magnet and an explicit `via:"p2p"` both route through debrid when a provider is configured.

## Verification

- `npm test` — 169 files / 2973 tests pass
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (only the pre-existing `App.tsx` warning)
- `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
