### PR TITLE
feat(docker): share downloads over the LAN via optional Samba/NFS overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,63 @@ Four things in there are decisions rather than defaults, and are worth knowing b
 No BitTorrent port is published. Outbound peers connect fine, so the swarm works — but nothing can dial
 in, so seeding ratios suffer. Publish the port you've configured if that matters to you.
 
+### Sharing downloads over your LAN (Samba / NFS)
+
+Finished downloads land in `/state/Downloads/torlink`. To browse or copy them from another machine — a
+laptop, or a media server like Jellyfin or Plex — there are two overlay compose files that add a
+file-share sidecar next to a torlink you're already running: `docker-compose.smb.yml` for **Samba (SMB)**
+and `docker-compose.nfs.yml` for **NFS**. Pick whichever suits the machine that'll mount it.
+
+You turn a share on by adding its `-f` to the command, and off by dropping it again — that's the whole
+enable/disable switch, nothing to edit. Each share is independent, so you can run either, both, or
+neither:
+
+```sh
+# Samba — has a username/password; friendliest for Windows and Mac:
+docker compose -f docker-compose.yml -f docker-compose.smb.yml up -d
+
+# NFS — no user auth, gated by client subnet; best for Linux or a media server:
+docker compose -f docker-compose.yml -f docker-compose.nfs.yml up -d
+
+# both at once — just add both overlays:
+docker compose -f docker-compose.yml -f docker-compose.smb.yml -f docker-compose.nfs.yml up -d
+```
+
+Set `SMB_USER` and `SMB_PASS` in a `.env` next to the compose files (there's deliberately no default —
+like the main compose's token, the SMB share refuses to start until you set them). The export is
+**read-only by default** — the LAN usually just reads completed files — and `SHARE_READONLY=no` turns
+writes on, where any written-back file stays owned by torlink's uid 1000 rather than root.
+
+Both sidecars mount **only** `./state/Downloads/torlink`, never `./state` — that directory holds
+`config.json` with your debrid and OMDb tokens, so sharing the whole state tree would put those tokens on
+the LAN. The overlay shares the finished files and nothing else.
+
+Three things catch people out:
+
+- **Windows already owns port 445.** Its own "Server" service binds 445 on the host, so a Samba sidecar
+  on the same machine can't. Free it (stop that service) or map a different host port in the overlay —
+  or sidestep the clash entirely by using the NFS profile, which listens on 2049.
+- **WSL2 hides the ports from the LAN.** WSL2 runs in a NAT'd VM, so a published port isn't reachable
+  from other machines by default. Turn on **mirrored networking** (`%UserProfile%\.wslconfig` →
+  `[wsl2]` `networkingMode=mirrored`, Windows 11 22H2+) so the ports appear on your real LAN address, or
+  forward each one with `netsh interface portproxy` (fiddlier — the WSL VM's IP changes on reboot, so it
+  needs a startup script). On a native Linux host neither is needed.
+- **NFS needs a kernel with `nfsd`; SMB doesn't.** The NFS sidecar runs the kernel NFS server, so it
+  wants `privileged` and a host kernel that ships the `nfsd` module. A real Linux box (NAS, seedbox) has
+  it; the **stock WSL2 kernel often doesn't**, and the container will exit saying it can't start nfsd. So
+  on WSL, **SMB is the path of least resistance** — reach for NFS when the client is Linux or a media
+  server on a Linux host.
+
+Mounting it from the other machine, once the share is up and reachable — `HOST` is the address torlink
+runs on:
+
+```sh
+# Windows (SMB):   net use Z: \\HOST\torlink /user:SMB_USER
+# macOS (SMB):     open smb://SMB_USER@HOST/torlink        (or Finder → Go → Connect to Server)
+# Linux (SMB):     sudo mount -t cifs //HOST/torlink /mnt/torlink -o username=SMB_USER
+# Linux (NFS):     sudo mount -t nfs HOST:/ /mnt/torlink
+```
+
 ### Posters
 
 Posters are fetched once and cached on disk. The browser gets the full-quality image; the TUI

--- a/docker-compose.nfs.yml
+++ b/docker-compose.nfs.yml
@@ -1,0 +1,67 @@
+# Share torlink's finished downloads over the LAN via NFS.
+#
+# This is an OVERLAY. It adds an NFS sidecar next to a torlink you are already
+# running; it does not start torlink itself. You opt in by adding its `-f`, and
+# you opt out by dropping it again — that is the whole enable/disable switch,
+# with nothing here to edit. NFS suits a Linux client or a media server
+# (Jellyfin/Plex); for Windows/Mac laptops, SMB (docker-compose.smb.yml) is
+# friendlier, and on WSL it is the path of least resistance (see the kernel note
+# below).
+#
+#   # turn the share on (stack it on the plain compose, or the Access one):
+#   docker compose -f docker-compose.yml -f docker-compose.nfs.yml up -d
+#
+#   # run NFS and SMB together — just add both overlays:
+#   docker compose -f docker-compose.yml -f docker-compose.nfs.yml -f docker-compose.smb.yml up -d
+#
+#   # turn it off again:
+#   docker compose -f docker-compose.yml -f docker-compose.nfs.yml down
+#
+# WHAT IT SHARES, AND WHAT IT DELIBERATELY DOES NOT
+#   It mounts ONLY ./state/Downloads/torlink — the finished files. It never
+#   touches ./state itself, because that directory holds config.json with your
+#   Real-Debrid / TorBox / OMDb tokens. Sharing the whole state tree would put
+#   those tokens on the LAN; sharing the Downloads subdirectory does not.
+#
+# WSL2 USERS, READ THIS FIRST
+#   Two things stand between this and a machine on your LAN:
+#   1. WSL2 runs in a NAT'd VM, so port 2049 is NOT reachable from another
+#      machine by default. Turn on mirrored networking (%UserProfile%\.wslconfig
+#      -> [wsl2] networkingMode=mirrored, Win11 22H2+), or forward it with
+#      `netsh interface portproxy`.
+#   2. This image runs the KERNEL nfsd, so it needs `privileged: true` AND a host
+#      kernel that ships the `nfsd` module. The stock WSL2 kernel often does not
+#      — if the container exits saying it can't start nfsd, that is why, and SMB
+#      is the easier path on WSL. On a real Linux host (a NAS, a seedbox) it just
+#      works.
+#
+# Optional environment (a .env file next to this one, or a secrets manager):
+#   SHARE_READONLY / NFS_READ_ONLY - read-only export (default on); see below
+#   NFS_PERMITTED                  - client addresses allowed to mount
+
+services:
+  # itsthenetwork/nfs-server-alpine runs the kernel NFS server — simple, but see
+  # the WSL kernel caveat above.
+  torlnk-nfs:
+    image: itsthenetwork/nfs-server-alpine:latest
+    container_name: torlnk-nfs
+    restart: unless-stopped
+    privileged: true
+
+    ports:
+      - "2049:2049"
+
+    environment:
+      SHARED_DIRECTORY: /downloads
+      # NFS has no user login — mounting is gated by client address instead.
+      # Defaults to the private (RFC1918) ranges; tighten to your own subnet,
+      # e.g. NFS_PERMITTED=192.168.1.0/24, for a smaller blast radius.
+      PERMITTED: ${NFS_PERMITTED:-10.0.0.0/8 172.16.0.0/12 192.168.0.0/16}
+      # Presence-based in this image: any non-empty value exports read-only, and
+      # it defaults to read-only here. Set NFS_READ_ONLY= (empty) in your .env to
+      # allow writes; a written-back file stays owned by torlink's uid 1000.
+      READ_ONLY: ${NFS_READ_ONLY-true}
+
+    volumes:
+      # The finished-downloads directory ONLY — never ./state (tokens live there).
+      - ./state/Downloads/torlink:/downloads

--- a/docker-compose.smb.yml
+++ b/docker-compose.smb.yml
@@ -1,0 +1,77 @@
+# Share torlink's finished downloads over the LAN via Samba (SMB).
+#
+# This is an OVERLAY. It adds a Samba sidecar next to a torlink you are already
+# running; it does not start torlink itself. You opt in by adding its `-f`, and
+# you opt out by dropping it again — that is the whole enable/disable switch,
+# with nothing here to edit. SMB is the friendliest choice for Windows and Mac
+# clients, and the more WSL-friendly of the two shares (see the NFS note in
+# docker-compose.nfs.yml for why).
+#
+#   # turn the share on (stack it on the plain compose, or the Access one):
+#   docker compose -f docker-compose.yml -f docker-compose.smb.yml up -d
+#
+#   # run SMB and NFS together — just add both overlays:
+#   docker compose -f docker-compose.yml -f docker-compose.smb.yml -f docker-compose.nfs.yml up -d
+#
+#   # turn it off again:
+#   docker compose -f docker-compose.yml -f docker-compose.smb.yml down
+#
+# Because each share is its own file, its settings are only read when you include
+# it — so the credentials below are required exactly when you run this share, and
+# never force themselves on someone who only wants NFS.
+#
+# WHAT IT SHARES, AND WHAT IT DELIBERATELY DOES NOT
+#   It mounts ONLY ./state/Downloads/torlink — the finished files. It never
+#   touches ./state itself, because that directory holds config.json with your
+#   Real-Debrid / TorBox / OMDb tokens. Sharing the whole state tree would put
+#   those tokens on the LAN; sharing the Downloads subdirectory does not.
+#
+# WSL2 USERS
+#   WSL2 runs in a NAT'd VM, so a port published here is NOT reachable from
+#   another machine on the LAN by default. Turn on mirrored networking
+#   (%UserProfile%\.wslconfig -> [wsl2] networkingMode=mirrored, Win11 22H2+),
+#   or forward the port with `netsh interface portproxy`. See the README section
+#   "Sharing downloads over your LAN (Samba / NFS)".
+#
+# Secrets come from the environment — a .env file next to this one, or a secrets
+# manager. Following the repo's no-baked-secret rule, there is no default: the
+# share refuses to start until you set them.
+#   SMB_USER        - the Samba account name to log in with
+#   SMB_PASS        - its password
+# Optional:
+#   SHARE_READONLY  - "yes" (default) exports read-only; "no" allows writes
+
+services:
+  # dperson/samba is configured entirely through command args, which keeps this
+  # overlay self-contained and readable. It is stable but no longer actively
+  # updated; ghcr.io/servercontainers/samba is a maintained alternative if you
+  # prefer one (its config is env-based and more verbose).
+  torlnk-smb:
+    image: dperson/samba
+    container_name: torlnk-smb
+    restart: unless-stopped
+
+    # 445 is SMB proper; 139 is legacy NetBIOS, published for older clients.
+    # NOTE: Windows' own "Server" service already binds 445 on the host. If you
+    # run this on the same Windows machine, free 445 first (stop that service) or
+    # map a different host port here — otherwise the bind fails. That clash is a
+    # reason to reach for NFS (docker-compose.nfs.yml) instead, which uses 2049.
+    ports:
+      - "445:445"
+      - "139:139"
+
+    environment:
+      TZ: ${TZ:-UTC}
+
+    # -p        preserve permissions / run in the foreground
+    # -u        create a Samba user, pinned to uid;gid 1000 so any written file
+    #           is owned by torlink's `node` user rather than root
+    # -s        define the share: name;path;browsable;readonly;guest;users
+    command: >
+      -p
+      -u "${SMB_USER:?set SMB_USER in .env};${SMB_PASS:?set SMB_PASS in .env};1000;${SMB_USER};1000"
+      -s "torlink;/downloads;yes;${SHARE_READONLY:-yes};no;${SMB_USER}"
+
+    volumes:
+      # The finished-downloads directory ONLY — never ./state (tokens live there).
+      - ./state/Downloads/torlink:/downloads


### PR DESCRIPTION
## What

Two opt-in overlay compose files that stand a file-share sidecar next to a running torlink, so finished downloads in `/state/Downloads/torlink` can be mounted from another machine — a laptop, or a media server like Jellyfin/Plex.

- **`docker-compose.smb.yml`** — `dperson/samba`, username/password auth. Friendliest for Windows/Mac, and the more WSL-friendly of the two.
- **`docker-compose.nfs.yml`** — `itsthenetwork/nfs-server-alpine`, subnet-gated. Best for Linux or a media server.

```sh
docker compose -f docker-compose.yml -f docker-compose.smb.yml up -d                           # SMB
docker compose -f docker-compose.yml -f docker-compose.nfs.yml up -d                           # NFS
docker compose -f docker-compose.yml -f docker-compose.smb.yml -f docker-compose.nfs.yml up -d # both
```

## Why two files instead of one profiled file

I built the single-file-with-`profiles` version first and it has a real flaw: Compose interpolates **every** service's variables before it filters by profile, so `--profile nfs up` still hard-errors on a missing `SMB_USER`. The only way to keep one file was to ship a default Samba password — which contradicts this repo's own rule that a compose file must not bake a secret into git. Two files fixes it: you opt into a share with its `-f`, so its required vars only apply when you actually include it. Enable/flip per system by adding or dropping the `-f`.

## Safety

- Both mount **only** `./state/Downloads/torlink`, never `./state` — debrid/OMDb tokens in `config.json` stay off the LAN.
- **Read-only by default** (`SHARE_READONLY=no` / `NFS_READ_ONLY=` to allow writes); written-back files stay owned by uid 1000, not root.
- **No baked-in secret** — the SMB share refuses to start until `SMB_USER`/`SMB_PASS` are set, matching the main compose's token rule.

## Docs

README gains a "Sharing downloads over your LAN (Samba / NFS)" section covering the three things that actually bite: the **WSL2 mirrored-networking** prerequisite, the **Windows-owns-port-445** clash (→ reach for NFS), and NFS needing a kernel with `nfsd` that stock WSL2 often lacks (→ SMB is the WSL-friendly path). Plus client mount one-liners for Windows/Mac/Linux.

## Scope note

This is a deployment/ops artifact (like the other compose files), not an app feature, so the two-front-ends rule doesn't apply — there's no TUI/web surface to mirror.

## Verification

`npm test` (3140 tests), `npm run typecheck`, `npm run lint`, `npm run build` all pass. Overlays validated with `docker compose config` across SMB-only, NFS-only, and both — confirming NFS-only needs no SMB creds and SMB-only fails loud without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQfT6CSZyEC23krFXQczRS