### PR TITLE
feat(web): drag a .torrent onto the browser to add it

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ doesn't (see [Debrid](#debrid-real-debrid-or-torbox)). Where a debrid provider i
 **add** is replaced by **add via RD** / **add via TorBox**: the browser routes every add through the
 provider and never downloads direct peer-to-peer (the terminal keeps its plain `d`, which warns first).
 
+You can also **drag a `.torrent` file onto the page** — the browser's version of dropping one on the
+terminal's search field. An overlay confirms the target while you drag; on drop the file is read and
+queued through the same path as an add (so a configured debrid provider is still honoured).
+
 `torlnk serve --web` lands on serve's own port, **`http://127.0.0.1:9161`**, and **opens your browser
 there for you**. `torlnk --web` lands on **`http://127.0.0.1:9162`** and prints the address on the
 splash — it doesn't steal focus, because you asked for a terminal UI; press **shift+w** (anywhere but

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -29,6 +29,12 @@ export const DEFAULT_API_PORT = 9161;
 
 const MAX_BODY_BYTES = 64 * 1024; // a magnet is small; cap the body hard
 
+// The /api/add-torrent upload carries a base64'd .torrent, which is metadata
+// (capped at 16 MiB by torrentFile). Base64 inflates by ~4/3, plus JSON, so the
+// body cap is larger than the raw-torrent cap. Still bounded, so a stray upload
+// can't exhaust memory.
+export const MAX_TORRENT_BODY_BYTES = 24 * 1024 * 1024;
+
 export interface ApiResponse {
   status: number;
   body: Record<string, unknown>;
@@ -262,7 +268,10 @@ export async function handleApi(
 // Read the body up to the size cap. On overflow resolve tooLarge immediately
 // (further chunks are ignored) so the caller can answer 413 on a live socket
 // and close the connection afterwards, instead of writing to a destroyed one.
-export function readBody(req: http.IncomingMessage): Promise<{ text: string; tooLarge: boolean }> {
+export function readBody(
+  req: http.IncomingMessage,
+  maxBytes: number = MAX_BODY_BYTES,
+): Promise<{ text: string; tooLarge: boolean }> {
   return new Promise((resolve) => {
     let size = 0;
     let settled = false;
@@ -270,7 +279,7 @@ export function readBody(req: http.IncomingMessage): Promise<{ text: string; too
     req.on("data", (c: Buffer) => {
       if (settled) return;
       size += c.length;
-      if (size > MAX_BODY_BYTES) {
+      if (size > maxBytes) {
         settled = true;
         resolve({ text: "", tooLarge: true });
         return;

--- a/src/parse-torrent.d.ts
+++ b/src/parse-torrent.d.ts
@@ -3,6 +3,10 @@ declare module "parse-torrent" {
     infoHash: string;
     name?: string;
     announce?: string[];
+    // The decoded info dictionary. Present only when the input was actual
+    // .torrent file metadata; a bare infohash or a 20-byte buffer parses to just
+    // an infoHash with no `info`, which is how we tell a real file from junk.
+    info?: unknown;
   }
   export default function parseTorrent(
     torrentId: Uint8Array | string,

--- a/src/sources/torrentFile.test.ts
+++ b/src/sources/torrentFile.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { magnetFromTorrentFile } from "./torrentFile";
+import { magnetFromTorrentFile, magnetFromTorrentBytes } from "./torrentFile";
 
 // Hand-rolled bencode, so the fixture is a real .torrent parse-torrent accepts
 // rather than a checked-in binary blob.
@@ -90,5 +90,34 @@ describe("magnetFromTorrentFile", () => {
   it("refuses a file too large to be metadata rather than reading it in", async () => {
     const big = await write("big.torrent", Buffer.alloc(17 * 1024 * 1024));
     expect(await magnetFromTorrentFile(big)).toBe(null);
+  });
+});
+
+// The browser has the bytes, not a path, so the upload route parses them
+// directly. Same core as magnetFromTorrentFile, which now reads then delegates.
+describe("magnetFromTorrentBytes", () => {
+  it("reads the info hash and name straight from the bytes", async () => {
+    const parsed = await magnetFromTorrentBytes(new Uint8Array(makeTorrent([])));
+    expect(parsed?.name).toBe("test.bin");
+    expect(parsed?.infoHash).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("carries the torrent's own trackers, same as the file path", async () => {
+    const own = "http://private.example.org/announce?pk=xyz";
+    const parsed = await magnetFromTorrentBytes(new Uint8Array(makeTorrent([own])));
+    expect(parsed!.magnet).toContain(`&tr=${encodeURIComponent(own)}`);
+  });
+
+  it("returns null for empty, oversize, and junk bytes", async () => {
+    expect(await magnetFromTorrentBytes(new Uint8Array(0))).toBe(null);
+    expect(await magnetFromTorrentBytes(new Uint8Array(17 * 1024 * 1024))).toBe(null);
+    expect(await magnetFromTorrentBytes(new Uint8Array(Buffer.from("not a torrent")))).toBe(null);
+  });
+
+  it("rejects a bare 20-byte buffer instead of reading it as a raw infohash", async () => {
+    // parse-torrent treats any 20-byte buffer as an infohash, so without the
+    // info-dictionary guard a dropped 20-byte non-torrent file would be queued
+    // under its own bytes. It is not metadata, so it must be refused.
+    expect(await magnetFromTorrentBytes(new Uint8Array(20).fill(7))).toBe(null);
   });
 });

--- a/src/sources/torrentFile.ts
+++ b/src/sources/torrentFile.ts
@@ -11,10 +11,26 @@ export async function magnetFromTorrentFile(path: string): Promise<ParsedMagnet 
   try {
     const stat = await fs.stat(path);
     if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TORRENT_BYTES) return null;
-    const buf = await fs.readFile(path);
-    const parsed = await parseTorrent(new Uint8Array(buf));
+    return await magnetFromTorrentBytes(new Uint8Array(await fs.readFile(path)));
+  } catch {
+    return null;
+  }
+}
+
+// The parse/validate/build-magnet core, over bytes rather than a path: the watch
+// folder and `torlnk <file>.torrent` reach it through the file above, the web
+// upload route hands it the bytes it received. Keeping it in one place is why a
+// dragged .torrent behaves the same in the terminal and the browser.
+export async function magnetFromTorrentBytes(bytes: Uint8Array): Promise<ParsedMagnet | null> {
+  try {
+    if (bytes.length === 0 || bytes.length > MAX_TORRENT_BYTES) return null;
+    const parsed = await parseTorrent(bytes);
     const infoHash = parsed?.infoHash?.toLowerCase();
-    if (!infoHash) return null;
+    // Require the decoded info dictionary, not just an infoHash: parse-torrent
+    // reads a bare 20-byte buffer (or a magnet/hex string) as a raw infohash, so
+    // without this a dropped non-torrent file would be "added" under its own
+    // bytes rather than rejected. A real .torrent always carries `info`.
+    if (!infoHash || !parsed.info) return null;
     const name = parsed.name || infoHash;
     // Carry the file's own announce list into the magnet. Without it a torrent
     // that isn't on the public DHT — a private tracker, a small private swarm —

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -4348,3 +4348,106 @@ describe("handleWebApi — per-Access-email isolation", () => {
     expect(s.get().profiles).toBeUndefined();
   });
 });
+
+describe("POST /api/add-torrent — a .torrent dropped onto the browser", () => {
+  // Hand-rolled bencode, so the fixture is a real .torrent the parser accepts
+  // rather than a checked-in binary blob (mirrors torrentFile.test.ts).
+  function bstr(str: string): Buffer {
+    const b = Buffer.from(str, "utf8");
+    return Buffer.concat([Buffer.from(`${b.length}:`), b]);
+  }
+  function torrentBase64(name: string): string {
+    const info = Buffer.concat([
+      Buffer.from("d"),
+      bstr("length"), Buffer.from("i1024e"),
+      bstr("name"), bstr(name),
+      bstr("piece length"), Buffer.from("i16384e"),
+      bstr("pieces"), Buffer.from("20:"), Buffer.alloc(20, 7),
+      Buffer.from("e"),
+    ]);
+    return Buffer.concat([Buffer.from("d"), bstr("info"), info, Buffer.from("e")]).toString("base64");
+  }
+
+  function addRuntime(): { runtime: Runtime; add: ReturnType<typeof vi.fn> } {
+    const add = vi.fn();
+    return {
+      runtime: {
+        queue: { has: () => false, add, addDebrid: vi.fn() } as unknown as Runtime["queue"],
+        downloadDir: "/tmp/dl",
+        sessions: new StreamSessionRegistry(),
+        casts: new CastSessionRegistry(),
+      },
+      add,
+    };
+  }
+
+  const post = (d: WebDeps, body: unknown): Promise<WebResponse> =>
+    handleWebApi(d, "POST", "/api/add-torrent", new URLSearchParams(), AUTH, JSON.stringify(body));
+
+  it("parses the uploaded bytes and queues it under the torrent's own name", async () => {
+    const { runtime: rt, add } = addRuntime();
+    const res = await post(deps({ runtime: rt }), { torrent: torrentBase64("Kestrel.2010.torrent") });
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ ok: true, outcome: "added" });
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Kestrel.2010.torrent" }),
+      "/tmp/dl",
+    );
+  });
+
+  it("forces the add through debrid when a provider is configured", async () => {
+    const addDebrid = vi.fn(() => new Promise<void>(() => {}));
+    const add = vi.fn();
+    const rt = {
+      queue: { has: () => false, add, addDebrid } as unknown as Runtime["queue"],
+      downloadDir: "/tmp/dl",
+      sessions: new StreamSessionRegistry(),
+      casts: new CastSessionRegistry(),
+    };
+    const d = deps({
+      runtime: rt,
+      loadConfigImpl: async () => ({ ...defaultConfig, downloadDir: "/tmp/dl", realDebridToken: "rd-token" }),
+    });
+    const res = await post(d, { torrent: torrentBase64("Ashfall.1999.torrent") });
+    expect(res.status).toBe(200);
+    expect(addDebrid).toHaveBeenCalledTimes(1);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("rejects bytes that aren't a torrent, without queueing anything", async () => {
+    const { runtime: rt, add } = addRuntime();
+    const res = await post(deps({ runtime: rt }), {
+      torrent: Buffer.from("not a torrent").toString("base64"),
+    });
+    expect(res.status).toBe(400);
+    expect(res.json).toMatchObject({ error: "couldn't read a torrent from that file" });
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("rejects a 20-byte upload rather than queueing it as a raw infohash", async () => {
+    // parse-torrent reads any 20-byte buffer as an infohash; the route must not
+    // queue a dropped non-torrent file just because it happens to be 20 bytes.
+    const { runtime: rt, add } = addRuntime();
+    const res = await post(deps({ runtime: rt }), {
+      torrent: Buffer.alloc(20, 7).toString("base64"),
+    });
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing torrent field and a non-object body", async () => {
+    expect((await post(deps(), {})).status).toBe(400);
+    expect((await post(deps(), {})).json).toMatchObject({ error: "missing torrent" });
+    const bad = await handleWebApi(deps(), "POST", "/api/add-torrent", new URLSearchParams(), AUTH, "not json");
+    expect(bad.status).toBe(400);
+    expect(bad.json).toMatchObject({ error: "invalid json body" });
+  });
+
+  it("requires the token", async () => {
+    const res = await handleWebApi(
+      deps({ token: "secret" }), "POST", "/api/add-torrent", new URLSearchParams(), undefined,
+      JSON.stringify({ torrent: torrentBase64("Kestrel.2010.torrent") }),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -57,6 +57,7 @@ import {
 import { getDebridProvider } from "../integrations/debrid";
 import type { DebridProviderId, DebridStatus } from "../integrations/debrid/types";
 import { buildMagnet, isInfoHash, normalizeInfoHash, parseInput } from "../sources/magnet";
+import { magnetFromTorrentBytes } from "../sources/torrentFile";
 import {
   isFavourited,
   markWatched,
@@ -964,6 +965,47 @@ async function addToQueue(
   if (outcome === "invalid") return { status: 400, json: { error: "invalid magnet or info hash" } };
   const out: AddResponse = { ok: true, outcome };
   return { status: 200, json: out };
+}
+
+/**
+ * POST /api/add-torrent — queue a .torrent file dropped onto the browser.
+ *
+ * The browser half of the terminal's "drag a .torrent onto the search field".
+ * A file dropped on the page can't be turned into a magnet client-side without
+ * shipping a bencode + SHA-1 parser to static/, so the bytes are uploaded
+ * (base64, because the request-body plumbing is text) and parsed here with the
+ * very same parser the watch folder and `torlnk <file>.torrent` use — one
+ * parsing path, so a dragged torrent behaves identically in both front ends.
+ *
+ * Once it is a magnet the work is handed to addToQueue, so the debrid-vs-P2P
+ * policy, the queue call, and the added/duplicate outcome all stay in one place
+ * rather than being reimplemented with a chance to drift.
+ */
+async function addTorrentToQueue(
+  deps: WebDeps,
+  authHeader: string | undefined,
+  bodyText: string,
+): Promise<WebResponse> {
+  let body: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("not an object");
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return { status: 400, json: { error: "invalid json body" } };
+  }
+
+  const b64 = typeof body.torrent === "string" ? body.torrent : "";
+  if (!b64) return { status: 400, json: { error: "missing torrent" } };
+
+  // Buffer.from(…, "base64") is lenient (it drops non-base64 chars), and the
+  // decoded bytes are size-checked and validated by magnetFromTorrentBytes, so a
+  // junk or over-16MiB upload comes back null and is reported, never queued.
+  const parsed = await magnetFromTorrentBytes(new Uint8Array(Buffer.from(b64, "base64")));
+  if (!parsed) return { status: 400, json: { error: "couldn't read a torrent from that file" } };
+
+  // The name is the torrent's own, so the queue shows what the file says it is.
+  return addToQueue(deps, authHeader, JSON.stringify({ magnet: parsed.magnet, name: parsed.name }));
 }
 
 /**
@@ -2325,6 +2367,10 @@ export async function handleWebApi(
   // no-name/no-via shape this delegates back to.
   if (method === "POST" && urlPath === "/api/add") {
     return addToQueue(deps, authHeader, bodyText);
+  }
+
+  if (method === "POST" && urlPath === "/api/add-torrent") {
+    return addTorrentToQueue(deps, authHeader, bodyText);
   }
 
   // ---- streaming -------------------------------------------------------

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -37,7 +37,7 @@ import { HlsVerdictCache } from "../core/hlsVerdictCache";
 import { makeCheckHls, probeFetch } from "./hlsHealth";
 import { makeResolveHls } from "./hlsSource";
 import { contentTypeFor, findStaticDir, resolveAssetPath } from "./staticDir";
-import { readBody, statusPayload } from "../daemon/serve";
+import { MAX_TORRENT_BODY_BYTES, readBody, statusPayload } from "../daemon/serve";
 import { LOOPBACK_HOSTS, hostHeaderOk, isAuthorized, isCrossSiteHttpRequest } from "../daemon/auth";
 import { loadConfig, resolveCastAdvertiseHost } from "../config/config";
 import { createRemoteJWKSet, type JWTVerifyGetKey } from "jose";
@@ -598,7 +598,10 @@ export async function startWebServer(
       }
 
       if (isApiPath(urlPath)) {
-        const body = method === "POST" ? await readBody(req) : { text: "", tooLarge: false };
+        // A dropped .torrent (base64) is larger than the hard magnet cap; every
+        // other route keeps the small default so a stray body can't grow memory.
+        const cap = urlPath === "/api/add-torrent" ? MAX_TORRENT_BODY_BYTES : undefined;
+        const body = method === "POST" ? await readBody(req, cap) : { text: "", tooLarge: false };
         if (body.tooLarge) {
           // Answer on the still-live socket, then cut it: the client is mid-send
           // and will otherwise keep pushing into a half-closed connection.

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -210,6 +210,7 @@ import { routeFromSearch, urlForRoute, type RouteState } from "./route";
 import { rememberReturn } from "./returnTo";
 import { foldRecent, magnetFor, readRecent, writeRecent } from "./recentSearches";
 import { clipboardPorts, copyNotice, copyText } from "./copyText";
+import { dragHasFiles, pickTorrentFile } from "./torrentDrop";
 
 const EMPTY_TEXT = "Nothing in the queue.";
 const NOTICE_MS = 4000;
@@ -222,6 +223,7 @@ const tokenInput = el<HTMLInputElement>("token");
 const app = el<HTMLElement>("app");
 const addForm = el<HTMLFormElement>("add");
 const magnetInput = el<HTMLInputElement>("magnet");
+const dropOverlay = el<HTMLDivElement>("drop-overlay");
 const rowsList = el<HTMLUListElement>("rows");
 const emptyNote = el<HTMLParagraphElement>("empty");
 const notice = el<HTMLParagraphElement>("notice");
@@ -4330,6 +4332,92 @@ addForm.addEventListener("submit", (event) => {
     showError(body.error ?? `Add failed (HTTP ${res.status}).`);
   })();
 });
+
+// A .torrent dropped anywhere on the page is the browser's version of dropping
+// one on the terminal. dragover MUST preventDefault or the browser navigates
+// away to display the file; we only claim the gesture (and show the overlay)
+// while files are being dragged, so dragging selected text or a link is
+// unaffected. dragenter/dragleave fire once per element crossed, so a depth
+// counter keeps the overlay from flickering as the pointer moves over children.
+let dragDepth = 0;
+function endDrag(): void {
+  dragDepth = 0;
+  dropOverlay.hidden = true;
+}
+window.addEventListener("dragenter", (event) => {
+  if (!dragHasFiles(event.dataTransfer?.types)) return;
+  event.preventDefault();
+  dragDepth += 1;
+  dropOverlay.hidden = false;
+});
+window.addEventListener("dragover", (event) => {
+  if (!dragHasFiles(event.dataTransfer?.types)) return;
+  event.preventDefault();
+});
+window.addEventListener("dragleave", (event) => {
+  if (!dragHasFiles(event.dataTransfer?.types)) return;
+  dragDepth = Math.max(0, dragDepth - 1);
+  if (dragDepth === 0) dropOverlay.hidden = true;
+});
+window.addEventListener("drop", (event) => {
+  if (!dragHasFiles(event.dataTransfer?.types)) return;
+  event.preventDefault();
+  endDrag();
+  const file = pickTorrentFile([...(event.dataTransfer?.files ?? [])]);
+  if (!file) {
+    showError("That wasn't a .torrent file. Drop a .torrent to add it.");
+    return;
+  }
+  void uploadTorrent(file);
+});
+
+// readAsDataURL yields "data:…;base64,XXXX"; the route wants just the base64.
+// Base64 (not raw bytes) because the request-body plumbing is text.
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.onload = () => {
+      const result = reader.result;
+      const comma = typeof result === "string" ? result.indexOf(",") : -1;
+      if (typeof result !== "string" || comma < 0) {
+        reject(new Error("unexpected reader result"));
+        return;
+      }
+      resolve(result.slice(comma + 1));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+async function uploadTorrent(file: File): Promise<void> {
+  showNotice(`Reading ${file.name}…`);
+  let torrent: string;
+  try {
+    torrent = await fileToBase64(file);
+  } catch {
+    showError("Couldn't read the dropped file.");
+    return;
+  }
+  let res: Response;
+  try {
+    res = await fetch("/api/add-torrent", {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ torrent }),
+    });
+  } catch {
+    showError("Add failed — the server is not responding.");
+    setConn("lost");
+    return;
+  }
+  const body = await readEnvelope(res);
+  if (res.ok) {
+    showNotice(body.outcome === "duplicate" ? "Already in the queue." : "Added.");
+    return;
+  }
+  showError(body.error ?? `Add failed (HTTP ${res.status}).`);
+}
 
 // Startup. A tokenless (loopback) server answers /api/status straight away and
 // unlocks with no prompt; a 401 means we need one.

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -71,6 +71,17 @@
       <button id="alert-dismiss" type="button" aria-label="Dismiss">✕</button>
     </div>
 
+    <!-- Shown by app.js only while a file is being dragged over the page, the
+         browser's half of the terminal's "drag a .torrent onto the search
+         field". Static text with no interpolation — nothing here is built from a
+         filename, so the no-innerHTML rule is kept trivially. -->
+    <div id="drop-overlay" class="drop-overlay" role="status" aria-live="polite" hidden>
+      <div class="drop-overlay-card">
+        <span class="drop-overlay-icon" aria-hidden="true">↓</span>
+        <span>Drop a <strong>.torrent</strong> to add it</span>
+      </div>
+    </div>
+
     <!-- The stream file picker. Shown only when a session resolves to more than
          one playable file; every child below the heading is built by app.js with
          createElement, because the filenames come out of a torrent.

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1223,6 +1223,40 @@ select:focus-visible {
   cursor: zoom-in;
 }
 
+/* The drag-a-.torrent overlay. Fixed over everything, pointer-events off so it
+   never eats the drop the window listener is waiting for, shown only while a
+   file is dragged across the page. */
+.drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  pointer-events: none;
+  background: rgba(12, 13, 19, 0.82);
+}
+
+.drop-overlay-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 2.5rem;
+  border: 2px dashed var(--accent);
+  border-radius: 10px;
+  background: var(--raised);
+  color: var(--fg);
+  font-size: 1.1rem;
+  text-align: center;
+}
+
+.drop-overlay-icon {
+  font-size: 2rem;
+  color: var(--accent);
+}
+
 /* Full-size overlay. Fixed, dark, click or Escape to dismiss. */
 .screenshot-lightbox {
   position: fixed;

--- a/src/web/static/torrentDrop.test.ts
+++ b/src/web/static/torrentDrop.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { dragHasFiles, pickTorrentFile } from "./torrentDrop";
+
+describe("dragHasFiles", () => {
+  it("is true when the drag carries files (so the overlay should show)", () => {
+    expect(dragHasFiles(["Files"])).toBe(true);
+    expect(dragHasFiles(["text/plain", "Files"])).toBe(true);
+  });
+  it("is false for a text/link drag or nothing at all", () => {
+    expect(dragHasFiles(["text/plain"])).toBe(false);
+    expect(dragHasFiles([])).toBe(false);
+    expect(dragHasFiles(undefined)).toBe(false);
+  });
+});
+
+describe("pickTorrentFile", () => {
+  it("picks the first .torrent, case-insensitively", () => {
+    const files = [{ name: "notes.txt" }, { name: "Kestrel.2010.TORRENT" }, { name: "b.torrent" }];
+    expect(pickTorrentFile(files)?.name).toBe("Kestrel.2010.TORRENT");
+  });
+  it("ignores files that only contain 'torrent' in the middle of the name", () => {
+    expect(pickTorrentFile([{ name: "my-torrent-notes.txt" }])).toBe(null);
+  });
+  it("returns null when nothing dropped is a .torrent", () => {
+    expect(pickTorrentFile([{ name: "holiday.mp4" }, { name: "a.magnet" }])).toBe(null);
+    expect(pickTorrentFile([])).toBe(null);
+  });
+});

--- a/src/web/static/torrentDrop.ts
+++ b/src/web/static/torrentDrop.ts
@@ -1,0 +1,19 @@
+// The decisions behind "drop a .torrent onto the page", kept out of app.ts so
+// they can be tested without a DOM: what a drag is carrying, and which of the
+// dropped files (if any) is the torrent to upload. app.ts does the DOM wiring
+// and the FileReader work; it asks these two questions.
+
+// A dragover event's dataTransfer.types lists "Files" when the pointer is
+// dragging files (as opposed to selected text or a link). Deciding the overlay
+// on this — not on the file list, which dragover isn't allowed to read — is why
+// it lives here rather than inline.
+export function dragHasFiles(types: readonly string[] | undefined): boolean {
+  return !!types && types.includes("Files");
+}
+
+// The first dropped file whose name ends in .torrent, or null. A drop can carry
+// several files; we take one torrent and ignore the rest rather than queueing a
+// pile of them from a single gesture.
+export function pickTorrentFile<T extends { name: string }>(files: readonly T[]): T | null {
+  return files.find((f) => /\.torrent$/i.test(f.name)) ?? null;
+}


### PR DESCRIPTION
## What this does

Adds the browser's version of the terminal's "drag a `.torrent` onto the search
field" (shipped in #94). Drop a `.torrent` file anywhere on the page — an overlay
confirms the target while you drag — and it's read and queued.

This is the feature-parity half the house rule asks for: the drop now works in
**both** front ends.

## How it works

The browser can't build a magnet from a `.torrent` on its own without shipping a
bencode + SHA-1 parser to `src/web/static/` — which would duplicate tested
server logic and can't import `node:*`. So the bytes are uploaded and parsed
server-side by the **same** parser the watch folder and `torlnk <file>.torrent`
already use. One parsing path, no drift.

**Server**
- `torrentFile.ts` grows `magnetFromTorrentBytes(bytes)` — the parse/validate/
  build-magnet core; `magnetFromTorrentFile(path)` now reads then delegates.
- New `POST /api/add-torrent`: takes the `.torrent` as base64 JSON, decodes,
  caps at 16 MiB, parses → magnet → hands off to the existing `addToQueue`, so
  the **debrid-vs-P2P decision, the queue call, and the added/duplicate outcome
  live in exactly one place**. Behind the same token gate as `/api/add`.
- `readBody(req, maxBytes?)` gains a per-route cap (a base64 `.torrent` exceeds
  the 64 KB magnet cap); every other route keeps the hard default so a stray
  body can't grow memory.

**Browser** (`src/web/static/`)
- Whole-window drag-and-drop with a dimmed overlay while dragging. Drop
  decisions (`dragHasFiles`, `pickTorrentFile`) live in a pure, tested
  `torrentDrop.ts`; `app.ts` is DOM wiring only. No `innerHTML` — the overlay is
  static markup toggled via `hidden`.

## Robustness fix caught while verifying

`parse-torrent` reads **any 20-byte buffer as a raw infohash**, so a dropped
non-torrent file that happened to be 20 bytes would have been "added" under its
own bytes rather than rejected. `magnetFromTorrentBytes` now requires the decoded
`info` dictionary, which a real `.torrent` always carries. This tightens both
front ends (the file path went through the same fallback).

## Scope note

The **drop gesture** is browser-only here by the "a surface can't express it"
rule — the terminal already has its own drag path (#94), and a browser has native
file drag-and-drop the TUI has no equivalent for. The underlying capability
(turn a `.torrent` into a queued download) exists in both.

## Verification

- **Real browser** (Chrome via devtools): drag reveals the overlay, drop →
  **"Added."**, a non-`.torrent` drop reports the error, overlay hides after drop.
- **curl**: a valid `.torrent` → `200 {ok,outcome:"added"}`; a 20-byte junk
  upload → `400`; missing/!json → `400`.
- `npm test` (3140 passed) · `npm run typecheck` · `npm run lint` (only the known
  pre-existing `App.tsx` warning) · `npm run build` — all green.

New tests: `torrentDrop.test.ts`, `magnetFromTorrentBytes` cases (incl. the
20-byte guard), and five `/api/add-torrent` route tests (queue name, debrid
force, junk, missing field, auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156MANsbztS9jooeJ9ZwpKJ
