### PR TITLE
feat: anime metadata via AniList (posters + plots for the Anime group)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ reached, which is an honest thing to say, rather than guessing at every episode 
 
 Selecting a result shows its poster, plot and IMDb link, if you've added a free
 [OMDb](https://www.omdbapi.com/apikey.aspx) key under **Settings** in the TUI — the same key that powers
-the terminal's preview pane. Without one everything still works; you just get the release names.
+the terminal's preview pane. Without one everything still works; you just get the release names. The
+**Anime** tab is the exception: it fetches posters and plots from
+[AniList](https://anilist.co/), a free anime database that needs no key, so anime has artwork even
+before you set one up.
 
 That pane stays where you can see it: on a wide screen it pins below the toolbar and scrolls its own plot,
 and on a phone it becomes a bar across the bottom of the window rather than something 25,000 pixels below
@@ -282,8 +285,9 @@ on its best copy, so `v` streams the pick you'd have chosen anyway. Rows carry s
 
 On a wide enough terminal a preview pane opens beside the results: highlight a film or show and torlink
 fetches its poster and plot and renders them right in the terminal (bring your own free
-[OMDb](https://www.omdbapi.com/apikey.aspx) key, added under Settings). Press `p` to toggle the pane, or
-`i` on any result to open its IMDb page.
+[OMDb](https://www.omdbapi.com/apikey.aspx) key, added under Settings). Anime is the exception —
+its posters and plots come from [AniList](https://anilist.co/), a free anime database that needs no
+key. Press `p` to toggle the pane, or `i` on any result to open its IMDb page.
 
 Press `w` on any named search to add or remove it from your Saved searches. The pane keeps up to 50;
 press `Enter` to run one again or `x` to remove it.

--- a/docs/superpowers/plans/2026-08-12-anime-metadata-anilist.md
+++ b/docs/superpowers/plans/2026-08-12-anime-metadata-anilist.md
@@ -41,27 +41,32 @@
 import { describe, it, expect } from "vitest";
 import { animeSearchTitle } from "./animeTitle";
 
+// FIXTURES: invented cast only (Kestrel/Ashfall/Harrowgate per CLAUDE.md).
+// ケストレル / ケストレルの夜 are katakana of the invented "Kestrel" — used for
+// the CJK cases so no real title appears in a test.
 describe("animeSearchTitle", () => {
   it("strips a leading fansub group tag", () => {
-    expect(animeSearchTitle("[NanakoRaws] Yomi no Tsugai S01E18 (AT-X TV 1080p HEVC AAC)")).toBe(
-      "Yomi no Tsugai",
-    );
+    expect(animeSearchTitle("[NanakoRaws] Kestrel S01E18 (AT-X TV 1080p HEVC AAC)")).toBe("Kestrel");
   });
 
   it("strips the SubsPlease absolute-episode tail and resolution block", () => {
-    expect(animeSearchTitle("Tefuda ga Oome no Victoria - 06 [1080p]")).toBe("Tefuda ga Oome no Victoria");
+    expect(animeSearchTitle("Ashfall - 06 [1080p]")).toBe("Ashfall");
   });
 
   it("cuts a trailing quality/codec/subtitle block", () => {
-    expect(animeSearchTitle("Kestrel no Yoru [WebRip 1080p HEVC-10bit AAC][subs]")).toBe("Kestrel no Yoru");
+    expect(animeSearchTitle("Ashfall [WebRip 1080p HEVC-10bit AAC][subs]")).toBe("Ashfall");
   });
 
   it("prefers a Latin-script alternative over a CJK one when titles are slash-joined", () => {
-    expect(animeSearchTitle("[LoliHouse] 尼古喵喵 / Yani Neko - 06 [WebRip 1080p]")).toBe("Yani Neko");
+    expect(animeSearchTitle("[LoliHouse] ケストレル / Kestrel - 06 [WebRip 1080p]")).toBe("Kestrel");
   });
 
   it("keeps the first segment when every alternative is CJK", () => {
-    expect(animeSearchTitle("[Doomdos] 有兽焉 - 第63话 - [1080p BILIBILI COM WEB-DL]")).toBe("有兽焉");
+    expect(animeSearchTitle("[Doomdos] ケストレルの夜 - 06 [1080p BILIBILI COM WEB-DL]")).toBe("ケストレルの夜");
+  });
+
+  it("strips a Chinese episode-counter tail (第N话)", () => {
+    expect(animeSearchTitle("[ANi] ケストレルの夜 - 第12话 [1080p]")).toBe("ケストレルの夜");
   });
 
   it("drops an SxxExx marker", () => {
@@ -420,12 +425,12 @@ describe("fetchAnimeFirstMeta", () => {
     const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(hit);
     const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(miss);
     const res = await fetchAnimeFirstMeta({
-      rawName: "[NanakoRaws] Yomi no Tsugai S01E18 [1080p]",
-      omdb: { title: "Yomi no Tsugai", type: "series" },
+      rawName: "[NanakoRaws] Kestrel S01E18 [1080p]",
+      omdb: { title: "Kestrel", type: "series" },
       omdbApiKey: "KEY",
     });
     expect(res).toBe(hit);
-    expect(a).toHaveBeenCalledWith("Yomi no Tsugai", expect.anything());
+    expect(a).toHaveBeenCalledWith("Kestrel", expect.anything());
     expect(o).not.toHaveBeenCalled();
     a.mockRestore();
     o.mockRestore();
@@ -435,12 +440,12 @@ describe("fetchAnimeFirstMeta", () => {
     const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
     const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
     const res = await fetchAnimeFirstMeta({
-      rawName: "Kestrel no Yoru - 06 [1080p]",
-      omdb: { title: "Kestrel no Yoru", year: 2010, type: "series" },
+      rawName: "Ashfall - 06 [1080p]",
+      omdb: { title: "Ashfall", year: 1999, type: "series" },
       omdbApiKey: "KEY",
     });
     expect(res).toBe(hit);
-    expect(o).toHaveBeenCalledWith("Kestrel no Yoru", "KEY", { year: 2010, type: "series" });
+    expect(o).toHaveBeenCalledWith("Ashfall", "KEY", { year: 1999, type: "series" });
     a.mockRestore();
     o.mockRestore();
   });
@@ -449,8 +454,8 @@ describe("fetchAnimeFirstMeta", () => {
     const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
     const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
     const res = await fetchAnimeFirstMeta({
-      rawName: "Kestrel no Yoru - 06 [1080p]",
-      omdb: { title: "Kestrel no Yoru" },
+      rawName: "Ashfall - 06 [1080p]",
+      omdb: { title: "Ashfall" },
       omdbApiKey: "",
     });
     expect(res).toEqual(miss);
@@ -634,7 +639,7 @@ describe("/api/title anime routing", () => {
   it("routes the Anime group through the AniList-first resolver", async () => {
     let sawRawName = "";
     const res = await handleTitle(
-      "release=" + encodeURIComponent("[NanakoRaws] Yomi no Tsugai S01E18 [1080p]") + "&group=Anime",
+      "release=" + encodeURIComponent("[NanakoRaws] Kestrel S01E18 [1080p]") + "&group=Anime",
       {
         loadConfigImpl: async () => ({ ...baseConfig }), // no omdb key
         fetchAnimeFirstMetaImpl: async (args) => {
@@ -648,7 +653,7 @@ describe("/api/title anime routing", () => {
     );
     expect(res.status).toBe(200);
     expect(res.json).toMatchObject({ status: "ok", posterUrl: "https://s4.anilist.co/x.jpg" });
-    expect(sawRawName).toContain("Yomi no Tsugai");
+    expect(sawRawName).toContain("Kestrel");
   });
 
   it("does not return no-key for anime even without an OMDb key", async () => {

--- a/docs/superpowers/plans/2026-08-12-anime-metadata-anilist.md
+++ b/docs/superpowers/plans/2026-08-12-anime-metadata-anilist.md
@@ -1,0 +1,1091 @@
+# Anime Metadata via AniList Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Anime group real posters and plots by looking metadata up on AniList (keyless) instead of OMDb, with OMDb as a fallback.
+
+**Architecture:** A new pure title normalizer (`src/util/animeTitle.ts`) cleans a raw release name into an AniList search string. A new AniList GraphQL client (`src/recc/anilist.ts`) returns the same `FetchTitleMetaResult` union OMDb uses. A single resolver (`src/recc/animeMeta.ts`) owns the "AniList first, OMDb fallback" ordering, and both front ends call it on their existing anime path. AniList poster host is added to the one poster allowlist.
+
+**Tech Stack:** TypeScript, Vitest, Ink/React (TUI), plain DOM bundle (web). AniList public GraphQL API (`https://graphql.anilist.co`, no key).
+
+## Global Constraints
+
+- **Ships in both front ends.** This change touches the web (`src/web`) and the terminal (`src/ui`); do not land one without the other.
+- **Layering:** `src/web` must not import from `src/ui`; `src/core` must not import from `src/ui`/`src/web`. Shared logic lives in `src/util` or `src/recc`.
+- **Browser-safety:** `src/util/animeTitle.ts` and anything reachable from `src/web/static/` must not import `node:*` (directly or transitively). `npm run build` is the check.
+- **No `innerHTML`/`insertAdjacentHTML`/`document.write`/`outerHTML`** anywhere in `src/web/static/`.
+- **Test fixtures never name a real film/show.** Reuse the invented cast where a generic title is needed; anime-shaped fixtures below are invented on purpose. Never introduce a real anime title into a test, helper, doc comment, or copy.
+- **Config writes from web are read-modify-write per request.** (Not exercised here — no config writes — but do not introduce a cached snapshot.)
+- **Conventional Commits.** Each task commits with a `feat:`/`test:`/`docs:` message.
+- **Definition of done gate:** `npm test`, `npm run typecheck`, `npm run lint`, `npm run build` all pass. One known pre-existing lint warning (`react-hooks/exhaustive-deps`, `src/ui/App.tsx`) is expected — leave it.
+- **`FetchImpl`** is `(url: string, init?: RequestInit) => Promise<Response>` from `src/util/net.ts`. Every network client takes `opts.fetchImpl?` defaulting to global `fetch`, for offline tests.
+- **`FetchTitleMetaResult`** (from `src/recc/omdb.ts`) is the shared return union:
+  `{ ok: true; type?: OmdbType | null; imdbId: string | null; plot: string | null; posterUrl: string | null } | { ok: false; error: string }`, where `OmdbType = "movie" | "series"`.
+
+---
+
+### Task 1: Anime title normalizer
+
+**Files:**
+- Create: `src/util/animeTitle.ts`
+- Test: `src/util/animeTitle.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `animeSearchTitle(rawName: string): string | null` — raw release name → clean AniList search string, or `null` when nothing usable survives.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/util/animeTitle.test.ts
+import { describe, it, expect } from "vitest";
+import { animeSearchTitle } from "./animeTitle";
+
+describe("animeSearchTitle", () => {
+  it("strips a leading fansub group tag", () => {
+    expect(animeSearchTitle("[NanakoRaws] Yomi no Tsugai S01E18 (AT-X TV 1080p HEVC AAC)")).toBe(
+      "Yomi no Tsugai",
+    );
+  });
+
+  it("strips the SubsPlease absolute-episode tail and resolution block", () => {
+    expect(animeSearchTitle("Tefuda ga Oome no Victoria - 06 [1080p]")).toBe("Tefuda ga Oome no Victoria");
+  });
+
+  it("cuts a trailing quality/codec/subtitle block", () => {
+    expect(animeSearchTitle("Kestrel no Yoru [WebRip 1080p HEVC-10bit AAC][subs]")).toBe("Kestrel no Yoru");
+  });
+
+  it("prefers a Latin-script alternative over a CJK one when titles are slash-joined", () => {
+    expect(animeSearchTitle("[LoliHouse] 尼古喵喵 / Yani Neko - 06 [WebRip 1080p]")).toBe("Yani Neko");
+  });
+
+  it("keeps the first segment when every alternative is CJK", () => {
+    expect(animeSearchTitle("[Doomdos] 有兽焉 - 第63话 - [1080p BILIBILI COM WEB-DL]")).toBe("有兽焉");
+  });
+
+  it("drops an SxxExx marker", () => {
+    expect(animeSearchTitle("Harrowgate S03E04 [1080p]")).toBe("Harrowgate");
+  });
+
+  it("returns null when only noise survives", () => {
+    expect(animeSearchTitle("[Group] [1080p HEVC AAC]")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/util/animeTitle.test.ts`
+Expected: FAIL — `animeSearchTitle` is not exported / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/util/animeTitle.ts
+
+// Turn a raw anime torrent release name into a title string suitable for an
+// AniList search, or null when nothing usable survives.
+//
+// AniList indexes anime by romaji / English / native title plus synonyms, and
+// its search tolerates extra words far better than OMDb's exact title match —
+// but fansub release names bury the title under group tags, quality blocks and
+// an absolute episode number, and often glue several language variants together
+// with "/". This strips it down to one best candidate.
+//
+// Pure and browser-safe: no node:* imports, direct or transitive.
+
+// Does a string contain any Latin letter? Used to prefer a romaji/English
+// alternative title (which AniList ranks strongly) over a CJK-only one.
+function hasLatin(s: string): boolean {
+  return /[A-Za-z]/.test(s);
+}
+
+// Is a token pure release noise (resolution / codec / source / sub markers)?
+// Deliberately small and anchored to whole tokens — the goal is only to notice
+// that a candidate is entirely metadata, not to enumerate every release word.
+const NOISE = /^(?:\d{3,4}p|4k|2160p|1080p|720p|480p|hevc|x264|x265|h264|h265|10bit|aac|flac|ac3|eac3|ddp?\d?|web-?dl|webrip|bluray|bdrip|bdremux|remux|hdr|dv|multi-?subs?|dual|audio|sub|subs|raws?|tv|bili?bili|amzn|iqiyi|iq|baha|com)$/i;
+
+// Split a title into whitespace tokens and drop the trailing run of pure-noise
+// tokens ("Kestrel no Yoru WebRip 1080p" -> "Kestrel no Yoru"). Only trailing
+// noise is trimmed; interior words are left alone.
+function trimTrailingNoise(s: string): string {
+  const tokens = s.split(/\s+/).filter(Boolean);
+  while (tokens.length && NOISE.test(tokens[tokens.length - 1]!)) tokens.pop();
+  return tokens.join(" ");
+}
+
+export function animeSearchTitle(rawName: string): string | null {
+  let s = rawName;
+
+  // 1. Strip leading bracketed group/source tags: "[NanakoRaws] ", "(2026) ".
+  //    Repeated because releases often stack two ("[ANi] [Baha] ...").
+  s = s.replace(/^\s*(?:\[[^\]]*\]|\([^)]*\))\s*/g, "");
+
+  // 2. Cut everything from the first remaining bracketed block onward — that is
+  //    where the quality/codec/subtitle metadata lives ("... [WebRip 1080p]").
+  const bracket = s.search(/[[(]/);
+  if (bracket >= 0) s = s.slice(0, bracket);
+
+  // 3. Strip an episode tail: "- 06", "- 1173", "- 第63话", "S01E04", "E06".
+  s = s.replace(/\s*-\s*(?:第\s*\d+\s*话|\d{1,4})\s*$/u, "");
+  s = s.replace(/\s+S\d{1,2}(?:E\d{1,4})?\s*$/i, "");
+  s = s.replace(/\s+E\d{1,4}\s*$/i, "");
+
+  // 4. Several language variants joined by "/" or "|": prefer a Latin-script
+  //    segment (romaji/English), else keep the first.
+  const parts = s.split(/[/|]/).map((p) => p.trim()).filter(Boolean);
+  if (parts.length > 1) {
+    s = parts.find((p) => hasLatin(p)) ?? parts[0]!;
+  } else {
+    s = parts[0] ?? "";
+  }
+
+  // 5. Trim trailing pure-noise tokens and collapse whitespace.
+  s = trimTrailingNoise(s).replace(/\s+/g, " ").trim();
+
+  return s.length > 0 ? s : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/util/animeTitle.test.ts`
+Expected: PASS (all 7 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/util/animeTitle.ts src/util/animeTitle.test.ts
+git commit -m "feat(util): normalize anime release names for AniList search"
+```
+
+---
+
+### Task 2: AniList GraphQL client
+
+**Files:**
+- Create: `src/recc/anilist.ts`
+- Test: `src/recc/anilist.test.ts`
+
+**Interfaces:**
+- Consumes: `FetchImpl` from `src/util/net.ts`; `FetchTitleMetaResult`, `OmdbType` from `src/recc/omdb.ts`.
+- Produces: `fetchAnimeMetaByName(title: string, opts?: { fetchImpl?: FetchImpl; timeoutMs?: number }): Promise<FetchTitleMetaResult>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/recc/anilist.test.ts
+import { describe, it, expect } from "vitest";
+import { fetchAnimeMetaByName } from "./anilist";
+import type { FetchImpl } from "../util/net";
+
+function postImpl(status: number, body: unknown): { impl: FetchImpl; calls: { url: string; init?: RequestInit }[] } {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const impl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, calls };
+}
+
+const media = (over: Record<string, unknown> = {}) => ({
+  data: {
+    Media: {
+      id: 1,
+      title: { romaji: "Kestrel no Yoru", english: "Kestrel Nights", native: "ケストレル" },
+      description: "A quiet town.<br><br>Then it isn't.",
+      coverImage: { extraLarge: "https://s4.anilist.co/xl.jpg", large: "https://s4.anilist.co/l.jpg" },
+      format: "TV",
+      siteUrl: "https://anilist.co/anime/1",
+      ...over,
+    },
+  },
+});
+
+describe("fetchAnimeMetaByName", () => {
+  it("returns poster, tag-stripped plot, series type and null imdbId on a hit", async () => {
+    const { impl, calls } = postImpl(200, media());
+    const res = await fetchAnimeMetaByName("Kestrel no Yoru", { fetchImpl: impl });
+    expect(res).toEqual({
+      ok: true,
+      type: "series",
+      imdbId: null,
+      plot: "A quiet town. Then it isn't.",
+      posterUrl: "https://s4.anilist.co/xl.jpg",
+    });
+    expect(calls[0]!.url).toBe("https://graphql.anilist.co");
+    expect(calls[0]!.init?.method).toBe("POST");
+  });
+
+  it("maps format MOVIE to movie", async () => {
+    const { impl } = postImpl(200, media({ format: "MOVIE" }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok && res.type).toBe("movie");
+  });
+
+  it("falls back to coverImage.large when extraLarge is missing", async () => {
+    const { impl } = postImpl(200, media({ coverImage: { large: "https://s4.anilist.co/l.jpg" } }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok && res.posterUrl).toBe("https://s4.anilist.co/l.jpg");
+  });
+
+  it("treats Media: null as a miss", async () => {
+    const { impl } = postImpl(200, { data: { Media: null } });
+    const res = await fetchAnimeMetaByName("Nothing Here", { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "not found" });
+  });
+
+  it("treats a GraphQL errors payload as a miss", async () => {
+    const { impl } = postImpl(200, { errors: [{ message: "Not Found." }] });
+    const res = await fetchAnimeMetaByName("Nothing", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns a reach error when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as FetchImpl;
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "couldn't reach AniList" });
+  });
+
+  it("returns a miss for a non-video format", async () => {
+    const { impl } = postImpl(200, media({ format: "MUSIC" }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns an empty-title error without calling the network", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }) as unknown as FetchImpl;
+    const res = await fetchAnimeMetaByName("   ", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+    expect(called).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/recc/anilist.test.ts`
+Expected: FAIL — module/function not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/recc/anilist.ts
+import type { FetchImpl } from "../util/net";
+import { log } from "../util/logger";
+import type { FetchTitleMetaResult, OmdbType } from "./omdb";
+
+// AniList is a free, keyless GraphQL API for anime. It is the right database for
+// the Anime group, where OMDb (an IMDb mirror) cannot match romaji/CJK titles or
+// absolute episode numbering. We return the SAME FetchTitleMetaResult union OMDb
+// returns so every caller — TUI hook and web route — handles one shape.
+
+const ENDPOINT = "https://graphql.anilist.co";
+
+// One media match, ranked by search relevance. type: ANIME excludes manga.
+const QUERY = `
+query ($search: String) {
+  Media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+    id
+    title { romaji english native }
+    description(asHtml: false)
+    coverImage { extraLarge large }
+    format
+    siteUrl
+  }
+}`;
+
+interface AniListMedia {
+  description?: string | null;
+  coverImage?: { extraLarge?: string | null; large?: string | null } | null;
+  format?: string | null;
+}
+
+interface AniListResponse {
+  data?: { Media?: AniListMedia | null } | null;
+  errors?: unknown;
+}
+
+function isResponse(v: unknown): v is AniListResponse {
+  return typeof v === "object" && v !== null;
+}
+
+// AniList descriptions carry light HTML (<br>, <i>, ...) even with asHtml:false.
+// Strip tags and collapse whitespace to a single-paragraph plot.
+function cleanPlot(desc: string | null | undefined): string | null {
+  const s = (desc ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return s.length > 0 ? s : null;
+}
+
+// Map AniList's format enum to the two media types we model. MOVIE is a film;
+// every other video format (TV, TV_SHORT, OVA, ONA, SPECIAL) is a series.
+// MUSIC and anything unrecognised is not something we can present -> null.
+function mapType(format: string | null | undefined): OmdbType | null {
+  if (format === "MOVIE") return "movie";
+  if (format === "TV" || format === "TV_SHORT" || format === "OVA" || format === "ONA" || format === "SPECIAL") {
+    return "series";
+  }
+  return null;
+}
+
+export async function fetchAnimeMetaByName(
+  title: string,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchTitleMetaResult> {
+  const search = title.trim();
+  if (!search) return { ok: false, error: "no title" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  try {
+    const res = await fetchImpl(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ query: QUERY, variables: { search } }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 8000),
+    });
+    if (!res.ok) return { ok: false, error: `AniList unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!isResponse(body) || body.errors) return { ok: false, error: "not found" };
+    const media = body.data?.Media;
+    if (!media) return { ok: false, error: "not found" };
+    const type = mapType(media.format);
+    if (type === null) return { ok: false, error: "not found" };
+    const posterUrl = media.coverImage?.extraLarge || media.coverImage?.large || null;
+    return { ok: true, type, imdbId: null, plot: cleanPlot(media.description), posterUrl };
+  } catch (err) {
+    log.debug(`anilist by name ${search}: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, error: "couldn't reach AniList" };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/recc/anilist.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/recc/anilist.ts src/recc/anilist.test.ts
+git commit -m "feat(recc): add keyless AniList metadata client"
+```
+
+---
+
+### Task 3: Anime-first resolver
+
+**Files:**
+- Create: `src/recc/animeMeta.ts`
+- Test: `src/recc/animeMeta.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchAnimeMetaByName` (Task 2), `fetchTitleMetaByName` (`src/recc/omdb.ts`), `animeSearchTitle` (Task 1), `FetchImpl`, `FetchTitleMetaResult`, `OmdbType`.
+- Produces:
+  ```typescript
+  interface AnimeFirstArgs {
+    rawName: string;
+    omdb: { title: string; year?: number; type?: OmdbType };
+    omdbApiKey: string;
+    fetchImpl?: FetchImpl;
+    timeoutMs?: number;
+  }
+  fetchAnimeFirstMeta(args: AnimeFirstArgs): Promise<FetchTitleMetaResult>
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/recc/animeMeta.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { fetchAnimeFirstMeta } from "./animeMeta";
+import * as anilist from "./anilist";
+import * as omdb from "./omdb";
+import type { FetchTitleMetaResult } from "./omdb";
+
+const hit: FetchTitleMetaResult = { ok: true, type: "series", imdbId: null, plot: "p", posterUrl: "https://s4.anilist.co/x.jpg" };
+const miss: FetchTitleMetaResult = { ok: false, error: "not found" };
+
+describe("fetchAnimeFirstMeta", () => {
+  it("returns the AniList hit and never calls OMDb", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(hit);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(miss);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "[NanakoRaws] Yomi no Tsugai S01E18 [1080p]",
+      omdb: { title: "Yomi no Tsugai", type: "series" },
+      omdbApiKey: "KEY",
+    });
+    expect(res).toBe(hit);
+    expect(a).toHaveBeenCalledWith("Yomi no Tsugai", expect.anything());
+    expect(o).not.toHaveBeenCalled();
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("falls back to OMDb (no season/episode) when AniList misses and a key is present", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "Kestrel no Yoru - 06 [1080p]",
+      omdb: { title: "Kestrel no Yoru", year: 2010, type: "series" },
+      omdbApiKey: "KEY",
+    });
+    expect(res).toBe(hit);
+    expect(o).toHaveBeenCalledWith("Kestrel no Yoru", "KEY", { year: 2010, type: "series" });
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("does NOT call OMDb on an AniList miss when no key is configured", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "Kestrel no Yoru - 06 [1080p]",
+      omdb: { title: "Kestrel no Yoru" },
+      omdbApiKey: "",
+    });
+    expect(res).toEqual(miss);
+    expect(o).not.toHaveBeenCalled();
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("skips AniList and goes straight to OMDb when the name normalizes to nothing", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(hit);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "[Group] [1080p HEVC]",
+      omdb: { title: "Fallback Title" },
+      omdbApiKey: "KEY",
+    });
+    expect(a).not.toHaveBeenCalled();
+    expect(o).toHaveBeenCalledWith("Fallback Title", "KEY", {});
+    expect(res).toBe(hit);
+    a.mockRestore();
+    o.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/recc/animeMeta.test.ts`
+Expected: FAIL — module/function not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/recc/animeMeta.ts
+import type { FetchImpl } from "../util/net";
+import { animeSearchTitle } from "../util/animeTitle";
+import { fetchAnimeMetaByName } from "./anilist";
+import { fetchTitleMetaByName, type FetchTitleMetaResult, type OmdbType } from "./omdb";
+
+// The one place the "anime is AniList first, OMDb second" ordering lives. Both
+// front ends call this on their Anime path so the ordering and the fallback rule
+// cannot drift between a server route and a React hook.
+export interface AnimeFirstArgs {
+  // Raw torrent release name, normalized here for the AniList search.
+  rawName: string;
+  // The already-parsed OMDb query, used only for the fallback. No season/episode:
+  // anime absolute numbering is meaningless to OMDb's per-season index.
+  omdb: { title: string; year?: number; type?: OmdbType };
+  // "" when no OMDb key is configured — the fallback is then skipped entirely,
+  // which is what lets keyless users still get AniList artwork.
+  omdbApiKey: string;
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+}
+
+export async function fetchAnimeFirstMeta(args: AnimeFirstArgs): Promise<FetchTitleMetaResult> {
+  const { rawName, omdb, omdbApiKey, fetchImpl, timeoutMs } = args;
+
+  const search = animeSearchTitle(rawName);
+  if (search) {
+    const anilist = await fetchAnimeMetaByName(search, { fetchImpl, timeoutMs });
+    if (anilist.ok) return anilist;
+  }
+
+  // AniList missed (or the name had no usable title). Fall back to OMDb only
+  // when a key exists; otherwise return the AniList miss (or a "no title" miss).
+  if (!omdbApiKey) {
+    return search
+      ? { ok: false, error: "not found" }
+      : { ok: false, error: "no title in that release name" };
+  }
+  return fetchTitleMetaByName(omdb.title, omdbApiKey, {
+    ...(omdb.year !== undefined ? { year: omdb.year } : {}),
+    ...(omdb.type !== undefined ? { type: omdb.type } : {}),
+    fetchImpl,
+    timeoutMs,
+  });
+}
+```
+
+> NOTE: `fetchTitleMetaByName`'s opts accept `fetchImpl`/`timeoutMs` (see `src/recc/omdb.ts:80`), so threading them through is valid. The test mocks `fetchTitleMetaByName` and asserts it is called with `{ year, type }` — the mock ignores the extra `fetchImpl`/`timeoutMs`, and in the no-year/no-type case the object is `{}` plus those, so assert with `expect.objectContaining` if the exact-match assertion is brittle. The provided tests pass `fetchImpl`/`timeoutMs` as `undefined`, so `{ year, type }` matches exactly.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/recc/animeMeta.test.ts`
+Expected: PASS. If the exact-match `toHaveBeenCalledWith("...", "KEY", { year, type })` fails because `fetchImpl`/`timeoutMs` keys are present as `undefined`, switch those assertions to `expect.objectContaining({ year, type })`. (They are not spread when undefined, so the object is exactly `{ year, type }` — the assertions as written are correct.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/recc/animeMeta.ts src/recc/animeMeta.test.ts
+git commit -m "feat(recc): resolver — AniList first, OMDb fallback for anime"
+```
+
+---
+
+### Task 4: Allow AniList poster host
+
+**Files:**
+- Modify: `src/core/posterCache.ts:18-22` (the `POSTER_HOSTS` Set)
+- Test: `src/core/posterCache.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `s4.anilist.co` accepted by `POSTER_HOSTS`, which gates both `getPoster` (core) and `allowedPosterUrl` + `/api/poster` (web).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/core/posterCache.test.ts` (append inside the file; if it imports `POSTER_HOSTS` already, reuse that import):
+
+```typescript
+import { POSTER_HOSTS } from "./posterCache";
+
+describe("POSTER_HOSTS allowlist", () => {
+  it("accepts the AniList cover CDN", () => {
+    expect(POSTER_HOSTS.has("s4.anilist.co")).toBe(true);
+  });
+  it("still accepts the OMDb/Amazon hosts", () => {
+    expect(POSTER_HOSTS.has("m.media-amazon.com")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/core/posterCache.test.ts`
+Expected: FAIL — `s4.anilist.co` not in the Set.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `src/core/posterCache.ts`:
+
+```typescript
+export const POSTER_HOSTS = new Set([
+  "m.media-amazon.com",
+  "ia.media-imdb.com",
+  "img.omdbapi.com",
+  // AniList cover art (the Anime group's metadata provider).
+  "s4.anilist.co",
+]);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/core/posterCache.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/posterCache.ts src/core/posterCache.test.ts
+git commit -m "feat(core): allow AniList cover host in poster allowlist"
+```
+
+---
+
+### Task 5: Web route — send the Anime group to AniList
+
+**Files:**
+- Modify: `src/web/routes.ts` — add `fetchAnimeFirstMetaImpl?` to `WebDeps` (near line 203), import `fetchAnimeFirstMeta`, and branch inside `titleMeta()` (lines ~1615-1646).
+- Test: `src/web/routes.test.ts` (add a describe block near the existing `/api/title` tests)
+
+**Interfaces:**
+- Consumes: `fetchAnimeFirstMeta` (Task 3); the existing `parseTitleLookup`, `resolveOmdbApiKey`, `allowedPosterUrl`, `withParse`, cache helpers.
+- Produces: `WebDeps.fetchAnimeFirstMetaImpl?` injection point:
+  ```typescript
+  fetchAnimeFirstMetaImpl?: (args: {
+    rawName: string;
+    omdb: { title: string; year?: number; type?: OmdbType };
+    omdbApiKey: string;
+  }) => Promise<FetchTitleMetaResult>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/web/routes.test.ts — add near the other /api/title tests.
+// (Match the file's existing pattern for building a request + deps; the snippet
+//  below shows the intent — adapt to the local `handle`/`makeDeps` helpers.)
+describe("/api/title anime routing", () => {
+  it("routes the Anime group through the AniList-first resolver", async () => {
+    let sawRawName = "";
+    const res = await handleTitle(
+      "release=" + encodeURIComponent("[NanakoRaws] Yomi no Tsugai S01E18 [1080p]") + "&group=Anime",
+      {
+        loadConfigImpl: async () => ({ ...baseConfig }), // no omdb key
+        fetchAnimeFirstMetaImpl: async (args) => {
+          sawRawName = args.rawName;
+          return { ok: true, type: "series", imdbId: null, plot: "p", posterUrl: "https://s4.anilist.co/x.jpg" };
+        },
+        fetchTitleMetaByNameImpl: async () => {
+          throw new Error("OMDb must not be called for the Anime group");
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ status: "ok", posterUrl: "https://s4.anilist.co/x.jpg" });
+    expect(sawRawName).toContain("Yomi no Tsugai");
+  });
+
+  it("does not return no-key for anime even without an OMDb key", async () => {
+    const res = await handleTitle("release=" + encodeURIComponent("Kestrel - 06 [1080p]") + "&group=Anime", {
+      loadConfigImpl: async () => ({ ...baseConfig }),
+      fetchAnimeFirstMetaImpl: async () => ({ ok: false, error: "not found" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ status: "error", error: "not found" });
+  });
+
+  it("still routes non-anime groups through OMDb", async () => {
+    let omdbCalled = false;
+    const res = await handleTitle("release=" + encodeURIComponent("Kestrel.2010.1080p.BluRay.x264") + "&group=Movies", {
+      loadConfigImpl: async () => ({ ...baseConfig, omdbApiKey: "KEY" }),
+      fetchTitleMetaByNameImpl: async () => {
+        omdbCalled = true;
+        return { ok: true, type: "movie", imdbId: "tt1", plot: "p", posterUrl: null };
+      },
+      fetchAnimeFirstMetaImpl: async () => {
+        throw new Error("AniList must not be called for Movies");
+      },
+    });
+    expect(omdbCalled).toBe(true);
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+> Implementer: reuse the file's existing helpers for invoking `/api/title` and building a base config/deps. `handleTitle`/`baseConfig` above are stand-ins for whatever the file already uses (grep the file for the existing `/api/title` tests and copy their harness). Do not invent a new harness.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: FAIL — `fetchAnimeFirstMetaImpl` not honored / anime path not implemented (OMDb throw fires, or no-key returned).
+
+- [ ] **Step 3: Write minimal implementation**
+
+3a. Add the import at the top of `src/web/routes.ts` (near the `fetchTitleMetaByName` import at line ~61):
+
+```typescript
+import { fetchAnimeFirstMeta } from "../recc/animeMeta";
+```
+
+3b. Add the dep to the `WebDeps` interface (after `fetchTitleMetaByNameImpl`, ~line 207):
+
+```typescript
+  /**
+   * AniList-first metadata for `/api/title?release=&group=Anime`. Injected to
+   * keep tests offline. Defaults to the real resolver in src/recc/animeMeta.
+   */
+  fetchAnimeFirstMetaImpl?: (args: {
+    rawName: string;
+    omdb: { title: string; year?: number; type?: OmdbType };
+    omdbApiKey: string;
+  }) => Promise<FetchTitleMetaResult>;
+```
+
+3c. Rewrite the key-gate + fetch block inside `titleMeta()` (currently ~lines 1615-1646). Replace:
+
+```typescript
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const apiKey = resolveOmdbApiKey(config);
+  if (!apiKey) {
+    const out: PublicTitleMeta = { status: "no-key" };
+    return { status: 200, json: withParse(out, lookup.parsed) };
+  }
+
+  const result =
+    lookup.imdbId !== undefined
+      ? await (deps.fetchTitleMetaImpl ?? fetchTitleMeta)(lookup.imdbId, apiKey)
+      : await (deps.fetchTitleMetaByNameImpl ?? fetchTitleMetaByName)(lookup.name ?? "", apiKey, {
+          ...(lookup.year !== undefined ? { year: lookup.year } : {}),
+          ...(lookup.type !== undefined ? { type: lookup.type } : {}),
+          ...(lookup.season !== undefined ? { season: lookup.season } : {}),
+          ...(lookup.episode !== undefined ? { episode: lookup.episode } : {}),
+        });
+```
+
+with:
+
+```typescript
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const apiKey = resolveOmdbApiKey(config);
+
+  // Anime (name lookups in the Anime group) resolves via AniList, which needs no
+  // key — so the no-key short-circuit below must not apply to it, and its
+  // resolver skips the OMDb fallback when apiKey is "".
+  const isAnime = query.get("group") === "Anime" && lookup.imdbId === undefined;
+
+  if (!apiKey && !isAnime) {
+    // 200 with its own status — nothing is broken, the user simply has no key.
+    const out: PublicTitleMeta = { status: "no-key" };
+    return { status: 200, json: withParse(out, lookup.parsed) };
+  }
+
+  const result =
+    lookup.imdbId !== undefined
+      ? await (deps.fetchTitleMetaImpl ?? fetchTitleMeta)(lookup.imdbId, apiKey)
+      : isAnime
+        ? await (deps.fetchAnimeFirstMetaImpl ?? fetchAnimeFirstMeta)({
+            rawName: query.get("release") ?? lookup.name ?? "",
+            omdb: {
+              title: lookup.name ?? "",
+              ...(lookup.year !== undefined ? { year: lookup.year } : {}),
+              ...(lookup.type !== undefined ? { type: lookup.type } : {}),
+            },
+            omdbApiKey: apiKey,
+          })
+        : await (deps.fetchTitleMetaByNameImpl ?? fetchTitleMetaByName)(lookup.name ?? "", apiKey, {
+            ...(lookup.year !== undefined ? { year: lookup.year } : {}),
+            ...(lookup.type !== undefined ? { type: lookup.type } : {}),
+            ...(lookup.season !== undefined ? { season: lookup.season } : {}),
+            ...(lookup.episode !== undefined ? { episode: lookup.episode } : {}),
+          });
+```
+
+> `resolveOmdbApiKey` returns `""` when unset (`src/config/config.ts:438`), so `apiKey` is `""` for a keyless anime lookup — the resolver treats that as "no fallback", exactly as Task 3 tests. Successful anime results cache normally at the existing `cacheSet(lookup.cacheKey, out)`; misses stay uncached (unchanged policy). `OmdbType` and `FetchTitleMetaResult` are already imported in this file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: PASS (new anime cases + existing `/api/title` cases untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web/routes.ts src/web/routes.test.ts
+git commit -m "feat(web): route Anime-group title lookups through AniList"
+```
+
+---
+
+### Task 6: Web gating — anime previews without an OMDb key
+
+**Files:**
+- Modify: `src/web/static/resultPosters.ts` — `postersApply` (lines 73-75) and `searchHint` (lines 99-108)
+- Test: `src/web/static/resultPosters.test.ts`
+
+**Interfaces:**
+- Consumes: `previewApplies` (already imported), `OMDB_KEY_HINT`.
+- Produces: `postersApply(group, omdbConfigured)` returns `true` for `"Anime"` regardless of key; `searchHint(...)` never nudges for a key on the Anime tab. Signatures unchanged, so `app.ts` call sites need no edits.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/web/static/resultPosters.test.ts`:
+
+```typescript
+import { postersApply, searchHint } from "./resultPosters";
+
+describe("postersApply — Anime is keyless", () => {
+  it("applies for Anime even without an OMDb key", () => {
+    expect(postersApply("Anime", false)).toBe(true);
+  });
+  it("still requires a key for Movies", () => {
+    expect(postersApply("Movies", false)).toBe(false);
+    expect(postersApply("Movies", true)).toBe(true);
+  });
+  it("does not apply to a non-preview group regardless", () => {
+    expect(postersApply("Games", true)).toBe(false);
+  });
+});
+
+describe("searchHint — no OMDb nudge on the Anime tab", () => {
+  it("returns null (no key hint) for Anime with no key", () => {
+    expect(searchHint(false, "Anime", null)).toBeNull();
+  });
+  it("still nudges for a key on Movies with no key", () => {
+    expect(searchHint(false, "Movies", null)).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/static/resultPosters.test.ts`
+Expected: FAIL — `postersApply("Anime", false)` currently returns `false`; `searchHint(false, "Anime", null)` currently returns the key hint.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `postersApply`:
+
+```typescript
+export function postersApply(group: string, omdbConfigured: boolean): boolean {
+  if (!previewApplies(group)) return false;
+  // The Anime group uses AniList, which needs no key — so it previews whether or
+  // not OMDb is configured. Every other group still needs an OMDb key, since a
+  // keyless server would otherwise fire lookups that can only return no-key.
+  if (group === "Anime") return true;
+  return omdbConfigured;
+}
+```
+
+Edit `searchHint` (add the Anime short-circuit after the `previewApplies` guard):
+
+```typescript
+export function searchHint(
+  omdbConfigured: boolean | null,
+  group: string,
+  cacheHint: string | null,
+): string | null {
+  if (omdbConfigured === null) return null;
+  if (!previewApplies(group)) return null;
+  // Anime needs no OMDb key (AniList is keyless), so never nudge for one here.
+  if (group === "Anime") return cacheHint;
+  if (!omdbConfigured) return OMDB_KEY_HINT;
+  return cacheHint;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/web/static/resultPosters.test.ts`
+Expected: PASS (new cases + existing ones).
+
+- [ ] **Step 5: Verify the client already passes group through (no code change expected)**
+
+Run: `grep -n "postersApply(" src/web/static/app.ts`
+Confirm each call passes the current tab group and `sources?.omdbConfigured === true`. Because the signature is unchanged and the Anime branch ignores the key, these call sites need no edit. If any call site hard-codes a non-Anime group, leave it. Do not change `app.ts` here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/static/resultPosters.ts src/web/static/resultPosters.test.ts
+git commit -m "feat(web): preview anime posters without an OMDb key"
+```
+
+---
+
+### Task 7: TUI — anime preview via AniList
+
+**Files:**
+- Modify: `src/ui/hooks/useTitlePreview.ts` — add `anime?` flag + `rawName` on the name query, branch the metadata fetch, relax the key gate.
+- Modify: `src/ui/components/Results.tsx` — pass `anime` + `rawName`, relax `showPreview` for the anime section.
+
+**Interfaces:**
+- Consumes: `fetchAnimeFirstMeta` (Task 3).
+- Produces: `useTitlePreview` accepts `anime?: boolean`; its `MetaQuery` name variant accepts `rawName?: string`.
+
+- [ ] **Step 1: Extend `MetaQuery` and `Args` in `useTitlePreview.ts`**
+
+In the `by: "name"` variant of `MetaQuery` (line ~10), add:
+
+```typescript
+      /** The raw release name, for AniList normalization on the anime path. */
+      rawName?: string;
+```
+
+In `interface Args` (line ~40), add:
+
+```typescript
+  // Look this selection up on AniList first (Anime section), OMDb as fallback.
+  // AniList is keyless, so the metadata effect below does not require an OMDb key
+  // when this is set.
+  anime?: boolean;
+```
+
+Destructure it in the hook body (line ~61), defaulting to `false`:
+
+```typescript
+    anime = false,
+```
+
+- [ ] **Step 2: Branch the metadata fetch and relax the key gate**
+
+Add the import (top of file):
+
+```typescript
+import { fetchAnimeFirstMeta } from "../../recc/animeMeta";
+```
+
+Change the effect guard (line ~85) from:
+
+```typescript
+    if (!omdbApiKey || !enabled || !cacheKey || metas.current.has(cacheKey)) return;
+```
+
+to:
+
+```typescript
+    // Anime does not need an OMDb key (AniList is keyless); every other path
+    // still does.
+    if ((!omdbApiKey && !anime) || !enabled || !cacheKey || metas.current.has(cacheKey)) return;
+```
+
+Change the fetch dispatch (lines ~90-99) from:
+
+```typescript
+      const p =
+        q.by === "id"
+          ? fetchTitleMeta(q.imdbId, omdbApiKey, { fetchImpl })
+          : fetchTitleMetaByName(q.title, omdbApiKey, {
+              year: q.year,
+              type: q.type,
+              season: q.season,
+              episode: q.episode,
+              fetchImpl,
+            });
+```
+
+to:
+
+```typescript
+      const p =
+        q.by === "id"
+          ? fetchTitleMeta(q.imdbId, omdbApiKey, { fetchImpl })
+          : anime
+            ? fetchAnimeFirstMeta({
+                rawName: q.rawName ?? q.title,
+                omdb: { title: q.title, year: q.year, type: q.type },
+                omdbApiKey,
+                fetchImpl,
+              })
+            : fetchTitleMetaByName(q.title, omdbApiKey, {
+                year: q.year,
+                type: q.type,
+                season: q.season,
+                episode: q.episode,
+                fetchImpl,
+              });
+```
+
+Add `anime` to the effect's dependency array (line ~115):
+
+```typescript
+  }, [omdbApiKey, enabled, cacheKey, fetchImpl, debounceMs, anime]);
+```
+
+- [ ] **Step 3: Wire `Results.tsx`**
+
+Near `previewSection`/`showPreview` (lines ~530-535), add an anime flag and relax the key requirement:
+
+```typescript
+  const sectionIsAnime = section === "anime";
+  const showPreview =
+    previewOn &&
+    (omdbApiKey !== "" || sectionIsAnime) &&
+    previewSection &&
+    mode !== "detail" &&
+    contentWidth >= PREVIEW_MIN_WIDTH;
+```
+
+In the `useTitlePreview({ ... })` call (lines ~579-596), add `anime` and `rawName`:
+
+```typescript
+  const preview = useTitlePreview({
+    omdbApiKey,
+    enabled: showPreview,
+    anime: sectionIsAnime,
+    cacheKey: parsed
+      ? `${parsed.key}|${previewEpisode ? `s${previewEpisode.season}e${previewEpisode.episode}` : ""}`
+      : "",
+    query: parsed
+      ? {
+          by: "name",
+          title: parsed.title,
+          year: parsed.year,
+          type: parsed.type,
+          rawName: selectedResult?.name,
+          ...(previewEpisode ?? {}),
+        }
+      : null,
+    posterCols: Math.max(8, previewWidth - 4),
+    posterMaxRows: Math.max(4, panelOuter - 8),
+  });
+```
+
+- [ ] **Step 4: Typecheck the TUI wiring**
+
+Run: `npm run typecheck`
+Expected: PASS (the one known pre-existing `exhaustive-deps` warning is lint, not typecheck; typecheck is clean).
+
+- [ ] **Step 5: Verify at runtime**
+
+Run: `npm run dev -- serve --web` and open the browser UI; run an anime search (e.g. the Anime tab) and confirm posters/plots now render with no OMDb key set. Then launch the TUI, go to the Anime section, and confirm the preview pane shows a poster/plot for a highlighted anime result. (No jsdom exists for this wiring — running it is the check, per CLAUDE.md.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/hooks/useTitlePreview.ts src/ui/components/Results.tsx
+git commit -m "feat(ui): preview anime via AniList in the terminal"
+```
+
+---
+
+### Task 8: Docs + full gate
+
+**Files:**
+- Modify: `README.md` (the web UI limitations list and any OMDb-only phrasing about posters/metadata)
+
+- [ ] **Step 1: Update README**
+
+Grep for the web UI's limitations list and any statement that posters/metadata require OMDb:
+
+```bash
+grep -ni "omdb\|poster\|no metadata\|limitation" README.md
+```
+
+Edit the relevant lines so they read that anime posters/plots come from AniList (no key needed), while other groups still use OMDb (key required). Keep the existing tone. Do not touch `preview/web-*.jpg|png` screenshots.
+
+- [ ] **Step 2: Full definition-of-done gate**
+
+Run, in order, and confirm each is clean:
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Expected: tests pass; typecheck clean; lint clean except the one known pre-existing `react-hooks/exhaustive-deps` warning in `src/ui/App.tsx`; build succeeds (this is also the check that `src/web/static` and `src/util/animeTitle.ts` pull in no `node:*`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: anime metadata now comes from AniList"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AniList-first for Anime, OMDb fallback → Tasks 2, 3, 5, 7. ✓
+- Always on, no key, no toggle → Tasks 5 (no-key gate skip), 6 (postersApply/searchHint), 7 (hook key gate); no config field added. ✓
+- Series-level only, strip absolute episode → Task 1 (episode strip) + Task 3 (no season/episode to OMDb). ✓
+- `imdbId` null for AniList → Task 2 mapping. ✓
+- Title normalization pipeline → Task 1. ✓
+- AniList GraphQL client shape/mapping/errors → Task 2. ✓
+- Shared resolver as single home of ordering → Task 3, consumed by Tasks 5 & 7. ✓
+- Poster host allowlist → Task 4. ✓
+- Both front ends → web (Tasks 5, 6), TUI (Task 7). ✓
+- Docs → Task 8. ✓
+- All-tab limitation is intentionally *not* implemented (documented in spec). ✓ (No task, by design.)
+
+**Placeholder scan:** No TBD/TODO. The `handleTitle`/`baseConfig` in Task 5 are explicitly flagged as stand-ins for the file's existing test harness, with instructions to grep and reuse it — because the exact harness name must match whatever `routes.test.ts` already defines.
+
+**Type consistency:** `fetchAnimeMetaByName(title, opts)` (Task 2) is called by Task 3; `fetchAnimeFirstMeta(args)` signature (Task 3) matches the `WebDeps.fetchAnimeFirstMetaImpl` (Task 5) and the TUI call (Task 7). `FetchTitleMetaResult`/`OmdbType` reused from `omdb.ts` throughout. `postersApply`/`searchHint` signatures unchanged (Task 6), so no call-site drift.

--- a/docs/superpowers/specs/2026-08-12-anime-metadata-anilist-design.md
+++ b/docs/superpowers/specs/2026-08-12-anime-metadata-anilist-design.md
@@ -1,0 +1,243 @@
+# Anime metadata via AniList
+
+**Date:** 2026-08-12
+**Surfaces:** both front ends (web + terminal), shared logic in `src/recc` and `src/util`
+
+## Problem
+
+Every result in the **Anime** group renders with no poster and no plot — the
+preview pane shows "No match on OMDb (Series or episode not found!)". This is not
+a matching bug; it is the wrong database. OMDb is an IMDb mirror, and anime
+releases from Nyaa and SubsPlease ask it questions it cannot answer:
+
+1. **The titles are not the titles IMDb indexes.** `parseRelease`
+   (`src/util/release.ts:97`) runs `parse-torrent-title`, built for Western scene
+   naming. Fed anime it yields romaji (`Mushoku Tensei III`,
+   `Gaikotsu Kishi-sama…`), CJK text (`[LoliHouse] 尼古喵喵`, `[ANi] Animatica「…」`),
+   or a fansub-tag-mangled string. IMDb indexes these under their English titles,
+   and OMDb cannot translate romaji → English, so the `t=` query misses.
+2. **Absolute episode numbering.** SubsPlease/Nyaa use `- 06` or `One Piece 1173`,
+   not `S01E06`. The parser reads `1173` as *episode 1173*, so the lookup becomes
+   `Season=1&Episode=1173`, which IMDb — organised by real seasons — never has.
+   That is the exact "Series or episode not found!" string, OMDb's own `Error`
+   surfaced verbatim (`src/recc/omdb.ts:56` → `src/web/routes.ts:1644` →
+   `src/web/static/previewModel.ts:229`).
+3. **A lot of it is not on IMDb at all** — Chinese donghua (`[Doomdos] … BILIBILI
+   WEB-DL`), light-novel/manga scans (`第01-03巻`, artbook `.zip`s), brand-new
+   seasonal shows.
+
+The whole Anime tab is asking an English movie/TV database questions in the wrong
+language, with the wrong episode scheme, about titles it often does not carry.
+
+## Desired behaviour
+
+For the **Anime** group, look up metadata against **AniList** — a free, keyless
+GraphQL API that indexes anime by romaji, English, and native titles plus
+synonyms, and serves cover art and descriptions. AniList is tried **first**; OMDb
+is a fallback used only when AniList misses **and** an OMDb key is configured.
+Because AniList needs no key, anime posters/plots appear even for users who have
+never configured OMDb.
+
+All other groups (Movies, TV, All, …) are unchanged: OMDb only.
+
+### Settled decisions
+
+- **AniList-first for the Anime group; OMDb-only elsewhere.** (Not a universal
+  OMDb→AniList fallback, and not an AniList-only split that would drop OMDb as a
+  safety net.)
+- **Always on, no key, no toggle.** AniList is keyless and host-agnostic, so the
+  Anime group stops requiring an OMDb key to preview. No config field, no
+  `/api/sources` capability flag, no settings dialog entry. If a toggle is ever
+  wanted it is a later, additive change.
+- **Series-level metadata only.** AniList has no per-episode plots; anime shows
+  the series poster + description. The absolute episode number is stripped from
+  the query, never sent as `Season`/`Episode`.
+- **`imdbId` stays `null` for AniList matches.** The TUI's "open on IMDb" action
+  keeps its existing name-search fallback; expanding that action is out of scope.
+
+## Scope boundary (documented limitation, not a bug)
+
+This is scoped to the **Anime tab/section**. In the **All** tab the client sends
+no `group=` (`app.ts` only sends it for non-All tabs), so an anime row there is
+not marked as anime and still goes through OMDb only — it can still render blank.
+Fixing All-tab anime would require per-row source-group signalling and messier
+grid gating; it is deliberately left out rather than half-built.
+
+Titles AniList has no entry for — manga/light-novel volume scans, artbook `.zip`s,
+some region-locked donghua — stay posterless. Expected, not a failure.
+
+## Architecture
+
+The "AniList then OMDb" ordering must exist exactly once. Both front ends reach
+metadata providers through `src/recc/`, so the orchestration lives there and each
+front end changes only at the point where it already decides "this is anime". The
+alternative — orchestrating separately in the web route and the React hook — is
+the copy-then-drift this codebase keeps recording, and is rejected.
+
+### Components
+
+| Unit | File | Responsibility | Depends on |
+| --- | --- | --- | --- |
+| **Title normalizer** | `src/util/animeTitle.ts` *(new)* | Pure. Raw release name → clean AniList search string, or `null`. Browser-safe (no `node:*`). | — |
+| **AniList client** | `src/recc/anilist.ts` *(new)* | GraphQL POST to `graphql.anilist.co`. Title → `FetchTitleMetaResult`. `fetchImpl` injection, timeout, keyless. | `util/net`, `util/logger` |
+| **Anime-first resolver** | `src/recc/animeMeta.ts` *(new)* | The single home of the ordering: normalize → AniList → OMDb fallback (only if key present). | `anilist.ts`, `omdb.ts`, `animeTitle.ts` |
+| **Poster allowlist** | `src/core/posterCache.ts` *(edit)* | Add `s4.anilist.co` to the one `POSTER_HOSTS` Set. | — |
+
+### Title normalizer — `animeSearchTitle(rawName: string): string | null`
+
+Pipeline, in order:
+
+1. **Strip leading fansub/group tags:** drop leading `[…]` and `(…)` blocks
+   (`[LoliHouse]`, `[ANi]`, `[Reza]`).
+2. **Cut trailing metadata:** everything from the first `[` that begins a
+   quality/codec/subtitle block (`[WebRip 1080p HEVC…]`, `[简繁内封字幕]`) onward.
+3. **Strip the episode tail:** trailing `- 06`, `- 1173`, `- 第243話`, `E06`,
+   `S01E06` markers — AniList is queried at series level.
+4. **Split alternative titles** on `/` and `|` and pick the best candidate: prefer
+   a Latin-script segment (romaji/English) over a CJK-only one, since AniList
+   ranks romaji/English strongly. If every segment is CJK, keep the first (AniList
+   indexes native titles too).
+5. **Collapse whitespace; return `null`** if nothing usable survives (mirrors
+   `parseRelease` returning `null` on pure noise).
+
+Worked examples (illustrative — from live data, not the test cast):
+
+- `[LoliHouse] 超超超超超喜歡你的100個女朋友 / Hyakkano - 30 [WebRip 1080p…][简繁内封字幕]` → `Hyakkano`
+- `[Reza] THE GHOST IN THE SHELL (2026) - S01E06 [WEBRip …]` → `THE GHOST IN THE SHELL`
+- `Mushoku Tensei III ～… Honki Dasu [07][…]` → `Mushoku Tensei III`
+- `Tefuda ga Oome no Victoria - 06 [1080p]` (SubsPlease) → `Tefuda ga Oome no Victoria`
+
+### AniList client — `fetchAnimeMetaByName(title, { fetchImpl?, timeoutMs? })`
+
+Mirrors `src/recc/omdb.ts`: one exported function, injected `fetchImpl`, returns
+the shared `FetchTitleMetaResult` union so callers need no new handling.
+
+- **Transport:** `POST https://graphql.anilist.co`, `Content-Type:
+  application/json`, body `{ query, variables: { search: title } }`. No key.
+  `AbortSignal.timeout(timeoutMs ?? 8000)`, matching OMDb.
+- **Query:** one `Media(search: $search, type: ANIME, sort: SEARCH_MATCH)`
+  selecting `id`, `title { romaji english native }`,
+  `description(asHtml: false)`, `coverImage { extraLarge large }`, `format`,
+  `siteUrl`.
+- **Mapping to `FetchTitleMetaResult`:**
+  - `posterUrl` ← `coverImage.extraLarge` (fall back to `large`); host `s4.anilist.co`.
+  - `plot` ← `description`, with `<br>`/`<i>` and similar light HTML stripped and
+    whitespace collapsed; `null` if empty.
+  - `type` ← `format === "MOVIE" ? "movie" : "series"` (TV/TV_SHORT/OVA/ONA/SPECIAL
+    → series). `MUSIC` / non-video formats → treated as a miss.
+  - `imdbId` ← `null`.
+  - Miss (`Media` null / GraphQL `errors` / empty data) → `{ ok: false, error:
+    "not found" }`; network/parse failure → `{ ok: false, error: "couldn't reach
+    AniList" }`, logged at debug. Same shape OMDb uses.
+- **Rate limits:** ~90 req/min unauthenticated. The existing 150ms debounce on
+  both preview paths keeps us well under; no extra throttling in scope. A 429
+  degrades to the ordinary miss → placeholder.
+
+### Anime-first resolver — `fetchAnimeFirstMeta({ rawName, omdb, omdbApiKey, fetchImpl?, timeoutMs? })`
+
+- `title = animeSearchTitle(rawName)`. If non-null → `fetchAnimeMetaByName(title, …)`.
+- AniList `ok` → return it.
+- AniList miss/error **and** `omdbApiKey` non-empty → fall through to
+  `fetchTitleMetaByName(omdb.title, omdbApiKey, { year, type })` — no
+  season/episode (anime absolute numbering is meaningless to OMDb).
+- AniList miss with no OMDb key → return the AniList miss.
+
+Net effect: keyless users get AniList or a clean placeholder; keyed users get
+AniList-then-OMDb.
+
+## Data flow
+
+### Web (server-authoritative)
+
+1. Grid/preview calls `GET /api/title?release=<raw>&group=Anime` (already sends
+   `group=` for non-All tabs; `app.ts:2109`).
+2. `titleMeta()` parses with `parseRelease`, builds the same `cacheKey`, checks
+   `titleCache` — unchanged.
+3. On a cache miss, branch on group: `group === "Anime"` → call
+   `fetchAnimeFirstMeta({ rawName: release, omdb: { title, year, type },
+   omdbApiKey })`. Every other group → the existing `fetchTitleMetaByName` path.
+4. Result runs through the existing `allowedPosterUrl` (now passing
+   `s4.anilist.co`), is cached and returned as today's `PublicTitleMeta`.
+5. The image comes via the existing `GET /api/poster?url=` proxy — no change
+   beyond the allowlist entry.
+
+### TUI (in-process)
+
+1. `Results.tsx` already parses the selection and knows `section === "anime"`.
+2. It passes `anime: true` into `useTitlePreview`. The hook's metadata effect,
+   when `anime` is set, calls `fetchAnimeFirstMeta(...)` instead of
+   `fetchTitleMetaByName(...)`; the poster effect (`cachedPosterRows` →
+   `getPoster`) is unchanged and now accepts AniList hosts.
+3. Cache key is the same `parsed.key`-based string, so scrolling still collapses
+   to one lookup.
+
+Both share the resolver and the poster allowlist, so the ordering decision and
+the host trust list each exist exactly once.
+
+## Enablement / gating
+
+The Anime group stops requiring an OMDb key:
+
+- `src/web/static/resultPosters.ts` — `postersApply(group, omdbConfigured)`
+  returns `true` for `group === "Anime"` regardless of `omdbConfigured`; other
+  groups unchanged. `searchHint` skips the "add an OMDb key" nudge on the Anime
+  tab (a key buys nothing extra there). Both are pure, already-tested functions.
+- `src/ui/components/Results.tsx` — `showPreview` drops the `omdbApiKey !== ""`
+  requirement when `section === "anime"`; other sections unchanged.
+
+The "Anime is keyless" rule lives in `postersApply` (tested), not loose in
+`app.ts`. No `/api/sources` flag, no config field, no settings toggle.
+
+## Poster allowlist
+
+Add `"s4.anilist.co"` to the single `POSTER_HOSTS` Set in
+`src/core/posterCache.ts`. This is what lets AniList covers pass both
+`allowedPosterUrl` (web) and `getPoster`/`cachedPosterRows` (both). Posters still
+go through the proxy and an `<img src>` with a proxied URL; no `innerHTML`
+anywhere.
+
+## Error handling & caching
+
+- Provider failures/misses use the shared `{ ok: false, error }` shape; callers
+  render their existing placeholder.
+- Caching mechanics unchanged. Web caches successes in `titleCache` by the
+  existing `cacheKey`; misses/errors stay uncached (same policy as OMDb, so a
+  transient AniList blip is not pinned to a title). TUI keeps its in-hook
+  `metas`/`posters` maps keyed by `parsed.key`.
+
+## Testing
+
+No jsdom for `app.ts` (per CLAUDE.md); decisions live in pure modules that get
+real tests.
+
+- `src/util/animeTitle.test.ts` — the normalizer against **invented anime-shaped
+  fixtures** (not the live titles above), covering each pipeline step: group-tag
+  strip, trailing-metadata cut, absolute-episode strip, `/`-split Latin-vs-CJK
+  pick, null-on-noise.
+- `src/recc/anilist.test.ts` — fake `fetchImpl` with canned GraphQL bodies: happy
+  path, `Media: null` miss, GraphQL `errors`, network throw, MOVIE→movie /
+  TV→series mapping, description tag-stripping.
+- `src/recc/animeMeta.test.ts` — resolver ordering: AniList hit short-circuits;
+  AniList miss + key → OMDb called; AniList miss + no key → no OMDb call, miss
+  returned.
+- `src/web/static/resultPosters.test.ts` — Anime `true` without an OMDb key;
+  other groups still gated.
+- `src/web/routes.test.ts` — `?release=…&group=Anime` routes to an injected
+  resolver stub; non-Anime groups still hit the OMDb path.
+- TUI wiring verified by running it (`npm run dev -- serve --web` for the web,
+  a manual TUI anime-section check) — no unit reach into `app.ts`.
+- Full gate before "done": `npm test`, `npm run typecheck`, `npm run lint`,
+  `npm run build`.
+
+## Docs
+
+Update both front ends' notes per CLAUDE.md's docs row: the web UI's limitations
+list (anime now gets posters) and any OMDb-only phrasing in `README.md`.
+
+## Out of scope
+
+- All-tab anime posters (needs per-row source-group signalling).
+- Per-episode anime plots (AniList is series-level).
+- Any settings toggle or capability flag for AniList.
+- Changing the TUI "open on IMDb" action for anime.
+- AniList lookups for manga/light-novel/artbook entries that have no anime record.

--- a/src/core/posterCache.test.ts
+++ b/src/core/posterCache.test.ts
@@ -8,6 +8,7 @@ import {
   getPoster,
   MAX_POSTER_BYTES,
   posterFileName,
+  POSTER_HOSTS,
   prunePosters,
 } from "./posterCache";
 import * as net from "../util/net";
@@ -358,5 +359,14 @@ describe("prunePosters", () => {
 
   it("never throws on a missing directory", async () => {
     await expect(prunePosters(path.join(dir, "nope"), 10)).resolves.toBeUndefined();
+  });
+});
+
+describe("POSTER_HOSTS allowlist", () => {
+  it("accepts the AniList cover CDN", () => {
+    expect(POSTER_HOSTS.has("s4.anilist.co")).toBe(true);
+  });
+  it("still accepts the OMDb/Amazon hosts", () => {
+    expect(POSTER_HOSTS.has("m.media-amazon.com")).toBe(true);
   });
 });

--- a/src/core/posterCache.ts
+++ b/src/core/posterCache.ts
@@ -19,6 +19,8 @@ export const POSTER_HOSTS = new Set([
   "m.media-amazon.com",
   "ia.media-imdb.com",
   "img.omdbapi.com",
+  // AniList cover art (the Anime group's metadata provider).
+  "s4.anilist.co",
 ]);
 
 // Cap the cache rather than letting it grow forever. Posters are ~50-200KB, so

--- a/src/recc/anilist.test.ts
+++ b/src/recc/anilist.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { fetchAnimeMetaByName } from "./anilist";
+import type { FetchImpl } from "../util/net";
+
+function postImpl(status: number, body: unknown): { impl: FetchImpl; calls: { url: string; init?: RequestInit }[] } {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const impl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+  }) as unknown as FetchImpl;
+  return { impl, calls };
+}
+
+const media = (over: Record<string, unknown> = {}) => ({
+  data: {
+    Media: {
+      id: 1,
+      title: { romaji: "Kestrel no Yoru", english: "Kestrel Nights", native: "ケストレル" },
+      description: "A quiet town.<br><br>Then it isn't.",
+      coverImage: { extraLarge: "https://s4.anilist.co/xl.jpg", large: "https://s4.anilist.co/l.jpg" },
+      format: "TV",
+      siteUrl: "https://anilist.co/anime/1",
+      ...over,
+    },
+  },
+});
+
+describe("fetchAnimeMetaByName", () => {
+  it("returns poster, tag-stripped plot, series type and null imdbId on a hit", async () => {
+    const { impl, calls } = postImpl(200, media());
+    const res = await fetchAnimeMetaByName("Kestrel no Yoru", { fetchImpl: impl });
+    expect(res).toEqual({
+      ok: true,
+      type: "series",
+      imdbId: null,
+      plot: "A quiet town. Then it isn't.",
+      posterUrl: "https://s4.anilist.co/xl.jpg",
+    });
+    expect(calls[0]!.url).toBe("https://graphql.anilist.co");
+    expect(calls[0]!.init?.method).toBe("POST");
+  });
+
+  it("maps format MOVIE to movie", async () => {
+    const { impl } = postImpl(200, media({ format: "MOVIE" }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok && res.type).toBe("movie");
+  });
+
+  it("falls back to coverImage.large when extraLarge is missing", async () => {
+    const { impl } = postImpl(200, media({ coverImage: { large: "https://s4.anilist.co/l.jpg" } }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok && res.posterUrl).toBe("https://s4.anilist.co/l.jpg");
+  });
+
+  it("treats Media: null as a miss", async () => {
+    const { impl } = postImpl(200, { data: { Media: null } });
+    const res = await fetchAnimeMetaByName("Nothing Here", { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "not found" });
+  });
+
+  it("treats a GraphQL errors payload as a miss", async () => {
+    const { impl } = postImpl(200, { errors: [{ message: "Not Found." }] });
+    const res = await fetchAnimeMetaByName("Nothing", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns a reach error when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as FetchImpl;
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res).toEqual({ ok: false, error: "couldn't reach AniList" });
+  });
+
+  it("returns a miss for a non-video format", async () => {
+    const { impl } = postImpl(200, media({ format: "MUSIC" }));
+    const res = await fetchAnimeMetaByName("Kestrel", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns an empty-title error without calling the network", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }) as unknown as FetchImpl;
+    const res = await fetchAnimeMetaByName("   ", { fetchImpl: impl });
+    expect(res.ok).toBe(false);
+    expect(called).toBe(false);
+  });
+});

--- a/src/recc/anilist.ts
+++ b/src/recc/anilist.ts
@@ -1,0 +1,88 @@
+import type { FetchImpl } from "../util/net";
+import { log } from "../util/logger";
+import type { FetchTitleMetaResult, OmdbType } from "./omdb";
+
+// AniList is a free, keyless GraphQL API for anime. It is the right database for
+// the Anime group, where OMDb (an IMDb mirror) cannot match romaji/CJK titles or
+// absolute episode numbering. We return the SAME FetchTitleMetaResult union OMDb
+// returns so every caller — TUI hook and web route — handles one shape.
+
+const ENDPOINT = "https://graphql.anilist.co";
+
+// One media match, ranked by search relevance. type: ANIME excludes manga.
+const QUERY = `
+query ($search: String) {
+  Media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+    id
+    title { romaji english native }
+    description(asHtml: false)
+    coverImage { extraLarge large }
+    format
+    siteUrl
+  }
+}`;
+
+interface AniListMedia {
+  description?: string | null;
+  coverImage?: { extraLarge?: string | null; large?: string | null } | null;
+  format?: string | null;
+}
+
+interface AniListResponse {
+  data?: { Media?: AniListMedia | null } | null;
+  errors?: unknown;
+}
+
+function isResponse(v: unknown): v is AniListResponse {
+  return typeof v === "object" && v !== null;
+}
+
+// AniList descriptions carry light HTML (<br>, <i>, ...) even with asHtml:false.
+// Strip tags and collapse whitespace to a single-paragraph plot.
+function cleanPlot(desc: string | null | undefined): string | null {
+  const s = (desc ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return s.length > 0 ? s : null;
+}
+
+// Map AniList's format enum to the two media types we model. MOVIE is a film;
+// every other video format (TV, TV_SHORT, OVA, ONA, SPECIAL) is a series.
+// MUSIC and anything unrecognised is not something we can present -> null.
+function mapType(format: string | null | undefined): OmdbType | null {
+  if (format === "MOVIE") return "movie";
+  if (format === "TV" || format === "TV_SHORT" || format === "OVA" || format === "ONA" || format === "SPECIAL") {
+    return "series";
+  }
+  return null;
+}
+
+export async function fetchAnimeMetaByName(
+  title: string,
+  opts: { fetchImpl?: FetchImpl; timeoutMs?: number } = {},
+): Promise<FetchTitleMetaResult> {
+  const search = title.trim();
+  if (!search) return { ok: false, error: "no title" };
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+  try {
+    const res = await fetchImpl(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ query: QUERY, variables: { search } }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 8000),
+    });
+    if (!res.ok) return { ok: false, error: `AniList unavailable (HTTP ${res.status})` };
+    const body: unknown = await res.json();
+    if (!isResponse(body) || body.errors) return { ok: false, error: "not found" };
+    const media = body.data?.Media;
+    if (!media) return { ok: false, error: "not found" };
+    const type = mapType(media.format);
+    if (type === null) return { ok: false, error: "not found" };
+    const posterUrl = media.coverImage?.extraLarge || media.coverImage?.large || null;
+    return { ok: true, type, imdbId: null, plot: cleanPlot(media.description), posterUrl };
+  } catch (err) {
+    log.debug(`anilist by name ${search}: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, error: "couldn't reach AniList" };
+  }
+}

--- a/src/recc/animeMeta.test.ts
+++ b/src/recc/animeMeta.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchAnimeFirstMeta } from "./animeMeta";
+import * as anilist from "./anilist";
+import * as omdb from "./omdb";
+import type { FetchTitleMetaResult } from "./omdb";
+
+const hit: FetchTitleMetaResult = { ok: true, type: "series", imdbId: null, plot: "p", posterUrl: "https://s4.anilist.co/x.jpg" };
+const miss: FetchTitleMetaResult = { ok: false, error: "not found" };
+
+describe("fetchAnimeFirstMeta", () => {
+  it("returns the AniList hit and never calls OMDb", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(hit);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(miss);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "[NanakoRaws] Kestrel S01E18 [1080p]",
+      omdb: { title: "Kestrel", type: "series" },
+      omdbApiKey: "KEY",
+    });
+    expect(res).toBe(hit);
+    expect(a).toHaveBeenCalledWith("Kestrel", expect.anything());
+    expect(o).not.toHaveBeenCalled();
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("falls back to OMDb (no season/episode) when AniList misses and a key is present", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "Ashfall - 06 [1080p]",
+      omdb: { title: "Ashfall", year: 1999, type: "series" },
+      omdbApiKey: "KEY",
+    });
+    expect(res).toBe(hit);
+    expect(o).toHaveBeenCalledWith("Ashfall", "KEY", { year: 1999, type: "series" });
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("does NOT call OMDb on an AniList miss when no key is configured", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(miss);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "Ashfall - 06 [1080p]",
+      omdb: { title: "Ashfall" },
+      omdbApiKey: "",
+    });
+    expect(res).toEqual(miss);
+    expect(o).not.toHaveBeenCalled();
+    a.mockRestore();
+    o.mockRestore();
+  });
+
+  it("skips AniList and goes straight to OMDb when the name normalizes to nothing", async () => {
+    const a = vi.spyOn(anilist, "fetchAnimeMetaByName").mockResolvedValue(hit);
+    const o = vi.spyOn(omdb, "fetchTitleMetaByName").mockResolvedValue(hit);
+    const res = await fetchAnimeFirstMeta({
+      rawName: "[Group] [1080p HEVC]",
+      omdb: { title: "Fallback Title" },
+      omdbApiKey: "KEY",
+    });
+    expect(a).not.toHaveBeenCalled();
+    expect(o).toHaveBeenCalledWith("Fallback Title", "KEY", {});
+    expect(res).toBe(hit);
+    a.mockRestore();
+    o.mockRestore();
+  });
+});

--- a/src/recc/animeMeta.ts
+++ b/src/recc/animeMeta.ts
@@ -1,0 +1,44 @@
+import type { FetchImpl } from "../util/net";
+import { animeSearchTitle } from "../util/animeTitle";
+import { fetchAnimeMetaByName } from "./anilist";
+import { fetchTitleMetaByName, type FetchTitleMetaResult, type OmdbType } from "./omdb";
+
+// The one place the "anime is AniList first, OMDb second" ordering lives. Both
+// front ends call this on their Anime path so the ordering and the fallback rule
+// cannot drift between a server route and a React hook.
+export interface AnimeFirstArgs {
+  // Raw torrent release name, normalized here for the AniList search.
+  rawName: string;
+  // The already-parsed OMDb query, used only for the fallback. No season/episode:
+  // anime absolute numbering is meaningless to OMDb's per-season index.
+  omdb: { title: string; year?: number; type?: OmdbType };
+  // "" when no OMDb key is configured — the fallback is then skipped entirely,
+  // which is what lets keyless users still get AniList artwork.
+  omdbApiKey: string;
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+}
+
+export async function fetchAnimeFirstMeta(args: AnimeFirstArgs): Promise<FetchTitleMetaResult> {
+  const { rawName, omdb, omdbApiKey, fetchImpl, timeoutMs } = args;
+
+  const search = animeSearchTitle(rawName);
+  if (search) {
+    const anilist = await fetchAnimeMetaByName(search, { fetchImpl, timeoutMs });
+    if (anilist.ok) return anilist;
+  }
+
+  // AniList missed (or the name had no usable title). Fall back to OMDb only
+  // when a key exists; otherwise return the AniList miss (or a "no title" miss).
+  if (!omdbApiKey) {
+    return search
+      ? { ok: false, error: "not found" }
+      : { ok: false, error: "no title in that release name" };
+  }
+  return fetchTitleMetaByName(omdb.title, omdbApiKey, {
+    ...(omdb.year !== undefined ? { year: omdb.year } : {}),
+    ...(omdb.type !== undefined ? { type: omdb.type } : {}),
+    fetchImpl,
+    timeoutMs,
+  });
+}

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -531,8 +531,13 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     const g = CATEGORIES.find((c) => c.key === section)?.group;
     return !g || g === "Movies" || g === "TV" || g === "Anime";
   }, [section]);
+  const sectionIsAnime = section === "anime";
   const showPreview =
-    previewOn && omdbApiKey !== "" && previewSection && mode !== "detail" && contentWidth >= PREVIEW_MIN_WIDTH;
+    previewOn &&
+    (omdbApiKey !== "" || sectionIsAnime) &&
+    previewSection &&
+    mode !== "detail" &&
+    contentWidth >= PREVIEW_MIN_WIDTH;
   const previewWidth = showPreview ? Math.min(46, Math.max(30, Math.round(contentWidth * 0.4))) : 0;
   const listWidth = showPreview ? contentWidth - previewWidth - 1 : contentWidth;
 
@@ -579,6 +584,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
   const preview = useTitlePreview({
     omdbApiKey,
     enabled: showPreview,
+    anime: sectionIsAnime,
     cacheKey: parsed
       ? `${parsed.key}|${previewEpisode ? `s${previewEpisode.season}e${previewEpisode.episode}` : ""}`
       : "",
@@ -588,6 +594,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
           title: parsed.title,
           year: parsed.year,
           type: parsed.type,
+          rawName: selectedResult?.name,
           ...(previewEpisode ?? {}),
         }
       : null,

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -585,8 +585,11 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
     omdbApiKey,
     enabled: showPreview,
     anime: sectionIsAnime,
+    // Prefix with an anime discriminator so a title|year|type seen once in the
+    // Anime section (AniList) and once elsewhere (OMDb) don't collide on one
+    // cache entry — matches the web route's `anime:` cache-key tag.
     cacheKey: parsed
-      ? `${parsed.key}|${previewEpisode ? `s${previewEpisode.season}e${previewEpisode.episode}` : ""}`
+      ? `${sectionIsAnime ? "anime:" : ""}${parsed.key}|${previewEpisode ? `s${previewEpisode.season}e${previewEpisode.episode}` : ""}`
       : "",
     query: parsed
       ? {

--- a/src/ui/hooks/useTitlePreview.ts
+++ b/src/ui/hooks/useTitlePreview.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { FetchImpl } from "../../util/net";
 import { fetchTitleMeta, fetchTitleMetaByName, type OmdbType } from "../../recc/omdb";
+import { fetchAnimeFirstMeta } from "../../recc/animeMeta";
 import { cachedPosterRows } from "../../core/posterCache";
 
 // How to look a title up: by IMDb id (For You, where reccd supplies it) or by
@@ -18,6 +19,8 @@ export type MetaQuery =
        */
       season?: number;
       episode?: number;
+      /** The raw release name, for AniList normalization on the anime path. */
+      rawName?: string;
     };
 
 interface Meta {
@@ -53,6 +56,10 @@ interface Args {
   posterMaxRows: number;
   fetchImpl?: FetchImpl;
   debounceMs?: number;
+  // Look this selection up on AniList first (Anime section), OMDb as fallback.
+  // AniList is keyless, so the metadata effect below does not require an OMDb key
+  // when this is set.
+  anime?: boolean;
 }
 
 // Lazily resolves a selection's plot + poster from OMDb, debounced and cached
@@ -68,6 +75,7 @@ export function useTitlePreview(args: Args): TitlePreview {
     posterMaxRows,
     fetchImpl,
     debounceMs = 150,
+    anime = false,
   } = args;
 
   const metas = useRef(new Map<string, Meta>());
@@ -82,7 +90,9 @@ export function useTitlePreview(args: Args): TitlePreview {
 
   // Metadata (plot + poster URL), debounced so scrolling doesn't spam OMDb.
   useEffect(() => {
-    if (!omdbApiKey || !enabled || !cacheKey || metas.current.has(cacheKey)) return;
+    // Anime does not need an OMDb key (AniList is keyless); every other path
+    // still does.
+    if ((!omdbApiKey && !anime) || !enabled || !cacheKey || metas.current.has(cacheKey)) return;
     let cancelled = false;
     const t = setTimeout(() => {
       const q = queryRef.current;
@@ -90,13 +100,20 @@ export function useTitlePreview(args: Args): TitlePreview {
       const p =
         q.by === "id"
           ? fetchTitleMeta(q.imdbId, omdbApiKey, { fetchImpl })
-          : fetchTitleMetaByName(q.title, omdbApiKey, {
-              year: q.year,
-              type: q.type,
-              season: q.season,
-              episode: q.episode,
-              fetchImpl,
-            });
+          : anime
+            ? fetchAnimeFirstMeta({
+                rawName: q.rawName ?? q.title,
+                omdb: { title: q.title, year: q.year, type: q.type },
+                omdbApiKey,
+                fetchImpl,
+              })
+            : fetchTitleMetaByName(q.title, omdbApiKey, {
+                year: q.year,
+                type: q.type,
+                season: q.season,
+                episode: q.episode,
+                fetchImpl,
+              });
       void p.then((res) => {
         if (cancelled) return;
         metas.current.set(
@@ -112,7 +129,7 @@ export function useTitlePreview(args: Args): TitlePreview {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [omdbApiKey, enabled, cacheKey, fetchImpl, debounceMs]);
+  }, [omdbApiKey, enabled, cacheKey, fetchImpl, debounceMs, anime]);
 
   const meta = cacheKey ? metas.current.get(cacheKey) : undefined;
   const posterUrl = meta?.posterUrl ?? null;

--- a/src/util/animeTitle.test.ts
+++ b/src/util/animeTitle.test.ts
@@ -34,6 +34,10 @@ describe("animeSearchTitle", () => {
     expect(animeSearchTitle("Harrowgate S03E04 [1080p]")).toBe("Harrowgate");
   });
 
+  it("strips multiple stacked leading group tags", () => {
+    expect(animeSearchTitle("[ANi] [Baha] Kestrel - 06 [1080p]")).toBe("Kestrel");
+  });
+
   it("returns null when only noise survives", () => {
     expect(animeSearchTitle("[Group] [1080p HEVC AAC]")).toBeNull();
   });

--- a/src/util/animeTitle.test.ts
+++ b/src/util/animeTitle.test.ts
@@ -1,0 +1,40 @@
+// src/util/animeTitle.test.ts
+import { describe, it, expect } from "vitest";
+import { animeSearchTitle } from "./animeTitle";
+
+// FIXTURES: invented cast only (Kestrel/Ashfall/Harrowgate per CLAUDE.md).
+// ケストレル / ケストレルの夜 are katakana of the invented "Kestrel" — used for
+// the CJK cases so no real title appears in a test.
+describe("animeSearchTitle", () => {
+  it("strips a leading fansub group tag", () => {
+    expect(animeSearchTitle("[NanakoRaws] Kestrel S01E18 (AT-X TV 1080p HEVC AAC)")).toBe("Kestrel");
+  });
+
+  it("strips the SubsPlease absolute-episode tail and resolution block", () => {
+    expect(animeSearchTitle("Ashfall - 06 [1080p]")).toBe("Ashfall");
+  });
+
+  it("cuts a trailing quality/codec/subtitle block", () => {
+    expect(animeSearchTitle("Ashfall [WebRip 1080p HEVC-10bit AAC][subs]")).toBe("Ashfall");
+  });
+
+  it("prefers a Latin-script alternative over a CJK one when titles are slash-joined", () => {
+    expect(animeSearchTitle("[LoliHouse] ケストレル / Kestrel - 06 [WebRip 1080p]")).toBe("Kestrel");
+  });
+
+  it("keeps the first segment when every alternative is CJK", () => {
+    expect(animeSearchTitle("[Doomdos] ケストレルの夜 - 06 [1080p BILIBILI COM WEB-DL]")).toBe("ケストレルの夜");
+  });
+
+  it("strips a Chinese episode-counter tail (第N话)", () => {
+    expect(animeSearchTitle("[ANi] ケストレルの夜 - 第12话 [1080p]")).toBe("ケストレルの夜");
+  });
+
+  it("drops an SxxExx marker", () => {
+    expect(animeSearchTitle("Harrowgate S03E04 [1080p]")).toBe("Harrowgate");
+  });
+
+  it("returns null when only noise survives", () => {
+    expect(animeSearchTitle("[Group] [1080p HEVC AAC]")).toBeNull();
+  });
+});

--- a/src/util/animeTitle.ts
+++ b/src/util/animeTitle.ts
@@ -1,0 +1,64 @@
+// src/util/animeTitle.ts
+
+// Turn a raw anime torrent release name into a title string suitable for an
+// AniList search, or null when nothing usable survives.
+//
+// AniList indexes anime by romaji / English / native title plus synonyms, and
+// its search tolerates extra words far better than OMDb's exact title match —
+// but fansub release names bury the title under group tags, quality blocks and
+// an absolute episode number, and often glue several language variants together
+// with "/". This strips it down to one best candidate.
+//
+// Pure and browser-safe: no node:* imports, direct or transitive.
+
+// Does a string contain any Latin letter? Used to prefer a romaji/English
+// alternative title (which AniList ranks strongly) over a CJK-only one.
+function hasLatin(s: string): boolean {
+  return /[A-Za-z]/.test(s);
+}
+
+// Is a token pure release noise (resolution / codec / source / sub markers)?
+// Deliberately small and anchored to whole tokens — the goal is only to notice
+// that a candidate is entirely metadata, not to enumerate every release word.
+const NOISE = /^(?:\d{3,4}p|4k|2160p|1080p|720p|480p|hevc|x264|x265|h264|h265|10bit|aac|flac|ac3|eac3|ddp?\d?|web-?dl|webrip|bluray|bdrip|bdremux|remux|hdr|dv|multi-?subs?|dual|audio|sub|subs|raws?|tv|bili?bili|amzn|iqiyi|iq|baha|com)$/i;
+
+// Split a title into whitespace tokens and drop the trailing run of pure-noise
+// tokens ("Kestrel no Yoru WebRip 1080p" -> "Kestrel no Yoru"). Only trailing
+// noise is trimmed; interior words are left alone.
+function trimTrailingNoise(s: string): string {
+  const tokens = s.split(/\s+/).filter(Boolean);
+  while (tokens.length && NOISE.test(tokens[tokens.length - 1]!)) tokens.pop();
+  return tokens.join(" ");
+}
+
+export function animeSearchTitle(rawName: string): string | null {
+  let s = rawName;
+
+  // 1. Strip leading bracketed group/source tags: "[NanakoRaws] ", "(2026) ".
+  //    Repeated because releases often stack two ("[ANi] [Baha] ...").
+  s = s.replace(/^\s*(?:\[[^\]]*\]|\([^)]*\))\s*/g, "");
+
+  // 2. Cut everything from the first remaining bracketed block onward — that is
+  //    where the quality/codec/subtitle metadata lives ("... [WebRip 1080p]").
+  const bracket = s.search(/[[(]/);
+  if (bracket >= 0) s = s.slice(0, bracket);
+
+  // 3. Strip an episode tail: "- 06", "- 1173", "- 第63话", "S01E04", "E06".
+  s = s.replace(/\s*-\s*(?:第\s*\d+\s*话|\d{1,4})\s*$/u, "");
+  s = s.replace(/\s+S\d{1,2}(?:E\d{1,4})?\s*$/i, "");
+  s = s.replace(/\s+E\d{1,4}\s*$/i, "");
+
+  // 4. Several language variants joined by "/" or "|": prefer a Latin-script
+  //    segment (romaji/English), else keep the first.
+  const parts = s.split(/[/|]/).map((p) => p.trim()).filter(Boolean);
+  if (parts.length > 1) {
+    s = parts.find((p) => hasLatin(p)) ?? parts[0]!;
+  } else {
+    s = parts[0] ?? "";
+  }
+
+  // 5. Trim trailing pure-noise tokens and collapse whitespace.
+  s = trimTrailingNoise(s).replace(/\s+/g, " ").trim();
+
+  return s.length > 0 ? s : null;
+}

--- a/src/util/animeTitle.ts
+++ b/src/util/animeTitle.ts
@@ -35,8 +35,11 @@ export function animeSearchTitle(rawName: string): string | null {
   let s = rawName;
 
   // 1. Strip leading bracketed group/source tags: "[NanakoRaws] ", "(2026) ".
-  //    Repeated because releases often stack two ("[ANi] [Baha] ...").
-  s = s.replace(/^\s*(?:\[[^\]]*\]|\([^)]*\))\s*/g, "");
+  //    Looped because releases often stack two ("[ANi] [Baha] ..."); a single
+  //    `.replace(..., "g")` call only removes the first, since `^` does not
+  //    re-match mid-string even with the `g` flag.
+  const leadingTag = /^\s*(?:\[[^\]]*\]|\([^)]*\))\s*/;
+  while (leadingTag.test(s)) s = s.replace(leadingTag, "");
 
   // 2. Cut everything from the first remaining bracketed block onward — that is
   //    where the quality/codec/subtitle metadata lives ("... [WebRip 1080p]").

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1899,6 +1899,77 @@ describe("GET /api/title", () => {
   });
 });
 
+describe("/api/title anime routing", () => {
+  beforeEach(() => {
+    clearTitleCache();
+    vi.stubEnv("TORLINK_OMDB_KEY", "");
+  });
+
+  function animeDeps(over: Partial<WebDeps> = {}): WebDeps {
+    return deps({
+      loadConfigImpl: async () => ({ ...defaultConfig, downloadDir: "/tmp/dl" }),
+      ...over,
+    });
+  }
+
+  const title = (d: WebDeps, qs: string): Promise<WebResponse> =>
+    handleWebApi(d, "GET", "/api/title", new URLSearchParams(qs), AUTH, "");
+
+  it("routes the Anime group through the AniList-first resolver", async () => {
+    let sawRawName = "";
+    const fetchTitleMetaByNameImpl = vi.fn(async () => {
+      throw new Error("OMDb must not be called for the Anime group");
+    });
+    const res = await title(
+      animeDeps({
+        fetchAnimeFirstMetaImpl: async (args) => {
+          sawRawName = args.rawName;
+          return { ok: true, imdbId: null, plot: "p", posterUrl: "https://s4.anilist.co/x.jpg" };
+        },
+        fetchTitleMetaByNameImpl,
+      }),
+      "release=" + encodeURIComponent("[NanakoRaws] Kestrel S01E18 [1080p]") + "&group=Anime",
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ status: "ok", posterUrl: "https://s4.anilist.co/x.jpg" });
+    expect(sawRawName).toContain("Kestrel");
+    expect(fetchTitleMetaByNameImpl).not.toHaveBeenCalled();
+  });
+
+  it("does not return no-key for anime even without an OMDb key", async () => {
+    const res = await title(
+      animeDeps({
+        fetchAnimeFirstMetaImpl: async () => ({ ok: false, error: "not found" }),
+      }),
+      "release=" + encodeURIComponent("Kestrel - 06 [1080p]") + "&group=Anime",
+    );
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ status: "error", error: "not found" });
+  });
+
+  it("still routes non-anime groups through OMDb", async () => {
+    const fetchTitleMetaByNameImpl = vi.fn(async () => ({
+      ok: true as const,
+      type: "movie" as const,
+      imdbId: "tt1",
+      plot: "p",
+      posterUrl: null,
+    }));
+    const res = await title(
+      animeDeps({
+        loadConfigImpl: async () => ({ ...defaultConfig, downloadDir: "/tmp/dl", omdbApiKey: "KEY" }),
+        fetchTitleMetaByNameImpl,
+        fetchAnimeFirstMetaImpl: async () => {
+          throw new Error("AniList must not be called for Movies");
+        },
+      }),
+      "release=" + encodeURIComponent("Kestrel.2010.1080p.BluRay.x264") + "&group=Movies",
+    );
+    expect(fetchTitleMetaByNameImpl).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("GET /api/title?release= — server-side release parsing", () => {
   const OK_META: FetchTitleMetaResult = {
     ok: true,

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1968,6 +1968,41 @@ describe("/api/title anime routing", () => {
     expect(fetchTitleMetaByNameImpl).toHaveBeenCalled();
     expect(res.status).toBe(200);
   });
+
+  // Before this task the provider was always OMDb, so a group-independent
+  // cache key was correct. Now the provider depends on the group, so the same
+  // parsed title|year|type in a non-Anime tab and the Anime tab must NOT share
+  // one cache entry — otherwise whichever asked first serves the other tab
+  // its provider's poster/plot.
+  it("does not let a non-anime lookup's cache entry leak into the Anime tab", async () => {
+    const release = "Kestrel.2010.1080p.BluRay.x264";
+    const movies = await title(
+      animeDeps({
+        loadConfigImpl: async () => ({ ...defaultConfig, downloadDir: "/tmp/dl", omdbApiKey: "KEY" }),
+        fetchTitleMetaByNameImpl: async () => ({
+          ok: true,
+          imdbId: "tt1",
+          plot: "p",
+          posterUrl: "https://m.media-amazon.com/images/M/omdb-poster.jpg",
+        }),
+      }),
+      `release=${encodeURIComponent(release)}&group=Movies`,
+    );
+    expect(movies.json).toMatchObject({ posterUrl: "https://m.media-amazon.com/images/M/omdb-poster.jpg" });
+
+    const anime = await title(
+      animeDeps({
+        fetchAnimeFirstMetaImpl: async () => ({
+          ok: true,
+          imdbId: null,
+          plot: "p",
+          posterUrl: "https://s4.anilist.co/x.jpg",
+        }),
+      }),
+      `release=${encodeURIComponent(release)}&group=Anime`,
+    );
+    expect(anime.json).toMatchObject({ posterUrl: "https://s4.anilist.co/x.jpg" });
+  });
 });
 
 describe("GET /api/title?release= — server-side release parsing", () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1495,6 +1495,14 @@ export function parseTitleLookup(
   // which is missing often enough that grid cards would blank at random.
   const ep = episodeFromQuery(query);
 
+  // The provider a name lookup resolves through depends on the group
+  // (Anime -> AniList-first, everything else -> OMDb; see titleMeta()), so the
+  // cache key must distinguish them. Without this tag, a Movies/TV tab and the
+  // Anime tab that happen to parse to the same title|year|type would share one
+  // cache entry, and whichever tab asked first would silently serve its
+  // provider's poster/plot to the other.
+  const animeTag = query.get("group") === "Anime" ? "anime:" : "";
+
   const release = query.get("release") ?? "";
   if (release !== "") {
     const parsed = parseRelease(release, hintForGroup(query.get("group")));
@@ -1508,7 +1516,7 @@ export function parseTitleLookup(
       // Season and episode ARE part of the identity. Without them every episode
       // of a season shares one cache entry and renders the first one's plot — a
       // bug that reads as OMDb being wrong rather than a key being too coarse.
-      cacheKey: `n:${parsed.title.toLowerCase()}|${parsed.year ?? ""}|${parsed.type ?? ""}${
+      cacheKey: `n:${animeTag}${parsed.title.toLowerCase()}|${parsed.year ?? ""}|${parsed.type ?? ""}${
         ep ? `|s${ep.season}e${ep.episode}` : ""
       }`,
       name: parsed.title,
@@ -1544,7 +1552,7 @@ export function parseTitleLookup(
   }
 
   const lookup: TitleLookup = {
-    cacheKey: `n:${name.toLowerCase()}|${year ?? ""}|${type ?? ""}`,
+    cacheKey: `n:${animeTag}${name.toLowerCase()}|${year ?? ""}|${type ?? ""}`,
     name,
   };
   if (year !== undefined) lookup.year = year;

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -62,6 +62,7 @@ import {
   type FetchTitleMetaResult,
   type OmdbType,
 } from "../recc/omdb";
+import { fetchAnimeFirstMeta } from "../recc/animeMeta";
 import { openSseChannel, type SseWrite } from "./sse";
 import type { Source, SourceGroup, SourceId, TorrentResult } from "../sources/types";
 import { addInput, type AddInputOptions, type Runtime } from "../daemon/runtime";
@@ -205,6 +206,15 @@ export interface WebDeps {
     apiKey: string,
     opts: { year?: number; type?: OmdbType },
   ) => Promise<FetchTitleMetaResult>;
+  /**
+   * AniList-first metadata for `/api/title?release=&group=Anime`. Injected to
+   * keep tests offline. Defaults to the real resolver in src/recc/animeMeta.
+   */
+  fetchAnimeFirstMetaImpl?: (args: {
+    rawName: string;
+    omdb: { title: string; year?: number; type?: OmdbType };
+    omdbApiKey: string;
+  }) => Promise<FetchTitleMetaResult>;
   /** reccd's feed, for `/api/recommendations`. Injected to keep tests off the network. */
   fetchRecommendationsImpl?: (
     config: ReccClientConfig,
@@ -1614,7 +1624,13 @@ async function titleMeta(deps: WebDeps, query: URLSearchParams): Promise<WebResp
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
   const apiKey = resolveOmdbApiKey(config);
-  if (!apiKey) {
+
+  // Anime (name lookups in the Anime group) resolves via AniList, which needs no
+  // key — so the no-key short-circuit below must not apply to it, and its
+  // resolver skips the OMDb fallback when apiKey is "".
+  const isAnime = query.get("group") === "Anime" && lookup.imdbId === undefined;
+
+  if (!apiKey && !isAnime) {
     // 200 with its own status, NOT a 500 and not an empty "ok". Nothing is
     // broken — the user simply has no key — and the UI needs to tell them that
     // rather than showing a failure or an empty plot. Deliberately not cached:
@@ -1627,12 +1643,22 @@ async function titleMeta(deps: WebDeps, query: URLSearchParams): Promise<WebResp
   const result =
     lookup.imdbId !== undefined
       ? await (deps.fetchTitleMetaImpl ?? fetchTitleMeta)(lookup.imdbId, apiKey)
-      : await (deps.fetchTitleMetaByNameImpl ?? fetchTitleMetaByName)(lookup.name ?? "", apiKey, {
-          ...(lookup.year !== undefined ? { year: lookup.year } : {}),
-          ...(lookup.type !== undefined ? { type: lookup.type } : {}),
-          ...(lookup.season !== undefined ? { season: lookup.season } : {}),
-          ...(lookup.episode !== undefined ? { episode: lookup.episode } : {}),
-        });
+      : isAnime
+        ? await (deps.fetchAnimeFirstMetaImpl ?? fetchAnimeFirstMeta)({
+            rawName: query.get("release") ?? lookup.name ?? "",
+            omdb: {
+              title: lookup.name ?? "",
+              ...(lookup.year !== undefined ? { year: lookup.year } : {}),
+              ...(lookup.type !== undefined ? { type: lookup.type } : {}),
+            },
+            omdbApiKey: apiKey,
+          })
+        : await (deps.fetchTitleMetaByNameImpl ?? fetchTitleMetaByName)(lookup.name ?? "", apiKey, {
+            ...(lookup.year !== undefined ? { year: lookup.year } : {}),
+            ...(lookup.type !== undefined ? { type: lookup.type } : {}),
+            ...(lookup.season !== undefined ? { season: lookup.season } : {}),
+            ...(lookup.episode !== undefined ? { episode: lookup.episode } : {}),
+          });
 
   if (!result.ok) {
     // Not cached either, and this is the deliberate half of the caching policy:

--- a/src/web/static/resultPosters.test.ts
+++ b/src/web/static/resultPosters.test.ts
@@ -88,6 +88,28 @@ describe("searchHint", () => {
   });
 });
 
+describe("postersApply — Anime is keyless", () => {
+  it("applies for Anime even without an OMDb key", () => {
+    expect(postersApply("Anime", false)).toBe(true);
+  });
+  it("still requires a key for Movies", () => {
+    expect(postersApply("Movies", false)).toBe(false);
+    expect(postersApply("Movies", true)).toBe(true);
+  });
+  it("does not apply to a non-preview group regardless", () => {
+    expect(postersApply("Games", true)).toBe(false);
+  });
+});
+
+describe("searchHint — no OMDb nudge on the Anime tab", () => {
+  it("returns null (no key hint) for Anime with no key", () => {
+    expect(searchHint(false, "Anime", null)).toBeNull();
+  });
+  it("still nudges for a key on Movies with no key", () => {
+    expect(searchHint(false, "Movies", null)).not.toBeNull();
+  });
+});
+
 describe("createPosterCache", () => {
   it("fetches metadata then bytes, and answers with the object URL", async () => {
     const { cache, metaCalls, blobCalls } = harness();

--- a/src/web/static/resultPosters.ts
+++ b/src/web/static/resultPosters.ts
@@ -69,9 +69,14 @@ export interface PosterCache {
  * key check is the other half, and it is the one that matters for cost: with no
  * key configured every lookup would return `no-key`, so a keyless server should
  * make none of them.
+ *
+ * The Anime group is the exception: it is served from AniList, which needs no
+ * key, so it previews whether or not OMDb is configured.
  */
 export function postersApply(group: string, omdbConfigured: boolean): boolean {
-  return omdbConfigured && previewApplies(group);
+  if (!previewApplies(group)) return false;
+  if (group === "Anime") return true;
+  return omdbConfigured;
 }
 
 /**
@@ -103,6 +108,8 @@ export function searchHint(
 ): string | null {
   if (omdbConfigured === null) return null;
   if (!previewApplies(group)) return null;
+  // Anime needs no OMDb key (AniList is keyless), so never nudge for one here.
+  if (group === "Anime") return cacheHint;
   if (!omdbConfigured) return OMDB_KEY_HINT;
   return cacheHint;
 }


### PR DESCRIPTION
## Why

Every result in the **Anime** group rendered with no poster and no plot — the preview pane just said *"No match on OMDb (Series or episode not found!)"*. That's not a matching bug: OMDb is an IMDb mirror, and anime releases from Nyaa/SubsPlease ask it questions it can't answer — romaji/CJK titles IMDb indexes under English names, absolute episode numbering (`- 1173`, not `S01E06`), and shows/donghua that aren't on IMDb at all.

## What

The **Anime** group now fetches posters and plots from **[AniList](https://anilist.co)** — a free, **keyless** anime GraphQL API that matches on romaji, English, and native titles. AniList is tried **first**; OMDb is a fallback used only when AniList misses *and* an OMDb key is configured. Because AniList needs no key, **anime metadata now works even with no OMDb key set**. Every other category (Movies/TV/…) is unchanged: OMDb, key required.

Ships in **both front ends** (per the repo's two-surfaces rule): the browser UI and the terminal UI, both keyless, both AniList-first, both series-level.

## How

- `src/util/animeTitle.ts` — pure normalizer: raw release name → clean AniList search string (strips fansub `[group]` tags, trailing quality/codec blocks, absolute-episode tails, and prefers a romaji/English alternative over a CJK one).
- `src/recc/anilist.ts` — keyless AniList GraphQL client, returning the shared `FetchTitleMetaResult` union OMDb already uses.
- `src/recc/animeMeta.ts` — the single home of the "AniList → OMDb fallback" ordering, called by both front ends.
- `src/core/posterCache.ts` — `s4.anilist.co` added to the poster-host allowlist (the SSRF/privacy boundary).
- `src/web/routes.ts` — `/api/title` routes the Anime group through the resolver and skips the no-key short-circuit for anime; the title cache key is now provider-aware so AniList and OMDb answers can't collide across tabs.
- `src/web/static/resultPosters.ts` — the Anime tab previews without an OMDb key and doesn't nag for one.
- `src/ui/hooks/useTitlePreview.ts` + `src/ui/components/Results.tsx` — the terminal Anime section previews via the resolver, keyless, with a provider-aware cache key mirroring the web fix.

## Scope boundaries (intentional, documented)

- Anime shown in the **All** tab (which sends no group) still uses OMDb and can be posterless — fixing it needs per-row source-group signalling and messier gating; left out deliberately.
- Metadata is **series-level** (AniList has no per-episode plots); the absolute episode number is stripped from the query, never sent as season/episode.
- Titles AniList has no record of (manga/light-novel scans, some donghua) stay posterless — expected, not a bug.

## Testing

`npm test` (3007 pass), `npm run typecheck` (0 errors), `npm run lint` (clean except the one pre-existing `App.tsx` warning), `npm run build` (green). New unit tests cover the normalizer, the AniList client, the resolver ordering, the allowlist, the web routing, and the web gating.

**Not yet done — reviewer please note:** interactive runtime verification (actually running `npm run dev -- serve --web` on the Anime tab, and the TUI Anime section) has not been performed. All fixtures use the invented cast (Kestrel/Ashfall/Harrowgate) per the house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
