### PR TITLE
fix(serve): warn loudly when the state directory isn't writable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,9 @@ dist
 .env
 .env.*
 config.json
+# Bind-mounted runtime state (torlnk's data/config/cache under a compose ./state
+# mount). Letting it into the build context busts the layer cache every run.
+state
 
 # Test and docs output that the runtime has no use for.
 coverage

--- a/README.md
+++ b/README.md
@@ -965,6 +965,10 @@ The parts that catch people out:
   already does.
 - **The healthcheck hits `/health`, not `/`** — with Access on, `/` needs an assertion the check can't
   present, whereas `/health` is exempt.
+- **`./state` must be writable by uid 1000.** Same as the plain compose above: the container runs as the
+  `node` user (uid 1000) and the bind mount keeps the host directory's ownership, so a root-owned `./state`
+  leaves posters blank and the log file empty (config still loads, because it is only read). Run `mkdir -p
+  ./state && sudo chown -R 1000:1000 ./state` before the first `up`.
 
 `CF_TUNNEL_TOKEN` and the two `TORLINK_CF_ACCESS_*` values are read from the environment, so they pair
 with a `.env` file or a secrets manager rather than being written into the compose file.
@@ -1045,6 +1049,13 @@ Four things in there are decisions rather than defaults, and are worth knowing b
 - **One volume, `/state`.** `TORLINK_STATE_DIR` puts config, data and cache under a single directory, so
   that one mount holds your tokens, the queue, watch history, seeds and the poster cache. Downloads land
   in `/state/Downloads/torlink` — repoint that mount at a bigger disk and the files follow.
+- **The bind mount must be writable by uid 1000.** The image runs as the non-root `node` user (uid 1000),
+  and a bind mount keeps the *host* directory's ownership — Docker only applies the image's ownership to a
+  *named* volume, not to `./state`. So if `./state` is owned by root, uid 1000 can't create `/state/cache`
+  or `/state/data`, and posters and the log file silently fail to persist while `config.json` (only *read*)
+  still works. Make it writable once, before the first `up`: `mkdir -p ./state && sudo chown -R 1000:1000
+  ./state`. torlink also prints a loud warning on startup if it can't write `/state`, so `docker logs`
+  names the cause.
 - **`ffmpeg` is in the image.** It's what lets the player [know a release's real codecs](#press-play) up
   front instead of guessing from its name. It stays optional in the code — torlink runs fine without it —
   but a container is a controlled environment, so there's no reason to ship one without.

--- a/docker-compose.access.yml
+++ b/docker-compose.access.yml
@@ -43,6 +43,12 @@ services:
 
     volumes:
       # One directory holds config (tokens), queue, watch history, seeds, posters.
+      #
+      # The image runs as uid 1000 (node). A bind mount keeps the HOST dir's
+      # ownership, so if ./state is root-owned, uid 1000 can't create /state/cache
+      # or /state/data — posters and logs then silently fail to persist. Make it
+      # writable by uid 1000 before the first `up`:
+      #   mkdir -p ./state && sudo chown -R 1000:1000 ./state
       - ./state:/state
       - ./state/Downloads/torlink:/state/Downloads/torlink
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,13 @@ services:
       # Everything torlnk persists: config (including tokens), the queue, watch
       # history, seeds, the poster cache. One directory, because
       # src/config/paths.ts puts all three of its trees under TORLINK_STATE_DIR.
+      #
+      # The image runs as the non-root `node` user (uid 1000). A bind mount keeps
+      # the HOST directory's ownership — unlike a named volume, Docker does NOT
+      # apply the image's chown to it — so if ./state is owned by root, uid 1000
+      # cannot create /state/cache or /state/data and posters and logs silently
+      # fail to persist. Make it writable by uid 1000 before the first `up`:
+      #   mkdir -p ./state && sudo chown -R 1000:1000 ./state
       - ./state:/state
       # Downloads default to $HOME/Downloads/torlink and HOME is /state, so this
       # is that path made explicit. Repoint it at a bigger disk and the files

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -19,6 +19,7 @@ import { startWebServer, type WebServerHandle } from "../web/server";
 import type { StatusPayload } from "../web/wire";
 import { VERSION } from "../version";
 import { openUrl } from "../util/openUrl";
+import { checkStateDirsWritable } from "../util/stateDirCheck";
 import { ensureReccAccount } from "../recc/provision";
 import { loadConfig, resolveCloudflareAccess, isCloudflareAccessHalfConfigured } from "../config/config";
 
@@ -385,6 +386,16 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
   }
 
   const runtime = await startRuntime(options.downloadDir);
