### PR TITLE
feat: split watch history and reccd per Cloudflare Access login

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,26 @@ Once enforced, the **Settings** pane in both front ends shows **Cloudflare Acces
 the browser reports the status but, being a client of the config rather than an editor of it, never sees
 or sets the team domain or the AUD.
 
+#### Sharing the server with a friend
+
+With Access enforcing named users, you can hand a friend the URL without them landing in your watch list.
+Set `ownerEmail` to your own Access email — as env on the service, or in `config.json`:
+
+```sh
+TORLINK_OWNER_EMAIL=you@example.com
+```
+
+Then torlink partitions the personal lists by who signed in:
+
+- **You** (that email, and the terminal UI) keep the existing watch history, favourites, saved searches,
+  and recommendations — nothing moves.
+- **Anyone else** who signs in through Access gets their *own* private watch history, favourites, saved
+  searches, and their own anonymous reccd account, so their viewing never touches yours.
+
+Sources, tokens, and machine settings stay shared — this splits only the per-user lists. Like the Access
+settings above, `ownerEmail` is host-specific config: set it in the TUI/env, never from the browser. With
+no `ownerEmail` set, torlink behaves exactly as before — one shared set of lists for everyone.
+
 #### As containers
 
 `docker-compose.access.yml` brings up torlink **and** its Tunnel connector together. Build from this

