### PR TITLE
fix: don't auto-expand the top group when browsing with no query

### DIFF
--- a/src/util/resultGroup.test.ts
+++ b/src/util/resultGroup.test.ts
@@ -550,12 +550,18 @@ describe("defaultExpandedKeys", () => {
       ],
       "series",
     );
-    expect(defaultExpandedKeys(groups)).toEqual(["harrowgate|series|s3"]);
+    // "1080p" is a real query (a real search happened) that names no title, so
+    // this exercises the ranked fallback rather than the exact-title branch.
+    expect(defaultExpandedKeys(groups, undefined, "1080p")).toEqual(["harrowgate|series|s3"]);
   });
 
   it("opens nothing when there is no season to open", () => {
     expect(
-      defaultExpandedKeys(groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")])),
+      defaultExpandedKeys(
+        groupResults([r("Kestrel.2010.1080p"), r("Kestrel.2010.2160p")]),
+        undefined,
+        "kestrel",
+      ),
     ).toEqual([]);
   });
 
@@ -565,7 +571,7 @@ describe("defaultExpandedKeys", () => {
       [r("Harrowgate.S03E01.1080p.WEB-DL"), r("Harrowgate.S03E01.2160p.WEB-DL")],
       "series",
     );
-    expect(defaultExpandedKeys(groups)).toEqual([]);
+    expect(defaultExpandedKeys(groups, undefined, "harrowgate")).toEqual([]);
   });
 
   it("prefers the show the query actually named over a higher-ranked stray", () => {
@@ -581,8 +587,27 @@ describe("defaultExpandedKeys", () => {
       "series",
     );
     expect(defaultExpandedKeys(groups, undefined, "harrowgate")).toEqual(["harrowgate|series|s3"]);
-    // No query: rank alone still wins — this is a tie-break, not a replacement.
-    expect(defaultExpandedKeys(groups)).toEqual(["kepler|series|s2"]);
+    // A real query that names neither show: rank alone wins — this is a
+    // tie-break, not a replacement.
+    expect(defaultExpandedKeys(groups, undefined, "1080p")).toEqual(["kepler|series|s2"]);
+  });
+
+  it("opens nothing when there is no query and no watch position — a browse listing, not a search", () => {
+    // The "All" tab landing with nothing typed: no position to seed from and
+    // no query naming a show, so "highest-ranked" would just mean "first in
+    // whatever order the sources happened to answer" — nothing a user would
+    // recognise as a reason that group opened. Leave every group closed.
+    const groups = groupResults(
+      [
+        r("Harrowgate.S03E01.1080p.WEB-DL"),
+        r("Harrowgate.S03E01.2160p.WEB-DL"),
+        r("Harrowgate.S03.1080p.WEB-DL"),
+        r("Harrowgate.S03.2160p.WEB-DL"),
+      ],
+      "series",
+    );
+    expect(defaultExpandedKeys(groups)).toEqual([]);
+    expect(defaultExpandedKeys(groups, undefined, "")).toEqual([]);
   });
 });
 
@@ -611,21 +636,25 @@ describe("defaultExpandedKeys with a watch position", () => {
   });
 
   it("falls back to the highest-ranked season when the show has no position", () => {
+    // A position implies the show was actually searched for, so the fallback
+    // is exercised with the query that would realistically accompany it.
     const groups = groupResults(SHOW, "series");
-    expect(defaultExpandedKeys(groups, () => null)).toEqual(defaultExpandedKeys(groups));
+    expect(defaultExpandedKeys(groups, () => null, "harrowgate")).toEqual(
+      defaultExpandedKeys(groups, undefined, "harrowgate"),
+    );
   });
 
   it("is unchanged when no lookup is given, so Piece A's behaviour is intact", () => {
     const groups = groupResults(SHOW, "series");
     // [show key, season key] — this show has two seasons, so it wraps in a
     // show node that also needs opening.
-    expect(defaultExpandedKeys(groups)).toHaveLength(2);
+    expect(defaultExpandedKeys(groups, undefined, "harrowgate")).toHaveLength(2);
   });
 
   it("falls back when the position names a season the results do not have", () => {
     const groups = groupResults(SHOW, "series");
-    expect(defaultExpandedKeys(groups, () => ({ season: 9, episode: 1 }))).toEqual(
-      defaultExpandedKeys(groups),
+    expect(defaultExpandedKeys(groups, () => ({ season: 9, episode: 1 }), "harrowgate")).toEqual(
+      defaultExpandedKeys(groups, undefined, "harrowgate"),
     );
   });
 });
@@ -839,6 +868,18 @@ describe("expansionSeed", () => {
     );
     const seed = expansionSeed(groups, undefined, true, "harrowgate");
     expect(seed.expandKeys).toEqual(["harrowgate|series|s3"]);
+    expect(seed.latch).toBe(true);
+  });
+
+  it("opens nothing for a settled browse listing with no query and no position", () => {
+    // The "All" tab landing with nothing typed — not a search, so nothing
+    // should pop open on its own.
+    const groups = groupResults(
+      [r("Harrowgate.S03E01.1080p.WEB-DL"), r("Harrowgate.S03E02.1080p.WEB-DL")],
+      "series",
+    );
+    const seed = expansionSeed(groups, undefined, true);
+    expect(seed.expandKeys).toEqual([]);
     expect(seed.latch).toBe(true);
   });
 });

--- a/src/util/resultGroup.ts
+++ b/src/util/resultGroup.ts
@@ -597,8 +597,13 @@ export function defaultExpandedKeys<T extends GroupableResult>(
     const wanted = normaliseTitle(query);
     const exact = candidates.find((entry) => normaliseTitle(entry.season.title) === wanted);
     if (exact) return expandKeysFor(exact);
+    return expandKeysFor(candidates[0]!);
   }
-  return expandKeysFor(candidates[0]!);
+  // No query and no position to seed from: this is the default/browse listing
+  // (e.g. the "All" tab with nothing typed), not a search for a particular
+  // show. Opening "whichever season happens to rank first" there has no
+  // rationale a user would recognise, so leave every group closed.
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Summary
- On the "All" tab in grouped view, submitting an empty search (browsing) popped the top-ranked group open with no query typed and no watch position to justify it.
- `defaultExpandedKeys` (`src/util/resultGroup.ts`) now only falls back to "highest-ranked season" when a real search query was given; a bare browse listing leaves every group closed. This is a shared `src/util` module, so both the TUI and web grouped views pick up the fix.

## Test plan
- [x] `npx vitest run src/util/resultGroup.test.ts` — updated existing cases and added coverage for the no-query/no-position browse case
- [x] `npm run lint` on changed files
- [x] Built the app (`npm run build`) and verified in Chrome: All tab, grouped view, empty search — every group renders closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)