+
+  // State lives under TORLINK_STATE_DIR (config, data, cache). If this process
+  // can't write there — the classic being a root-owned Docker bind mount under a
+  // non-root container user — posters, the log file and the download queue all
+  // fail silently, because the poster cache and the logger swallow the EACCES by
+  // design (a caching or logging failure must never crash a download). Probe it
+  // once at boot and say so loudly, so `docker logs` names the cause instead of
+  // showing a wall of blank posters with no explanation.
+  const stateWarning = await checkStateDirsWritable();
+  if (stateWarning) log(stateWarning);
 
   // A headless seedbox and `serve --web` get an account too. Fire-and-forget,
   // never awaited: reccd is a value-add, never a dependency. No onProvisioned

--- a/src/util/stateDirCheck.test.ts
+++ b/src/util/stateDirCheck.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { formatStateDirWarning, checkStateDirsWritable, type DirWriteCheck } from "./stateDirCheck";
+
+const ok = (dir: string): DirWriteCheck => ({ dir, writable: true });
+const bad = (dir: string, code = "EACCES"): DirWriteCheck => ({ dir, writable: false, code });
+
+describe("formatStateDirWarning", () => {
+  it("returns null when every directory is writable", () => {
+    const checks = [ok("/state/config"), ok("/state/data"), ok("/state/cache")];
+    expect(formatStateDirWarning(checks, { uid: 1000, stateRoot: "/state", ownerUid: 1000 })).toBeNull();
+  });
+
+  it("names each unwritable directory and its errno", () => {
+    const checks = [ok("/state/config"), bad("/state/data"), bad("/state/cache")];
+    const msg = formatStateDirWarning(checks, { uid: 1000, stateRoot: "/state", ownerUid: 0 });
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("/state/data");
+    expect(msg).toContain("/state/cache");
+    expect(msg).toContain("EACCES");
+    // The writable one is never named — a warning that lists working paths reads
+    // as noise and hides the two that matter.
+    expect(msg).not.toContain("/state/config");
+  });
+
+  it("spells out the uid/owner mismatch and a copy-pasteable chown when they differ", () => {
+    const msg = formatStateDirWarning([bad("/state/cache")], {
+      uid: 1000,
+      stateRoot: "/state",
+      ownerUid: 0,
+    });
+    expect(msg).toContain("uid 1000");
+    expect(msg).toContain("uid 0");
+    // The fix that resolves the Docker bind-mount case, with the running uid
+    // filled in so it can be pasted as-is.
+    expect(msg).toContain("chown -R 1000:1000");
+  });
+
+  it("does not blame ownership when the uid already owns the dir but still can't write", () => {
+    // Same uid but unwritable is a mode problem (e.g. 0555), not ownership —
+    // suggesting chown would send the operator down the wrong path.
+    const msg = formatStateDirWarning([bad("/state/cache")], {
+      uid: 1000,
+      stateRoot: "/state",
+      ownerUid: 1000,
+    });
+    expect(msg).not.toBeNull();
+    expect(msg).not.toContain("owned by");
+    expect(msg).not.toContain("chown");
+    expect(msg).toContain("permission");
+  });
+
+  it("still warns without a chown line where uids do not apply (uid undefined)", () => {
+    const msg = formatStateDirWarning([bad("/state/cache", "EPERM")], {
+      uid: undefined,
+      stateRoot: "/state",
+      ownerUid: undefined,
+    });
+    expect(msg).toContain("/state/cache");
+    expect(msg).toContain("EPERM");
+    expect(msg).not.toContain("chown");
+  });
+
+  it("offers the chown hint when the owner could not be stat-ed but a uid is known", () => {
+    const msg = formatStateDirWarning([bad("/state/cache")], {
+      uid: 1000,
+      stateRoot: "/state",
+      ownerUid: undefined,
+    });
+    expect(msg).toContain("chown -R 1000:1000");
+  });
+});
+
+describe("checkStateDirsWritable", () => {
+  it("returns null when the given dirs can be created and written", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "torlnk-state-ok-"));
+    try {
+      const dirs = ["config", "data", "cache"].map((d) => path.join(root, d));
+      expect(await checkStateDirsWritable({ dirs, stateRoot: root })).toBeNull();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns and names the offending path when a dir cannot be created", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "torlnk-state-bad-"));
+    try {
+      // A regular file where a directory needs to be: mkdir of a child throws
+      // ENOTDIR/EEXIST, which is exactly the never-writable shape we must surface.
+      const wall = path.join(root, "cache");
+      await fs.writeFile(wall, "");
+      const dirs = [path.join(wall, "posters")];
+      const msg = await checkStateDirsWritable({ dirs, stateRoot: root });
+      expect(msg).not.toBeNull();
+      expect(msg).toContain(path.join(wall, "posters"));
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/util/stateDirCheck.ts
+++ b/src/util/stateDirCheck.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { configFile, logFile, postersDir } from "../config/paths";
+
+// The result of probing one directory: whether torlink can create it and write
+// a file inside it, and — when it can't — the errno that says why.
+export interface DirWriteCheck {
+  dir: string;
+  writable: boolean;
+  code?: string;
+}
+
+// Everything the message needs that isn't in the per-dir checks: who we run as,
+// which root the dirs live under, and who owns that root. `uid`/`ownerUid` are
+// undefined where POSIX uids don't apply (Windows) or the root couldn't be
+// stat-ed — the message adapts rather than printing "undefined".
+export interface StateDirContext {
+  uid?: number;
+  stateRoot: string;
+  ownerUid?: number;
+}
+
+/**
+ * A loud, actionable warning when torlink can't write parts of its state
+ * directory, or null when every directory is writable.
+ *
+ * Kept pure — the caller probes the filesystem and hands the results here — so
+ * the exact wording is unit-tested without a real unwritable directory to set
+ * up. This exists because the poster cache and the logger both swallow EACCES
+ * (by design: a logging or caching failure must never crash a download), which
+ * once turned a root-owned Docker bind mount into a silent "all posters blank,
+ * no log file" with nothing on screen to explain it.
+ */
+export function formatStateDirWarning(
+  checks: readonly DirWriteCheck[],
+  ctx: StateDirContext,
+): string | null {
+  const failed = checks.filter((c) => !c.writable);
+  if (failed.length === 0) return null;
+
+  const lines: string[] = [
+    "warning: torlink cannot write its state directory — posters, logs and the download queue will not persist.",
+  ];
+  // Only the failing paths: a warning that also lists the directories that work
+  // reads as noise and buries the ones that matter.
+  for (const f of failed) {
+    lines.push(`  cannot write ${f.dir}${f.code ? ` (${f.code})` : ""}`);
+  }
+
+  const { uid, ownerUid, stateRoot } = ctx;
+  const chownHint = (): string =>
+    `  if ${stateRoot} is a Docker bind mount, run on the host: chown -R ${uid}:${uid} <the mounted directory>`;
+
+  if (uid !== undefined && ownerUid !== undefined && uid !== ownerUid) {
+    // The case this whole check exists for: a non-root process against a
+    // root-owned bind mount. Naming both uids turns "permission denied" into a
+    // fix the operator can paste.
+    lines.push(`  running as uid ${uid}, but ${stateRoot} is owned by uid ${ownerUid}.`);
+    lines.push(chownHint());
+  } else if (uid !== undefined && ownerUid === undefined) {
+    // Couldn't stat the root, so can't prove a mismatch — but a uid is still
+    // worth offering the same fix against, since a bind mount is the usual cause.
+    lines.push(`  running as uid ${uid}.`);
+    lines.push(chownHint());
+  } else {
+    // uid === ownerUid, or uids don't apply: ownership is fine or irrelevant, so
+    // chown is the wrong advice. This is a mode problem (e.g. a 0555 directory).
+    lines.push("  the directory exists but is not writable — check its permissions.");
+  }
+  return lines.join("\n");
+}
+
+// Try to create `dir` and write (then remove) a probe file in it. Never throws:
+// a failure is reported as `{ writable: false, code }`, which is the whole point
+// — this is the one place that must NOT swallow the error it finds.
+async function probeDir(dir: string): Promise<DirWriteCheck> {
+  const probe = path.join(dir, `.torlnk-write-test-${randomUUID()}`);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(probe, "");
+    await fs.rm(probe, { force: true });
+    return { dir, writable: true };
+  } catch (err) {
+    const code = err instanceof Error && "code" in err ? String((err as { code: unknown }).code) : undefined;
+    return { dir, writable: false, ...(code ? { code } : {}) };
+  }
+}
+
+/**
+ * Probe the three directories torlink persists to — config, data and cache —
+ * and return a warning string if any is unwritable, else null. The dirs are
+ * derived from the leaf paths in config/paths.ts (which honour TORLINK_STATE_DIR)
+ * so this tracks wherever state actually lives.
+ *
+ * `dirs` and `stateRoot` are injectable so the probe can be exercised against a
+ * temp directory in tests; the defaults are the real locations.
+ */
+export async function checkStateDirsWritable(opts: {
+  dirs?: readonly string[];
+  stateRoot?: string;
+} = {}): Promise<string | null> {
+  const dataDir = path.dirname(logFile);
+  const configDir = path.dirname(configFile);
+  const cacheDir = path.dirname(postersDir);
+  const dirs = opts.dirs ?? [configDir, dataDir, cacheDir];
+  // The nearest common ancestor of the state dirs is the mount that needs fixing
+  // (TORLINK_STATE_DIR, or its platform default parent). dataDir's parent is that
+  // root under the override; good enough for the hint without a new export.
+  const stateRoot = opts.stateRoot ?? path.dirname(dataDir);
+
+  const checks = await Promise.all(dirs.map(probeDir));
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  let ownerUid: number | undefined;
+  try {
+    ownerUid = (await fs.stat(stateRoot)).uid;
+  } catch {
+    ownerUid = undefined;
+  }
+  return formatStateDirWarning(checks, { uid, stateRoot, ...(ownerUid !== undefined ? { ownerUid } : {}) });
+}


### PR DESCRIPTION
## What

When torlink runs in a container with a **root-owned `./state` bind mount** under the non-root `node` user (uid 1000), the process can *read* `config.json` but can't create `/state/cache` or `/state/data`. The poster cache and the logger both swallow `EACCES` by design (a caching/logging failure must never crash a download), so the failure is completely silent: **every poster is blank and no log file is ever written**, with nothing on screen — or in `docker logs` — to explain why.

This came out of a real debugging session where the only symptom was a wall of `GET /api/poster -> 404` and an empty log file. The fetch and the CDN were fine; the cache *write* was failing with `EACCES`, and nothing surfaced it.

## Changes

- **Loud startup warning** (`src/daemon/serve.ts`): probe config/data/cache once at serve boot; if any is unwritable, log an actionable multi-line warning through the same stdout logger as the request log, so `docker logs` names the cause. Covers both `serve` and `serve --web`.
  - The message names the failing paths, spells out the uid/owner mismatch, and prints a copy-pasteable `chown -R <uid>:<uid>` — but only when ownership is actually the problem (same-uid-but-unwritable is reported as a mode issue instead, so the fix advice never misleads).
- **Pure, unit-tested formatter** (`src/util/stateDirCheck.ts` + `.test.ts`): the decision of *what to say* lives in `formatStateDirWarning` (no I/O, 6 cases covered); the thin `checkStateDirsWritable` probe does the filesystem work and is exercised against a temp dir. Follows the repo's "decisions go in pure modules" rule.
- **Bonus fix**: the probe's `mkdir -p` pre-creates the `data` dir that the logger never made for itself — so in the *writable* case, first-run logging now works too.
- **Docs**: document the uid-1000 bind-mount requirement in `docker-compose.yml`, `docker-compose.access.yml`, and both README container sections; add `state` to `.dockerignore` so the bind-mounted runtime state doesn't bust the build cache.

## Not changed

Poster caching itself is untouched — it already caches to `/state/cache/posters`, shares across viewers, and proxies bytes so the CDN never sees a viewer. The bug was purely that the write was failing silently; this makes it fail *loudly*.

## Verification

`npm run typecheck`, `npm run lint` (only the pre-existing `App.tsx` warning), `npm test` (2983 pass), `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)