### PR TITLE
fix(omdb): stop sending a series release's year to OMDb

### DIFF
--- a/src/recc/omdb.test.ts
+++ b/src/recc/omdb.test.ts
@@ -66,13 +66,35 @@ describe("fetchTitleMeta (by id)", () => {
 });
 
 describe("fetchTitleMetaByName", () => {
-  it("builds a title lookup with year and type", async () => {
+  it("builds a title lookup with year and type, for a film", async () => {
+    // A film's OMDb year IS its identity — Ashfall 1999 and Ashfall 2024 are
+    // different films — so unlike a series (below), it is sent unconditionally.
     const { impl, urls } = jsonImpl(200, { Response: "True", imdbID: "tt2", Plot: "P", Poster: "https://p.jpg" });
-    const res = await fetchTitleMetaByName("Harrowgate", "KEY", { year: 2022, type: "series", fetchImpl: impl });
+    const res = await fetchTitleMetaByName("Ashfall", "KEY", { year: 1999, type: "movie", fetchImpl: impl });
     expect(res).toEqual({ ok: true, type: null, imdbId: "tt2", plot: "P", posterUrl: "https://p.jpg" });
     const u = urls[0]!;
-    expect(u).toContain("t=Harrowgate");
-    expect(u).toContain("y=2022");
+    expect(u).toContain("t=Ashfall");
+    expect(u).toContain("y=1999");
+    expect(u).toContain("type=movie");
+  });
+
+  it("drops the year for a series — it names the release's own air date, not the show's debut", async () => {
+    // "The Boys S05 Season 5 2026 1080p..." parses year 2026, the season's own
+    // air year. OMDb keys a series by when it DEBUTED (2019 here), so sending
+    // y=2026 finds no match and OMDb falls back to an unrelated title that
+    // happens to answer to that year — a real bug this protects against.
+    const { impl, urls } = jsonImpl(200, { Response: "True", imdbID: "tt1190634", Plot: "P", Poster: "https://p.jpg" });
+    const res = await fetchTitleMetaByName("The Boys", "KEY", { year: 2026, type: "series", fetchImpl: impl });
+    expect(res).toEqual({
+      ok: true,
+      type: null,
+      imdbId: "tt1190634",
+      plot: "P",
+      posterUrl: "https://p.jpg",
+    });
+    const u = urls[0]!;
+    expect(u).toContain("t=The+Boys");
+    expect(u).not.toContain("y=2026");
     expect(u).toContain("type=series");
   });
 

--- a/src/recc/omdb.ts
+++ b/src/recc/omdb.ts
@@ -96,8 +96,19 @@ export async function fetchTitleMetaByName(
   } = {},
 ): Promise<FetchTitleMetaResult> {
   if (!title.trim()) return { ok: false, error: "no title" };
+  // A film's OMDb year IS its identity — "Ashfall" 1999 and "Ashfall" 2024 are
+  // different films, and `y=` is what tells OMDb which one. A SERIES release's
+  // year is not the same kind of fact: it is usually when the release's own
+  // season aired, not when the show debuted, and OMDb keys a series by the
+  // latter. "The Boys S05 Season 5 2026 1080p..." parses year 2026 — the
+  // season's air year — and OMDb has no "The Boys" answering to that year, so
+  // an exact-match search comes back empty and falls back to an unrelated
+  // title that does. Every season of a show would carry a different embedded
+  // year and searching wrongly narrowed on each one, so the correct fix is not
+  // sending y= for a series at all — the title alone is the disambiguator here.
+  const seriesSafeYear = opts.type !== "series" ? opts.year : undefined;
   const params = new URLSearchParams({ t: title.trim() });
-  if (opts.year) params.set("y", String(opts.year));
+  if (seriesSafeYear) params.set("y", String(seriesSafeYear));
   if (opts.type) params.set("type", opts.type);
   const wantsEpisode = opts.season !== undefined && opts.episode !== undefined;
   if (opts.season !== undefined) params.set("Season", String(opts.season));
@@ -114,7 +125,7 @@ export async function fetchTitleMetaByName(
   // function — the terminal directly, the browser via `/api/title` — and a
   // fallback written twice is the copy-then-drift this codebase keeps recording.
   const seriesParams = new URLSearchParams({ t: title.trim() });
-  if (opts.year) seriesParams.set("y", String(opts.year));
+  if (seriesSafeYear) seriesParams.set("y", String(seriesSafeYear));
   if (opts.type) seriesParams.set("type", opts.type);
   const series = await request(seriesParams, apiKey, opts, `by name ${title} (poster)`);
   // A failed fallback leaves the episode answer exactly as it was: no poster is


### PR DESCRIPTION
## Summary
Found while visually verifying the show/season nesting work in #105 — "The Boys" and "The Boys S05" were both showing a poster that had nothing to do with the actual show, despite the app resolving the correct IMDb ID for a simplified query.

Root cause: `fetchTitleMetaByName` sends the release's parsed `year` to OMDb's `y=` parameter unconditionally. For a film that's correct and necessary — "Ashfall" 1999 and "Ashfall" 2024 are different films, and `y=` is what tells OMDb which one. But a **series** release's embedded year is a different kind of fact: it's usually when the release's own season aired, not when the show debuted, and OMDb keys a series by the latter.

The actual release name behind this bug: `The Boys S05 Season 5 2026 1080p AMZN WEBRip AAC5.1 10bits x265-Rapta` — parses `year: 2026`, the season's own air year. Verified directly against the running server:

```
release=...2026...           → imdbId: tt38593439 (an unrelated 1910s-Ottoman-Empire title)
release=The Boys S05 (no year) → imdbId: tt1190634 (the correct show)
```

OMDb has no "The Boys" answering to `y=2026`, so the exact-match search comes back empty and falls back to an unrelated title that does happen to answer that year — wrong `imdbId`, wrong plot, wrong poster. Every season of a long-running or returning show carries a different embedded year, so this wasn't one show's edge case — it was every poster/plot lookup for any series whose current season aired later than its debut year.

## Fix
`fetchTitleMetaByName` (`src/recc/omdb.ts`) now drops `year` for `type: "series"` before building either OMDb query it can send — the primary lookup and the episode-then-series-poster fallback. This is shared by both front ends (the terminal calls it directly, the browser via `/api/title`), so one change fixes it everywhere title metadata is fetched by name.

## Test plan
- [x] `npm test` (3267 passing — updated the existing "builds a title lookup with year and type" test to a film-specific case where sending the year is still correct, and added a new test proving a series drops it)
- [x] `npm run typecheck`
- [x] `npm run lint` (only the known pre-existing `App.tsx` warning)
- [x] `npm run build`
- [x] Live-verified against the running server and the actual release name from the bug report: `imdbId` now resolves to `tt1190634` (the correct show) instead of the unrelated title, and the poster shown in the app for both "The Boys" and "The Boys S05" is now correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QTsg7ie21bP9JpEPFMkyP