--- a/docs/superpowers/plans/2026-08-12-per-profile-watch-and-reccd.md
+++ b/docs/superpowers/plans/2026-08-12-per-profile-watch-and-reccd.md
@@ -1,0 +1,989 @@
+# Per-profile watch history and reccd Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Partition watch history, favourites, saved searches, and reccd recommendations per authenticated Cloudflare Access login, so the server owner can share the server with a friend without their activity mixing.
+
+**Architecture:** Introduce a front-end-agnostic *profile* keyed by the verified Access email. The **owner** profile is the existing top-level storage (`config.favourites`/`savedSearches`/`reccToken` and `stream-history.json`) — unchanged. **Friend** profiles get namespaced storage (`config.profiles[id]` and `stream-history/<id>.json`). Which profile a web request uses is resolved from the email that `verifyAccessAssertion` already extracts and the server currently discards. The TUI and any non-Access request resolve to the owner profile via default parameters, so they are unaffected.
+
+**Tech Stack:** TypeScript, Node (`node:fs`, `node:crypto`), Vitest, Ink/React (TUI), plain DOM (web). reccd HTTP client already exists.
+
+## Global Constraints
+
+- **Fixtures name invented titles only** — reuse the cast `Kestrel`, `Ashfall`, `Tin.Rivers`, `Kepler`, `Harrowgate`; use invented emails (`owner@example.com`, `friend@example.com`). Never a real title.
+- **`src/web` must not import `src/ui`; `src/core` must not import `src/ui`/`src/web`.** Share by placing code in `src/core`/`src/util`/`src/config`.
+- **No `innerHTML`/`insertAdjacentHTML`/`outerHTML`/`document.write` in `src/web/static/`** (not touched by this plan, but do not introduce).
+- **Config writes are read-modify-write per request**: `loadConfig()` → change → `saveConfig()`. Never hold a snapshot across a write. All new setters return a fresh `Config`; callers save it immediately.
+- **`ownerEmail`, `profiles`, and per-profile reccd tokens are host/secret config → NOT web-writable.** Do not add them to `sanitiseSettingsPatch`. `ownerEmail` is resolved env-first (`TORLINK_OWNER_EMAIL`) then config, exactly like `cfAccessTeamDomain`.
+- **Fail soft**: with no `ownerEmail`, or no Access, every request resolves to the owner profile — today's single-user behaviour. The feature is a strict no-op until `ownerEmail` is set.
+- **Gate before done**: `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`. One known pre-existing lint warning in `src/ui/App.tsx` (`react-hooks/exhaustive-deps`) stays.
+- **Commit style**: Conventional Commits. Commit at the end of each task.
+
+---
+
+## File Structure
+
+- `src/core/profile.ts` — **new.** Pure profile-identity logic: `OWNER_PROFILE`, `slugForEmail`, `resolveProfileId`, `isOwnerProfile`. No I/O.
+- `src/core/profile.test.ts` — **new.** Unit tests for the above.
+- `src/config/paths.ts` — **modify.** Add `streamHistoryDir` and `reccProvisionLockFileForProfile`.
+- `src/config/config.ts` — **modify.** `ownerEmail` + `profiles` schema; `resolveOwnerEmail`; profile-aware `resolveReccConfig`; profile list accessors/setters; `loadConfig` validation.
+- `src/config/config.test.ts` (or the existing config test file) — **modify.** Cover the new helpers and validation.
+- `src/core/streamHistory.ts` — **modify.** `loadStreamHistory`/`saveStreamHistory`/`forgetStreamHistory` take an optional `profileId` (default owner); friend files live under `streamHistoryDir`.
+- `src/core/streamHistory.test.ts` — **modify.** Friend vs owner isolation.
+- `src/recc/provision.ts` — **modify.** `shouldProvision`/`ensureReccAccount` accept a `profileId`; friend accounts write to `profiles[id]` with a per-profile lock.
+- `src/recc/provision.test.ts` — **modify.** Friend provisioning writes to the profile.
+- `src/web/routes.ts` — **modify.** `handleWebApi` gains an `accessEmail` param, threaded to every handler that touches the four lists; each resolves `profileId` from its already-loaded config.
+- `src/web/routes.test.ts` — **modify.** Two emails get two independent lists; owner path unchanged.
+- `src/web/server.ts` — **modify.** Capture `verdict.email` and pass it to `handleWebApi`.
+- `README.md` — **modify.** "Sharing the server behind Cloudflare Access" section.
+
+---
+
+## Task 1: Profile identity module (`src/core/profile.ts`)
+
+**Files:**
+- Create: `src/core/profile.ts`
+- Test: `src/core/profile.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module; imports only `node:crypto`).
+- Produces:
+  - `export const OWNER_PROFILE = "owner"`
+  - `export function slugForEmail(email: string): string`
+  - `export function resolveProfileId(email: string | null | undefined, ownerEmail: string | undefined): string`
+  - `export function isOwnerProfile(profileId: string): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/core/profile.test.ts
+import { describe, expect, it } from "vitest";
+import { OWNER_PROFILE, isOwnerProfile, resolveProfileId, slugForEmail } from "./profile";
+
+describe("resolveProfileId", () => {
+  it("returns the owner profile when no email is present", () => {
+    expect(resolveProfileId(undefined, "owner@example.com")).toBe(OWNER_PROFILE);
+    expect(resolveProfileId(null, "owner@example.com")).toBe(OWNER_PROFILE);
+    expect(resolveProfileId("", "owner@example.com")).toBe(OWNER_PROFILE);
+  });
+
+  it("returns the owner profile when no owner email is configured (fail-soft)", () => {
+    expect(resolveProfileId("friend@example.com", undefined)).toBe(OWNER_PROFILE);
+  });
+
+  it("maps the owner's own email to the owner profile, case-insensitively", () => {
+    expect(resolveProfileId("Owner@Example.com", "owner@example.com")).toBe(OWNER_PROFILE);
+  });
+
+  it("maps a friend to a stable non-owner slug", () => {
+    const a = resolveProfileId("friend@example.com", "owner@example.com");
+    const b = resolveProfileId("friend@example.com", "owner@example.com");
+    expect(a).toBe(b);
+    expect(a).not.toBe(OWNER_PROFILE);
+    expect(isOwnerProfile(a)).toBe(false);
+  });
+
+  it("gives distinct, filesystem-safe slugs to distinct emails that differ only in a separator", () => {
+    const a = slugForEmail("a.b@example.com");
+    const b = slugForEmail("a_b@example.com");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[a-f0-9]+$/);
+    expect(b).toMatch(/^[a-f0-9]+$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/core/profile.test.ts`
+Expected: FAIL — cannot find module `./profile`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/core/profile.ts
+// Front-end-agnostic profile identity. A "profile" is the container for the four
+// per-user lists (watch history, favourites, saved searches, reccd account). Which
+// profile a web request uses is derived from the Cloudflare Access email; the TUI
+// and any non-Access request use the owner profile. Lives in src/core because both
+// front ends resolve it and eslint forbids src/web importing src/ui.
+import { createHash } from "node:crypto";
+
+/**
+ * The reserved id for the server owner — the existing top-level config fields and
+ * stream-history.json. Not a hex slug, so it can never collide with slugForEmail.
+ */
+export const OWNER_PROFILE = "owner";
+
+/**
+ * A stable, collision-free, filesystem-safe id for a friend's email. A hash rather
+ * than a sanitised string precisely so `a.b@x` and `a_b@x` cannot merge into one
+ * profile — a lossy strip of unsafe characters would let them. 128 bits is ample.
+ */
+export function slugForEmail(email: string): string {
+  const normalised = email.trim().toLowerCase();
+  return createHash("sha256").update(normalised).digest("hex").slice(0, 32);
+}
+
+/**
+ * The profile a request belongs to. Fails soft to the owner: no email, no configured
+ * owner, or the owner's own email all resolve to OWNER_PROFILE, so torlink behaves
+ * exactly as it does today until an owner email is set and a *different* user signs in.
+ */
+export function resolveProfileId(
+  email: string | null | undefined,
+  ownerEmail: string | undefined,
+): string {
+  const e = email?.trim().toLowerCase();
+  if (!e) return OWNER_PROFILE;
+  const owner = ownerEmail?.trim().toLowerCase();
+  if (!owner) return OWNER_PROFILE;
+  if (e === owner) return OWNER_PROFILE;
+  return slugForEmail(e);
+}
+
+export function isOwnerProfile(profileId: string): boolean {
+  return profileId === OWNER_PROFILE;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/core/profile.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/profile.ts src/core/profile.test.ts
+git commit -m "feat(core): profile identity resolution keyed by Access email"
+```
+
+---
+
+## Task 2: Config schema, owner resolution, and profile accessors
+
+**Files:**
+- Modify: `src/config/config.ts`
+- Test: `src/config/config.test.ts` (create if absent; otherwise add to the existing config test file — grep `resolveReccConfig` under `src/**/*.test.ts` to find it)
+
+**Interfaces:**
+- Consumes: `OWNER_PROFILE`, `isOwnerProfile` from `src/core/profile` (Task 1).
+- Produces:
+  - `export interface ProfileState { favourites?: FavouriteItem[]; savedSearches?: string[]; reccToken?: string; reccAccountName?: string; reccAccountClaimed?: boolean }`
+  - `Config.ownerEmail?: string`, `Config.profiles?: Record<string, ProfileState>`
+  - `export function resolveOwnerEmail(config: Config): string | undefined`
+  - `resolveReccConfig(config: Config, profileId?: string): ReccClientConfig` (new optional 2nd arg; default owner)
+  - `export function profileFavourites(config: Config, profileId: string): FavouriteItem[]`
+  - `export function withProfileFavourites(config: Config, profileId: string, favourites: FavouriteItem[]): Config`
+  - `export function profileSavedSearches(config: Config, profileId: string): string[]`
+  - `export function withProfileSavedSearches(config: Config, profileId: string, savedSearches: string[]): Config`
+  - `export function withProfileReccAccount(config: Config, profileId: string, patch: { reccToken: string; reccAccountName: string; reccAccountClaimed: boolean }): Config`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/config/config.test.ts  (add these; keep any existing tests in the file)
+import { describe, expect, it } from "vitest";
+import {
+  profileFavourites,
+  profileSavedSearches,
+  resolveOwnerEmail,
+  resolveReccConfig,
+  withProfileFavourites,
+  withProfileReccAccount,
+  withProfileSavedSearches,
+  type Config,
+} from "./config";
+import { OWNER_PROFILE, slugForEmail } from "../core/profile";
+
+const base: Config = { downloadDir: "/dl", trackers: [] };
+const FRIEND = slugForEmail("friend@example.com");
+
+describe("resolveOwnerEmail", () => {
+  it("prefers the env var, trimmed and lower-cased", () => {
+    process.env.TORLINK_OWNER_EMAIL = "  Owner@Example.com ";
+    try {
+      expect(resolveOwnerEmail({ ...base, ownerEmail: "other@example.com" })).toBe("owner@example.com");
+    } finally {
+      delete process.env.TORLINK_OWNER_EMAIL;
+    }
+  });
+  it("falls back to config, and undefined when unset", () => {
+    expect(resolveOwnerEmail({ ...base, ownerEmail: "owner@example.com" })).toBe("owner@example.com");
+    expect(resolveOwnerEmail(base)).toBeUndefined();
+  });
+});
+
+describe("profile list accessors", () => {
+  it("owner reads and writes the top-level fields", () => {
+    const cfg = withProfileFavourites(base, OWNER_PROFILE, [{ id: "x", name: "Kestrel", addedAt: 1 } as never]);
+    expect(cfg.favourites).toHaveLength(1);
+    expect(profileFavourites(cfg, OWNER_PROFILE)).toHaveLength(1);
+    expect(profileFavourites(cfg, FRIEND)).toEqual([]);
+  });
+  it("a friend reads and writes profiles[id], leaving the owner untouched", () => {
+    const cfg = withProfileSavedSearches(base, FRIEND, ["harrowgate"]);
+    expect(profileSavedSearches(cfg, FRIEND)).toEqual(["harrowgate"]);
+    expect(cfg.savedSearches ?? []).toEqual([]);
+    expect(profileSavedSearches(cfg, OWNER_PROFILE)).toEqual([]);
+  });
+});
+
+describe("resolveReccConfig per profile", () => {
+  it("owner uses the top-level token; a friend uses its own", () => {
+    const cfg = withProfileReccAccount(
+      { ...base, reccUrl: "https://reccd.stream", reccToken: "owner-tok" },
+      FRIEND,
+      { reccToken: "friend-tok", reccAccountName: "anon", reccAccountClaimed: false },
+    );
+    expect(resolveReccConfig(cfg).reccToken).toBe("owner-tok");
+    expect(resolveReccConfig(cfg, OWNER_PROFILE).reccToken).toBe("owner-tok");
+    expect(resolveReccConfig(cfg, FRIEND).reccToken).toBe("friend-tok");
+    expect(resolveReccConfig(cfg, FRIEND).reccUrl).toBe("https://reccd.stream");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/config/config.test.ts`
+Expected: FAIL — the new exports do not exist.
+
+- [ ] **Step 3: Add the schema**
+
+In the `Config` interface (near the reccd fields at `src/config/config.ts:40-57` and `favourites` at `:99`), add:
+
+```ts
+  // The Access email that owns this install. Its profile is the existing top-level
+  // fields and stream-history.json; every other authenticated email gets its own
+  // profile. Host/security config: env (TORLINK_OWNER_EMAIL) or config, never
+  // web-writable — mirrors cfAccessTeamDomain.
+  ownerEmail?: string;
+  // Per-friend state, keyed by slugForEmail(email). The OWNER never appears here —
+  // the owner is the top-level fields above. Absent until a second user signs in.
+  profiles?: Record<string, ProfileState>;
+```
+
+Above the `Config` interface, add the type (place it near `FavouriteItem`'s import/definition):
+
+```ts
+/** One friend's isolated lists. Mirrors the owner's top-level fields. */
+export interface ProfileState {
+  favourites?: FavouriteItem[];
+  savedSearches?: string[];
+  reccToken?: string;
+  reccAccountName?: string;
+  reccAccountClaimed?: boolean;
+}
+```
+
+- [ ] **Step 4: Add the helpers**
+
+Add an import at the top of `src/config/config.ts`:
+
+```ts
+import { OWNER_PROFILE, isOwnerProfile } from "../core/profile";
+```
+
+Add `resolveOwnerEmail` beside the other `resolve*` helpers (near `resolveCloudflareAccess`, `src/config/config.ts:413`):
+
+```ts
+const OWNER_EMAIL_ENV = "TORLINK_OWNER_EMAIL";
+
+/**
+ * The Access email that owns this install, normalised (trimmed + lower-cased), or
+ * undefined. env wins over config, matching every other resolve* helper. Undefined
+ * means "no owner set" — the whole feature then fails soft to single-user.
+ */
+export function resolveOwnerEmail(config: Config): string | undefined {
+  const v = process.env[OWNER_EMAIL_ENV]?.trim() || config.ownerEmail?.trim();
+  return v ? v.toLowerCase() : undefined;
+}
+```
+
+Replace `resolveReccConfig` (`src/config/config.ts:377-381`) with the profile-aware form:
+
+```ts
+export function resolveReccConfig(config: Config, profileId: string = OWNER_PROFILE): ReccClientConfig {
+  // reccUrl is shared infrastructure — every profile talks to the same reccd host.
+  const url = process.env[RECC_URL_ENV]?.trim() || config.reccUrl?.trim() || undefined;
+  if (isOwnerProfile(profileId)) {
+    const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
+    return { reccUrl: url, reccToken: token };
+  }
+  // A friend never inherits the env/owner token — isolation is the whole point.
+  const token = config.profiles?.[profileId]?.reccToken?.trim() || undefined;
+  return { reccUrl: url, reccToken: token };
+}
+```
+
+Add the list accessors/setters near the bottom of the file (after `loadConfig`):
+
+```ts
+export function profileFavourites(config: Config, profileId: string): FavouriteItem[] {
+  if (isOwnerProfile(profileId)) return config.favourites ?? [];
+  return config.profiles?.[profileId]?.favourites ?? [];
+}
+
+export function withProfileFavourites(config: Config, profileId: string, favourites: FavouriteItem[]): Config {
+  if (isOwnerProfile(profileId)) return { ...config, favourites };
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, favourites } } };
+}
+
+export function profileSavedSearches(config: Config, profileId: string): string[] {
+  if (isOwnerProfile(profileId)) return config.savedSearches ?? [];
+  return config.profiles?.[profileId]?.savedSearches ?? [];
+}
+
+export function withProfileSavedSearches(config: Config, profileId: string, savedSearches: string[]): Config {
+  if (isOwnerProfile(profileId)) return { ...config, savedSearches };
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, savedSearches } } };
+}
+
+export function withProfileReccAccount(
+  config: Config,
+  profileId: string,
+  patch: { reccToken: string; reccAccountName: string; reccAccountClaimed: boolean },
+): Config {
+  if (isOwnerProfile(profileId)) {
+    return { ...config, reccUrl: DEFAULT_RECC_URL, ...patch };
+  }
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, ...patch } } };
+}
+```
+
+> `DEFAULT_RECC_URL` is exported from `src/recc/provision.ts`. If importing it into `config.ts` creates a cycle (config → recc → config), inline the string literal `"https://reccd.stream"` here with a comment pointing at `provision.ts` as the canonical copy, OR set only the token fields for the owner and leave `reccUrl` to the caller. Prefer setting the token fields only: `return { ...config, ...patch }` for the owner — the owner's `reccUrl` is already set by the time provisioning runs.
+
+Use the simpler owner branch to avoid the cycle:
+
+```ts
+  if (isOwnerProfile(profileId)) {
+    return { ...config, ...patch };
+  }
+```
+
+- [ ] **Step 5: Validate the new fields in `loadConfig`**
+
+Inside `loadConfig` (after the `favourites` block, `src/config/config.ts:478`), add:
+
+```ts
+    cfg.ownerEmail =
+      typeof parsed.ownerEmail === "string" && parsed.ownerEmail.trim().length > 0
+        ? parsed.ownerEmail.trim()
+        : undefined;
+    cfg.profiles = sanitiseProfiles(parsed.profiles);
+```
+
+Add the helper (near `isFavouriteItem`):
+
+```ts
+function sanitiseProfiles(input: unknown): Record<string, ProfileState> | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const out: Record<string, ProfileState> = {};
+  for (const [id, raw] of Object.entries(input as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const state: ProfileState = {};
+    if (Array.isArray(r.favourites)) {
+      state.favourites = r.favourites
+        .filter(isFavouriteItem)
+        .map((f) => ({ ...f, addedAt: typeof f.addedAt === "number" ? f.addedAt : 0 }))
+        .slice(0, 100);
+    }
+    if (Array.isArray(r.savedSearches)) {
+      state.savedSearches = r.savedSearches
+        .filter((q): q is string => typeof q === "string" && q.trim().length > 0)
+        .slice(0, 50);
+    }
+    if (typeof r.reccToken === "string" && r.reccToken.trim()) state.reccToken = r.reccToken;
+    if (typeof r.reccAccountName === "string") state.reccAccountName = r.reccAccountName;
+    if (typeof r.reccAccountClaimed === "boolean") state.reccAccountClaimed = r.reccAccountClaimed;
+    out[id] = state;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run src/config/config.test.ts && npx tsc --noEmit`
+Expected: PASS and no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/config/config.ts src/config/config.test.ts
+git commit -m "feat(config): ownerEmail, per-profile state, and profile-aware reccd config"
+```
+
+---
+
+## Task 3: Per-profile watch history (`src/core/streamHistory.ts`)
+
+**Files:**
+- Modify: `src/config/paths.ts`, `src/core/streamHistory.ts`
+- Test: `src/core/streamHistory.test.ts`
+
+**Interfaces:**
+- Consumes: `OWNER_PROFILE`, `isOwnerProfile` (Task 1); `streamHistoryDir` (added here).
+- Produces (signatures change — new optional trailing arg, default owner, so existing callers are unaffected):
+  - `loadStreamHistory(profileId?: string): Promise<StreamHistoryItem[]>`
+  - `saveStreamHistory(items: readonly StreamHistoryItem[], profileId?: string): Promise<void>`
+  - `forgetStreamHistory(key: string, profileId?: string, deps?): Promise<StreamHistoryItem[]>`
+
+- [ ] **Step 1: Add the directory path**
+
+In `src/config/paths.ts`, after `streamHistoryFile` (`:34`):
+
+```ts
+// Per-friend stream history. The OWNER keeps streamHistoryFile above unchanged; a
+// friend's history is <dataDir>/stream-history/<profileId>.json. A directory, not a
+// suffix on the same file, so listing/clearing one friend never risks the others.
+export const streamHistoryDir = path.join(dataDir, "stream-history");
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// src/core/streamHistory.test.ts  (add; keep existing tests)
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { slugForEmail } from "./profile";
+
+describe("stream history is isolated per profile", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-sh-"));
+    process.env.TORLINK_STATE_DIR = dir;
+    vi.resetModules(); // paths.ts reads TORLINK_STATE_DIR at import time
+  });
+  afterEach(async () => {
+    delete process.env.TORLINK_STATE_DIR;
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps a friend's history in a separate file from the owner's", async () => {
+    const { loadStreamHistory, saveStreamHistory } = await import("./streamHistory");
+    const friend = slugForEmail("friend@example.com");
+    const item = (key: string) => ({
+      key, title: key, rawName: `${key}.1080p`, infoHash: key, magnet: "magnet:", startedAt: 1,
+    });
+    await saveStreamHistory([item("Kestrel")]); // owner (default)
+    await saveStreamHistory([item("Harrowgate")], friend);
+
+    expect((await loadStreamHistory()).map((e) => e.key)).toEqual(["Kestrel"]);
+    expect((await loadStreamHistory(friend)).map((e) => e.key)).toEqual(["Harrowgate"]);
+  });
+});
+```
+
+> Add `import { vi } from "vitest";` if not already imported in the file.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/core/streamHistory.test.ts`
+Expected: FAIL — `saveStreamHistory` ignores the second argument / writes one file.
+
+- [ ] **Step 4: Make the module profile-aware**
+
+In `src/core/streamHistory.ts`:
+
+Add imports:
+
+```ts
+import path from "node:path";
+import { streamHistoryFile, streamHistoryDir } from "../config/paths";
+import { OWNER_PROFILE, isOwnerProfile } from "./profile";
+```
+
+(replace the existing `import { streamHistoryFile } from "../config/paths";`)
+
+Add a path resolver:
+
+```ts
+function fileFor(profileId: string): string {
+  return isOwnerProfile(profileId) ? streamHistoryFile : path.join(streamHistoryDir, `${profileId}.json`);
+}
+```
+
+Change the three functions:
+
+```ts
+export function saveStreamHistory(
+  items: readonly StreamHistoryItem[],
+  profileId: string = OWNER_PROFILE,
+): Promise<void> {
+  const file = fileFor(profileId);
+  return write(async () => {
+    if (!isOwnerProfile(profileId)) await fs.mkdir(streamHistoryDir, { recursive: true }).catch(() => {});
+    await writeJsonAtomic(file, items.slice(0, STREAM_HISTORY_CAP));
+  });
+}
+
+export async function loadStreamHistory(profileId: string = OWNER_PROFILE): Promise<StreamHistoryItem[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(fileFor(profileId), "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isStreamHistoryItem).slice(0, STREAM_HISTORY_CAP);
+  } catch {
+    return [];
+  }
+}
+
+export async function forgetStreamHistory(
+  key: string,
+  profileId: string = OWNER_PROFILE,
+  deps: {
+    load?: () => Promise<StreamHistoryItem[]>;
+    save?: (items: readonly StreamHistoryItem[]) => Promise<void>;
+  } = {},
+): Promise<StreamHistoryItem[]> {
+  const next = removeStreamHistory(await (deps.load ?? (() => loadStreamHistory(profileId)))(), key);
+  await (deps.save ?? ((items) => saveStreamHistory(items, profileId)))(next);
+  return next;
+}
+```
+
+> Note: existing callers (`forgetStreamHistory(key)` and `forgetStreamHistory(key, { load, save })`) — the TUI at `src/ui/App.tsx:2148` calls `forgetStreamHistory(key)`. That still resolves to the owner and still works. Any caller that passed a deps object as the 2nd arg must move it to the 3rd. Grep `forgetStreamHistory(` across `src/` and fix any call that passed deps positionally.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run src/core/streamHistory.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors. If `tsc` flags a `forgetStreamHistory` caller, fix per the note above and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/paths.ts src/core/streamHistory.ts src/core/streamHistory.test.ts
+git commit -m "feat(core): per-profile stream history files (owner keeps legacy path)"
+```
+
+---
+
+## Task 4: Per-profile reccd provisioning (`src/recc/provision.ts`)
+
+**Files:**
+- Modify: `src/config/paths.ts`, `src/recc/provision.ts`
+- Test: `src/recc/provision.test.ts`
+
+**Interfaces:**
+- Consumes: `OWNER_PROFILE`, `isOwnerProfile` (Task 1); `withProfileReccAccount`, `resolveReccConfig` (Task 2); `reccProvisionLockFileForProfile` (added here).
+- Produces:
+  - `shouldProvision(config: Config, profileId?: string): boolean`
+  - `ensureReccAccount(opts?: EnsureReccAccountOptions & { profileId?: string }): Promise<void>`
+
+- [ ] **Step 1: Add the per-profile lock path**
+
+In `src/config/paths.ts`, after `reccProvisionLockFile` (`:24`):
+
+```ts
+// A friend's provisioning lock, one per profile so two friends signing up at once
+// don't block each other. The owner keeps reccProvisionLockFile above.
+export function reccProvisionLockFileForProfile(profileId: string): string {
+  return path.join(configDir, `recc-provision.${profileId}.lock`);
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// src/recc/provision.test.ts  (add; keep existing tests)
+import { describe, expect, it, vi } from "vitest";
+import { ensureReccAccount, shouldProvision } from "./provision";
+import { slugForEmail } from "../core/profile";
+import type { Config } from "../config/config";
+
+const FRIEND = slugForEmail("friend@example.com");
+const base: Config = { downloadDir: "/dl", trackers: [] };
+
+describe("per-profile provisioning", () => {
+  it("shouldProvision looks at the friend's own token, not the owner's", () => {
+    const ownerHasToken: Config = { ...base, reccToken: "owner-tok" };
+    // Owner already provisioned, but the friend has nothing → the friend still needs one.
+    expect(shouldProvision(ownerHasToken, FRIEND)).toBe(true);
+    const friendHasToken: Config = { ...ownerHasToken, profiles: { [FRIEND]: { reccToken: "f" } } };
+    expect(shouldProvision(friendHasToken, FRIEND)).toBe(false);
+  });
+
+  it("writes the new account into profiles[id], leaving the owner untouched", async () => {
+    let saved: Config | undefined;
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "anon-123", token: "friend-tok" }),
+    });
+    await ensureReccAccount({
+      profileId: FRIEND,
+      fetchImpl: fetchImpl as never,
+      lockFile: `/tmp/torlink-test-${FRIEND}.lock`,
+      loadConfigImpl: async () => ({ ...base }),
+      saveConfigImpl: async (c) => { saved = c; },
+    });
+    expect(saved?.profiles?.[FRIEND]?.reccToken).toBe("friend-tok");
+    expect(saved?.reccToken).toBeUndefined(); // owner untouched
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/recc/provision.test.ts`
+Expected: FAIL — `shouldProvision`/`ensureReccAccount` take no `profileId`.
+
+- [ ] **Step 4: Parameterise provisioning by profile**
+
+In `src/recc/provision.ts`:
+
+Add imports:
+
+```ts
+import { OWNER_PROFILE, isOwnerProfile } from "../core/profile";
+import { resolveReccConfig, withProfileReccAccount } from "../config/config";
+import { reccProvisionLockFileForProfile } from "../config/paths";
+```
+
+(extend the existing config/paths imports rather than duplicating).
+
+Change `shouldProvision` to take a profile and check the *profile's* token via `resolveReccConfig`:
+
+```ts
+export function shouldProvision(config: Config, profileId: string = OWNER_PROFILE): boolean {
+  const auto = config.reccAutoSignup;
+  if (auto !== undefined && auto !== true) return false;
+  const { reccUrl, reccToken } = resolveReccConfig(config, profileId);
+  if (reccToken) return false;
+  if (reccUrl && normaliseUrl(reccUrl) !== DEFAULT_RECC_URL) return false;
+  return true;
+}
+```
+
+Add `profileId` to `EnsureReccAccountOptions`:
+
+```ts
+  /** Which profile to provision. Defaults to the owner (top-level fields). */
+  profileId?: string;
+```
+
+In `ensureReccAccount`, resolve the profile, its lock, and route the write through `withProfileReccAccount`:
+
+```ts
+export async function ensureReccAccount(opts: EnsureReccAccountOptions = {}): Promise<void> {
+  const profileId = opts.profileId ?? OWNER_PROFILE;
+  const load = opts.loadConfigImpl ?? loadConfig;
+  const save = opts.saveConfigImpl ?? saveConfig;
+  const lockFile = opts.lockFile
+    ?? (isOwnerProfile(profileId) ? reccProvisionLockFile : reccProvisionLockFileForProfile(profileId));
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
+
+  try {
+    if (!shouldProvision(await load(), profileId)) return;
+    if (!(await takeLock(lockFile))) {
+      log.debug("recc provision: another process holds the lock, skipping");
+      return;
+    }
+    try {
+      const res = await fetchImpl(`${DEFAULT_RECC_URL}/signup/anonymous`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+        signal: AbortSignal.timeout(opts.timeoutMs ?? 8000),
+      });
+      if (!res.ok) { log.debug(`recc provision: signup returned ${res.status}`); return; }
+      const body: unknown = await res.json();
+      if (!isAnonSignupBody(body)) { log.debug("recc provision: unexpected signup response shape"); return; }
+
+      const fresh = await load();
+      if (!shouldProvision(fresh, profileId)) {
+        log.debug("recc provision: config changed under us, discarding the new account");
+        return;
+      }
+      const patch: ProvisionedPatch = {
+        reccUrl: DEFAULT_RECC_URL,
+        reccToken: body.token,
+        reccAccountName: body.name,
+        reccAccountClaimed: false,
+      };
+      await save(withProfileReccAccount(fresh, profileId, {
+        reccToken: patch.reccToken,
+        reccAccountName: patch.reccAccountName,
+        reccAccountClaimed: patch.reccAccountClaimed,
+      }));
+      opts.onProvisioned?.(patch);
+      log.debug(`recc provision: created anonymous account ${body.name} for profile ${profileId}`);
+    } finally {
+      await fs.unlink(lockFile).catch(() => {});
+    }
+  } catch (err) {
+    log.debug(`recc provision: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+```
+
+> The owner path is unchanged: `withProfileReccAccount(fresh, OWNER_PROFILE, …)` spreads the same fields onto the top level that the old `{ ...fresh, ...patch }` did (minus `reccUrl`, which the owner already has by the time provisioning succeeds; if any existing owner test asserts `reccUrl` is written, keep `reccUrl: DEFAULT_RECC_URL` in the owner branch of `withProfileReccAccount`). Run the existing provision tests and honour whatever they assert.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run src/recc/provision.test.ts && npx tsc --noEmit`
+Expected: PASS. If a pre-existing owner test fails on `reccUrl`, adjust the owner branch of `withProfileReccAccount` (Task 2) to also set `reccUrl: DEFAULT_RECC_URL` — but resolve the import cycle by inlining the literal with a comment, as noted in Task 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/paths.ts src/recc/provision.ts src/recc/provision.test.ts
+git commit -m "feat(recc): provision an isolated anonymous account per friend profile"
+```
+
+---
+
+## Task 5: Thread identity through the web (`src/web/routes.ts` + `src/web/server.ts`)
+
+This is the widest task. `handleWebApi` gains an `accessEmail` parameter; every handler that touches the four lists resolves `profileId` from its own already-loaded config and uses the profile-aware accessors.
+
+**Files:**
+- Modify: `src/web/routes.ts`, `src/web/server.ts`
+- Test: `src/web/routes.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveProfileId` (Task 1); `resolveOwnerEmail`, `profileFavourites`, `withProfileFavourites`, `profileSavedSearches`, `withProfileSavedSearches`, `resolveReccConfig(config, profileId)` (Task 2); `loadStreamHistory`/`saveStreamHistory`/`forgetStreamHistory` with `profileId` (Task 3); `ensureReccAccount({ profileId })` (Task 4).
+- Produces: `handleWebApi(deps, method, urlPath, query, authHeader, bodyText, accessEmail?: string)`.
+
+**The call sites to convert** (from `rg -n "resolveReccConfig|loadStreamHistory|saveStreamHistory|forgetStreamHistory|config\.favourites|config\.savedSearches|profileFavourites" src/web/routes.ts` — re-run this grep to get current line numbers, then convert each):
+- `recordStreamStart` (`~525`): `loadStreamHistory` / `saveStreamHistory` / `resolveReccConfig` for the `started` event.
+- `/api/sources` capability payload (`~815`): `resolveReccConfig(config).reccUrl` — **leave as owner** (this reports whether reccd is configured at all; capability, not per-user). Do NOT thread here.
+- favourites GET/POST + `favourited`/`unfavourited` reccd events (`~1205`).
+- saved-searches GET/POST.
+- recommendations fetch (`fetchRecommendations`), title suggestions (`fetchTitleSuggestions`).
+- watch-history list endpoint (`loadStreamHistory`) and forget endpoint (`forgetStreamHistory`).
+- generic rate event `/api/recc/event` (`~1869`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/web/routes.test.ts  (add; keep existing tests)
+import { describe, expect, it } from "vitest";
+import { handleWebApi } from "./routes";
+import { slugForEmail } from "../core/profile";
+// Reuse the file's existing WebDeps test factory. If none exists, build a minimal
+// deps object with in-memory loadConfigImpl/saveConfigImpl and stream-history impls,
+// following the pattern already used by the other tests in this file.
+
+describe("web favourites are isolated per Access email", () => {
+  it("a friend's favourite does not appear in the owner's list", async () => {
+    let config = { downloadDir: "/dl", trackers: [], ownerEmail: "owner@example.com" } as never;
+    const deps = makeTestDeps({
+      loadConfigImpl: async () => config,
+      saveConfigImpl: async (c: never) => { config = c; },
+    });
+
+    // Friend adds a favourite (exact route/body per this file's favourites endpoint).
+    await handleWebApi(deps, "POST", "/api/favourites", new URLSearchParams(), undefined,
+      JSON.stringify({ /* favourite payload used elsewhere in this test file */ }),
+      "friend@example.com");
+
+    // Owner reads favourites → empty; friend reads → one.
+    const ownerList = await handleWebApi(deps, "GET", "/api/favourites", new URLSearchParams(), undefined, "", "owner@example.com");
+    const friendList = await handleWebApi(deps, "GET", "/api/favourites", new URLSearchParams(), undefined, "", "friend@example.com");
+    expect(JSON.stringify(ownerList)).not.toContain(slugForEmail("friend@example.com"));
+    // Assert the owner payload has zero favourites and the friend payload has one,
+    // reading the shape the favourites GET handler actually returns.
+  });
+});
+```
+
+> Adapt the assertions to the favourites endpoint's real request/response shape (read the handler first). The point the test must prove: with `ownerEmail` set, a write as `friend@example.com` lands in `config.profiles[slug]` and is invisible to a read as `owner@example.com`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/web/routes.test.ts`
+Expected: FAIL — `handleWebApi` ignores the 7th argument; the friend's favourite lands in the shared list.
+
+- [ ] **Step 3: Add the parameter and resolve profileId per handler**
+
+In `handleWebApi` (`src/web/routes.ts:2114`), add the trailing parameter:
+
+```ts
+export async function handleWebApi(
+  deps: WebDeps,
+  method: string,
+  urlPath: string,
+  query: URLSearchParams,
+  authHeader: string | undefined,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
+```
+
+For **each** converted handler, right after it loads config, resolve the profile and use it. The pattern:
+
+```ts
+const config = await (deps.loadConfigImpl ?? loadConfig)();
+const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+```
+
+Then substitute:
+- `resolveReccConfig(config)` → `resolveReccConfig(config, profileId)`
+- `loadStreamHistory()` → `loadStreamHistory(profileId)`; `saveStreamHistory(x)` → `saveStreamHistory(x, profileId)`; `forgetStreamHistory(key)` → `forgetStreamHistory(key, profileId)`
+- reads of `config.favourites` → `profileFavourites(config, profileId)`; writes that build a new config with favourites → `withProfileFavourites(config, profileId, next)` before `saveConfig`
+- `config.savedSearches` → `profileSavedSearches` / `withProfileSavedSearches` likewise
+
+`recordStreamStart` takes the email through and provisions a friend's reccd account lazily. Change its signature to accept `accessEmail` and add, before sending the `started` event:
+
+```ts
+const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+// A friend's first stream provisions their own reccd account so their taste never
+// mixes with the owner's. Fire-and-forget, same rule as the event send below.
+if (!isOwnerProfile(profileId) && !resolveReccConfig(config, profileId).reccToken) {
+  void ensureReccAccount({ profileId }).catch(() => {});
+}
+const reccConfig = resolveReccConfig(config, profileId);
+```
+
+Add the imports at the top of `routes.ts`:
+
+```ts
+import { resolveProfileId, isOwnerProfile } from "../core/profile";
+import {
+  resolveOwnerEmail, profileFavourites, withProfileFavourites,
+  profileSavedSearches, withProfileSavedSearches,
+} from "../config/config";
+import { ensureReccAccount } from "../recc/provision";
+```
+
+(merge with existing imports from those modules).
+
+Thread `accessEmail` from `handleWebApi` into `recordStreamStart` and any other converted helper that currently receives `deps` but not the email.
+
+- [ ] **Step 4: Pass the verified email from the server**
+
+In `src/web/server.ts`, capture the email at the Access check (`:521-536`) and pass it to the router (`:611`):
+
+```ts
+      let accessEmail: string | undefined;
+      if (accessCfg) {
+        const exempt = urlPath === "/health" || isStreamPath(urlPath) || isPlayPath(urlPath);
+        if (!exempt) {
+          const assertion = accessTokenFromHeaders(req.headers);
+          const verdict = await verifyAccessAssertion(assertion, accessKeySet!, accessCfg);
+          if (!verdict.ok) {
+            writeJson(res, 403, { error: "forbidden" });
+            log(`${method} ${urlPath} -> 403 (access: ${verdict.reason})`);
+            return;
+          }
+          accessEmail = verdict.email;
+        }
+      }
+```
+
+And at the `handleWebApi(...)` call (`:611`), add `accessEmail` as the final argument:
+
+```ts
+          out = await handleWebApi(
+            routeDeps,
+            method === "HEAD" ? "GET" : method,
+            urlPath,
+            url.searchParams,
+            req.headers.authorization,
+            body.text,
+            accessEmail,
+          );
+```
+
+- [ ] **Step 5: Run tests + full gate**
+
+Run: `npx vitest run src/web/routes.test.ts && npm test && npm run typecheck && npm run lint && npm run build`
+Expected: PASS. `npm run build` also confirms `src/web/static/` still imports no `node:*`.
+
+- [ ] **Step 6: Manual smoke (wiring is only verified by running it)**
+
+Run: `npm run dev -- serve --web`, then with `ownerEmail` set in config, send two requests with different `Cf-Access-Jwt-Assertion`-derived emails (or temporarily hardcode `accessEmail` in a dev build) and confirm favourites/watch-history diverge. Revert any temporary hack.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/web/routes.ts src/web/server.ts src/web/routes.test.ts
+git commit -m "feat(web): partition watch history, favourites, saved searches, and reccd per Access login"
+```
+
+---
+
+## Task 6: Confirm the TUI is owner-only (parity check) + docs
+
+The TUI needs no functional change: every profile-aware function defaults to `OWNER_PROFILE`, and the TUI passes no profile, so it operates on the owner's existing storage. This task proves that with a test and documents the feature.
+
+**Files:**
+- Test: `src/core/streamHistory.test.ts` (add one assertion) — or a small `src/config/config.test.ts` assertion.
+- Modify: `README.md`.
+
+- [ ] **Step 1: Add a regression test that the default is the owner**
+
+```ts
+// Add to src/config/config.test.ts
+import { OWNER_PROFILE } from "../core/profile";
+it("resolveReccConfig with no profile is identical to the owner profile", () => {
+  const cfg = { downloadDir: "/dl", trackers: [], reccToken: "owner-tok" } as Config;
+  expect(resolveReccConfig(cfg)).toEqual(resolveReccConfig(cfg, OWNER_PROFILE));
+});
+```
+
+Run: `npx vitest run src/config/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 2: Document the feature in `README.md`**
+
+Add a short section (place near any existing Cloudflare Access / `serve --web` docs):
+
+```markdown
+### Sharing the server behind Cloudflare Access
+
+When torlink runs behind Cloudflare Access with named users, set `ownerEmail` (in
+`config.json`, or the `TORLINK_OWNER_EMAIL` env var) to your own Access email. Then:
+
+- **You** (that email, and the terminal UI) keep the existing watch history,
+  favourites, saved searches, and recommendations.
+- **Anyone else** who signs in through Access gets their own private watch history,
+  favourites, saved searches, and their own anonymous reccd account — so their viewing
+  never touches yours.
+
+Sources, tokens, and machine settings stay shared. With no `ownerEmail` set, torlink
+behaves exactly as before (single shared state).
+```
+
+- [ ] **Step 3: Full gate**
+
+Run: `npm test && npm run typecheck && npm run lint && npm run build`
+Expected: PASS (the one pre-existing `App.tsx` exhaustive-deps warning aside).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md src/config/config.test.ts
+git commit -m "docs: document per-login isolation behind Cloudflare Access"
+```
+
+---
+
+## PR notes
+
+State explicitly in the PR body: **reading identity from Cloudflare Access headers is deliberately web-only** — Access headers exist only on the web transport and the TUI has no remote users, so the TUI always operates as the owner. This is the documented "a surface can't express it / host-specific" exception to the both-front-ends rule. The profile concept and all four profile-scoped accessors live in `src/core`/`src/config` and are driven by both surfaces (the TUI via owner defaults).
+
+Base the PR against `origin`/`WarlaxZ/torlink` (`gh pr create --repo WarlaxZ/torlink --base main`); never `forked-from`. Push as the `WarlaxZ` gh user.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** profiles keyed by email (Task 1) ✓; owner explicit via `ownerEmail`/env (Task 2) ✓; reccd auto-provision per profile (Task 4 + lazy trigger in Task 5) ✓; owner-keeps-legacy storage / no migration (Tasks 2–3) ✓; four lists partitioned — watch history (Task 3), favourites + saved searches (Task 2 accessors, wired Task 5), reccd (Tasks 2/4/5) ✓; fail-soft to owner (Task 1 + defaults) ✓; web-only identity, TUI owner (Task 6 + PR note) ✓; tests + fixtures rule (each task) ✓; docs (Task 6) ✓.
+- **Placeholder scan:** the one soft spot is Task 5 Step 1's test body, which references "the favourites payload used elsewhere in this file" — this is deliberate (the implementer must read the real endpoint shape first) and the *behaviour* to prove is stated exactly. No `TODO`/`TBD` remain.
+- **Type consistency:** `resolveProfileId(email, ownerEmail)`, `resolveReccConfig(config, profileId)`, `profileFavourites/withProfileFavourites`, `saveStreamHistory(items, profileId)`, `ensureReccAccount({ profileId })`, `handleWebApi(..., accessEmail)` are used with the same signatures across tasks. `OWNER_PROFILE`/`isOwnerProfile` come from `src/core/profile` everywhere.
+- **Import-cycle watch:** `config.ts` importing `DEFAULT_RECC_URL` from `provision.ts` would cycle (provision imports config). Task 2 avoids it (owner branch spreads only the token patch); if `reccUrl` must be written, inline the literal. Flagged in Tasks 2 and 4.

--- a/docs/superpowers/specs/2026-08-12-per-profile-watch-and-reccd-design.md
+++ b/docs/superpowers/specs/2026-08-12-per-profile-watch-and-reccd-design.md
@@ -1,0 +1,181 @@
+# Per-profile watch history and reccd (split by Cloudflare Access login)
+
+**Date:** 2026-08-12
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+torlink runs behind Cloudflare Access (Zero Trust) with named users, so the owner
+can share the server with a friend. Today all "personal" state is a single global
+blob per install, so the friend's activity contaminates the owner's:
+
+- Watch history / "Continue Watching"
+- Favourites
+- Saved searches
+- reccd recommendations (one shared account learns from everyone's watches)
+
+The goal is to **partition these four lists by the authenticated login**, while
+leaving all shared/host-specific configuration untouched.
+
+## What stays shared (explicitly out of scope)
+
+Sources, debrid tokens, OMDb key, custom DNS, extra trackers, VPN interface, cast
+device/host, download folder, and all playback/transfer settings remain a single
+shared config. Only the four personal lists fork per user.
+
+## Key existing facts (verified in the codebase)
+
+- **Watch history**: `<dataDir>/stream-history.json` — flat array, cap 200
+  (`STREAM_HISTORY_CAP`), path at `src/config/paths.ts`. Model in
+  `src/core/streamHistory.ts` (`loadStreamHistory`, `saveStreamHistory`,
+  `forgetStreamHistory` — the last re-reads before writing because the TUI and
+  `serve --web` are separate processes sharing the file). Written by the web at
+  `src/web/routes.ts:530` and by the TUI (`src/ui/App.tsx`). Dedupe key derived in
+  `src/util/streamHistoryKey.ts` (kept in `util` so the browser bundle avoids `node:fs`).
+- **Favourites / saved searches**: top-level `config.json` fields
+  `favourites?: FavouriteItem[]` and `savedSearches?: string[]`
+  (`src/config/config.ts:96,99`). List helpers in `src/util/favouriteList.ts` and
+  `src/util/savedSearchList.ts`.
+- **reccd**: single anonymous account per install. Client `src/recc/client.ts`
+  (`postEvent`, `fetchRecommendations`, `fetchTitleSuggestions`, `claimReccAccount`)
+  all take a `ReccClientConfig { reccUrl?, reccToken? }`. Config resolved by
+  `resolveReccConfig` (`src/config/config.ts`) from env or the top-level `reccToken`
+  / `reccAccountName` / `reccAccountClaimed` / `reccAutoSignup` fields. Anonymous
+  auto-signup in `src/recc/provision.ts` (`ensureReccAccount`,
+  `DEFAULT_RECC_URL = "https://reccd.stream"`). **Event payloads carry no identity** —
+  only release name, timestamp, and the literal `"torlink"` as source. Isolation is
+  therefore entirely a function of *which token* the call uses.
+- **Identity**: Cloudflare Access is already verified per request in
+  `src/web/server.ts:521-536`. `verifyAccessAssertion` (`src/core/cloudflareAccess.ts`)
+  already extracts `email` and `sub` from the JWT, but the server only checks
+  `verdict.ok` and **discards the email** (`server.ts:529`). No per-user identity is
+  used anywhere today. This discarded email is the hook.
+
+## Design
+
+### Concept: a "profile"
+
+A **profile** is the container for the four personal lists. Which profile a request
+uses is resolved from the verified Access email:
+
+- **Web request through Access** → profile = the caller's email, slugified to a
+  stable, filesystem-safe `profileId`.
+- **The TUI, and any non-Access request** → the **owner** profile.
+
+### Owner identity (decision: explicit)
+
+A new `ownerEmail` config field designates which Access email is "you". Settable via
+the TUI settings and via `TORLINK_OWNER_EMAIL` env. The owner profile inherits the
+existing global lists on migration, and the TUI always maps to it.
+
+### reccd per profile (decision: auto-provision)
+
+`resolveReccConfig` becomes profile-aware and returns the profile's own `reccToken`.
+When a web request's profile has no token yet and `reccAutoSignup` is on,
+`ensureReccAccount` runs an anonymous signup against `reccd.stream` and writes the new
+token into `profiles[id]` (read-modify-write). All reccd calls already flow through a
+`ReccClientConfig`, so the only change is *which* config they receive. Account
+*claiming* (name + password) stays owner/TUI-only; friends get an anonymous account,
+which is sufficient for isolated recommendations.
+
+### Data model
+
+`config.json` gains:
+
+```ts
+ownerEmail?: string;                 // which Access email is the owner
+profiles?: {
+  [profileId: string]: {
+    favourites?: FavouriteItem[];
+    savedSearches?: string[];
+    reccToken?: string;              // this profile's own reccd account
+    reccAccountName?: string;
+    reccAccountClaimed?: boolean;
+  };
+};
+```
+
+Favourites, saved searches, and the reccd token move *into* the profile map. Keeping
+them in `config.json` preserves the existing read-modify-write discipline and the
+`sanitiseSettingsPatch` validation path. Watch history stays a separate per-profile
+file — `stream-history/<profileId>.json` — retaining the reasons it is separate today
+(the 200 cap and the cross-process re-read-before-write).
+
+### Identity resolution module
+
+New front-end-agnostic `src/core/profile.ts`:
+
+- `resolveProfileId(email: string | null, config): string` — email present and not
+  the owner → `slug(email)`; otherwise → the owner profile id.
+- `slug(email)` — lowercase and reduce to a stable, filesystem-safe id. Must be
+  **collision-free**: two distinct emails must never map to the same id (e.g. a hash
+  of the normalised email, or percent-style encoding — not a lossy strip of unsafe
+  characters, which could merge `a.b@x` and `a_b@x`).
+- Owner profile id derived from `ownerEmail` (or a reserved constant when unset).
+
+This lives in `core` so **both** front ends use it: the web passes the caller's email,
+the TUI passes the owner. Pure and fully unit-tested.
+
+### Wiring
+
+- **Web** (`src/web/`): capture the verified `email` at `server.ts:521-536` into a
+  small per-request context, resolve `profileId` once, and thread it to every route
+  that touches the four lists — watch history record/read/forget (`routes.ts:530`),
+  favourites (`routes.ts:1205`), reccd events (`routes.ts:539`, `routes.ts:1869`),
+  recommendations, and saved searches. Routes stay thin; decisions live in
+  `src/core/profile.ts` and the profile-scoped accessors.
+- **TUI** (`src/ui/`): resolve the owner profile at startup and pass that id to the
+  same core accessors. No new keybinding or pane — the TUI shows the owner's lists,
+  which is what the owner wants.
+
+### Migration
+
+One-time, in `loadConfig`, guarded and idempotent so concurrent TUI / `serve --web` /
+worktree processes cannot double-migrate: if `profiles` is absent, create
+`profiles[ownerId]` from the existing top-level `favourites` / `savedSearches` /
+`reccToken` / `reccAccountName` / `reccAccountClaimed`, and move
+`stream-history.json` → `stream-history/<ownerId>.json`. The owner loses nothing.
+
+### Fail-soft behaviour
+
+Access not configured, or `ownerEmail` unset, or a request with no verifiable JWT →
+everything resolves to the owner profile, i.e. today's single-user behaviour. The
+feature is a no-op until Access is enforced and `ownerEmail` is set.
+
+## Front-end parity note (CLAUDE.md rule)
+
+The profile concept and all four profile-scoped accessors live in `core`/`util` and
+are driven by both front ends. The one deliberately web-only piece is **reading
+identity from Cloudflare Access headers**: Access headers exist only on the web
+transport, and the TUI has no remote users, so the TUI legitimately always operates as
+the owner. This is the documented "a surface can't express it / host-specific" 
+exception and must be stated explicitly in the PR body.
+
+## Testing
+
+- `src/core/profile.ts` — email→id, owner resolution, slug safety, unset-owner
+  fallback. Pure unit tests.
+- Migration — unit test against a legacy `config.json` + `stream-history.json` fixture;
+  assert idempotency.
+- Profile-scoped list accessors — two ids yield two independent watch histories,
+  favourites, and saved searches; reccd calls use the per-profile token.
+- Fail-soft — no Access / no owner resolves to the owner profile.
+- Fixtures use the invented cast (`Kestrel`, `Ashfall`, `Harrowgate`, `Kepler`, …) and
+  invented emails only — never real titles (CLAUDE.md).
+- Full gate before "done": `npm test`, `npm run typecheck`, `npm run lint`,
+  `npm run build`.
+
+## Docs
+
+`README.md` gains a short "sharing the server behind Cloudflare Access" section
+covering `ownerEmail` and what forks per user. The PR body records the web-only
+identity exception.
+
+## Out of scope (YAGNI)
+
+- No profile-management UI (list/delete friends). Profiles auto-create on first
+  authenticated request.
+- No per-user sources, tokens, or machine settings.
+- No reccd account claiming for friends.
+- Not "full multi-user" — this is list partitioning, not multi-tenant profiles for
+  everything.

--- a/docs/superpowers/specs/2026-08-12-per-profile-watch-and-reccd-design.md
+++ b/docs/superpowers/specs/2026-08-12-per-profile-watch-and-reccd-design.md
@@ -64,9 +64,11 @@ uses is resolved from the verified Access email:
 
 ### Owner identity (decision: explicit)
 
-A new `ownerEmail` config field designates which Access email is "you". Settable via
-the TUI settings and via `TORLINK_OWNER_EMAIL` env. The owner profile inherits the
-existing global lists on migration, and the TUI always maps to it.
+A new `ownerEmail` config field designates which Access email is "you". Resolved by a
+`resolveOwnerEmail` helper with `TORLINK_OWNER_EMAIL` env winning over the config
+field — exactly how `cfAccessTeamDomain` / `cfAccessAud` work today (env + config,
+no `Settings.tsx` UI row, since this is host-specific security config). The owner
+profile *is* the existing top-level storage, and the TUI always maps to it.
 
 ### reccd per profile (decision: auto-provision)
 
@@ -95,11 +97,16 @@ profiles?: {
 };
 ```
 
-Favourites, saved searches, and the reccd token move *into* the profile map. Keeping
-them in `config.json` preserves the existing read-modify-write discipline and the
-`sanitiseSettingsPatch` validation path. Watch history stays a separate per-profile
-file — `stream-history/<profileId>.json` — retaining the reasons it is separate today
-(the 200 cap and the cross-process re-read-before-write).
+**The owner keeps today's storage; only friends get namespaced storage.** The owner
+profile *is* the existing top-level `favourites` / `savedSearches` / `reccToken` fields
+and the existing `stream-history.json`. A friend profile's lists live in
+`profiles[id]`, and its watch history lives in `stream-history/<profileId>.json`.
+
+This choice deletes migration entirely: there is nothing to move, because the owner's
+data never changes location. It also makes the feature a strict no-op until
+`ownerEmail` is set (with no owner, every request resolves to the owner view = today's
+single shared state). Watch history stays a per-profile file for friends for the same
+reasons it is separate today (the 200 cap and the cross-process re-read-before-write).
 
 ### Identity resolution module
 
@@ -130,11 +137,8 @@ the TUI passes the owner. Pure and fully unit-tested.
 
 ### Migration
 
-One-time, in `loadConfig`, guarded and idempotent so concurrent TUI / `serve --web` /
-worktree processes cannot double-migrate: if `profiles` is absent, create
-`profiles[ownerId]` from the existing top-level `favourites` / `savedSearches` /
-`reccToken` / `reccAccountName` / `reccAccountClaimed`, and move
-`stream-history.json` → `stream-history/<ownerId>.json`. The owner loses nothing.
+None. The owner's data never moves (see the data model above). Friend profiles are
+created empty on first authenticated request.
 
 ### Fail-soft behaviour
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -16,8 +16,15 @@ import {
   qualityPrefsFrom,
   sanitiseQualityPrefs,
   sanitiseSettingsPatch,
+  resolveOwnerEmail,
+  profileFavourites,
+  withProfileFavourites,
+  profileSavedSearches,
+  withProfileSavedSearches,
+  withProfileReccAccount,
 } from "./config";
-import type { Config } from "./config";
+import type { Config, FavouriteItem } from "./config";
+import { OWNER_PROFILE, slugForEmail } from "../core/profile";
 
 describe("config realDebridToken", () => {
   it("round-trips the token through save and load", async () => {
@@ -537,5 +544,82 @@ describe("cast resolvers", () => {
     expect(
       resolveCastAdvertiseHost({ downloadDir: "/tmp", trackers: [], castAdvertiseHost: "  " }),
     ).toBeUndefined();
+  });
+});
+
+describe("per-profile config helpers", () => {
+  const base: Config = { downloadDir: "/dl", trackers: [] };
+  const FRIEND = slugForEmail("friend@example.com");
+  const fav = (name: string): FavouriteItem => ({ id: name, name, magnet: `magnet:${name}`, addedAt: 1 });
+
+  describe("resolveOwnerEmail", () => {
+    afterEach(() => { delete process.env.TORLINK_OWNER_EMAIL; });
+    it("prefers the env var, trimmed and lower-cased", () => {
+      process.env.TORLINK_OWNER_EMAIL = "  Owner@Example.com ";
+      expect(resolveOwnerEmail({ ...base, ownerEmail: "other@example.com" })).toBe("owner@example.com");
+    });
+    it("falls back to config, and undefined when unset", () => {
+      expect(resolveOwnerEmail({ ...base, ownerEmail: "Owner@Example.com" })).toBe("owner@example.com");
+      expect(resolveOwnerEmail(base)).toBeUndefined();
+    });
+  });
+
+  describe("list accessors", () => {
+    it("owner reads and writes the top-level fields", () => {
+      const cfg = withProfileFavourites(base, OWNER_PROFILE, [fav("Kestrel")]);
+      expect(cfg.favourites).toHaveLength(1);
+      expect(profileFavourites(cfg, OWNER_PROFILE)).toHaveLength(1);
+      expect(profileFavourites(cfg, FRIEND)).toEqual([]);
+    });
+    it("a friend reads and writes profiles[id], leaving the owner untouched", () => {
+      const cfg = withProfileSavedSearches(base, FRIEND, ["harrowgate"]);
+      expect(profileSavedSearches(cfg, FRIEND)).toEqual(["harrowgate"]);
+      expect(cfg.savedSearches ?? []).toEqual([]);
+      expect(profileSavedSearches(cfg, OWNER_PROFILE)).toEqual([]);
+    });
+    it("two friends do not see each other's favourites", () => {
+      const other = slugForEmail("other@example.com");
+      let cfg = withProfileFavourites(base, FRIEND, [fav("Ashfall")]);
+      cfg = withProfileFavourites(cfg, other, [fav("Kepler")]);
+      expect(profileFavourites(cfg, FRIEND).map((f) => f.name)).toEqual(["Ashfall"]);
+      expect(profileFavourites(cfg, other).map((f) => f.name)).toEqual(["Kepler"]);
+    });
+  });
+
+  describe("resolveReccConfig per profile", () => {
+    it("owner uses the top-level token; a friend uses its own", () => {
+      const cfg = withProfileReccAccount(
+        { ...base, reccUrl: "https://reccd.stream", reccToken: "owner-tok" },
+        FRIEND,
+        { reccToken: "friend-tok", reccAccountName: "anon", reccAccountClaimed: false },
+      );
+      expect(resolveReccConfig(cfg).reccToken).toBe("owner-tok");
+      expect(resolveReccConfig(cfg, OWNER_PROFILE).reccToken).toBe("owner-tok");
+      expect(resolveReccConfig(cfg, FRIEND).reccToken).toBe("friend-tok");
+      expect(resolveReccConfig(cfg, FRIEND).reccUrl).toBe("https://reccd.stream");
+    });
+    it("with no profile is identical to the owner profile", () => {
+      const cfg: Config = { ...base, reccToken: "owner-tok" };
+      expect(resolveReccConfig(cfg)).toEqual(resolveReccConfig(cfg, OWNER_PROFILE));
+    });
+  });
+
+  describe("loadConfig validation", () => {
+    it("drops junk profiles and keeps valid ones", async () => {
+      await saveConfig({
+        ...base,
+        profiles: {
+          [FRIEND]: {
+            savedSearches: ["kepler", 3 as unknown as string, ""],
+            favourites: [{ nope: true } as unknown as FavouriteItem],
+          },
+          bad: 7 as unknown as never,
+        },
+      });
+      const cfg = await loadConfig();
+      expect(cfg.profiles?.[FRIEND]?.savedSearches).toEqual(["kepler"]);
+      expect(cfg.profiles?.[FRIEND]?.favourites).toEqual([]);
+      expect(cfg.profiles?.bad).toBeUndefined();
+    });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -595,15 +595,19 @@ export function withProfileSavedSearches(
 export function withProfileReccAccount(
   config: Config,
   profileId: string,
-  patch: { reccToken: string; reccAccountName: string; reccAccountClaimed: boolean },
+  patch: { reccToken: string; reccAccountName: string; reccAccountClaimed: boolean; reccUrl?: string },
 ): Config {
+  const { reccUrl, ...account } = patch;
   // Owner: spread onto the top level, exactly as provisioning did before profiles
-  // existed. reccUrl is intentionally left to the caller (the owner already has one
-  // by the time provisioning succeeds), which also keeps this file from importing
-  // DEFAULT_RECC_URL out of src/recc and creating a cycle.
-  if (isOwnerProfile(profileId)) return { ...config, ...patch };
+  // existed (reccUrl included, when the caller supplies it). The caller passes the
+  // URL rather than this file importing DEFAULT_RECC_URL out of src/recc, which
+  // would create a cycle (src/recc already imports this module).
+  if (isOwnerProfile(profileId)) {
+    return { ...config, ...account, ...(reccUrl ? { reccUrl } : {}) };
+  }
+  // A friend never gets its own reccUrl — the reccd host is shared top-level infra.
   const prev = config.profiles?.[profileId] ?? {};
-  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, ...patch } } };
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, ...account } } };
 }
 
 const write = serializeWrites();

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,6 +9,7 @@ import {
   isFeatureId, isMaxResolution, NO_PREFS,
   type FeatureId, type MaxResolution, type QualityPrefs,
 } from "../util/releasePick";
+import { OWNER_PROFILE, isOwnerProfile } from "../core/profile";
 
 // A pinned VIDEO torrent/series to return to, remembering which episodes have
 // been streamed. Never stores stream URLs — only the magnet + metadata, so it
@@ -21,6 +22,15 @@ export interface FavouriteItem {
   sizeBytes?: number;
   addedAt: number;
   watched?: string[]; // episode filenames already streamed
+}
+
+/** One friend's isolated lists. Mirrors the owner's top-level fields. */
+export interface ProfileState {
+  favourites?: FavouriteItem[];
+  savedSearches?: string[];
+  reccToken?: string;
+  reccAccountName?: string;
+  reccAccountClaimed?: boolean;
 }
 
 export interface Config {
@@ -97,6 +107,14 @@ export interface Config {
   // Pinned VIDEO torrents (the "Library"), most-recent first, each remembering
   // which episodes have been watched.
   favourites?: FavouriteItem[];
+  // The Access email that owns this install. Its profile is the existing top-level
+  // fields and stream-history.json; every other authenticated email gets its own
+  // profile. Host/security config: env (TORLINK_OWNER_EMAIL) or config, never
+  // web-writable — mirrors cfAccessTeamDomain.
+  ownerEmail?: string;
+  // Per-friend state, keyed by slugForEmail(email). The OWNER never appears here —
+  // the owner is the top-level fields above. Absent until a second user signs in.
+  profiles?: Record<string, ProfileState>;
   // Ceiling for auto-picked releases. Absent = no ceiling. Note that with no
   // ceiling set the highest resolution available wins, which will usually be a
   // remux — that is the intended reading of "best available", not a bug.
@@ -169,6 +187,34 @@ function isFavouriteItem(v: unknown): v is FavouriteItem {
     typeof r.name === "string" && r.name.length > 0 &&
     typeof r.magnet === "string" && r.magnet.length > 0
   );
+}
+
+// Drops hand-edited junk from the per-friend profiles map before it reaches a UI,
+// mirroring the top-level favourites/savedSearches validation in loadConfig.
+function sanitiseProfiles(input: unknown): Record<string, ProfileState> | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const out: Record<string, ProfileState> = {};
+  for (const [id, raw] of Object.entries(input as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const state: ProfileState = {};
+    if (Array.isArray(r.favourites)) {
+      state.favourites = r.favourites
+        .filter(isFavouriteItem)
+        .map((f) => ({ ...f, addedAt: typeof f.addedAt === "number" ? f.addedAt : 0 }))
+        .slice(0, 100);
+    }
+    if (Array.isArray(r.savedSearches)) {
+      state.savedSearches = r.savedSearches
+        .filter((q): q is string => typeof q === "string" && q.trim().length > 0)
+        .slice(0, 50);
+    }
+    if (typeof r.reccToken === "string" && r.reccToken.trim()) state.reccToken = r.reccToken;
+    if (typeof r.reccAccountName === "string") state.reccAccountName = r.reccAccountName;
+    if (typeof r.reccAccountClaimed === "boolean") state.reccAccountClaimed = r.reccAccountClaimed;
+    out[id] = state;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 interface RawQualityPrefs {
@@ -374,9 +420,17 @@ const RECC_TOKEN_ENV = "TORLINK_RECC_TOKEN";
 // The effective reccd connection (env wins over config, matching the other
 // resolve* helpers). An undefined reccUrl means "recommendations not
 // configured" — the For You view then shows a setup hint instead of fetching.
-export function resolveReccConfig(config: Config): ReccClientConfig {
+//
+// With a friend's profileId, the token comes from that profile alone: reccUrl is
+// shared infrastructure (every profile talks to the same reccd host), but a friend
+// never inherits the env/owner token — isolating their recommendations is the point.
+export function resolveReccConfig(config: Config, profileId: string = OWNER_PROFILE): ReccClientConfig {
   const url = process.env[RECC_URL_ENV]?.trim() || config.reccUrl?.trim() || undefined;
-  const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
+  if (isOwnerProfile(profileId)) {
+    const token = process.env[RECC_TOKEN_ENV]?.trim() || config.reccToken?.trim() || undefined;
+    return { reccUrl: url, reccToken: token };
+  }
+  const token = config.profiles?.[profileId]?.reccToken?.trim() || undefined;
   return { reccUrl: url, reccToken: token };
 }
 
@@ -400,6 +454,18 @@ export function resolveCastAdvertiseHost(config: Config): string | undefined {
 export function resolveCastDevice(config: Config): string | undefined {
   const env = process.env[CAST_DEVICE_ENV]?.trim();
   return env || config.castDevice?.trim() || undefined;
+}
+
+const OWNER_EMAIL_ENV = "TORLINK_OWNER_EMAIL";
+
+/**
+ * The Access email that owns this install, normalised (trimmed + lower-cased), or
+ * undefined. env wins over config, matching every other resolve* helper. Undefined
+ * means "no owner set" — the whole feature then fails soft to single-user.
+ */
+export function resolveOwnerEmail(config: Config): string | undefined {
+  const v = process.env[OWNER_EMAIL_ENV]?.trim() || config.ownerEmail?.trim();
+  return v ? v.toLowerCase() : undefined;
 }
 
 const CF_ACCESS_TEAM_DOMAIN_ENV = "TORLINK_CF_ACCESS_TEAM_DOMAIN";
@@ -476,6 +542,11 @@ export async function loadConfig(): Promise<Config> {
           })
           .slice(0, 100)
       : [];
+    cfg.ownerEmail =
+      typeof parsed.ownerEmail === "string" && parsed.ownerEmail.trim().length > 0
+        ? parsed.ownerEmail.trim()
+        : undefined;
+    cfg.profiles = sanitiseProfiles(parsed.profiles);
     const quality = sanitiseQualityPrefs(parsed);
     cfg.maxResolution = quality.maxResolution;
     cfg.requireFeatures = quality.requireFeatures;
@@ -484,6 +555,55 @@ export async function loadConfig(): Promise<Config> {
   } catch {
     return { ...defaultConfig };
   }
+}
+
+// Per-profile list accessors. The owner reads/writes the top-level fields; a friend
+// reads/writes profiles[id], leaving the owner and every other friend untouched. All
+// setters return a fresh Config for the caller to saveConfig — read-modify-write, per
+// CLAUDE.md, never a held snapshot.
+
+export function profileFavourites(config: Config, profileId: string): FavouriteItem[] {
+  if (isOwnerProfile(profileId)) return config.favourites ?? [];
+  return config.profiles?.[profileId]?.favourites ?? [];
+}
+
+export function withProfileFavourites(
+  config: Config,
+  profileId: string,
+  favourites: FavouriteItem[],
+): Config {
+  if (isOwnerProfile(profileId)) return { ...config, favourites };
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, favourites } } };
+}
+
+export function profileSavedSearches(config: Config, profileId: string): string[] {
+  if (isOwnerProfile(profileId)) return config.savedSearches ?? [];
+  return config.profiles?.[profileId]?.savedSearches ?? [];
+}
+
+export function withProfileSavedSearches(
+  config: Config,
+  profileId: string,
+  savedSearches: string[],
+): Config {
+  if (isOwnerProfile(profileId)) return { ...config, savedSearches };
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, savedSearches } } };
+}
+
+export function withProfileReccAccount(
+  config: Config,
+  profileId: string,
+  patch: { reccToken: string; reccAccountName: string; reccAccountClaimed: boolean },
+): Config {
+  // Owner: spread onto the top level, exactly as provisioning did before profiles
+  // existed. reccUrl is intentionally left to the caller (the owner already has one
+  // by the time provisioning succeeds), which also keeps this file from importing
+  // DEFAULT_RECC_URL out of src/recc and creating a cycle.
+  if (isOwnerProfile(profileId)) return { ...config, ...patch };
+  const prev = config.profiles?.[profileId] ?? {};
+  return { ...config, profiles: { ...config.profiles, [profileId]: { ...prev, ...patch } } };
 }
 
 const write = serializeWrites();

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -33,6 +33,11 @@ export const historyFile = path.join(dataDir, "history.json");
 // see one list misreport the other.
 export const streamHistoryFile = path.join(dataDir, "stream-history.json");
 
+// Per-friend stream history. The OWNER keeps streamHistoryFile above unchanged; a
+// friend's history is <dataDir>/stream-history/<profileId>.json. A directory, not a
+// suffix on the same file, so listing/clearing one friend never risks the others.
+export const streamHistoryDir = path.join(dataDir, "stream-history");
+
 export const seedsFile = path.join(dataDir, "seeds.json");
 
 export const rutrackerFile = path.join(dataDir, "rutracker.json");

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -23,6 +23,12 @@ export const configFile = path.join(configDir, "config.json");
 // dataDir because what it protects is a config write.
 export const reccProvisionLockFile = path.join(configDir, "recc-provision.lock");
 
+// A friend's provisioning lock, one per profile so two friends signing up at once
+// don't block each other. The owner keeps reccProvisionLockFile above.
+export function reccProvisionLockFileForProfile(profileId: string): string {
+  return path.join(configDir, `recc-provision.${profileId}.lock`);
+}
+
 export const queueFile = path.join(dataDir, "queue.json");
 
 export const historyFile = path.join(dataDir, "history.json");

--- a/src/core/profile.test.ts
+++ b/src/core/profile.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { OWNER_PROFILE, isOwnerProfile, resolveProfileId, slugForEmail } from "./profile";
+
+describe("resolveProfileId", () => {
+  it("returns the owner profile when no email is present", () => {
+    expect(resolveProfileId(undefined, "owner@example.com")).toBe(OWNER_PROFILE);
+    expect(resolveProfileId(null, "owner@example.com")).toBe(OWNER_PROFILE);
+    expect(resolveProfileId("", "owner@example.com")).toBe(OWNER_PROFILE);
+  });
+
+  it("returns the owner profile when no owner email is configured (fail-soft)", () => {
+    expect(resolveProfileId("friend@example.com", undefined)).toBe(OWNER_PROFILE);
+  });
+
+  it("maps the owner's own email to the owner profile, case-insensitively", () => {
+    expect(resolveProfileId("Owner@Example.com", "owner@example.com")).toBe(OWNER_PROFILE);
+  });
+
+  it("maps a friend to a stable non-owner slug", () => {
+    const a = resolveProfileId("friend@example.com", "owner@example.com");
+    const b = resolveProfileId("friend@example.com", "owner@example.com");
+    expect(a).toBe(b);
+    expect(a).not.toBe(OWNER_PROFILE);
+    expect(isOwnerProfile(a)).toBe(false);
+  });
+
+  it("gives distinct, filesystem-safe slugs to distinct emails that differ only in a separator", () => {
+    const a = slugForEmail("a.b@example.com");
+    const b = slugForEmail("a_b@example.com");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[a-f0-9]+$/);
+    expect(b).toMatch(/^[a-f0-9]+$/);
+  });
+});

--- a/src/core/profile.ts
+++ b/src/core/profile.ts
@@ -1,0 +1,43 @@
+// Front-end-agnostic profile identity. A "profile" is the container for the four
+// per-user lists (watch history, favourites, saved searches, reccd account). Which
+// profile a web request uses is derived from the Cloudflare Access email; the TUI
+// and any non-Access request use the owner profile. Lives in src/core because both
+// front ends resolve it and eslint forbids src/web importing src/ui.
+import { createHash } from "node:crypto";
+
+/**
+ * The reserved id for the server owner — the existing top-level config fields and
+ * stream-history.json. Not a hex slug, so it can never collide with slugForEmail.
+ */
+export const OWNER_PROFILE = "owner";
+
+/**
+ * A stable, collision-free, filesystem-safe id for a friend's email. A hash rather
+ * than a sanitised string precisely so `a.b@x` and `a_b@x` cannot merge into one
+ * profile — a lossy strip of unsafe characters would let them. 128 bits is ample.
+ */
+export function slugForEmail(email: string): string {
+  const normalised = email.trim().toLowerCase();
+  return createHash("sha256").update(normalised).digest("hex").slice(0, 32);
+}
+
+/**
+ * The profile a request belongs to. Fails soft to the owner: no email, no configured
+ * owner, or the owner's own email all resolve to OWNER_PROFILE, so torlink behaves
+ * exactly as it does today until an owner email is set and a *different* user signs in.
+ */
+export function resolveProfileId(
+  email: string | null | undefined,
+  ownerEmail: string | undefined,
+): string {
+  const e = email?.trim().toLowerCase();
+  if (!e) return OWNER_PROFILE;
+  const owner = ownerEmail?.trim().toLowerCase();
+  if (!owner) return OWNER_PROFILE;
+  if (e === owner) return OWNER_PROFILE;
+  return slugForEmail(e);
+}
+
+export function isOwnerProfile(profileId: string): boolean {
+  return profileId === OWNER_PROFILE;
+}

--- a/src/core/streamHistory.test.ts
+++ b/src/core/streamHistory.test.ts
@@ -208,7 +208,7 @@ describe("forgetStreamHistory", () => {
     // so. This is the read-modify-write rule, one process out.
     const onDisk = [item({ key: "harrowgate|series", title: "Harrowgate" }), item({ key: "kepler|series" })];
     const saved: StreamHistoryItem[][] = [];
-    const next = await forgetStreamHistory("kepler|series", {
+    const next = await forgetStreamHistory("kepler|series", undefined, {
       load: async () => onDisk,
       save: async (items) => {
         saved.push([...items]);
@@ -222,7 +222,7 @@ describe("forgetStreamHistory", () => {
   it("propagates a failing read rather than writing a truncated file", async () => {
     const saved: StreamHistoryItem[][] = [];
     await expect(
-      forgetStreamHistory("kepler|series", {
+      forgetStreamHistory("kepler|series", undefined, {
         load: async () => {
           throw new Error("unreadable");
         },
@@ -347,5 +347,25 @@ describe("recordPlayedFile", () => {
     const s4 = recordPlayedFile([packEntry()], HASH, "Harrowgate.S04E01.mkv");
     expect(s4[0]!.season).toBe(4);
     expect(s4[0]!.episode).toBe(1);
+  });
+});
+
+describe("stream history is isolated per profile", () => {
+  it("keeps a friend's history in a separate file from the owner's", async () => {
+    const { dir, mod } = await isolated();
+    const { slugForEmail } = await import("./profile");
+    try {
+      const friend = slugForEmail("friend@example.com");
+      const row = (key: string): StreamHistoryItem => ({
+        key, title: key, rawName: `${key}.1080p`, infoHash: key, magnet: "magnet:", startedAt: 1,
+      });
+      await mod.saveStreamHistory([row("Kestrel")]); // owner (default)
+      await mod.saveStreamHistory([row("Harrowgate")], friend);
+
+      expect((await mod.loadStreamHistory()).map((e) => e.key)).toEqual(["Kestrel"]);
+      expect((await mod.loadStreamHistory(friend)).map((e) => e.key)).toEqual(["Harrowgate"]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/core/streamHistory.ts
+++ b/src/core/streamHistory.ts
@@ -4,7 +4,9 @@
 //
 // Deliberately NOT src/download/history.ts, which is completed downloads.
 import { promises as fs } from "node:fs";
-import { streamHistoryFile } from "../config/paths";
+import path from "node:path";
+import { streamHistoryFile, streamHistoryDir } from "../config/paths";
+import { OWNER_PROFILE, isOwnerProfile } from "./profile";
 import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 import { parseRelease } from "../util/release";
 import type { EpisodeRef } from "../util/episode";
@@ -194,27 +196,42 @@ export function removeStreamHistory(
  */
 export async function forgetStreamHistory(
   key: string,
+  profileId: string = OWNER_PROFILE,
   deps: {
     load?: () => Promise<StreamHistoryItem[]>;
     save?: (items: readonly StreamHistoryItem[]) => Promise<void>;
   } = {},
 ): Promise<StreamHistoryItem[]> {
-  const next = removeStreamHistory(await (deps.load ?? loadStreamHistory)(), key);
-  await (deps.save ?? saveStreamHistory)(next);
+  const next = removeStreamHistory(await (deps.load ?? (() => loadStreamHistory(profileId)))(), key);
+  await (deps.save ?? ((items) => saveStreamHistory(items, profileId)))(next);
   return next;
 }
 
 const write = serializeWrites();
 
-export function saveStreamHistory(items: readonly StreamHistoryItem[]): Promise<void> {
-  return write(() => writeJsonAtomic(streamHistoryFile, items.slice(0, STREAM_HISTORY_CAP)));
+// The owner keeps the legacy flat file; a friend gets its own file in a directory,
+// so the feature never touches the owner's data on disk.
+function fileFor(profileId: string): string {
+  return isOwnerProfile(profileId) ? streamHistoryFile : path.join(streamHistoryDir, `${profileId}.json`);
+}
+
+export function saveStreamHistory(
+  items: readonly StreamHistoryItem[],
+  profileId: string = OWNER_PROFILE,
+): Promise<void> {
+  const file = fileFor(profileId);
+  return write(async () => {
+    // The per-friend directory does not exist until the first friend streams.
+    if (!isOwnerProfile(profileId)) await fs.mkdir(streamHistoryDir, { recursive: true }).catch(() => {});
+    await writeJsonAtomic(file, items.slice(0, STREAM_HISTORY_CAP));
+  });
 }
 
 /** An unreadable or corrupt file is an empty list, exactly as `loadHistory` treats one. */
-export async function loadStreamHistory(): Promise<StreamHistoryItem[]> {
+export async function loadStreamHistory(profileId: string = OWNER_PROFILE): Promise<StreamHistoryItem[]> {
   let raw: string;
   try {
-    raw = await fs.readFile(streamHistoryFile, "utf8");
+    raw = await fs.readFile(fileFor(profileId), "utf8");
   } catch {
     return [];
   }

--- a/src/recc/provision.test.ts
+++ b/src/recc/provision.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { DEFAULT_RECC_URL, shouldProvision, ensureReccAccount, type ProvisionedPatch } from "./provision";
 import { defaultConfig, type Config } from "../config/config";
+import { slugForEmail } from "../core/profile";
 import type { FetchImpl } from "../util/net";
 
 const base = (over: Partial<Config> = {}): Config => ({ ...defaultConfig, downloadDir: "/tmp/dl", ...over });
@@ -445,4 +446,41 @@ describe("call sites", () => {
       expect(source).toMatch(/void ensureReccAccount\([\s\S]{0,600}?\)\.catch\(/);
     });
   }
+});
+
+describe("ensureReccAccount per profile", () => {
+  const FRIEND = slugForEmail("friend@example.com");
+
+  beforeEach(() => {
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+  });
+  afterEach(async () => {
+    await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+  });
+
+  it("shouldProvision looks at the friend's own token, not the owner's", () => {
+    // Owner already provisioned, but the friend has nothing → the friend still needs one.
+    const ownerHasToken = base({ reccToken: "owner-tok" });
+    expect(shouldProvision(ownerHasToken, FRIEND)).toBe(true);
+    const friendHasToken = base({ reccToken: "owner-tok", profiles: { [FRIEND]: { reccToken: "f" } } });
+    expect(shouldProvision(friendHasToken, FRIEND)).toBe(false);
+  });
+
+  it("writes the new account into profiles[id], leaving the owner untouched", async () => {
+    const store = fakeStore(base());
+    await ensureReccAccount({
+      profileId: FRIEND,
+      fetchImpl: signupFetch({ n: 0 }),
+      lockFile: await tmpLock(),
+      loadConfigImpl: store.load,
+      saveConfigImpl: store.save,
+    });
+    expect(store.get().profiles?.[FRIEND]?.reccToken).toBe("tok123");
+    expect(store.get().profiles?.[FRIEND]?.reccAccountName).toBe("quiet-heron-4f2a");
+    expect(store.get().profiles?.[FRIEND]?.reccAccountClaimed).toBe(false);
+    // Owner untouched, and reccUrl is NOT written into the friend's profile.
+    expect(store.get().reccToken).toBeUndefined();
+    expect(store.get().profiles?.[FRIEND]).not.toHaveProperty("reccUrl");
+  });
 });

--- a/src/recc/provision.ts
+++ b/src/recc/provision.ts
@@ -1,7 +1,14 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { loadConfig, resolveReccConfig, saveConfig, type Config } from "../config/config";
-import { reccProvisionLockFile } from "../config/paths";
+import {
+  loadConfig,
+  resolveReccConfig,
+  saveConfig,
+  withProfileReccAccount,
+  type Config,
+} from "../config/config";
+import { reccProvisionLockFile, reccProvisionLockFileForProfile } from "../config/paths";
+import { OWNER_PROFILE, isOwnerProfile } from "../core/profile";
 import type { FetchImpl } from "../util/net";
 import { log } from "../util/logger";
 
@@ -33,7 +40,7 @@ function normaliseUrl(url: string): string {
  *    hand and left the token blank.
  * 3. Not opted out. Absent means opted in: a fresh install has no config.json.
  */
-export function shouldProvision(config: Config): boolean {
+export function shouldProvision(config: Config, profileId: string = OWNER_PROFILE): boolean {
   // `=== false` would be the obvious test and it is WRONG here. This is the
   // only boolean in Config whose absent state means ON, so it is the only one
   // where the usual `=== true` idiom inverts. config.json is hand-editable, and
@@ -42,9 +49,13 @@ export function shouldProvision(config: Config): boolean {
   // having explicitly asked not to be. So: absent or exactly `true` is on;
   // anything else present is an opt-out. It fails safe in the direction of not
   // contacting a third-party host, which is the only safe direction here.
+  //
+  // reccAutoSignup is a single install-wide switch: opting out turns off signup
+  // for the owner AND every friend. The token check, though, is per profile —
+  // the owner having an account says nothing about whether a friend needs one.
   const auto = config.reccAutoSignup;
   if (auto !== undefined && auto !== true) return false;
-  const { reccUrl, reccToken } = resolveReccConfig(config);
+  const { reccUrl, reccToken } = resolveReccConfig(config, profileId);
   if (reccToken) return false;
   if (reccUrl && normaliseUrl(reccUrl) !== DEFAULT_RECC_URL) return false;
   return true;
@@ -77,6 +88,8 @@ export interface EnsureReccAccountOptions {
    * calls loadConfig() per request.
    */
   onProvisioned?: (patch: ProvisionedPatch) => void;
+  /** Which profile to provision. Defaults to the owner (top-level fields). */
+  profileId?: string;
 }
 
 const LOCK_STALE_MS = 60_000;
@@ -146,13 +159,15 @@ function isAnonSignupBody(v: unknown): v is { name: string; token: string } {
  * self-limiting.
  */
 export async function ensureReccAccount(opts: EnsureReccAccountOptions = {}): Promise<void> {
+  const profileId = opts.profileId ?? OWNER_PROFILE;
   const load = opts.loadConfigImpl ?? loadConfig;
   const save = opts.saveConfigImpl ?? saveConfig;
-  const lockFile = opts.lockFile ?? reccProvisionLockFile;
+  const lockFile = opts.lockFile
+    ?? (isOwnerProfile(profileId) ? reccProvisionLockFile : reccProvisionLockFileForProfile(profileId));
   const fetchImpl = opts.fetchImpl ?? (fetch as FetchImpl);
 
   try {
-    if (!shouldProvision(await load())) return;
+    if (!shouldProvision(await load(), profileId)) return;
     if (!(await takeLock(lockFile))) {
       log.debug("recc provision: another process holds the lock, skipping");
       return;
@@ -182,7 +197,7 @@ export async function ensureReccAccount(opts: EnsureReccAccountOptions = {}): Pr
       // account is discarded — an orphan account on reccd is a far smaller
       // problem than overwriting what the user configured.
       const fresh = await load();
-      if (!shouldProvision(fresh)) {
+      if (!shouldProvision(fresh, profileId)) {
         log.debug("recc provision: config changed under us, discarding the new account");
         return;
       }
@@ -192,9 +207,18 @@ export async function ensureReccAccount(opts: EnsureReccAccountOptions = {}): Pr
         reccAccountName: body.name,
         reccAccountClaimed: false,
       };
-      await save({ ...fresh, ...patch });
+      // withProfileReccAccount routes the write: owner → top-level (exactly the old
+      // `{ ...fresh, ...patch }` minus reccUrl, which the owner already has by now),
+      // friend → profiles[id]. reccUrl stays as the caller's; the owner keeps its
+      // existing one and a friend shares the same host.
+      await save(withProfileReccAccount(fresh, profileId, {
+        reccToken: patch.reccToken,
+        reccAccountName: patch.reccAccountName,
+        reccAccountClaimed: patch.reccAccountClaimed,
+        reccUrl: patch.reccUrl,
+      }));
       opts.onProvisioned?.(patch);
-      log.debug(`recc provision: created anonymous account ${body.name}`);
+      log.debug(`recc provision: created anonymous account ${body.name} for profile ${profileId}`);
     } finally {
       await fs.unlink(lockFile).catch(() => {});
     }

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./routes";
 import { DownloadQueue } from "../download/queue";
 import { defaultConfig, type Config, type FavouriteItem } from "../config/config";
+import { slugForEmail } from "../core/profile";
 import { StreamSessionRegistry, type StreamSession } from "../core/streamSession";
 import { CastSessionRegistry } from "../core/cast/session";
 import { CastError } from "../core/cast/connection";
@@ -4196,5 +4197,69 @@ describe("POST /api/export — exporting a search hit as a .torrent", () => {
     );
     expect(res.status).toBe(401);
     expect(fetchAndExportTorrent).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleWebApi — per-Access-email isolation", () => {
+  const HASH = "c".repeat(40);
+  const OWNER = "owner@example.com";
+  const FRIEND_EMAIL = "friend@example.com";
+  const FRIEND = slugForEmail(FRIEND_EMAIL);
+
+  beforeEach(() => {
+    vi.stubEnv("TORLINK_RECC_URL", "");
+    vi.stubEnv("TORLINK_RECC_TOKEN", "");
+    vi.stubEnv("TORLINK_OWNER_EMAIL", "");
+  });
+
+  // A config store that actually persists writes, so a favourite added by one
+  // caller is visible to the next request — the whole point being who sees it.
+  function store(initial: Partial<Config> = {}) {
+    let current: Config = { ...defaultConfig, downloadDir: "/tmp/dl", ownerEmail: OWNER, ...initial };
+    const d = deps({
+      loadConfigImpl: async () => ({ ...current }),
+      saveConfigImpl: async (c: Config) => { current = c; },
+    });
+    return { deps: d, get: () => current };
+  }
+
+  const addFav = (d: WebDeps, email: string | undefined) =>
+    handleWebApi(
+      d, "POST", "/api/library", new URLSearchParams(), undefined,
+      JSON.stringify({ infoHash: HASH, name: "Ashfall.1999.1080p", action: "toggle" }),
+      email,
+    );
+
+  const saved = (d: WebDeps, email: string | undefined) =>
+    handleWebApi(d, "GET", "/api/saved", new URLSearchParams(), undefined, "", email);
+
+  it("a friend's favourite is invisible to the owner and stored under their profile", async () => {
+    const s = store();
+    await addFav(s.deps, FRIEND_EMAIL);
+
+    const ownerView = (await saved(s.deps, OWNER)).json as SavedResponse;
+    const friendView = (await saved(s.deps, FRIEND_EMAIL)).json as SavedResponse;
+    expect(ownerView.library).toHaveLength(0);
+    expect(friendView.library.map((f) => f.name)).toEqual(["Ashfall.1999.1080p"]);
+
+    // Persisted under profiles[slug], never the owner's top-level fields.
+    expect(s.get().favourites ?? []).toHaveLength(0);
+    expect(s.get().profiles?.[FRIEND]?.favourites?.map((f) => f.name)).toEqual(["Ashfall.1999.1080p"]);
+  });
+
+  it("the owner's own email writes the top-level list, exactly as before", async () => {
+    const s = store();
+    await addFav(s.deps, OWNER);
+    expect(s.get().favourites?.map((f) => f.name)).toEqual(["Ashfall.1999.1080p"]);
+    expect(s.get().profiles).toBeUndefined();
+    expect(((await saved(s.deps, OWNER)).json as SavedResponse).library).toHaveLength(1);
+  });
+
+  it("with no owner configured, a friend's email still maps to the shared owner list (fail-soft)", async () => {
+    const s = store({ ownerEmail: undefined });
+    await addFav(s.deps, FRIEND_EMAIL);
+    // No owner set → everyone is the owner → the top-level shared list, as today.
+    expect(s.get().favourites?.map((f) => f.name)).toEqual(["Ashfall.1999.1080p"]);
+    expect(s.get().profiles).toBeUndefined();
   });
 });

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -25,13 +25,20 @@ import {
   resolveAdultContent,
   resolveMediaPlayer,
   resolveOmdbApiKey,
+  resolveOwnerEmail,
   resolveReccConfig,
+  profileFavourites,
+  withProfileFavourites,
+  profileSavedSearches,
+  withProfileSavedSearches,
   sanitiseQualityPrefs,
   sanitiseSettingsPatch,
   saveConfig,
   type Config,
   type FavouriteItem,
 } from "../config/config";
+import { resolveProfileId, isOwnerProfile } from "../core/profile";
+import { ensureReccAccount } from "../recc/provision";
 import {
   fetchRecommendations,
   fetchTitleSuggestions,
@@ -430,7 +437,11 @@ function parseStartBody(bodyText: string): StartStreamBody | null {
  * never as a silent swarm. With no provider configured, P2P is the only option
  * and is used directly. `confirm` in the body is therefore ignored.
  */
-async function startStream(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+async function startStream(
+  deps: WebDeps,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const body = parseStartBody(bodyText);
   if (!body) return { status: 400, json: { error: "invalid json body" } };
 
@@ -515,26 +526,40 @@ async function startStream(deps: WebDeps, bodyText: string): Promise<WebResponse
       // resolve", said in the terminal's words, and the two surfaces cannot
       // drift apart on what counts as watchable.
       if (resolved.state !== "ready" || streamCandidates(resolved.files).length === 0) return;
-      return recordStreamStart(deps, parsed.infoHash, name).catch(() => {});
+      return recordStreamStart(deps, parsed.infoHash, name, accessEmail).catch(() => {});
     },
     () => {},
   );
   return { status: 200, json: out };
 }
 
-async function recordStreamStart(deps: WebDeps, infoHash: string, name: string): Promise<void> {
+async function recordStreamStart(
+  deps: WebDeps,
+  infoHash: string,
+  name: string,
+  accessEmail?: string,
+): Promise<void> {
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
   const item = historyItemFor({ id: infoHash, name, magnet: buildMagnet(infoHash, name) }, Date.now());
   // No title in the release name means no row worth drawing.
   if (item) {
     try {
-      const current = await (deps.loadStreamHistoryImpl ?? loadStreamHistory)();
-      await (deps.saveStreamHistoryImpl ?? saveStreamHistory)(recordStream(current, item));
+      const current = await (deps.loadStreamHistoryImpl ?? (() => loadStreamHistory(profileId)))();
+      await (deps.saveStreamHistoryImpl ?? ((items) => saveStreamHistory(items, profileId)))(
+        recordStream(current, item),
+      );
     } catch {
       // A convenience list must never take a stream down with it.
     }
   }
-  const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const reccConfig = resolveReccConfig(config);
+  // A friend's first stream provisions their own reccd account, so their taste
+  // never mixes with the owner's. Fire-and-forget, same rule as the event below;
+  // this stream's own `started` event may miss the fresh token, but the next won't.
+  if (!isOwnerProfile(profileId) && !resolveReccConfig(config, profileId).reccToken) {
+    void ensureReccAccount({ profileId }).catch(() => {});
+  }
+  const reccConfig = resolveReccConfig(config, profileId);
   if (!reccConfig.reccUrl || !name) return;
   const event: ReccEvent = { type: "started", rawName: name, ts: Date.now(), source: "torlink" };
   void (deps.postEventImpl ?? postEvent)(reccConfig, event).catch(() => {});
@@ -1021,14 +1046,15 @@ export function toPublicStreamHistoryItem(item: StreamHistoryItem): PublicStream
 }
 
 /** `GET /api/saved`: both lists, in one round trip because the pane shows both. */
-async function savedLists(deps: WebDeps): Promise<WebResponse> {
+async function savedLists(deps: WebDeps, accessEmail?: string): Promise<WebResponse> {
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const history = await (deps.loadStreamHistoryImpl ?? loadStreamHistory)();
+  const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+  const history = await (deps.loadStreamHistoryImpl ?? (() => loadStreamHistory(profileId)))();
   const out: SavedResponse = {
     // loadConfig already normalises both (junk dropped, caps applied), so these
     // coalesces are for a config object built in a test, not for disk data.
-    savedSearches: config.savedSearches ?? [],
-    library: (config.favourites ?? []).map(toPublicFavourite),
+    savedSearches: profileSavedSearches(config, profileId),
+    library: profileFavourites(config, profileId).map(toPublicFavourite),
     continueWatching: history.map(toPublicStreamHistoryItem),
   };
   return { status: 200, json: out };
@@ -1045,7 +1071,11 @@ function parseObjectBody(bodyText: string): Record<string, unknown> | null {
   }
 }
 
-async function savedSearchesAction(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+async function savedSearchesAction(
+  deps: WebDeps,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const body = parseObjectBody(bodyText);
   if (!body) return { status: 400, json: { error: "invalid JSON body" } };
 
@@ -1064,11 +1094,12 @@ async function savedSearchesAction(deps: WebDeps, bodyText: string): Promise<Web
   if (!query) return { status: 400, json: { error: "missing query" } };
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const current = config.savedSearches ?? [];
+  const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+  const current = profileSavedSearches(config, profileId);
   const savedSearches =
     action === "remove" ? current.filter((q) => q !== query) : toggleSavedSearches(current, query);
 
-  await (deps.saveConfigImpl ?? saveConfig)({ ...config, savedSearches });
+  await (deps.saveConfigImpl ?? saveConfig)(withProfileSavedSearches(config, profileId, savedSearches));
 
   const out: SavedSearchesResponse = { saved: savedSearches.includes(query), savedSearches };
   return { status: 200, json: out };
@@ -1083,7 +1114,11 @@ async function savedSearchesAction(deps: WebDeps, bodyText: string): Promise<Web
  * ✕ pattern as the saved-searches remove, which exists for exactly that phone
  * behaviour) is a no-op the second time rather than an error.
  */
-async function continueWatchingAction(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+async function continueWatchingAction(
+  deps: WebDeps,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const body = parseObjectBody(bodyText);
   if (!body) return { status: 400, json: { error: "invalid JSON body" } };
 
@@ -1092,7 +1127,9 @@ async function continueWatchingAction(deps: WebDeps, bodyText: string): Promise<
   const key = typeof body.key === "string" ? body.key.trim() : "";
   if (!key) return { status: 400, json: { error: "missing key" } };
 
-  const current = await (deps.loadStreamHistoryImpl ?? loadStreamHistory)();
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+  const current = await (deps.loadStreamHistoryImpl ?? (() => loadStreamHistory(profileId)))();
   const next = removeStreamHistory(current, key);
   // Only write when something actually changed. removeStreamHistory always
   // returns a new array (it is a plain `.filter`), so the write gate here is a
@@ -1100,14 +1137,18 @@ async function continueWatchingAction(deps: WebDeps, bodyText: string): Promise<
   // "watched" branch uses — either way, a no-op remove (a stale page, a
   // double-fired click) does not churn the history file.
   if (next.length !== current.length) {
-    await (deps.saveStreamHistoryImpl ?? saveStreamHistory)(next);
+    await (deps.saveStreamHistoryImpl ?? ((items) => saveStreamHistory(items, profileId)))(next);
   }
 
   const out: ContinueWatchingResponse = { continueWatching: next.map(toPublicStreamHistoryItem) };
   return { status: 200, json: out };
 }
 
-async function libraryAction(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+async function libraryAction(
+  deps: WebDeps,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const body = parseObjectBody(bodyText);
   if (!body) return { status: 400, json: { error: "invalid JSON body" } };
 
@@ -1133,7 +1174,8 @@ async function libraryAction(deps: WebDeps, bodyText: string): Promise<WebRespon
   if (!name) return { status: 400, json: { error: "missing name" } };
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const current = config.favourites ?? [];
+  const profileId = resolveProfileId(accessEmail, resolveOwnerEmail(config));
+  const current = profileFavourites(config, profileId);
   const wasFavourited = isFavourited(current, infoHash);
 
   if (action === "watched") {
@@ -1147,7 +1189,7 @@ async function libraryAction(deps: WebDeps, bodyText: string): Promise<WebRespon
     // every re-watch, so the reference check is the write gate.
     const favourites = markWatched(current, infoHash, filename);
     if (favourites !== current) {
-      await (deps.saveConfigImpl ?? saveConfig)({ ...config, favourites });
+      await (deps.saveConfigImpl ?? saveConfig)(withProfileFavourites(config, profileId, favourites));
     }
 
     // The same moment, for the same reason as the TUI's markPlayed: this is the
@@ -1160,9 +1202,9 @@ async function libraryAction(deps: WebDeps, bodyText: string): Promise<WebRespon
     // this same file in another process. Same reference back means nothing
     // moved, which is the write gate.
     try {
-      const history = await loadStreamHistory();
+      const history = await loadStreamHistory(profileId);
       const advanced = recordPlayedFile(history, infoHash, filename);
-      if (advanced !== history) await saveStreamHistory(advanced);
+      if (advanced !== history) await saveStreamHistory(advanced, profileId);
     } catch {
       // A convenience list must never fail a play the user already started.
     }
@@ -1194,13 +1236,13 @@ async function libraryAction(deps: WebDeps, bodyText: string): Promise<WebRespon
     favourites = toggleInFavourites(current, item);
   }
 
-  await (deps.saveConfigImpl ?? saveConfig)({ ...config, favourites });
+  await (deps.saveConfigImpl ?? saveConfig)(withProfileFavourites(config, profileId, favourites));
 
   // Only a toggle rates anything. Removing a row from the library is
   // housekeeping — the TUI's ✕ posts no event either, and treating it as a
   // verdict would teach reccd that tidying up is a dislike.
   if (action === "toggle") {
-    const reccConfig = resolveReccConfig(config);
+    const reccConfig = resolveReccConfig(config, profileId);
     if (reccConfig.reccUrl) {
       const event: ReccEvent = {
         type: wasFavourited ? "unfavourited" : "favourited",
@@ -1714,7 +1756,11 @@ const RECC_LIMIT = 20;
  * reccd URL can be pasted into the Accounts pane at any moment, and a snapshot
  * taken at boot would answer "not configured" until the app restarted.
  */
-async function recommendations(deps: WebDeps, query: URLSearchParams): Promise<WebResponse> {
+async function recommendations(
+  deps: WebDeps,
+  query: URLSearchParams,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const rawType = (query.get("type") ?? "").trim();
   // "all" is the browser's own name for "no filter" and is accepted as such, so
   // the UI can round-trip its select value without a special case. Anything
@@ -1730,7 +1776,7 @@ async function recommendations(deps: WebDeps, query: URLSearchParams): Promise<W
   const explore = rawExplore === "true" || rawExplore === "1";
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const reccConfig = resolveReccConfig(config);
+  const reccConfig = resolveReccConfig(config, resolveProfileId(accessEmail, resolveOwnerEmail(config)));
   if (!reccConfig.reccUrl) {
     // 200 with its own status, NOT a 500 — the same call `/api/title` makes for
     // a missing OMDb key. Nothing is broken: the user has no reccd, and the
@@ -1771,14 +1817,18 @@ async function recommendations(deps: WebDeps, query: URLSearchParams): Promise<W
  * `recommendations` does it: a reccd URL can be pasted into the Accounts pane
  * at any moment, and `serve --web` is a separate process from any running TUI.
  */
-async function titleSearch(deps: WebDeps, query: URLSearchParams): Promise<WebResponse> {
+async function titleSearch(
+  deps: WebDeps,
+  query: URLSearchParams,
+  accessEmail?: string,
+): Promise<WebResponse> {
   const raw = query.get("q");
   // Absent, not empty: a client that forgot the param is a bug worth a 400,
   // and it matches reccd's own behaviour for a missing q.
   if (raw === null) return { status: 400, json: { error: "missing q" } };
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const reccConfig = resolveReccConfig(config);
+  const reccConfig = resolveReccConfig(config, resolveProfileId(accessEmail, resolveOwnerEmail(config)));
   if (!reccConfig.reccUrl) {
     const out: PublicTitleSuggestions = { status: "not-configured" };
     return { status: 200, json: out };
@@ -1833,7 +1883,11 @@ const RECC_EVENTS: ReadonlySet<string> = new Set<PublicReccEventType>([
  * own process. So the 200 says "accepted", meaning handed off, and says so in
  * the type.
  */
-async function reccEvent(deps: WebDeps, bodyText: string): Promise<WebResponse> {
+async function reccEvent(
+  deps: WebDeps,
+  bodyText: string,
+  accessEmail?: string,
+): Promise<WebResponse> {
   let body: Record<string, unknown> = {};
   try {
     const parsed: unknown = JSON.parse(bodyText);
@@ -1855,7 +1909,7 @@ async function reccEvent(deps: WebDeps, bodyText: string): Promise<WebResponse> 
   if (!rawName) return { status: 400, json: { error: "missing rawName" } };
 
   const config = await (deps.loadConfigImpl ?? loadConfig)();
-  const reccConfig = resolveReccConfig(config);
+  const reccConfig = resolveReccConfig(config, resolveProfileId(accessEmail, resolveOwnerEmail(config)));
   if (!reccConfig.reccUrl) {
     // Same clean answer as the feed. `postEvent` would no-op on this anyway;
     // saying so explicitly is what lets the browser stop offering the buttons.
@@ -2118,6 +2172,10 @@ export async function handleWebApi(
   query: URLSearchParams,
   authHeader: string | undefined,
   bodyText: string,
+  // The Cloudflare Access email the server verified for this request, or undefined
+  // (no Access, an exempt path, or the owner). Each handler that touches a per-user
+  // list resolves it to a profileId against its own freshly-loaded config.
+  accessEmail?: string,
 ): Promise<WebResponse> {
   const { runtime, token } = deps;
 
@@ -2164,19 +2222,19 @@ export async function handleWebApi(
   }
 
   if (method === "GET" && urlPath === "/api/saved") {
-    return savedLists(deps);
+    return savedLists(deps, accessEmail);
   }
 
   if (method === "POST" && urlPath === "/api/saved-searches") {
-    return savedSearchesAction(deps, bodyText);
+    return savedSearchesAction(deps, bodyText, accessEmail);
   }
 
   if (method === "POST" && urlPath === "/api/library") {
-    return libraryAction(deps, bodyText);
+    return libraryAction(deps, bodyText, accessEmail);
   }
 
   if (method === "POST" && urlPath === "/api/continue-watching") {
-    return continueWatchingAction(deps, bodyText);
+    return continueWatchingAction(deps, bodyText, accessEmail);
   }
 
   if (method === "POST" && urlPath === "/api/preferences") {
@@ -2205,15 +2263,15 @@ export async function handleWebApi(
   // user's taste profile or reccd's catalog — reading it, searching it, or
   // writing to it.
   if (method === "GET" && urlPath === "/api/recommendations") {
-    return recommendations(deps, query);
+    return recommendations(deps, query, accessEmail);
   }
 
   if (method === "GET" && urlPath === "/api/title-search") {
-    return titleSearch(deps, query);
+    return titleSearch(deps, query, accessEmail);
   }
 
   if (method === "POST" && urlPath === "/api/recc-event") {
-    return reccEvent(deps, bodyText);
+    return reccEvent(deps, bodyText, accessEmail);
   }
 
   // Ahead of the legacy passthrough below, which still owns `POST /add` and the
@@ -2229,7 +2287,7 @@ export async function handleWebApi(
   // none of these delegate to handleApi, which re-checks.
 
   if (method === "POST" && urlPath === STREAM_BASE) {
-    return startStream(deps, bodyText);
+    return startStream(deps, bodyText, accessEmail);
   }
 
   // Below the gate with the streaming routes, not up with /api/add, and for the

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -518,6 +518,10 @@ export async function startWebServer(
       // Access, so it is safe even if this port is ever reachable directly. Health
       // and the media routes are exempt — the latter carry the per-session ?k=
       // capability instead, because <video>/VLC/Chromecast can't present a cert.
+      // The Access-verified email for this request, threaded into the router so
+      // per-user lists (watch history, favourites, saved searches, reccd) are
+      // partitioned by login. Undefined for exempt paths and when Access is off.
+      let accessEmail: string | undefined;
       if (accessCfg) {
         // INVARIANT: any path added here MUST carry its own capability (the
         // stream/play ?k=) or return nothing sensitive — under Access the
@@ -532,6 +536,7 @@ export async function startWebServer(
             log(`${method} ${urlPath} -> 403 (access: ${verdict.reason})`);
             return;
           }
+          accessEmail = verdict.email;
         }
       }
 
@@ -620,6 +625,7 @@ export async function startWebServer(
             url.searchParams,
             req.headers.authorization,
             body.text,
+            accessEmail,
           );
         } catch (err) {
           log(`${method} ${urlPath} threw: ${String(err)}`);


### PR DESCRIPTION
## What & why

Run torlink behind Cloudflare Access with named users and you can now share the server
with a friend without their activity landing in your lists. Cloudflare Access already
verifies each caller's email on every request; torlink previously discarded it. This
threads that identity through so the four **personal** lists are partitioned per login:

- watch history / "Continue Watching"
- favourites
- saved searches
- reccd recommendations (each profile gets its own anonymous reccd account)

Sources, debrid/OMDb tokens, DNS, trackers, VPN, cast, and all machine/playback settings
stay **shared** — only the per-user lists fork.

## How it works

- A new front-end-agnostic `src/core/profile.ts` resolves `email → profileId`. The
  **owner** (set via `ownerEmail` / `TORLINK_OWNER_EMAIL`) *is* the existing top-level
  config fields and `stream-history.json` — **nothing migrates**. A **friend** gets
  namespaced storage: `config.profiles[<slug>]` and `stream-history/<slug>.json`.
- `resolveReccConfig(config, profileId)`, the stream-history load/save/forget functions,
  and new `profileFavourites` / `profileSavedSearches` accessors are all profile-aware,
  defaulting to the owner so existing callers are unchanged.
- A friend's first stream lazily auto-provisions their own anonymous reccd account
  (`ensureReccAccount({ profileId })`), so their taste never mixes with the owner's.
- The web server captures the verified `verdict.email` (previously thrown away) and
  threads it into `handleWebApi`, which resolves the profile per handler.
- **Fail-soft:** no `ownerEmail`, no Access, or an exempt path all resolve to the owner —
  i.e. today's single-user behaviour. The feature is a strict no-op until you opt in.

## Front-end scope (both-front-ends rule)

The profile concept and all four profile-scoped accessors live in `src/core` / `src/config`
and are driven by **both** front ends — the TUI simply resolves the owner profile via
default parameters, so it needs no functional change and shows the owner's lists (correct).

The one **deliberately web-only** piece is *reading identity from Cloudflare Access
headers*: those headers exist only on the web transport, and the TUI has no remote users.
This is the documented "a surface can't express it / host-specific" exception to the
ships-in-both rule.

## Testing

- New unit tests: `profile.ts` (id resolution, collision-safe slugs, fail-soft), config
  accessors + `loadConfig` validation of the `profiles` map, per-profile stream-history
  isolation, per-friend reccd provisioning, and web-layer isolation (a friend's favourite
  is invisible to the owner and stored under their profile; owner path unchanged; fail-soft
  with no owner).
- Full gate green: `npm test` (3034 passed), `npm run typecheck`, `npm run lint` (only the
  pre-existing `App.tsx` exhaustive-deps warning), `npm run build`.

## Docs

README gains a "Sharing the server with a friend" subsection under Cloudflare Access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
