### PR TITLE
fix(grouping): auto-expand race, and nest a show's seasons under it

### DIFF
--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -375,7 +375,11 @@ describe("Results watch position", () => {
 
   it("marks nothing and opens the newest season when the show is unwatched", async () => {
     const u = await mountWideWithHistory(SHOW, [], 120);
-    await vi.waitFor(() => expect(u.frame()).toContain("Harrowgate S04"));
+    // S04 has one episode group (two releases of E01 only), so it renders
+    // directly with no season heading of its own once the show wrapping it
+    // opens — same "a group of one adds no wrapper" rule a season itself
+    // follows one level down.
+    await vi.waitFor(() => expect(u.frame()).toContain("S04E01"));
     expect(u.frame()).not.toContain("up to");
   });
 });

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -409,6 +409,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
       groupResults(results, hintForSection(section)),
       positionFor,
       !search.loading,
+      query,
     );
     if (seed.expandKeys.length > 0) setExpanded(new Set(seed.expandKeys));
     if (seed.latch) {
@@ -416,7 +417,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
       // Arm the cursor "land" only when there is somewhere to land.
       landed.current = seed.selectKey !== null;
     }
-  }, [results, section, positionFor, search.loading]);
+  }, [results, section, positionFor, search.loading, query]);
 
 
   useEffect(() => {

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -770,7 +770,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
         if (r) openDebrid(r);
       } else if (input === "v") {
         const row = rows[clamped];
-        if (row?.kind === "season") {
+        if (row?.kind === "season" || row?.kind === "show") {
           const plan = seasonPlayPlan(
             groupResults(results, hintForSection(section)),
             row.key,
@@ -780,7 +780,11 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
             // Reveal the episodes and land the cursor on the next-up one. selRef
             // moves the cursor to the row once the rebuilt rows include it.
             if (plan.select) selRef.current = { key: plan.selectKey!, hash: plan.select.infoHash };
-            setExpanded((current) => new Set(current).add(plan.expandKey));
+            setExpanded((current) => {
+              const next = new Set(current);
+              for (const key of plan.expandKeys) next.add(key);
+              return next;
+            });
           } else if (plan.result) {
             openStream(plan.result);
           }
@@ -1026,7 +1030,7 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
                   // from the release the row would act on if you pressed `v`.
                   // Never null: groupRowPlan does not emit empty groups.
                   const r = resultAtRow(row)!;
-                  const isGroup = row.kind === "group" || row.kind === "season";
+                  const isGroup = row.kind === "group" || row.kind === "season" || row.kind === "show";
                   const ss = sourceStyle(r.source);
                   // The disclosure arrow and the member indent live INSIDE the
                   // name cell rather than in columns of their own. At 80 columns
@@ -1048,9 +1052,11 @@ export function Results({ reccConfig, fetchImpl }: ResultsProps) {
                   const label =
                     row.kind === "season"
                       ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row)}${note ? ` ${ICON.dot} ${note}` : ""}`
-                      : row.kind === "group"
-                        ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row, { underSeason: row.depth > 0 })}`
-                        : `${indent}${cleanText(r.name)}`;
+                      : row.kind === "show"
+                        ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row)}`
+                        : row.kind === "group"
+                          ? `${indent}${row.expanded ? ICON.caretDown : ICON.caretRight} ${groupHeading(row, { underSeason: row.depth > 0 })}`
+                          : `${indent}${cleanText(r.name)}`;
                   return (
                     <Box key={row.key}>
                       <Box width={GUTTER} flexShrink={0}>

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -472,6 +472,23 @@ describe("defaultExpandedKeys", () => {
     );
     expect(defaultExpandedKeys(groups)).toEqual([]);
   });
+
+  it("prefers the show the query actually named over a higher-ranked stray", () => {
+    const groups = groupResults(
+      [
+        // Higher-ranked (first in the list) but not what was searched for.
+        r("Kepler.S02E01.1080p.WEB-DL"),
+        r("Kepler.S02E02.1080p.WEB-DL"),
+        // What the query named — ranked lower, would lose without the tie-break.
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E02.1080p.WEB-DL"),
+      ],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups, undefined, "harrowgate")).toEqual(["harrowgate|series|s3"]);
+    // No query: rank alone still wins — this is a tie-break, not a replacement.
+    expect(defaultExpandedKeys(groups)).toEqual(["kepler|series|s2"]);
+  });
 });
 
 describe("defaultExpandedKeys with a watch position", () => {
@@ -655,6 +672,35 @@ describe("expansionSeed", () => {
   it("latches once the search has settled even with nothing to open", () => {
     const oneEpisode = groupResults([r("Kepler.S02E01.1080p.WEB-DL")]);
     const seed = expansionSeed(oneEpisode, upTo1, true);
+    expect(seed.latch).toBe(true);
+  });
+
+  it("does not latch on a fully-formed stray season while the search still runs, with no position", () => {
+    // A search for "harrowgate" that so far only has a different show's season
+    // fully formed — the OLD behaviour opened this immediately because it was
+    // "the first candidate", which is exactly the bug: whichever show's
+    // sources answered first won the slot, not the one actually searched for.
+    const strayOnly = groupResults(
+      [r("Kepler.S02E01.1080p.WEB-DL"), r("Kepler.S02E02.1080p.WEB-DL")],
+      "series",
+    );
+    const seed = expansionSeed(strayOnly, undefined, false, "harrowgate");
+    expect(seed.expandKeys).toEqual([]);
+    expect(seed.latch).toBe(false);
+  });
+
+  it("opens the query's own show once settled, not the stray that formed first", () => {
+    const groups = groupResults(
+      [
+        r("Kepler.S02E01.1080p.WEB-DL"),
+        r("Kepler.S02E02.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E02.1080p.WEB-DL"),
+      ],
+      "series",
+    );
+    const seed = expansionSeed(groups, undefined, true, "harrowgate");
+    expect(seed.expandKeys).toEqual(["harrowgate|series|s3"]);
     expect(seed.latch).toBe(true);
   });
 });

--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -8,6 +8,7 @@ import {
   defaultExpandedKeys,
   expansionSeed,
   isSeasonNode,
+  isShowNode,
   nextUpRowKey,
   positionNote,
   showKeyOf,
@@ -269,7 +270,9 @@ describe("seasonTree", () => {
     expect(node.children.map((c) => c.episode)).toEqual([undefined, 1, 2]);
   });
 
-  it("orders seasons newest first", () => {
+  it("orders seasons newest first, inside the show node that wraps them", () => {
+    // Two seasons means a ShowNode wraps them — see "wraps more than one
+    // season of a show in a show node" below — so this checks ITS order.
     const tree = seasonTree(
       groupResults(
         [
@@ -281,10 +284,12 @@ describe("seasonTree", () => {
         "series",
       ),
     );
-    expect(tree.map((n) => (isSeasonNode(n) ? n.season : null))).toEqual([3, 1]);
+    const node = tree[0]!;
+    if (!isShowNode(node)) throw new Error("expected a show node");
+    expect(node.seasons.map((s) => s.season)).toEqual([3, 1]);
   });
 
-  it("emits a show's whole season block where its first group sat", () => {
+  it("emits a show's whole block — one show node — where its first group sat", () => {
     // Kestrel comes between the two Harrowgate groups in input order. The show's
     // seasons must stay contiguous, at the position of its FIRST group, so every
     // existing sort still means what it means.
@@ -301,11 +306,10 @@ describe("seasonTree", () => {
         "series",
       ),
     );
-    expect(tree.map((n) => (isSeasonNode(n) ? `s${n.season}` : "film"))).toEqual([
-      "s3",
-      "s1",
-      "film",
-    ]);
+    expect(tree.map((n) => (isShowNode(n) ? "show" : "film"))).toEqual(["show", "film"]);
+    const show = tree[0]!;
+    if (!isShowNode(show)) throw new Error("expected a show node");
+    expect(show.seasons.map((s) => s.season)).toEqual([3, 1]);
   });
 
   it("leaves a film alone", () => {
@@ -335,6 +339,45 @@ describe("seasonTree", () => {
       ),
     );
     expect(isSeasonNode(tree[0]!)).toBe(false);
+  });
+});
+
+describe("seasonTree wraps more than one season of a show in a show node", () => {
+  it("stays a bare season node when the show has exactly one season", () => {
+    // The overwhelmingly common case — a search that surfaces one season of a
+    // show — must not gain a heading over a heading.
+    const tree = seasonTree(
+      groupResults(
+        [r("Harrowgate.S03E01.1080p.WEB-DL"), r("Harrowgate.S03E02.1080p.WEB-DL")],
+        "series",
+      ),
+    );
+    expect(tree).toHaveLength(1);
+    expect(isSeasonNode(tree[0]!)).toBe(true);
+    expect(isShowNode(tree[0]!)).toBe(false);
+  });
+
+  it("wraps two or more seasons in one show node", () => {
+    const tree = seasonTree(
+      groupResults(
+        [
+          r("Harrowgate.S03E01.1080p.WEB-DL"),
+          r("Harrowgate.S03E02.1080p.WEB-DL"),
+          r("Harrowgate.S04E01.1080p.WEB-DL"),
+          r("Harrowgate.S04E02.1080p.WEB-DL"),
+        ],
+        "series",
+      ),
+    );
+    expect(tree).toHaveLength(1);
+    const node = tree[0]!;
+    if (!isShowNode(node)) throw new Error("expected a show node");
+    expect(node.key).toBe("harrowgate");
+    expect(node.title).toBe("Harrowgate");
+    expect(node.seasons.map((s) => s.season)).toEqual([4, 3]);
+    // Every season's members, newest season first — the same concatenation
+    // rule a SeasonNode's own `members` already follows one level down.
+    expect(node.members).toHaveLength(4);
   });
 });
 
@@ -415,6 +458,58 @@ describe("groupRowPlan with seasons", () => {
     const rows = groupRowPlan(
       groupResults(SEASON, "series"),
       new Set(["harrowgate|series|s3", "harrowgate|series|s3|e1", "harrowgate|series|s3|pack"]),
+    );
+    expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length);
+  });
+});
+
+describe("groupRowPlan with a show wrapping more than one season", () => {
+  const SHOW = [
+    r("Harrowgate.S04.1080p.WEB-DL"),
+    r("Harrowgate.S04.2160p.WEB-DL"),
+    r("Harrowgate.S03.1080p.WEB-DL"),
+    r("Harrowgate.S03.2160p.WEB-DL"),
+    r("Harrowgate.S03E01.1080p.WEB-DL"),
+    r("Harrowgate.S03E01.2160p.WEB-DL"),
+  ];
+
+  it("collapses the show to one row", () => {
+    const rows = groupRowPlan(groupResults(SHOW, "series"), new Set());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("show");
+    expect(rows[0]!.depth).toBe(0);
+  });
+
+  it("acts on the newest season's best release when the show row is collapsed", () => {
+    // S04 is a pack only (one child), S03 has a pack and an episode — newest
+    // season wins regardless of which has more members.
+    const rows = groupRowPlan(groupResults(SHOW, "series"), new Set());
+    expect(resultAtRow(rows[0]!)?.name).toBe("Harrowgate.S04.1080p.WEB-DL");
+  });
+
+  it("reveals its seasons at depth 1 when open, one of them collapsed to its lone pack", () => {
+    const rows = groupRowPlan(groupResults(SHOW, "series"), new Set(["harrowgate"]));
+    // S04 has a single child (its pack, two quality releases), so it drops its
+    // own season row and renders that pack's group directly — the same rule a
+    // season with one episode group already follows, one level up.
+    expect(rows.map((row) => `${row.kind}@${row.depth}`)).toEqual(["show@0", "group@1", "season@1"]);
+  });
+
+  it("puts a season's episodes at depth 2 and their releases at depth 3", () => {
+    const rows = groupRowPlan(
+      groupResults(SHOW, "series"),
+      new Set(["harrowgate", "harrowgate|series|s3", "harrowgate|series|s3|e1"]),
+    );
+    const s3 = rows.find((row) => row.kind === "season" && row.season === 3);
+    expect(s3?.depth).toBe(1);
+    const releases = rows.filter((row) => row.kind === "release" && row.depth === 3);
+    expect(releases.length).toBeGreaterThan(0);
+  });
+
+  it("gives every row a unique key across all four levels", () => {
+    const rows = groupRowPlan(
+      groupResults(SHOW, "series"),
+      new Set(["harrowgate", "harrowgate|series|s3", "harrowgate|series|s3|e1"]),
     );
     expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length);
   });
@@ -506,8 +601,11 @@ describe("defaultExpandedKeys with a watch position", () => {
   it("opens the season holding the next episode, not the highest-ranked one", () => {
     const groups = groupResults(SHOW, "series");
     // Seasons sort newest first, so S04 is the highest-ranked node. This only
-    // passes if the POSITION is what chose S03.
+    // passes if the POSITION is what chose S03. The show has two seasons here,
+    // so it wraps in a show node — both its key and the season's are returned,
+    // or the season row would sit inside a heading nobody opened.
     expect(defaultExpandedKeys(groups, () => ({ season: 3, episode: 0 }))).toEqual([
+      "harrowgate",
       "harrowgate|series|s3",
     ]);
   });
@@ -519,7 +617,9 @@ describe("defaultExpandedKeys with a watch position", () => {
 
   it("is unchanged when no lookup is given, so Piece A's behaviour is intact", () => {
     const groups = groupResults(SHOW, "series");
-    expect(defaultExpandedKeys(groups)).toHaveLength(1);
+    // [show key, season key] — this show has two seasons, so it wraps in a
+    // show node that also needs opening.
+    expect(defaultExpandedKeys(groups)).toHaveLength(2);
   });
 
   it("falls back when the position names a season the results do not have", () => {
@@ -599,7 +699,7 @@ describe("seasonPlayPlan", () => {
     const plan = seasonPlayPlan(looseSeason(), seasonKey, upTo(1));
     expect(plan.kind).toBe("reveal");
     if (plan.kind !== "reveal") throw new Error("expected reveal");
-    expect(plan.expandKey).toBe(seasonKey);
+    expect(plan.expandKeys).toEqual([seasonKey]);
     expect(plan.selectKey).toBe("kepler|series|s2|e2");
     expect(plan.select?.name).toBe("Kepler.S02E02.1080p.WEB-DL");
   });
@@ -643,6 +743,44 @@ describe("seasonPlayPlan", () => {
     expect(plan.kind).toBe("resolve");
     if (plan.kind !== "resolve") throw new Error("expected resolve");
     expect(plan.result).toBeNull();
+  });
+
+  it("acts on the newest season's pack when the show row is played, folding the show's key in", () => {
+    const groups = groupResults(
+      [
+        r("Harrowgate.S04.1080p.WEB-DL"),
+        r("Harrowgate.S03.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+      ],
+      "series",
+    );
+    // S04 (newest) is a pack, so this resolves rather than reveals — but the
+    // reveal case below is where a show's Play button actually has to expand
+    // two levels at once, which is the behaviour this test protects.
+    const plan = seasonPlayPlan(groups, "harrowgate", upTo(1));
+    expect(plan.kind).toBe("resolve");
+    if (plan.kind !== "resolve") throw new Error("expected resolve");
+    expect(plan.result?.name).toBe("Harrowgate.S04.1080p.WEB-DL");
+  });
+
+  it("reveals both the show and its newest season when that season has loose episodes", () => {
+    const groups = groupResults(
+      [
+        r("Harrowgate.S04E01.1080p.WEB-DL"),
+        r("Harrowgate.S04E02.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E02.1080p.WEB-DL"),
+      ],
+      "series",
+    );
+    const plan = seasonPlayPlan(groups, "harrowgate");
+    expect(plan.kind).toBe("reveal");
+    if (plan.kind !== "reveal") throw new Error("expected reveal");
+    // The show first, then the season it redirected to — in that order, so a
+    // caller adding both to an expanded-keys set opens the show before it
+    // needs the season inside it to already be visible.
+    expect(plan.expandKeys).toEqual(["harrowgate", "harrowgate|series|s4"]);
+    expect(plan.selectKey).toBe("harrowgate|series|s4|e1");
   });
 });
 

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -43,13 +43,25 @@ export interface ResultGroup<T> {
 }
 
 /**
- * One line of the rendered list: a season heading, a group heading, or a release.
+ * One line of the rendered list: a show heading, a season heading, a group
+ * heading, or a release.
  *
- * `depth` is how far the row is indented — 0 top level, 1 inside an open season,
- * 2 a release inside an episode group inside an open season. Both front ends
- * read it rather than deriving indent themselves.
+ * `depth` is how far the row is indented. For a show with more than one
+ * season: 0 the show, 1 an open season inside it, 2 an open episode group
+ * inside that season, 3 a release inside that group. For anything NOT nested
+ * under a show (a lone season, a film, a group with no season) the whole
+ * scale shifts down by one — a lone season is depth 0, same as before this
+ * existed. Both front ends read it rather than deriving indent themselves.
  */
 export type GroupRow<T> =
+  | {
+      kind: "show";
+      key: string;
+      title: string;
+      members: T[];
+      expanded: boolean;
+      depth: number;
+    }
   | {
       kind: "season";
       key: string;
@@ -243,12 +255,37 @@ export interface SeasonNode<T> {
   members: T[];
 }
 
-/** A top-level node: a season of a show, or a group with no season to sit under. */
-export type TreeNode<T> = SeasonNode<T> | ResultGroup<T>;
+/**
+ * A show with more than one season in the result set, holding them newest
+ * first.
+ *
+ * ONLY built for a show that HAS more than one season here — a show with
+ * exactly one stays a bare `SeasonNode` at the top level, the same "a group of
+ * one adds no wrapper" rule `pushGroupRows` already applies one level down.
+ * Without it, the overwhelmingly common case (a search that surfaces one
+ * season of a show) would gain a heading over a heading for no reason.
+ */
+export interface ShowNode<T> {
+  kind: "show";
+  key: string;
+  title: string;
+  /** Newest first. Always 2 or more — see the doc comment above. */
+  seasons: SeasonNode<T>[];
+  /** Every season's members concatenated, newest season first. Never empty. */
+  members: T[];
+}
 
-/** True for a `SeasonNode`. `ResultGroup` has no `kind`, which is the discriminator. */
+/** A top-level node: a show, a lone season, or a group with no season to sit under. */
+export type TreeNode<T> = ShowNode<T> | SeasonNode<T> | ResultGroup<T>;
+
+/** True for a `SeasonNode` specifically — NOT a `ShowNode`, which also has a `kind`. */
 export function isSeasonNode<T>(node: TreeNode<T>): node is SeasonNode<T> {
-  return "kind" in node;
+  return "kind" in node && node.kind === "season";
+}
+
+/** True for a `ShowNode`. */
+export function isShowNode<T>(node: TreeNode<T>): node is ShowNode<T> {
+  return "kind" in node && node.kind === "show";
 }
 
 /**
@@ -312,12 +349,15 @@ function compareSeasonChild<T>(a: ResultGroup<T>, b: ResultGroup<T>): number {
 }
 
 /**
- * Fold a show's single-season groups under season nodes.
+ * Fold a show's single-season groups under season nodes, and a show's seasons
+ * under one show node when it has more than one.
  *
- * ORDER IS PRESERVED at the top level: a show's whole season block is emitted at
- * the position of its FIRST group, so `groupResults`' promise that groups sit
- * where their best member sits — which every sort depends on — still holds.
- * Within a show, seasons are newest first.
+ * ORDER IS PRESERVED at the top level: a show's whole block — one show node,
+ * or its seasons individually — is emitted at the position of its FIRST
+ * group, so `groupResults`' promise that groups sit where their best member
+ * sits — which every sort depends on — still holds. Within a show, seasons
+ * are newest first, both as `ShowNode.seasons` and, for a show with only one,
+ * as the plain top-level order.
  *
  * The sort control therefore orders releases INSIDE a group, and orders
  * unrelated results against each other. A series' internal structure is
@@ -352,17 +392,30 @@ export function seasonTree<T extends GroupableResult>(
     if (done.has(show)) continue;
     done.add(show);
     const seasons = byShow.get(show)!;
-    for (const season of [...seasons.keys()].sort((a, b) => b - a)) {
-      const children = [...seasons.get(season)!].sort(compareSeasonChild);
-      out.push({
-        kind: "season",
-        key: `${show}|series|s${season}`,
-        title: children[0]!.title,
-        season,
-        children,
-        members: children.flatMap((child) => child.members),
+    const seasonNodes: SeasonNode<T>[] = [...seasons.keys()]
+      .sort((a, b) => b - a)
+      .map((season) => {
+        const children = [...seasons.get(season)!].sort(compareSeasonChild);
+        return {
+          kind: "season" as const,
+          key: `${show}|series|s${season}`,
+          title: children[0]!.title,
+          season,
+          children,
+          members: children.flatMap((child) => child.members),
+        };
       });
+    if (seasonNodes.length === 1) {
+      out.push(seasonNodes[0]!);
+      continue;
     }
+    out.push({
+      kind: "show",
+      key: show,
+      title: seasonNodes[0]!.title,
+      seasons: seasonNodes,
+      members: seasonNodes.flatMap((node) => node.members),
+    });
   }
   return out;
 }
@@ -379,37 +432,66 @@ export function seasonTree<T extends GroupableResult>(
  * one decision, and this codebase records four bugs caused by copying one
  * instead of moving it down here.
  */
+/**
+ * One season's row(s), at a given depth — 0 for a lone season sitting at the
+ * top level, 1 for a season nested inside an open show. Split out of
+ * `groupRowPlan` so both callers (the plain top-level loop and the show
+ * branch below) apply the same "one child needs no wrapper" rule.
+ */
+function pushSeasonRows<T extends GroupableResult>(
+  rows: GroupRow<T>[],
+  node: SeasonNode<T>,
+  expanded: ReadonlySet<string>,
+  depth: number,
+): void {
+  // A season node holding a SINGLE child is dropped and its child emitted in
+  // its place: wrapping one episode in a season row is the same noise as a
+  // disclosure over "1 release", and without this a search returning one
+  // release of one show would grow a heading it never had.
+  const only = node.children.length === 1 ? node.children[0] : undefined;
+  if (only) {
+    pushGroupRows(rows, only, expanded, depth);
+    return;
+  }
+  const isOpen = expanded.has(node.key);
+  rows.push({
+    kind: "season",
+    key: node.key,
+    title: node.title,
+    season: node.season,
+    members: node.members,
+    expanded: isOpen,
+    depth,
+  });
+  if (!isOpen) return;
+  for (const child of node.children) pushGroupRows(rows, child, expanded, depth + 1);
+}
+
 export function groupRowPlan<T extends GroupableResult>(
   groups: readonly ResultGroup<T>[],
   expanded: ReadonlySet<string>,
 ): GroupRow<T>[] {
   const rows: GroupRow<T>[] = [];
   for (const node of seasonTree(groups)) {
-    if (!isSeasonNode(node)) {
-      pushGroupRows(rows, node, expanded, 0);
+    if (isShowNode(node)) {
+      const isOpen = expanded.has(node.key);
+      rows.push({
+        kind: "show",
+        key: node.key,
+        title: node.title,
+        members: node.members,
+        expanded: isOpen,
+        depth: 0,
+      });
+      if (!isOpen) continue;
+      for (const season of node.seasons) pushSeasonRows(rows, season, expanded, 1);
       continue;
     }
-    // A season node holding a SINGLE child is dropped and its child emitted in
-    // its place: wrapping one episode in a season row is the same noise as a
-    // disclosure over "1 release", and without this a search returning one
-    // release of one show would grow a heading it never had.
-    const only = node.children.length === 1 ? node.children[0] : undefined;
-    if (only) {
-      pushGroupRows(rows, only, expanded, 0);
+    if (isSeasonNode(node)) {
+      pushSeasonRows(rows, node, expanded, 0);
       continue;
     }
-    const isOpen = expanded.has(node.key);
-    rows.push({
-      kind: "season",
-      key: node.key,
-      title: node.title,
-      season: node.season,
-      members: node.members,
-      expanded: isOpen,
-      depth: 0,
-    });
-    if (!isOpen) continue;
-    for (const child of node.children) pushGroupRows(rows, child, expanded, 1);
+    pushGroupRows(rows, node, expanded, 0);
   }
   return rows;
 }
@@ -441,6 +523,35 @@ export function groupRowPlan<T extends GroupableResult>(
  * already owns, so collapsing one behaves like collapsing anything else.
  */
 /**
+ * Every season in the tree, paired with its parent show node — null when the
+ * season sits at the top level on its own (a show with exactly one season).
+ *
+ * The one place that knows how to find a season regardless of whether
+ * `seasonTree` wrapped it in a show: `positionExpandedKey`, the ranked
+ * fallback below, and `seasonPlayPlan` would otherwise each re-derive "is
+ * this nested" their own way, which is exactly the copy-then-drift pattern
+ * this file already exists to avoid.
+ */
+function seasonEntries<T extends GroupableResult>(
+  nodes: readonly TreeNode<T>[],
+): { show: ShowNode<T> | null; season: SeasonNode<T> }[] {
+  const entries: { show: ShowNode<T> | null; season: SeasonNode<T> }[] = [];
+  for (const node of nodes) {
+    if (isShowNode(node)) {
+      for (const season of node.seasons) entries.push({ show: node, season });
+    } else if (isSeasonNode(node)) {
+      entries.push({ show: null, season: node });
+    }
+  }
+  return entries;
+}
+
+/** [show.key, season.key] when nested, or just [season.key] at the top level. */
+function expandKeysFor<T>(entry: { show: ShowNode<T> | null; season: SeasonNode<T> }): string[] {
+  return entry.show ? [entry.show.key, entry.season.key] : [entry.season.key];
+}
+
+/**
  * The position branch of {@link defaultExpandedKeys}, isolated so
  * `expansionSeed` can gate the order-dependent ranked fallback on
  * `searchSettled` without also delaying this one — it names an exact show by
@@ -450,13 +561,13 @@ export function groupRowPlan<T extends GroupableResult>(
 function positionExpandedKey<T extends GroupableResult>(
   nodes: readonly TreeNode<T>[],
   positionFor: PositionLookup,
-): string | null {
-  for (const node of nodes) {
-    if (!isSeasonNode(node) || node.children.length <= 1) continue;
-    const at = positionFor(showKeyOf(node.key));
-    if (at && nextOf(at).season === node.season) return node.key;
+): string[] {
+  for (const entry of seasonEntries(nodes)) {
+    if (entry.season.children.length <= 1) continue;
+    const at = positionFor(showKeyOf(entry.season.key));
+    if (at && nextOf(at).season === entry.season.season) return expandKeysFor(entry);
   }
-  return null;
+  return [];
 }
 
 export function defaultExpandedKeys<T extends GroupableResult>(
@@ -466,14 +577,14 @@ export function defaultExpandedKeys<T extends GroupableResult>(
 ): string[] {
   const nodes = seasonTree(groups);
   // WITH a position: the season holding the next episode, which is the whole
-  // point — you searched a show to carry on watching it.
+  // point — you searched a show to carry on watching it. Its parent show (if
+  // any) opens with it, or the season row it names would be nested inside a
+  // heading that never got the memo to expand.
   if (positionFor) {
-    const key = positionExpandedKey(nodes, positionFor);
-    if (key) return [key];
+    const keys = positionExpandedKey(nodes, positionFor);
+    if (keys.length > 0) return keys;
   }
-  const candidates = nodes.filter(
-    (node): node is SeasonNode<T> => isSeasonNode(node) && node.children.length > 1,
-  );
+  const candidates = seasonEntries(nodes).filter((entry) => entry.season.children.length > 1);
   if (candidates.length === 0) return [];
   // Prefer the season whose SHOW TITLE the query named exactly — "the boys"
   // normalises the same way "The Boys" does — over "highest-ranked", which is
@@ -484,10 +595,10 @@ export function defaultExpandedKeys<T extends GroupableResult>(
   // seeded, best-answering source wins the slot regardless of title.
   if (query) {
     const wanted = normaliseTitle(query);
-    const exact = candidates.find((node) => normaliseTitle(node.title) === wanted);
-    if (exact) return [exact.key];
+    const exact = candidates.find((entry) => normaliseTitle(entry.season.title) === wanted);
+    if (exact) return expandKeysFor(exact);
   }
-  return [candidates[0]!.key];
+  return expandKeysFor(candidates[0]!);
 }
 
 /**
@@ -566,21 +677,32 @@ export function resultAtRow<T>(row: GroupRow<T>): T | null {
  */
 export type SeasonPlayPlan<T> =
   | { kind: "resolve"; result: T | null }
-  | { kind: "reveal"; expandKey: string; selectKey: string | null; select: T | null };
+  | { kind: "reveal"; expandKeys: string[]; selectKey: string | null; select: T | null };
 
 export function seasonPlayPlan<T extends GroupableResult>(
   groups: readonly ResultGroup<T>[],
   seasonKey: string,
   positionFor?: PositionLookup,
 ): SeasonPlayPlan<T> {
-  const node = seasonTree(groups).find(
-    (n): n is SeasonNode<T> => isSeasonNode(n) && n.key === seasonKey,
-  );
-  // Not a season row (a film, a single-episode group) or gone: behave as play
-  // does today — resolve the first member.
-  if (!node) {
+  const nodes = seasonTree(groups);
+  const show = nodes.find((n): n is ShowNode<T> => isShowNode(n) && n.key === seasonKey);
+  // A show row's Play acts on its newest season — the heading is a wrapper
+  // around it, not a thing with a torrent of its own — and if that season
+  // reveals rather than resolves, the show has to open alongside it or the
+  // revealed row would sit inside a heading nobody told to expand.
+  if (show) {
+    const plan = seasonPlayPlan(groups, show.seasons[0]!.key, positionFor);
+    return plan.kind === "reveal" ? { ...plan, expandKeys: [show.key, ...plan.expandKeys] } : plan;
+  }
+  const entry = seasonEntries(nodes).find(({ season }) => season.key === seasonKey);
+  // Not a season or show row (a film, a single-episode group) or gone: behave
+  // as play does today — resolve the first member. A season NESTED inside a
+  // show needs no extra key here: reaching its Play button at all means the
+  // show is already expanded, so only the season itself needs to open.
+  if (!entry) {
     return { kind: "resolve", result: groups.find((g) => g.key === seasonKey)?.members[0] ?? null };
   }
+  const node = entry.season;
   // A child with no episode number is a pack: the whole season in one torrent.
   if (node.children.some((c) => c.episode === undefined)) {
     return { kind: "resolve", result: node.members[0] ?? null };
@@ -594,7 +716,7 @@ export function seasonPlayPlan<T extends GroupableResult>(
     node.children[0]!;
   return {
     kind: "reveal",
-    expandKey: node.key,
+    expandKeys: [node.key],
     selectKey: target.key,
     select: target.members[0] ?? null,
   };
@@ -637,11 +759,11 @@ export function expansionSeed<T extends GroupableResult>(
   query = "",
 ): ExpansionSeed {
   const nodes = seasonTree(groups);
-  const positioned = positionFor ? positionExpandedKey(nodes, positionFor) : null;
-  if (!positioned && !searchSettled) {
+  const positioned = positionFor ? positionExpandedKey(nodes, positionFor) : [];
+  if (positioned.length === 0 && !searchSettled) {
     return { expandKeys: [], selectKey: null, latch: false };
   }
-  const expandKeys = positioned ? [positioned] : defaultExpandedKeys(groups, undefined, query);
+  const expandKeys = positioned.length > 0 ? positioned : defaultExpandedKeys(groups, undefined, query);
   return {
     expandKeys,
     selectKey: positionFor ? nextUpRowKey(groups, positionFor) : null,

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -419,38 +419,75 @@ export function groupRowPlan<T extends GroupableResult>(
  *
  * WITH a position: the season holding the next episode.
  *
- * WITHOUT one: the highest-ranked season node, and only that one. Without it a search for one
- * season collapses to a single line, which reads as the list having failed.
+ * WITHOUT one: whichever candidate's TITLE matches `query`, when given one and
+ * it matches; otherwise the highest-ranked season node. Without opening
+ * something, a search for one season collapses to a single line, which reads
+ * as the list having failed.
  *
  * "Highest-ranked" rather than "the only one": a real search for one season of
  * one show also returned a different show's season and two unrelated episodes,
  * so a rule asking whether the season is alone would have left it shut on the
  * very query that motivated this. Ranking needs no counting and strays cannot
- * defeat it.
+ * defeat it. But "highest-ranked" is "first in the list this function was
+ * handed" — meaningful once that list is fully sorted, not mid-search, when
+ * it is source-answer-order and a same-named different show can easily
+ * out-race the one actually searched for. `query` is the tie-break for
+ * exactly that: `expansionSeed` only supplies it once results have settled,
+ * specifically so this never has to guess from a partial list.
  *
  * A season the row plan DROPS (one child) is skipped — there is no row to open.
  *
  * A SEED, not a running rule: the caller puts these into the expansion set it
  * already owns, so collapsing one behaves like collapsing anything else.
  */
+/**
+ * The position branch of {@link defaultExpandedKeys}, isolated so
+ * `expansionSeed` can gate the order-dependent ranked fallback on
+ * `searchSettled` without also delaying this one — it names an exact show by
+ * ID, so unlike the fallback it cannot lock onto the wrong one and needs no
+ * waiting.
+ */
+function positionExpandedKey<T extends GroupableResult>(
+  nodes: readonly TreeNode<T>[],
+  positionFor: PositionLookup,
+): string | null {
+  for (const node of nodes) {
+    if (!isSeasonNode(node) || node.children.length <= 1) continue;
+    const at = positionFor(showKeyOf(node.key));
+    if (at && nextOf(at).season === node.season) return node.key;
+  }
+  return null;
+}
+
 export function defaultExpandedKeys<T extends GroupableResult>(
   groups: readonly ResultGroup<T>[],
   positionFor?: PositionLookup,
+  query?: string,
 ): string[] {
   const nodes = seasonTree(groups);
   // WITH a position: the season holding the next episode, which is the whole
   // point — you searched a show to carry on watching it.
   if (positionFor) {
-    for (const node of nodes) {
-      if (!isSeasonNode(node) || node.children.length <= 1) continue;
-      const at = positionFor(showKeyOf(node.key));
-      if (at && nextOf(at).season === node.season) return [node.key];
-    }
+    const key = positionExpandedKey(nodes, positionFor);
+    if (key) return [key];
   }
-  for (const node of nodes) {
-    if (isSeasonNode(node) && node.children.length > 1) return [node.key];
+  const candidates = nodes.filter(
+    (node): node is SeasonNode<T> => isSeasonNode(node) && node.children.length > 1,
+  );
+  if (candidates.length === 0) return [];
+  // Prefer the season whose SHOW TITLE the query named exactly — "the boys"
+  // normalises the same way "The Boys" does — over "highest-ranked", which is
+  // really just "first in list order" and says nothing about which show that
+  // is. A search for one show routinely also returns a same-named or
+  // similarly-titled other one ("My Life With the Walter Boys" for "the
+  // boys"), and without this, whichever of the two happened to have the most
+  // seeded, best-answering source wins the slot regardless of title.
+  if (query) {
+    const wanted = normaliseTitle(query);
+    const exact = candidates.find((node) => normaliseTitle(node.title) === wanted);
+    if (exact) return [exact.key];
   }
-  return [];
+  return [candidates[0]!.key];
 }
 
 /**
@@ -572,6 +609,17 @@ export function seasonPlayPlan<T extends GroupableResult>(
  * retried, so a search for a show you are part-way through rendered collapsed
  * with no episode selected. Retry until either an expansion is applied or the
  * search settles — never latch on a frame that produced neither.
+ *
+ * THE RANKED FALLBACK WAITS FOR `searchSettled`; the position branch does not.
+ * A position names an exact show, so it is safe to act on the moment it
+ * appears. The fallback's "highest-ranked season" only means what it says
+ * once the list behind it is the final sorted one — mid-search it is
+ * source-answer order, so seeding from it opened whichever season had
+ * answered fastest, not the one actually searched for. A query for "the
+ * boys" that also matches "My Life With the Walter Boys" could latch onto
+ * the wrong show for the rest of the search if that one's sources answered
+ * first. Waiting costs one thing: the fallback case opens nothing until the
+ * search finishes, instead of guessing early and sometimes guessing wrong.
  */
 export interface ExpansionSeed {
   /** Season keys to open. */
@@ -586,12 +634,18 @@ export function expansionSeed<T extends GroupableResult>(
   groups: readonly ResultGroup<T>[],
   positionFor: PositionLookup | undefined,
   searchSettled: boolean,
+  query = "",
 ): ExpansionSeed {
-  const expandKeys = defaultExpandedKeys(groups, positionFor);
+  const nodes = seasonTree(groups);
+  const positioned = positionFor ? positionExpandedKey(nodes, positionFor) : null;
+  if (!positioned && !searchSettled) {
+    return { expandKeys: [], selectKey: null, latch: false };
+  }
+  const expandKeys = positioned ? [positioned] : defaultExpandedKeys(groups, undefined, query);
   return {
     expandKeys,
     selectKey: positionFor ? nextUpRowKey(groups, positionFor) : null,
-    latch: expandKeys.length > 0 || searchSettled,
+    latch: true,
   };
 }
 

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -2920,7 +2920,7 @@ function renderResults(): void {
     if (groups.length > 0) {
       const positionFor = positionLookup(savedState.continueWatching);
       // `running` is true between submit and the `done` frame; !running == settled.
-      const seed = expansionSeed(groups, positionFor, !searchView.running);
+      const seed = expansionSeed(groups, positionFor, !searchView.running, searchView.query);
       for (const key of seed.expandKeys) expandedGroups.add(key);
       // Select the episode you are up to, resolved from the GROUPS (rows do not
       // exist yet). Null when the results do not have it — nothing phantom.

--- a/src/web/static/app.ts
+++ b/src/web/static/app.ts
@@ -2559,8 +2559,25 @@ interface GroupFacts {
   episode?: number;
   count: number;
   expanded: boolean;
-  /** 0 top level, 1 inside an open season. Chooses the heading's form. */
+  /**
+   * How far the row is nested. Used to size the row/card, not to pick the
+   * heading's form — a season can now sit at depth 0 (top level) OR depth 1
+   * (inside an open show), and its heading reads the same either way. Only
+   * `seasonRow` decides that.
+   */
   depth: number;
+  /**
+   * True for a "season" kind row specifically — never for "group" or "show".
+   * A season's own heading ALWAYS uses the full "Title S03" form, at any
+   * depth; the short "S03E01" / "Season pack" form is for a GROUP nested
+   * under an open season, which is the only other row that can have depth
+   * > 0. Without this flag, `groupHeadingText` had one signal (depth > 0) for
+   * two different questions — "is this nested" and "is this a group under a
+   * season" — and a season nested under a show (depth 1, exactly like a
+   * group under a season) answered the first question the same way a group
+   * does, so it rendered as "Season pack" instead of "The Boys S05".
+   */
+  seasonRow?: boolean;
   /** "up to E07" on a season you are part-way through, else absent. */
   note?: string;
 }
@@ -2573,7 +2590,7 @@ interface GroupFacts {
  * and two front ends deciding that separately is how they drift apart.
  */
 function groupHeadingText(facts: GroupFacts): string {
-  return groupHeading(facts, { underSeason: facts.depth > 0 });
+  return groupHeading(facts, { underSeason: facts.depth > 0 && !facts.seasonRow });
 }
 
 /**
@@ -2603,9 +2620,9 @@ function groupToggleButton(facts: GroupFacts): HTMLButtonElement {
   return toggle;
 }
 
-/** The heading facts for a season or group row, so the row and the card agree. */
+/** The heading facts for a show, season or group row, so the row and the card agree. */
 function groupFactsFor(
-  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" }>,
+  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" } | { kind: "show" }>,
 ): GroupFacts {
   const facts: GroupFacts = {
     key: row.key,
@@ -2616,12 +2633,16 @@ function groupFactsFor(
   };
   if (row.kind === "season") {
     facts.season = row.season;
+    facts.seasonRow = true;
     // How far through this season you are — "up to E07", never "watched": the
     // store is a high-water mark and cannot honestly claim the episodes below it
     // were all seen.
     facts.note = positionNote(row.season, positionLookup(savedState.continueWatching)(showKeyOf(row.key)));
     return facts;
   }
+  // A show heading names no season/year/episode of its own — just the title
+  // and the count, same as `facts` already has.
+  if (row.kind === "show") return facts;
   if (row.year !== undefined) facts.year = row.year;
   if (row.season !== undefined) facts.season = row.season;
   if (row.seasonEnd !== undefined) facts.seasonEnd = row.seasonEnd;
@@ -2663,11 +2684,12 @@ function groupCountChip(count: number): HTMLSpanElement {
 /**
  * Marks a row nested under a heading. Purely structural — the CSS indents it and
  * draws a spine rather than recolouring it: a nested row must still read as the
- * same kind of row it was before grouping existed. Capped at 2, which is as deep
- * as the plan goes (season > episode > release).
+ * same kind of row it was before grouping existed. Capped at 3, which is as deep
+ * as the plan goes for a show with more than one season (show > season >
+ * episode > release) — anything else tops out at 2, same as before.
  */
 function applyDepth(li: HTMLElement, depth: number): void {
-  if (depth > 0) li.classList.add(`result-depth-${Math.min(depth, 2)}`);
+  if (depth > 0) li.classList.add(`result-depth-${Math.min(depth, 3)}`);
 }
 
 function renderResultCard(
@@ -2798,7 +2820,7 @@ function renderResult(
  * under the current sort is its best one. No new picking logic.
  */
 function renderGroupRow(
-  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" }>,
+  row: Extract<GroupRow<PublicSearchResult>, { kind: "group" } | { kind: "season" } | { kind: "show" }>,
 ): HTMLLIElement {
   const best = row.members[0]!;
   const li = document.createElement("li");
@@ -2843,8 +2865,11 @@ function renderGroupRow(
   // A season made of loose episodes plays nothing on click: it reveals the
   // episodes and lands on the one you are up to. The decision is seasonPlayPlan
   // (pure); this is only the wiring. A pack season / any other row keeps play.
+  // A show row runs the same decision — seasonPlayPlan treats it as "play the
+  // newest season" and folds the show's own key into expandKeys when that
+  // season also needs revealing.
   let onPlay: (() => void) | undefined;
-  if (row.kind === "season") {
+  if (row.kind === "season" || row.kind === "show") {
     const positionFor = positionLookup(savedState.continueWatching);
     const plan = seasonPlayPlan(
       visibleGroups(searchView, reportsHealthLookup(sources), downloadedHashes),
@@ -2854,7 +2879,7 @@ function renderGroupRow(
     if (plan.kind === "reveal") {
       const target = plan.select;
       onPlay = () => {
-        expandedGroups.add(plan.expandKey);
+        for (const key of plan.expandKeys) expandedGroups.add(key);
         if (target) selectResult(target);
         else renderResults();
       };
@@ -2943,7 +2968,7 @@ function renderResults(): void {
   const selectedRowKey =
     currentRows.find(
       (row) =>
-        !((row.kind === "group" || row.kind === "season") && row.expanded) &&
+        !((row.kind === "group" || row.kind === "season" || row.kind === "show") && row.expanded) &&
         resultAtRow(row)?.infoHash === selectedHash,
     )?.key ?? null;
 
@@ -2952,7 +2977,7 @@ function renderResults(): void {
   const focusBefore = captureRowFocus(resultsList);
   resultsList.replaceChildren(
     ...currentRows.map((row) => {
-      if (row.kind === "group" || row.kind === "season") {
+      if (row.kind === "group" || row.kind === "season" || row.kind === "show") {
         // Grid layout keeps a heading as a CARD — it exists to show artwork, and
         // a list-shaped heading in there turns a poster wall back into a list.
         return effective === "grid"

--- a/src/web/static/styles.css
+++ b/src/web/static/styles.css
@@ -1094,11 +1094,22 @@ select:focus-visible {
   border-bottom-left-radius: 0;
 }
 
+/* A third level, only reached inside a show with more than one season: a
+   release inside an open episode group inside an open season inside an open
+   show. */
+.result-depth-3 {
+  margin-left: 3.75rem;
+  border-left: 2px solid var(--line);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 /* The indent and spine are a LIST idiom. In the grid every card is the same size
    by definition, so an indented one just breaks the columns — belonging is shown
    there by the member cards following their group card instead. */
 .results-grid .result-depth-1,
-.results-grid .result-depth-2 {
+.results-grid .result-depth-2,
+.results-grid .result-depth-3 {
   margin-left: 0;
   border-left: 1px solid var(--line);
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
Two related fixes to search-result grouping, from the same investigation.

### 1. Auto-expand race
Reported: searching "the boys" appeared to auto-expand one group, then a different one, as results kept loading. Traced with a live-instrumented reproduction (polling which group was open, tick by tick, across a real search) before touching any code.

Root cause: `defaultExpandedKeys`' fallback ("open the highest-ranked season") relies on the results list already being fully sorted — true once a search settles, not mid-stream, when the list is source-answer order. The old code fired this fallback and **latched on the very first frame** with a qualifying season, so whichever show's sources happened to answer fastest could win the auto-expand slot — including a same-named different show a query also matches ("the boys" also returns "My Life With the Walter Boys" in this env), well before the actually-searched-for show had streamed in enough episodes to compete.

Fix: `expansionSeed` only runs the ranked fallback once `searchSettled` is true (the position-based branch — an exact show, by watch-history ID — is unaffected and still fires immediately). When settled data has multiple qualifying seasons, `defaultExpandedKeys` now prefers the one whose title matches the search exactly, ahead of "first in list order."

### 2. Show-level nesting
Follow-up question from the same report: why does "The Boys" show as S05, S04, S03... each as separate top-level entries, instead of one "The Boys" heading containing its seasons? That was the existing, deliberate design — until this PR. Now a show with more than one season wraps in one show heading, with its seasons nested one level in (newest first). A show with exactly one season is untouched — same "a group of one adds no wrapper" rule a season already follows one level down, so the common case (a search surfacing one season) gains nothing it didn't have.

This ripples through the whole grouping stack, all in the shared core (`src/util/resultGroup.ts`) so both front ends move together:
- `groupRowPlan` gains a `"show"` row kind; depth now goes to 3 for a release under an open episode group under an open season under an open show.
- `defaultExpandedKeys` / `expansionSeed` / `positionExpandedKey` return the show's key alongside the season's when the auto-expand target is nested, via a new `seasonEntries()` helper.
- `seasonPlayPlan` handles a show-row key by redirecting to its newest season, folding the show's key into `expandKeys` when that season also needs revealing. `SeasonPlayPlan.expandKey` (singular) is now `expandKeys` (`string[]`).
- Both renderers (`app.ts`, `Results.tsx`) treat `"show"` rows like `"group"`/`"season"` wherever those were already special-cased — and a genuine bug this surfaced on the web side: `groupHeadingText` derived "use the short heading form" from raw depth, which broke once a *season* itself could sit at depth 1 (nested in a show) the same way a *group* nested in a season always could — "The Boys S05" started rendering as the group-level "Season pack" label. Fixed with an explicit `seasonRow` flag rather than inferring it from depth.
- CSS: a fourth indent level, `.result-depth-3`.

## Test plan
- [x] `npm test` (3278 passing — 12 new tests: 3 for the auto-expand race, 9 for show-level nesting across `seasonTree`, `groupRowPlan`, and `seasonPlayPlan`)
- [x] `npm run typecheck`
- [x] `npm run lint` (only the known pre-existing `App.tsx` warning)
- [x] `npm run build`
- [x] Live-verified both fixes against a real "the boys" search: exactly one auto-expand event firing only once settled; "The Boys" (122 releases) at the top with S05/S04/S03/S02/S01 nested under it as independently-expandable siblings, down to individual releases at depth 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QTsg7ie21bP9JpEPFMkyP